### PR TITLE
[Easy] Only run one build per PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+if: (branch = master) OR (type = pull_request) OR (tag IS present)
 matrix:
   include:
     - language: rust


### PR DESCRIPTION
We are currently building twice for each pull request (once because it's a PR and once because of the branch matching rule).

This PR adds a line to the travis file that prevents it from building on every branch. This should reduce the build time per PR in half.

Thanks @luarx for pointing this out.