### PR TITLE
[Easy] Don't launch unnecessary docker images on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
         - git submodule update --init
         - npm install -C dex-contracts
         - cd dex-contracts && truffle compile && cd - # driver/listener require compiled contracts
-        - docker-compose up -d
+        - docker-compose up -d driver listener truffle
       script:
         - timeout 120 bash -c -- 'while [ ! -f dex-contracts/build/migration.flag ] ; do sleep .1; done' # wait for migrations to complete (max 60s)
         - sh ./test/e2e-tests-deposit.sh


### PR DESCRIPTION
As title.

Addresses one of the points suggested in #61 