### PR TITLE
[Driver] Defining an interface for the driver<->solver interaction

### DIFF
--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -11,6 +11,7 @@ extern crate sha2;
 pub mod contract;
 pub mod db_interface;
 pub mod error;
+pub mod price_finding;
 
 mod deposit_driver;
 mod models;

--- a/driver/src/models.rs
+++ b/driver/src/models.rs
@@ -14,7 +14,7 @@ pub trait RootHashable {
     fn root_hash(&self, valid_items: &Vec<bool>) -> H256;
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct State {
   pub state_hash: String,
@@ -105,6 +105,15 @@ fn merkleize(leafs: Vec<Vec<u8>>) -> H256 {
         hasher.result().to_vec()
     }).collect();
     merkleize(next_layer)
+}
+
+#[derive(PartialEq)]
+pub struct Order {
+    pub account_id: u16,
+    pub sell_token: u8,
+    pub buy_token: u8,
+    pub sell_amount: u128,
+    pub buy_amount: u128,
 }
 
 #[cfg(test)]

--- a/driver/src/price_finding/mod.rs
+++ b/driver/src/price_finding/mod.rs
@@ -1,0 +1,1 @@
+pub mod price_finder_interface;

--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -8,6 +8,7 @@ pub struct Solution {
     pub surplus: U256,
     pub prices: Vec<u128>,
     pub executed_sell_amounts: Vec<u128>,
+    pub executed_buy_amounts: Vec<u128>,
 }
 
 pub trait PriceFinding {
@@ -40,11 +41,11 @@ pub mod tests {
 
     impl PriceFinding for PriceFindingMock {
         fn find_prices(
-        &self, 
-        orders: Vec<models::Order>, 
-        state: models::State
-    ) -> Result<Solution, DriverError> {
-        self.find_prices.called((orders, state))
-    }
+            &self, 
+            orders: Vec<models::Order>, 
+            state: models::State
+        ) -> Result<Solution, DriverError> {
+            self.find_prices.called((orders, state))
+        }
     }
 }

--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -1,0 +1,51 @@
+use crate::models;
+
+use crate::error::DriverError;
+use web3::types::U256;
+
+#[derive(Clone)]
+pub struct Solution {
+    pub surplus: U256,
+    pub prices: Vec<u128>,
+    pub executed_sell_amounts: Vec<u128>,
+    pub executed_buy_amounts: Vec<u128>,
+}
+
+pub trait PriceFinding {
+    fn find_prices(
+        &self, 
+        orders: Vec<models::Order>, 
+        state: models::State
+    ) -> Result<Solution, DriverError>;
+}
+
+#[cfg(test)]
+pub mod tests {
+    extern crate mock_it;
+
+    use super::*;
+    use mock_it::Mock;
+    use crate::error::ErrorKind;
+
+    pub struct PriceFindingMock {
+        pub find_prices: Mock<(Vec<models::Order>, models::State), Result<Solution, DriverError>>,
+    }
+
+    impl PriceFindingMock {
+        pub fn new() -> PriceFindingMock {
+            PriceFindingMock {
+                find_prices: Mock::new(Err(DriverError::new("Unexpected call to find_prices", ErrorKind::Unknown))),
+            }
+        }
+    }
+
+    impl PriceFinding for PriceFindingMock {
+        fn find_prices(
+        &self, 
+        orders: Vec<models::Order>, 
+        state: models::State
+    ) -> Result<Solution, DriverError> {
+        self.find_prices.called((orders, state))
+    }
+    }
+}

--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -8,7 +8,6 @@ pub struct Solution {
     pub surplus: U256,
     pub prices: Vec<u128>,
     pub executed_sell_amounts: Vec<u128>,
-    pub executed_buy_amounts: Vec<u128>,
 }
 
 pub trait PriceFinding {


### PR DESCRIPTION
This PR defines a rust interface that the order_processor will interact with to invoke the solving engine. The solving engine can be implemented in different ways
1. Mocked (for unit tests)
2. Simple Solver (#58)
3. Tom's sophisticated solve (#59)

Let's discuss the interface and data structures here. I included the mock implementation so that we can start using this interface.

Addresses #57 