### PR TITLE
[Driver] Renaming State and Flux members to snake case

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,3 +66,4 @@ services:
       - DB_HOST=mongo
       - DB_PORT=27017
       - DB_NAME=dfusion2  
+      - RUST_BACKTRACE=1

--- a/driver/src/deposit_driver.rs
+++ b/driver/src/deposit_driver.rs
@@ -12,7 +12,7 @@ pub fn apply_deposits(
     deposits: &Vec<models::PendingFlux>,
 ) -> models::State {
     for i in deposits {
-        state.balances[((i.accountId - 1) * models::TOKENS + (i.tokenId as u16 - 1)) as usize] += i.amount;
+        state.balances[((i.account_id - 1) * models::TOKENS + (i.token_id as u16 - 1)) as usize] += i.amount;
     }
     state.clone()
 }
@@ -79,7 +79,7 @@ pub fn run_deposit_listener<D, C>(db: &D, contract: &C) -> Result<(bool), Driver
         } else {
             // calculate new state by applying all deposits
             state = apply_deposits(&mut state, &deposits);
-            println!("New StateHash is{:?}", state.rolling_hash());
+            println!("New State_hash is{:?}", state.rolling_hash());
 
             //send new state into blockchain
             //applyDeposits signature is (slot, _currStateRoot, _newStateRoot, deposit_slotHash)
@@ -111,8 +111,8 @@ mod tests {
         let state_hash = H256::zero();
         let deposits = vec![create_flux_for_test(1,1), create_flux_for_test(1,2)];
         let state = models::State {
-            stateHash: format!("{:x}", state_hash),
-            stateIndex: 1,
+            state_hash: format!("{:x}", state_hash),
+            state_index: 1,
             balances: vec![100; (models::TOKENS * 2) as usize],
         };
 
@@ -139,8 +139,8 @@ mod tests {
         let state_hash = H256::zero();
 
         let state = models::State {
-            stateHash: format!("{:x}", state_hash),
-            stateIndex: 1,
+            state_hash: format!("{:x}", state_hash),
+            state_index: 1,
             balances: vec![100; (models::TOKENS * 2) as usize],
         };
 
@@ -166,8 +166,8 @@ mod tests {
         let deposits = vec![create_flux_for_test(1,1), create_flux_for_test(1,2)];
 
         let state = models::State {
-            stateHash: format!("{:x}", state_hash),
-            stateIndex: 1,
+            state_hash: format!("{:x}", state_hash),
+            state_index: 1,
             balances: vec![100; (models::TOKENS * 2) as usize],
         };
 
@@ -208,8 +208,8 @@ mod tests {
         contract.apply_deposits.given((slot - 1, Any, Any, Any)).will_return(Ok(()));
 
         let state = models::State {
-            stateHash: format!("{:x}", state_hash),
-            stateIndex: 1,
+            state_hash: format!("{:x}", state_hash),
+            state_index: 1,
             balances: vec![100; (models::TOKENS * 2) as usize],
         };
 
@@ -228,8 +228,8 @@ mod tests {
         let deposits = vec![create_flux_for_test(1,1), create_flux_for_test(1,2)];
 
         let state = models::State {
-            stateHash: format!("{:x}", state_hash),
-            stateIndex: 1,
+            state_hash: format!("{:x}", state_hash),
+            state_index: 1,
             balances: vec![100; (models::TOKENS * 2) as usize],
         };
 

--- a/driver/src/models.rs
+++ b/driver/src/models.rs
@@ -14,11 +14,11 @@ pub trait RootHashable {
     fn root_hash(&self, valid_items: &Vec<bool>) -> H256;
 }
 
-#[allow(non_snake_case)]
 #[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct State {
-  pub stateHash: String,
-  pub stateIndex: i32,
+  pub state_hash: String,
+  pub state_index: i32,
   pub balances: Vec<u128>,
 }
 
@@ -40,13 +40,13 @@ impl RollingHashable for State {
   }
 }
 
-#[allow(non_snake_case)]
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct PendingFlux {
-  pub slotIndex: u32,
+  pub slot_index: u32,
   pub slot: u32,
-  pub accountId: u16,
-  pub tokenId: u8,
+  pub account_id: u16,
+  pub token_id: u8,
   pub amount: u128,
 }
 
@@ -63,8 +63,8 @@ impl PendingFlux {
 
   pub fn bytes(&self) -> Vec<u8> {
     let mut wtr = vec![0; 13];
-    wtr.write_u16::<BigEndian>(self.accountId).unwrap();
-    wtr.write_u8(self.tokenId).unwrap();
+    wtr.write_u16::<BigEndian>(self.account_id).unwrap();
+    wtr.write_u8(self.token_id).unwrap();
     wtr.write_u128::<BigEndian>(self.amount).unwrap();
     wtr
   }
@@ -116,10 +116,10 @@ pub mod tests {
   #[test]
   fn test_pending_flux_rolling_hash() {
     let deposit = PendingFlux {
-      slotIndex: 0,
+      slot_index: 0,
       slot: 0,
-      accountId: 0,
-      tokenId: 0,
+      account_id: 0,
+      token_id: 0,
       amount: 0,
     };
     assert_eq!(
@@ -139,10 +139,10 @@ pub mod tests {
   #[test]
   fn test_pending_flux_root_hash() {
     let deposit = PendingFlux {
-      slotIndex: 0,
+      slot_index: 0,
       slot: 0,
-      accountId: 3,
-      tokenId: 3,
+      account_id: 3,
+      token_id: 3,
       amount: 18,
     };
     // one valid withdraw
@@ -166,34 +166,34 @@ pub mod tests {
     // Empty state
     let mut balances = vec![0; 3000];
     let state = State {
-        stateHash: "77b01abfbad57cb7a1344b12709603ea3b9ad803ef5ea09814ca212748f54733".to_string(),
-        stateIndex:  1,
+        state_hash: "77b01abfbad57cb7a1344b12709603ea3b9ad803ef5ea09814ca212748f54733".to_string(),
+        state_index:  1,
         balances: balances.clone(),
     };
     assert_eq!(
       state.rolling_hash(),
-      H256::from_str(&state.stateHash).unwrap()
+      H256::from_str(&state.state_hash).unwrap()
     );
 
     // State with single deposit
     balances[62] = 18;
     let state = State {
-        stateHash: "73899d50b4ec5e351b4967e4c4e4a725e0fa3e8ab82d1bb6d3197f22e65f0c97".to_string(),
-        stateIndex:  1,
+        state_hash: "73899d50b4ec5e351b4967e4c4e4a725e0fa3e8ab82d1bb6d3197f22e65f0c97".to_string(),
+        state_index:  1,
         balances: balances,
     };
     assert_eq!(
       state.rolling_hash(),
-      H256::from_str(&state.stateHash).unwrap()
+      H256::from_str(&state.state_hash).unwrap()
     );
   }
 
   pub fn create_flux_for_test(slot: u32, slot_index: u32) -> PendingFlux {
       PendingFlux {
-          slotIndex: slot_index,
+          slot_index: slot_index,
           slot,
-          accountId: 1,
-          tokenId: 1,
+          account_id: 1,
+          token_id: 1,
           amount: 10,
       }
   }

--- a/driver/src/withdraw_driver.rs
+++ b/driver/src/withdraw_driver.rs
@@ -14,8 +14,8 @@ fn apply_withdraws(
     let mut state = state.clone();
     let mut valid_withdraws = vec![];
     for i in withdraws {
-        if state.balances[((i.accountId - 1) * models::TOKENS + (i.tokenId as u16 - 1)) as usize] >= i.amount {
-            state.balances[((i.accountId - 1) * models::TOKENS + (i.tokenId as u16 - 1)) as usize] -= i.amount;
+        if state.balances[((i.account_id - 1) * models::TOKENS + (i.token_id as u16 - 1)) as usize] >= i.amount {
+            state.balances[((i.account_id - 1) * models::TOKENS + (i.token_id as u16 - 1)) as usize] -= i.amount;
             valid_withdraws.push(true);
         } else {
             valid_withdraws.push(false);
@@ -77,7 +77,7 @@ pub fn run_withdraw_listener<D, C>(db: &D, contract: &C) -> Result<(bool), Drive
             let withdrawal_merkle_root = withdraws.root_hash(&valid_withdraws);
             let new_state_root = H256::from(updated_balances.rolling_hash());
             
-            println!("New StateHash is {}, Valid Withdraw Merkle Root is {}", new_state_root, withdrawal_merkle_root);
+            println!("New State_hash is {}, Valid Withdraw Merkle Root is {}", new_state_root, withdrawal_merkle_root);
             contract.apply_withdraws(slot, withdrawal_merkle_root, state_root, new_state_root, contract_withdraw_hash)?;
             return Ok(true);
         } else {
@@ -101,8 +101,8 @@ mod tests {
         let state_hash = H256::zero();
         let withdraws = vec![create_flux_for_test(1,1), create_flux_for_test(1,2)];
         let state = models::State {
-            stateHash: format!("{:x}", state_hash),
-            stateIndex: 1,
+            state_hash: format!("{:x}", state_hash),
+            state_index: 1,
             balances: vec![100; (models::TOKENS * 2) as usize],
         };
 
@@ -171,8 +171,8 @@ mod tests {
         contract.apply_withdraws.given((slot - 1, Any, Any, Any, Any)).will_return(Ok(()));
 
         let state = models::State {
-            stateHash: format!("{:x}", state_hash),
-            stateIndex: 1,
+            state_hash: format!("{:x}", state_hash),
+            state_index: 1,
             balances: vec![100; (models::TOKENS * 2) as usize],
         };
 
@@ -192,8 +192,8 @@ mod tests {
         let withdraws = vec![create_flux_for_test(1,1), create_flux_for_test(1,2)];
 
         let state = models::State {
-            stateHash: format!("{:x}", state_hash),
-            stateIndex: 1,
+            state_hash: format!("{:x}", state_hash),
+            state_index: 1,
             balances: vec![100; (models::TOKENS * 2) as usize],
         };
 
@@ -221,15 +221,15 @@ mod tests {
         let slot = U256::from(1);
         let state_hash = H256::zero();
         let withdraws = vec![create_flux_for_test(1,1), models::PendingFlux {
-            slotIndex: 2,
+            slot_index: 2,
             slot: 1,
-            accountId: 1,
-            tokenId: 2,
+            account_id: 1,
+            token_id: 2,
             amount: 10,
         }];
         let mut state = models::State {
-            stateHash: format!("{:x}", state_hash),
-            stateIndex: 1,
+            state_hash: format!("{:x}", state_hash),
+            state_index: 1,
             balances: vec![100; (models::TOKENS * 2) as usize],
         };
 


### PR DESCRIPTION
Rust naming convention suggests snake_case for its struct members. We originally chose to use CamelCase, because the event listener inputs events using CamelCase keys into the database and we couldn't find a simple way to parse the json into native rust objects if the keys didn't exactly match.

Turns out there is a simple macro for it: Using `#[serde(rename_all = "camelCase")]` will make snake case member variables work and parse from and to CamelCase objects.

🎈 