### PR TITLE
Adding a Mongo UI to docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,10 @@ mongodb, the data base storing the data of the snapp
 listener, a listener pulling data from the ganache-cli and inserting it into mongodb
 driver, a service calculating the new states and push these into the smart contract
 
-
-After the docker is up an running, we have to migrate the smart contracts into ganache-cli
-
-```bash
-git clone git@github.com:gnosis/dex-contracts.git
-cd dex-contracts
-truffle migrate --reset
-```
+You can see the current state of the mongodb by opening [localhost:3000](http://localhost:3000) and connecting to the default database (top right).
+On the left side bar, under *Collections* select the collection you want to inspect, e.g. *accounts*.
 
 In order to setup some testing accounts and make the first deposits (from account 3, of the third registered token with an amount of 18), run in the same repo the following scripts:
-
 
 ```bash
 truffle exec scripts/setup_environment.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,15 @@ services:
     restart: always  
     ports:
       - "27017:27017"
+  
+  mongoclient:
+    image: mongoclient/mongoclient:2.2.0
+    environment:
+      - MONGOCLIENT_DEFAULT_CONNECTION_URL=mongodb://mongo/dfusion2
+    ports:
+      - '3000:3000'
+    depends_on:
+      - mongo
 
   ganache-cli:
     ports:
@@ -16,8 +25,6 @@ services:
 
   truffle:
     command: /app/docker/truffle/run.sh
-    ports:
-      - '8546:8546' # opens after migration complete
     build:
       context: .
       dockerfile: docker/truffle/Dockerfile

--- a/test/e2e-tests-deposit.sh
+++ b/test/e2e-tests-deposit.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 set -e
 
 cd dex-contracts/


### PR DESCRIPTION
This will give us an easy to use a UI to inspect the current state of the database.

Run `docker-compose up`, visit [http://localhost:3000/](http://localhost:3000/), connect to the default database. On the left side bar, under Connections select accounts and execute query - notice initial account state.

Run e2e test from shell. Re-execute query in UI and observe that we now have three state updates.

<img width="1182" alt="screen shot 2019-02-20 at 11 49 04" src="https://user-images.githubusercontent.com/1200333/53087170-cef8d280-3506-11e9-8564-350e297ec313.png">
