### PR TITLE
[Driver] conditionally include solver to Docker setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,5 @@ venv.bak/
 .idea
 .vscode
 .DS_Store
+
+.ssh

--- a/.gitignore
+++ b/.gitignore
@@ -106,5 +106,3 @@ venv.bak/
 .idea
 .vscode
 .DS_Store
-
-.ssh

--- a/.ssh/.gitignore
+++ b/.ssh/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,6 @@ services:
     volumes:
       # Don't sync target, otherwise we rebuild on every deploy
       - ./driver/src:/app/driver/src
-      - ./driver/tests:/app/driver/tests
     environment:
       - SNAPP_CONTRACT_ADDRESS=C89Ce4735882C9F0f0FE26686c53074E09B0D550
       - DB_HOST=mongo

--- a/docker/driver/Dockerfile
+++ b/docker/driver/Dockerfile
@@ -22,5 +22,5 @@ COPY dex-contracts/build dex-contracts/build
 
 # Copy source code
 WORKDIR /app/driver
-COPY driver .
+COPY driver/src driver/tests ./
 RUN cargo build

--- a/docker/driver/Dockerfile
+++ b/docker/driver/Dockerfile
@@ -2,15 +2,25 @@ FROM fleupold/dfusion-solver-base:v1
 
 #Install Rust
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+RUN ln -s $HOME/.cargo/bin/* /usr/bin/
 
-# Copy data
-WORKDIR /app
-COPY . .
+# Copy requirements and install
+WORKDIR /app/driver
+COPY driver/Cargo.toml .
+RUN mkdir src && touch src/lib.rs
+RUN cargo build
 
 # Install solver if specified
 ARG use_solver
+WORKDIR /app
+COPY docker/driver/clone_solver.sh docker/driver/clone_solver.sh
+COPY .ssh/ .ssh/
 RUN if [ "$use_solver" = 1 ]; then docker/driver/clone_solver.sh; else echo "Not installing solver"; fi
 
-# Install Rust dependencies
+# Copy smart contract build artefacts
+COPY dex-contracts/build dex-contracts/build
+
+# Copy source code
 WORKDIR /app/driver
-RUN $HOME/.cargo/bin/cargo build
+COPY driver .
+RUN cargo build

--- a/docker/driver/Dockerfile
+++ b/docker/driver/Dockerfile
@@ -23,5 +23,5 @@ COPY dex-contracts/build dex-contracts/build
 
 # Copy source code
 WORKDIR /app/driver
-COPY driver/src ./
-RUN cargo build
+COPY driver/src ./src
+RUN cargo clean -p driver && cargo build

--- a/docker/driver/Dockerfile
+++ b/docker/driver/Dockerfile
@@ -16,11 +16,12 @@ WORKDIR /app
 COPY docker/driver/clone_solver.sh docker/driver/clone_solver.sh
 COPY .ssh/ .ssh/
 RUN if [ "$use_solver" = 1 ]; then docker/driver/clone_solver.sh; else echo "Not installing solver"; fi
+ENV PYTHONPATH ${PYTHONPATH}:/app/batchauctions/
 
 # Copy smart contract build artefacts
 COPY dex-contracts/build dex-contracts/build
 
 # Copy source code
 WORKDIR /app/driver
-COPY driver/src driver/tests ./
+COPY driver/src ./
 RUN cargo build

--- a/docker/driver/Dockerfile
+++ b/docker/driver/Dockerfile
@@ -1,6 +1,16 @@
-FROM rust:1.31.0
+FROM fleupold/dfusion-solver-base:v1
 
+#Install Rust
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+# Copy data
 WORKDIR /app
 COPY . .
+
+# Install solver if specified
+ARG use_solver
+RUN if [ "$use_solver" = 1 ]; then docker/driver/clone_solver.sh; else echo "Not installing solver"; fi
+
+# Install Rust dependencies
 WORKDIR /app/driver
-RUN cargo build
+RUN $HOME/.cargo/bin/cargo build

--- a/docker/driver/clone_solver.sh
+++ b/docker/driver/clone_solver.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+# Authorize SSH Host
+mkdir -p /root/.ssh
+chmod 0700 /root/.ssh && \
+ssh-keyscan gitlab.com > /root/.ssh/known_hosts
+
+# Copy SSH key
+cp .ssh/id_rsa /root/.ssh/id_rsa
+cp .ssh/id_rsa.pub /root/.ssh/id_rsa.pub
+
+# Clone and install dependencies
+git clone git@gitlab.com:twalth3r/batchauctions.git
+cd batchauctions
+pip install -r requirements.txt

--- a/docker/driver/clone_solver.sh
+++ b/docker/driver/clone_solver.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
+set -e
 
 # Authorize SSH Host
 mkdir -p /root/.ssh

--- a/docker/solver/Dockerfile
+++ b/docker/solver/Dockerfile
@@ -1,0 +1,33 @@
+FROM python:3.6
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends g++ zlib1g-dev bison flex libgmp-dev libreadline-dev libncurses5-dev
+
+# Install SCIP solver
+WORKDIR /opt
+RUN wget https://scip.zib.de/download/release/scipoptsuite-6.0.1.tgz
+RUN tar xzf scipoptsuite-6.0.1.tgz
+
+WORKDIR /opt/scipoptsuite-6.0.1
+RUN make
+
+WORKDIR /opt/scipoptsuite-6.0.1/scip/interfaces/ampl/
+RUN ./get.ASL
+
+WORKDIR /opt/scipoptsuite-6.0.1/scip/interfaces/ampl/solvers/
+RUN sh configurehere && make
+
+WORKDIR /opt/scipoptsuite-6.0.1/scip/interfaces/ampl/
+RUN make scipampl && make
+RUN cp bin/scipampl /usr/local/bin/
+
+# Install Gurobi solver
+WORKDIR /opt
+RUN wget https://packages.gurobi.com/8.1/gurobi8.1.0_linux64.tar.gz
+RUN tar xzf gurobi8.1.0_linux64.tar.gz
+
+WORKDIR /opt/gurobi810/linux64/
+RUN python setup.py install
+ENV GUROBI_HOME /opt/gurobi810/linux64/
+ENV PATH ${PATH}:${GUROBI_HOME}/bin
+ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:${GUROBI_HOME}/lib

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -20,7 +20,7 @@ rustc-hex = "*"
 sha2 = "*"
 byteorder = "*"
 hex = "*"
-web3 = { git = "https://github.com/tomusdrw/rust-web3" }
+web3 = { git = "https://github.com/tomusdrw/rust-web3", rev = "56ad08e" }
 
 [dev-dependencies]
 mock-it = "0.2.0"


### PR DESCRIPTION
This PR adds @twalth3r solver codebase tot he driver Docker image, if the driver is built with 

```
docker-compose build --build-args use_solver=1 driver
```

It then assumes to find ssh keys inside `dex-services/.ssh` which have permissions to read the batch auction repo (need to be whitelisted in some account that has read access first). 
The build file then clones the repo and installs the dependencies. 

Successful installation can be checked by running:

```
docker-compose run driver bash -c 'cd ../batchauctions/src && python main.py @input/run_single_docker.cfg'
```

This should show solver output.

In order to run the solver we need to download/install SCIP and Gurobi. Since those dependencies don't update very often I pulled them into a separate Docker image which will have to be specifically rebuilt and pushed if we update the underlying library. 

This new docker image is now the base image for the driver, which should make it so that the total build time is not dramatically increased.

@luarx happy to hear any suggestions on how to make this easier/more elegant/more efficient.

:octocat: 