### PR TITLE
[Docker] minimize the size of the solver base image

### DIFF
--- a/docker/driver/Dockerfile
+++ b/docker/driver/Dockerfile
@@ -1,4 +1,8 @@
-FROM fleupold/dfusion-solver-base:v1
+FROM fleupold/dfusion-solver-base:v2
+
+RUN apt-get update \ 
+    && apt-get install -y --no-install-recommends curl ssh git libc-dev gcc openssl pkg-config libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 #Install Rust
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
@@ -7,8 +11,7 @@ RUN ln -s $HOME/.cargo/bin/* /usr/bin/
 # Copy requirements and install
 WORKDIR /app/driver
 COPY driver/Cargo.toml .
-RUN mkdir src && touch src/lib.rs
-RUN cargo build
+RUN mkdir src && touch src/lib.rs && cargo build
 
 # Install solver if specified
 ARG use_solver

--- a/docker/solver/Dockerfile
+++ b/docker/solver/Dockerfile
@@ -1,33 +1,39 @@
-FROM python:3.6
+FROM debian:stretch-slim as SCIP
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends g++ zlib1g-dev bison flex libgmp-dev libreadline-dev libncurses5-dev
+    && apt-get install -y --no-install-recommends ca-certificates wget make g++ zlib1g-dev bison flex libgmp-dev libreadline-dev libncurses5-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install SCIP solver
 WORKDIR /opt
-RUN wget https://scip.zib.de/download/release/scipoptsuite-6.0.1.tgz
-RUN tar xzf scipoptsuite-6.0.1.tgz
+RUN wget https://scip.zib.de/download/release/scipoptsuite-6.0.1.tgz \
+    && tar xzf scipoptsuite-6.0.1.tgz \
+    && cd scipoptsuite-6.0.1 \
+    && make \
+    && cd scip/interfaces/ampl/ \
+    && ./get.ASL \
+    && cd solvers \
+    && sh configurehere && make \
+    && cd .. &&  make scipampl && make \
+    && cp bin/scipampl /usr/local/bin/
 
-WORKDIR /opt/scipoptsuite-6.0.1
-RUN make
+# Multi Stage Build, since all we need is the scipampl binary from before
+FROM python:3.6-slim-stretch
+COPY --from=SCIP /opt/scipoptsuite-6.0.1/scip/interfaces/ampl/bin/scipampl /usr/local/bin/
 
-WORKDIR /opt/scipoptsuite-6.0.1/scip/interfaces/ampl/
-RUN ./get.ASL
-
-WORKDIR /opt/scipoptsuite-6.0.1/scip/interfaces/ampl/solvers/
-RUN sh configurehere && make
-
-WORKDIR /opt/scipoptsuite-6.0.1/scip/interfaces/ampl/
-RUN make scipampl && make
-RUN cp bin/scipampl /usr/local/bin/
-
-# Install Gurobi solver
-WORKDIR /opt
-RUN wget https://packages.gurobi.com/8.1/gurobi8.1.0_linux64.tar.gz
-RUN tar xzf gurobi8.1.0_linux64.tar.gz
-
-WORKDIR /opt/gurobi810/linux64/
-RUN python setup.py install
 ENV GUROBI_HOME /opt/gurobi810/linux64/
 ENV PATH ${PATH}:${GUROBI_HOME}/bin
 ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:${GUROBI_HOME}/lib
+
+RUN apt-get update \ 
+    && apt-get install -y --no-install-recommends wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Gurobi solver
+WORKDIR /opt
+RUN wget https://packages.gurobi.com/8.1/gurobi8.1.0_linux64.tar.gz \
+    && tar xzf gurobi8.1.0_linux64.tar.gz \
+    && rm gurobi8.1.0_linux64.tar.gz \
+    && cd gurobi810/linux64/ \
+    && python setup.py install \
+    && ls | grep -v lib | xargs rm -r

--- a/driver/Cargo.lock
+++ b/driver/Cargo.lock
@@ -331,7 +331,7 @@ dependencies = [
  "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "web3 0.5.2 (git+https://github.com/tomusdrw/rust-web3)",
+ "web3 0.6.0 (git+https://github.com/tomusdrw/rust-web3?rev=56ad08e)",
 ]
 
 [[package]]
@@ -1750,8 +1750,8 @@ dependencies = [
 
 [[package]]
 name = "web3"
-version = "0.5.2"
-source = "git+https://github.com/tomusdrw/rust-web3#fc68ec1a9486938af6cd2f4c670cba37912f8fc6"
+version = "0.6.0"
+source = "git+https://github.com/tomusdrw/rust-web3?rev=56ad08e#56ad08e01742aa635854fe8cdbb1ded7a4bef7e0"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2044,7 +2044,7 @@ dependencies = [
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
-"checksum web3 0.5.2 (git+https://github.com/tomusdrw/rust-web3)" = "<none>"
+"checksum web3 0.6.0 (git+https://github.com/tomusdrw/rust-web3?rev=56ad08e)" = "<none>"
 "checksum websocket 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c9faed2bff8af2ea6b9f8b917d3d00b467583f6781fe3def174a9e33c879703"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"


### PR DESCRIPTION
The docker base image used to be >500MB in v1 (https://cloud.docker.com/repository/docker/fleupold/dfusion-solver-base/tags). 

This means on every travis run, we download 500MB to build our driver image. After learning a bit about docker (https://www.youtube.com/watch?v=vlS5EiapiII), I wrote this PR to try to minimize the size of this image.

New image size is 85MB.