### PR TITLE
[Easy] Adding simple docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+mongo:
+  image: mongo:latest
+  environment:
+    - AUTH=no
+  ports:
+    - "27017:27017"


### PR DESCRIPTION
We should be able to run all parts of our system by running a simple `docker compose up` command. This change creates the docker compose file and adds the first subsystem (mongodb) which doesn't require any customization. 
I'd hope that the event_listener and driver could be separate docker containers that will all be launched and connected with this docker compose file.

This is also how trading-db handles their subsystems.