### PR TITLE
[EventListener] Expose valid flag on withdraw record

### DIFF
--- a/event_listener/dfusion_db/database_interface.py
+++ b/event_listener/dfusion_db/database_interface.py
@@ -16,6 +16,9 @@ class DatabaseInterface(ABC):
     def write_withdraw(self, withdraw: Withdraw) -> None: pass
 
     @abstractmethod
+    def update_withdraw(self, old: Withdraw, new: Withdraw) -> None: pass
+
+    @abstractmethod
     def write_account_state(self, account_record: AccountRecord) -> None: pass
 
     @abstractmethod
@@ -56,17 +59,14 @@ class MongoDbInterface(DatabaseInterface):
             "Successfully included Deposit - {}".format(deposit_id))
 
     def write_withdraw(self, withdraw: Withdraw) -> None:
-        withdraws = self.db.withdraws
-        event = {
-            "accountId": withdraw.account_id,
-            "tokenId": withdraw.token_id,
-            "amount": withdraw.amount,
-            "slot": withdraw.slot,
-            "slotIndex": withdraw.slot_index
-        }
-        withdraw_id = withdraws.insert_one(event).inserted_id
+        withdraw_id = self.db.withdraws.insert_one(withdraw.to_dictionary()).inserted_id
         self.logger.info(
             "Successfully included Withdraw - {}".format(withdraw_id))
+
+    def update_withdraw(self, old: Withdraw, new: Withdraw) -> None:
+        self.db.withdraws.replace_one({'_id': old.id}, new.to_dictionary())
+        self.logger.info(
+            "Successfully included Withdraw - {}".format(old.id))
 
     def write_account_state(self, account_record: AccountRecord) -> None:
         record = {

--- a/event_listener/dfusion_db/models.py
+++ b/event_listener/dfusion_db/models.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import NamedTuple, Dict, Any, List
+from typing import NamedTuple, Dict, Any, List, Optional
 
 
 class TransitionType(Enum):
@@ -55,6 +55,8 @@ class Withdraw(NamedTuple):
     amount: int
     slot: int
     slot_index: int
+    valid: bool = False
+    id: Optional[str] = None
 
     @classmethod
     def from_dictionary(cls, data: Dict[str, Any]) -> "Withdraw":
@@ -66,8 +68,20 @@ class Withdraw(NamedTuple):
             int(data['tokenId']),
             int(data['amount']),
             int(data['slot']),
-            int(data['slotIndex'])
+            int(data['slotIndex']),
+            bool(data.get('valid', False)),
+            data.get('_id', None)
         )
+
+    def to_dictionary(self) -> Dict[str, Any]:
+        return {
+            "accountId": self.account_id,
+            "tokenId": self.token_id,
+            "amount": self.amount,
+            "slot": self.slot,
+            "slotIndex": self.slot_index,
+            "valid": self.valid
+        }
 
 
 class AccountRecord(NamedTuple):

--- a/event_listener/dfusion_db/snapp_event_receiver.py
+++ b/event_listener/dfusion_db/snapp_event_receiver.py
@@ -55,10 +55,12 @@ class StateTransitionReceiver(SnappEventListener):
                     datum.account_id, datum.token_id, datum.amount))
                 balances[index] += datum.amount
             elif transition.transition_type == TransitionType.Withdraw:
+                assert isinstance(datum, Withdraw)
                 if balances[index] - datum.amount >= 0:
                     self.logger.info("Decreasing balance of account {} - token {} by {}".format(
                         datum.account_id, datum.token_id, datum.amount))
                     balances[index] -= datum.amount
+                    self.database.update_withdraw(datum, datum._replace(valid=True))
                 else:
                     self.logger.info(
                         "Insufficient balance: account {} - token {} for amount {}".format(


### PR DESCRIPTION
Addresses #34

Upon processing withdraws, we mark them as being valid if their account balance was reduced.

To test, we can run the e2e test and afterwards run:
```
> mongo dfusion2 --eval "db.withdraws.find()"
{ "_id" : ObjectId("5c6d8008049883000f400164"), "accountId" : 3, "tokenId" : 3, "amount" : 18, "slot" : 1, "slotIndex" : 0, "valid" : true }
```