### PR TITLE
Refactoring Error to be package specific type for better unit testing

### DIFF
--- a/driver/Cargo.lock
+++ b/driver/Cargo.lock
@@ -321,6 +321,7 @@ version = "0.1.0"
 dependencies = [
  "bson 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethabi 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mongodb 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "pairing 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -9,6 +9,7 @@ name = "driver"
 path = "src/lib.rs"
 
 [dependencies]
+ethabi = "6.1.0"
 mongodb = "0.3.2"
 serde_json = "1.0"
 serde_derive = "1.0"
@@ -20,7 +21,6 @@ sha2 = "*"
 byteorder = "*"
 hex = "*"
 web3 = { git = "https://github.com/tomusdrw/rust-web3" }
-
 
 
 

--- a/driver/src/contract.rs
+++ b/driver/src/contract.rs
@@ -2,10 +2,12 @@ use web3::contract::{Contract, Options};
 use web3::futures::Future;
 use web3::types::{Address, H256, U256};
 
+use crate::error::DriverError;
+
 use std::env;
 use std::fs;
 
-type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+type Result<T> = std::result::Result<T, DriverError>;
 
 pub trait SnappContract {
     // General Blockchain interface
@@ -68,62 +70,62 @@ impl SnappContract for SnappContractImpl {
     fn get_current_state_root(&self) -> Result<H256> {
         self.contract.query(
             "getCurrentStateRoot", (), None, Options::default(), None
-        ).wait().map_err(|e| Box::new(e) as Box<std::error::Error>)
+        ).wait().map_err(|e| DriverError::from(e))
     }
 
     fn get_current_deposit_slot(&self) -> Result<U256> {
         self.contract.query(
             "depositIndex", (), None, Options::default(), None
-        ).wait().map_err(|e| Box::new(e) as Box<std::error::Error>)
+        ).wait().map_err(|e| DriverError::from(e))
     }
 
     fn has_deposit_slot_been_applied(&self, slot: U256) -> Result<bool> {
         self.contract.query(
             "hasDepositBeenApplied", slot, None, Options::default(), None,
-        ).wait().map_err(|e| Box::new(e) as Box<std::error::Error>)
+        ).wait().map_err(|e| DriverError::from(e))
     }
 
     fn deposit_hash_for_slot(&self, slot: U256) -> Result<H256> {
         self.contract.query(
             "getDepositHash", slot, None, Options::default(), None,
-        ).wait().map_err(|e| Box::new(e) as Box<std::error::Error>)
+        ).wait().map_err(|e| DriverError::from(e))
     }
 
     fn creation_block_for_deposit_slot(&self, slot: U256) -> Result<U256> {
         self.contract.query(
             "getDepositCreationBlock", slot, None, Options::default(), None,
-        ).wait().map_err(|e| Box::new(e) as Box<std::error::Error>)
+        ).wait().map_err(|e| DriverError::from(e))
     }
 
     fn get_current_withdraw_slot(&self) -> Result<U256> {
         self.contract.query(
             "withdrawIndex", (), None, Options::default(), None
-        ).wait().map_err(|e| Box::new(e) as Box<std::error::Error>)
+        ).wait().map_err(|e| DriverError::from(e))
     }
 
     fn has_withdraw_slot_been_applied(&self, slot: U256) -> Result<bool> {
         self.contract.query(
             "hasWithdrawBeenApplied", slot, None, Options::default(), None,
-        ).wait().map_err(|e| Box::new(e) as Box<std::error::Error>)
+        ).wait().map_err(|e| DriverError::from(e))
     }
 
     fn withdraw_hash_for_slot(&self, slot: U256) -> Result<H256> {
         self.contract.query(
             "getWithdrawHash", slot, None, Options::default(), None,
-        ).wait().map_err(|e| Box::new(e) as Box<std::error::Error>)
+        ).wait().map_err(|e| DriverError::from(e))
     }
 
     fn creation_block_for_withdraw_slot(&self, slot: U256) -> Result<U256> {
         self.contract.query(
             "getWithdrawCreationBlock", slot, None, Options::default(), None,
-        ).wait().map_err(|e| Box::new(e) as Box<std::error::Error>)
+        ).wait().map_err(|e| DriverError::from(e))
     }
 
     fn get_current_block_number(&self) -> Result<U256> {
         self.web3.eth()
             .block_number()
             .wait()
-            .map_err(|e| Box::new(e) as Box<std::error::Error>)
+            .map_err(|e| DriverError::from(e))
     }
     
     fn apply_deposits(
@@ -139,7 +141,7 @@ impl SnappContract for SnappContractImpl {
                 account,
                 Options::default(),
             ).wait()
-            .map_err(|e| Box::new(e) as Box<std::error::Error>)
+            .map_err(|e| DriverError::from(e))
             .map(|_|())
     }
 
@@ -161,7 +163,7 @@ impl SnappContract for SnappContractImpl {
             opt.gas = Some(1_000_000.into());
         }),
             ).wait()
-            .map_err(|e| Box::new(e) as Box<std::error::Error>)
+            .map_err(|e| DriverError::from(e))
             .map(|_|())
     }
 }

--- a/driver/src/deposit_driver.rs
+++ b/driver/src/deposit_driver.rs
@@ -1,11 +1,9 @@
 use crate::models;
 use crate::db_interface::DbInterface;
+use crate::error::{DriverError, ErrorKind};
 use crate::contract::SnappContract;
-use crate::error::DriverError;
 
 use web3::types::{H256, U256};
-
-use std::error::Error;
 
 pub fn apply_deposits(
     state: &mut models::State,
@@ -17,7 +15,7 @@ pub fn apply_deposits(
     state.clone()
 }
 
-pub fn run_deposit_listener<D, C>(db: &D, contract: &C) -> Result<(), Box<dyn Error>> 
+pub fn run_deposit_listener<D, C>(db: &D, contract: &C) -> Result<(), DriverError> 
     where   D: DbInterface,
             C: SnappContract
 {
@@ -68,10 +66,10 @@ pub fn run_deposit_listener<D, C>(db: &D, contract: &C) -> Result<(), Box<dyn Er
         }
 
         if deposit_hash != deposit_hash_pulled {
-            return Err(Box::new(DriverError::new(
+            return Err(DriverError::new(
                 &format!("Pending deposit hash from contract ({}), didn't match the one found in db ({})", 
-                deposit_hash, deposit_hash_pulled)
-            )));
+                deposit_hash, deposit_hash_pulled), ErrorKind::StateError
+            ));
         }
 
         if deposit_slot_empty && deposit_ind != U256::zero() {

--- a/driver/src/error.rs
+++ b/driver/src/error.rs
@@ -1,14 +1,85 @@
 use std::error::Error;
 use std::fmt;
+use ethabi;
 
-#[derive(Debug)]
-pub struct DriverError {
-    details: String
+#[derive(Debug, Clone, PartialEq)]
+pub enum ErrorKind {
+    MiscError,
+    IoError,
+    ContractError,
+    JsonError,
+    HexError,
+    AbiError,
+    EnvError,
+    DbError,
+    ParseIntError,
+    StateError,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct DriverError {
+    details: String,
+    kind: ErrorKind,
+}
+
+impl From<std::io::Error> for DriverError {
+    fn from(error: std::io::Error) -> Self {
+        DriverError::new(error.description(), ErrorKind::IoError)
+    }
+}
+impl From<web3::contract::Error> for DriverError {
+    fn from(error: web3::contract::Error) -> Self {
+        DriverError::new(error.description(), ErrorKind::ContractError)
+    }
+}
+impl From<web3::Error> for DriverError {
+    fn from(error: web3::Error) -> Self {
+        DriverError::new(error.description(), ErrorKind::ContractError)
+    }
+}
+impl From<serde_json::Error> for DriverError {
+    fn from(error: serde_json::Error) -> Self {
+        DriverError::new(error.description(), ErrorKind::JsonError)
+    }
+}
+impl From<hex::FromHexError> for DriverError {
+    fn from(error: hex::FromHexError) -> Self {
+        DriverError::new(error.description(), ErrorKind::HexError)
+    }
+}
+impl From<ethabi::Error> for DriverError {
+    fn from(error: ethabi::Error) -> Self {
+        DriverError::new(error.description(), ErrorKind::AbiError)
+    }
+}
+impl From<std::env::VarError> for DriverError {
+    fn from(error: std::env::VarError) -> Self {
+        DriverError::new(error.description(), ErrorKind::EnvError)
+    }
+}
+impl From<mongodb::Error> for DriverError {
+    fn from(error: mongodb::Error) -> Self {
+        DriverError::new(error.description(), ErrorKind::DbError)
+    }
+}
+impl From<std::num::ParseIntError> for DriverError {
+    fn from(error: std::num::ParseIntError) -> Self {
+        DriverError::new(error.description(), ErrorKind::ParseIntError)
+    }
+}
+impl From<mongodb::DecoderError> for DriverError {
+    fn from(error: mongodb::DecoderError) -> Self {
+        DriverError::new(error.description(), ErrorKind::DbError)
+    }
+}
+impl From<&str> for DriverError {
+    fn from(error: &str) -> Self {
+        DriverError::new(error, ErrorKind::MiscError)
+    }
+}
 impl DriverError {
-    pub fn new(msg: &str) -> DriverError {
-        DriverError{details: msg.to_string()}
+    pub fn new(msg: &str, kind: ErrorKind) -> DriverError {
+        DriverError{details: msg.to_string(), kind}
     }
 }
 impl fmt::Display for DriverError {

--- a/driver/src/models.rs
+++ b/driver/src/models.rs
@@ -5,6 +5,7 @@ use sha2::{Digest, Sha256};
 use std::num::ParseIntError;
 use web3::types::H256;
 use std::error::Error;
+use crate::error;
 
 pub const TOKENS: u16 = 30;
 
@@ -52,7 +53,7 @@ pub struct State {
 
 impl State {
   //Todo: Exchange sha with pederson hash
-  pub fn hash(&self) -> Result<[u8; 32], Box<dyn Error>> {
+  pub fn hash(&self) -> Result<[u8; 32], error::DriverError> {
     let mut hash: [u8; 32] = [0; 32];
     for i in &self.balances {
       let mut bs = [0u8; 64];
@@ -74,7 +75,7 @@ impl State {
 }
 
 #[allow(non_snake_case)]
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct PendingFlux {
   pub slotIndex: i32,
   pub slot: i32,


### PR DESCRIPTION
For use in Mock framework the return types have to be cloneable, which a generic error isn't. Also introducing a kind makes it easier to test, we are failing for the "right" reason.