### PR TITLE
#55 Order Event Listener

### DIFF
--- a/driver/src/contract.rs
+++ b/driver/src/contract.rs
@@ -48,7 +48,7 @@ impl SnappContractImpl {
         let (event_loop, transport) = web3::transports::Http::new("http://ganache-cli:8545")?;
         let web3 = web3::Web3::new(transport);
 
-        let contents = fs::read_to_string("../dex-contracts/build/contracts/SnappBase.json")?;
+        let contents = fs::read_to_string("../dex-contracts/build/contracts/SnappAuction.json")?;
         let snapp_base: serde_json::Value = serde_json::from_str(&contents)?;
         let snapp_base_abi: String = snapp_base.get("abi").ok_or("No ABI for contract")?.to_string();
 

--- a/event_listener/config/settings.py
+++ b/event_listener/config/settings.py
@@ -161,7 +161,7 @@ ETHEREUM_MAX_BATCH_REQUESTS = env.int('ETHEREUM_MAX_BATCH_REQUESTS', default=500
 ETH_EVENTS = [
     {
         'ADDRESSES': [os.environ['SNAPP_CONTRACT_ADDRESS']],
-        'EVENT_ABI': load_contract_abi(abi_file_path('SnappBase.json')),
+        'EVENT_ABI': load_contract_abi(abi_file_path('SnappAuction.json')),
         'EVENT_DATA_RECEIVER': 'event_listener.dfusion_db.generic_event_receiver.EventDispatcher',
         'NAME': 'SnappEventReceiver',
         'PUBLISH': True,

--- a/event_listener/dfusion_db/database_interface.py
+++ b/event_listener/dfusion_db/database_interface.py
@@ -108,3 +108,4 @@ class MongoDbInterface(DatabaseInterface):
 
     def get_orders(self, slot: int) -> List[Order]:
         return list(map(lambda d: Order.from_dictionary(d), self.db.orders.find({'slot': slot})))
+

--- a/event_listener/dfusion_db/database_interface.py
+++ b/event_listener/dfusion_db/database_interface.py
@@ -101,10 +101,10 @@ class MongoDbInterface(DatabaseInterface):
     def get_num_tokens(self) -> int:
         return int(self.db.constants.find_one()['num_tokens'])
 
-    def write_order(self, order: Order):
+    def write_order(self, order: Order) -> None:
         order_id = self.db.orders.insert_one(order.to_dictionary()).inserted_id
         self.logger.info(
             "Successfully included Order - {}".format(order_id))
 
-    def get_orders(self, slot: int):
+    def get_orders(self, slot: int) -> List[Order]:
         return list(map(lambda d: Order.from_dictionary(d), self.db.orders.find({'slot': slot})))

--- a/event_listener/dfusion_db/generic_event_receiver.py
+++ b/event_listener/dfusion_db/generic_event_receiver.py
@@ -4,13 +4,14 @@ from typing import Any, Dict
 from django_eth_events.chainevents import AbstractEventReceiver
 
 from .snapp_event_receiver import DepositReceiver, StateTransitionReceiver, \
-    SnappInitializationReceiver, WithdrawRequestReceiver
+    SnappInitializationReceiver, WithdrawRequestReceiver, OrderReceiver
 
 RECEIVER_MAPPING = {
     'Deposit': DepositReceiver(),
     'WithdrawRequest': WithdrawRequestReceiver(),
     'StateTransition': StateTransitionReceiver(),
     'SnappInitialization': SnappInitializationReceiver(),
+    'SellOrder': OrderReceiver(),
 }
 
 

--- a/event_listener/dfusion_db/models.py
+++ b/event_listener/dfusion_db/models.py
@@ -19,11 +19,9 @@ class StateTransition(NamedTuple):
         assert data.keys() == {'transitionType', 'stateIndex', 'stateHash', 'slot'}, \
             "Unexpected Event Keys: got {}".format(data.keys())
         _type = TransitionType(data['transitionType'])
-        assert isinstance(data['stateIndex'],
-                          int), "Transition to has unexpected values"
+        assert isinstance(data['stateIndex'], int), "Transition to has unexpected values"
         _hash = data['stateHash']
-        assert isinstance(_hash, str) and len(
-            _hash) == 64, "Transition from has unexpected values"
+        assert isinstance(_hash, str) and len(_hash) == 64, "Transition from has unexpected values"
         assert isinstance(data['slot'], int), "Transition slot not recognized"
         return StateTransition(_type, data['stateIndex'], _hash, data['slot'])
 
@@ -37,9 +35,8 @@ class Deposit(NamedTuple):
 
     @classmethod
     def from_dictionary(cls, data: Dict[str, Any]) -> "Deposit":
-        assert all(k in data for k in(
-            'accountId', 'tokenId', 'amount', 'slot', 'slotIndex')), \
-            "Unexpected Event Keys"
+        event_fields = ('accountId', 'tokenId', 'amount', 'slot', 'slotIndex')
+        assert all(k in data for k in event_fields), "Unexpected Event Keys"
         return Deposit(
             int(data['accountId']),
             int(data['tokenId']),
@@ -60,9 +57,8 @@ class Withdraw(NamedTuple):
 
     @classmethod
     def from_dictionary(cls, data: Dict[str, Any]) -> "Withdraw":
-        assert all(k in data for k in(
-            'accountId', 'tokenId', 'amount', 'slot', 'slotIndex')), \
-            "Unexpected Event Keys"
+        event_fields = ('accountId', 'tokenId', 'amount', 'slot', 'slotIndex')
+        assert all(k in data for k in event_fields), "Unexpected Event Keys"
         return Withdraw(
             int(data['accountId']),
             int(data['tokenId']),
@@ -88,3 +84,38 @@ class AccountRecord(NamedTuple):
     state_index: int
     state_hash: str
     balances: List[int]
+
+
+class Order(NamedTuple):
+    slot: int
+    slot_index: int
+    account_id: int
+    buy_token: int
+    sell_token: int
+    buy_amount: int
+    sell_amount: int
+
+    @classmethod
+    def from_dictionary(cls, data: Dict[str, Any]) -> "Order":
+        event_fields = ('auctionId', 'slotIndex', 'accountId', 'buyToken', 'sellToken', 'buyAmount', 'sellAmount')
+        assert all(k in data for k in event_fields), "Unexpected Event Keys"
+        return Order(
+            int(data['auctionId']),
+            int(data['slotIndex']),
+            int(data['accountId']),
+            int(data['buyToken']),
+            int(data['sellToken']),
+            int(data['buyAmount']),
+            int(data['sellAmount']),
+        )
+
+    def to_dictionary(self) -> Dict[str, Any]:
+        return {
+            "auctionId": self.slot,
+            "slotIndex": self.slot_index,
+            "accountId": self.account_id,
+            "buyToken": self.buy_token,
+            "sellToken": self.sell_token,
+            "buyAmount": self.buy_amount,
+            "sellAmount": self.sell_amount
+        }

--- a/event_listener/dfusion_db/snapp_event_receiver.py
+++ b/event_listener/dfusion_db/snapp_event_receiver.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from typing import Dict, Any, Union, List, Optional
 
 from .database_interface import DatabaseInterface, MongoDbInterface
-from .models import Deposit, StateTransition, TransitionType, Withdraw, AccountRecord
+from .models import Deposit, StateTransition, TransitionType, Withdraw, AccountRecord, Order
 
 
 class SnappEventListener(ABC):
@@ -126,3 +126,15 @@ class WithdrawRequestReceiver(SnappEventListener):
         except AssertionError as exc:
             logging.critical(
                 "Failed to record Deposit [{}] - {}".format(exc, withdraw))
+
+
+class OrderReceiver(SnappEventListener):
+    def save(self, event: Dict[str, Any], block_info: Dict[str, Any]) -> None:
+        self.save_parsed(Order.from_dictionary(event))
+
+    def save_parsed(self, order: Order) -> None:
+        try:
+            self.database.write_order(order)
+        except AssertionError as exc:
+            logging.critical(
+                "Failed to record Deposit [{}] - {}".format(exc, order))

--- a/event_listener/dfusion_db/tests/models_test.py
+++ b/event_listener/dfusion_db/tests/models_test.py
@@ -94,7 +94,7 @@ class OrderTest(unittest.TestCase):
 
     def test_throws_with_missing_key(self) -> None:
         with self.assertRaises(AssertionError):
-            Withdraw.from_dictionary({
+            Order.from_dictionary({
                 "auctionId": 1,
                 "slotIndex": 2,
                 "accountId": 3,
@@ -105,7 +105,7 @@ class OrderTest(unittest.TestCase):
 
     def test_throws_with_non_integer_value(self) -> None:
         with self.assertRaises(ValueError):
-            Withdraw.from_dictionary({
+            Order.from_dictionary({
                 "auctionId": "Bad Text!",
                 "slotIndex": 2,
                 "accountId": 3,

--- a/event_listener/dfusion_db/tests/models_test.py
+++ b/event_listener/dfusion_db/tests/models_test.py
@@ -1,5 +1,5 @@
 import unittest
-from ..models import Deposit, Withdraw
+from ..models import Deposit, Withdraw, Order
 
 
 class DepositTest(unittest.TestCase):
@@ -69,4 +69,48 @@ class WithdrawTest(unittest.TestCase):
                 "amount": 3,
                 "slot": 4,
                 "slotIndex": "foo"
+            })
+
+
+class OrderTest(unittest.TestCase):
+    def test_from_dictionary(self) -> None:
+        order = Order.from_dictionary({
+            "auctionId": 1,
+            "slotIndex": 2,
+            "accountId": 3,
+            "buyToken": 4,
+            "sellToken": 5,
+            "buyAmount": 6,
+            "sellAmount": 7
+        })
+
+        self.assertEqual(1, order.slot)
+        self.assertEqual(2, order.slot_index)
+        self.assertEqual(3, order.account_id)
+        self.assertEqual(4, order.buy_token)
+        self.assertEqual(5, order.sell_token)
+        self.assertEqual(6, order.buy_amount)
+        self.assertEqual(7, order.sell_amount)
+
+    def test_throws_with_missing_key(self) -> None:
+        with self.assertRaises(AssertionError):
+            Withdraw.from_dictionary({
+                "auctionId": 1,
+                "slotIndex": 2,
+                "accountId": 3,
+                "buyToken": 4,
+                "buyAmount": 6,
+                "sellAmount": 7
+            })
+
+    def test_throws_with_non_integer_value(self) -> None:
+        with self.assertRaises(ValueError):
+            Withdraw.from_dictionary({
+                "auctionId": "Bad Text!",
+                "slotIndex": 2,
+                "accountId": 3,
+                "buyToken": 4,
+                "sellToken": 5,
+                "buyAmount": 6,
+                "sellAmount": 7
             })

--- a/event_listener/dfusion_db/tests/snapp_event_receiver_test.py
+++ b/event_listener/dfusion_db/tests/snapp_event_receiver_test.py
@@ -1,8 +1,8 @@
 import unittest
 from unittest.mock import Mock
 from ..snapp_event_receiver import WithdrawRequestReceiver, DepositReceiver, StateTransitionReceiver, \
-    SnappInitializationReceiver
-from ..models import Deposit, StateTransition, TransitionType, Withdraw, AccountRecord
+    SnappInitializationReceiver, OrderReceiver
+from ..models import Deposit, StateTransition, TransitionType, Withdraw, AccountRecord, Order
 
 
 class DepositReceiverTest(unittest.TestCase):
@@ -21,6 +21,15 @@ class WithdrawRequestReceiverTest(unittest.TestCase):
         withdraw = Withdraw(1, 2, 10, 42, 51)
         receiver.save_parsed(withdraw)
         database.write_withdraw.assert_called_with(withdraw)
+
+
+class OrderReceiverTest(unittest.TestCase):
+    def test_writes_order(self) -> None:
+        database = Mock()
+        receiver = OrderReceiver(database)
+        order = Order(1, 1, 2, 1, 1, 1, 1)
+        receiver.save_parsed(order)
+        database.write_order.assert_called_with(order)
 
 
 class StateTransitionReceiverTest(unittest.TestCase):


### PR DESCRIPTION
This is currently working as expected, with Model and Receiver Tests. To try for yourself, 

```
docker-compose up
cd dex-contracts
truffle exec scripts/sell_order.js 1 1 2 1 2
```

Watch the container for the following message...

```
listener_1     | [INFO] [MainProcess] SellOrder received {'auctionId': 1, 'slotIndex': 0, 'accountId': 1, 'buyToken': 1, 'sellToken': 2, 'buyAmount': 1, 'sellAmount': 2}
listener_1     | [INFO] [MainProcess] Successfully included Order - 5c9cd4ed2ce8ce000c70aaa8
```