### PR TITLE
[Easy] Typos, Indentation, Rust warnings etc

### DIFF
--- a/driver/src/bin/main.rs
+++ b/driver/src/bin/main.rs
@@ -13,7 +13,7 @@ fn main() {
     let db_instance = MongoDB::new(db_host, db_port).unwrap();
     let contract = SnappContractImpl::new().unwrap();
     loop {
-        //start driver_componets
+        // Start driver_components
         run_driver_components(&db_instance, &contract);
         thread::sleep(Duration::from_secs(5));
     }

--- a/driver/src/contract.rs
+++ b/driver/src/contract.rs
@@ -161,7 +161,7 @@ impl SnappContract for SnappContractImpl {
                 "applyWithdrawals",
                 (slot, merkle_root, prev_state, new_state, withdraw_hash),
                 account,    
-                Options::with(|opt| { // usual gas estimate is not working
+                Options::with(|mut opt| { // usual gas estimate is not working
                     opt.gas_price = Some(25.into());
                     opt.gas = Some(1_000_000.into());
                 }),

--- a/driver/src/contract.rs
+++ b/driver/src/contract.rs
@@ -70,6 +70,13 @@ impl SnappContractImpl {
 }
 
 impl SnappContract for SnappContractImpl {
+    fn get_current_block_number(&self) -> Result<U256> {
+        self.web3.eth()
+            .block_number()
+            .wait()
+            .map_err(|e| DriverError::from(e))
+    }
+
     fn get_current_state_root(&self) -> Result<H256> {
         self.contract.query(
             "getCurrentStateRoot", (), None, Options::default(), None
@@ -82,15 +89,9 @@ impl SnappContract for SnappContractImpl {
         ).wait().map_err(|e| DriverError::from(e))
     }
 
-    fn has_deposit_slot_been_applied(&self, slot: U256) -> Result<bool> {
+    fn get_current_withdraw_slot(&self) -> Result<U256> {
         self.contract.query(
-            "hasDepositBeenApplied", slot, None, Options::default(), None,
-        ).wait().map_err(|e| DriverError::from(e))
-    }
-
-    fn deposit_hash_for_slot(&self, slot: U256) -> Result<H256> {
-        self.contract.query(
-            "getDepositHash", slot, None, Options::default(), None,
+            "withdrawIndex", (), None, Options::default(), None
         ).wait().map_err(|e| DriverError::from(e))
     }
 
@@ -100,21 +101,15 @@ impl SnappContract for SnappContractImpl {
         ).wait().map_err(|e| DriverError::from(e))
     }
 
-    fn get_current_withdraw_slot(&self) -> Result<U256> {
+    fn deposit_hash_for_slot(&self, slot: U256) -> Result<H256> {
         self.contract.query(
-            "withdrawIndex", (), None, Options::default(), None
+            "getDepositHash", slot, None, Options::default(), None,
         ).wait().map_err(|e| DriverError::from(e))
     }
 
-    fn has_withdraw_slot_been_applied(&self, slot: U256) -> Result<bool> {
+    fn has_deposit_slot_been_applied(&self, slot: U256) -> Result<bool> {
         self.contract.query(
-            "hasWithdrawBeenApplied", slot, None, Options::default(), None,
-        ).wait().map_err(|e| DriverError::from(e))
-    }
-
-    fn withdraw_hash_for_slot(&self, slot: U256) -> Result<H256> {
-        self.contract.query(
-            "getWithdrawHash", slot, None, Options::default(), None,
+            "hasDepositBeenApplied", slot, None, Options::default(), None,
         ).wait().map_err(|e| DriverError::from(e))
     }
 
@@ -124,11 +119,16 @@ impl SnappContract for SnappContractImpl {
         ).wait().map_err(|e| DriverError::from(e))
     }
 
-    fn get_current_block_number(&self) -> Result<U256> {
-        self.web3.eth()
-            .block_number()
-            .wait()
-            .map_err(|e| DriverError::from(e))
+    fn withdraw_hash_for_slot(&self, slot: U256) -> Result<H256> {
+        self.contract.query(
+            "getWithdrawHash", slot, None, Options::default(), None,
+        ).wait().map_err(|e| DriverError::from(e))
+    }
+
+    fn has_withdraw_slot_been_applied(&self, slot: U256) -> Result<bool> {
+        self.contract.query(
+            "hasWithdrawBeenApplied", slot, None, Options::default(), None,
+        ).wait().map_err(|e| DriverError::from(e))
     }
     
     fn apply_deposits(
@@ -162,9 +162,9 @@ impl SnappContract for SnappContractImpl {
                 (slot, merkle_root, prev_state, new_state, withdraw_hash),
                 account,    
                 Options::with(|opt| { // usual gas estimate is not working
-            opt.gas_price = Some(25.into());
-            opt.gas = Some(1_000_000.into());
-        }),
+                    opt.gas_price = Some(25.into());
+                    opt.gas = Some(1_000_000.into());
+                }),
             ).wait()
             .map_err(|e| DriverError::from(e))
             .map(|_|())

--- a/driver/src/models.rs
+++ b/driver/src/models.rs
@@ -51,7 +51,7 @@ pub struct PendingFlux {
 }
 
 impl PendingFlux {
-  //calcalutes the iterative hash of deposits
+  // calculates iterative hash of deposits
   pub fn iter_hash(&self, prev_hash: &H256) -> H256 {
     let mut hasher = Sha256::new();
     hasher.input(prev_hash);
@@ -189,7 +189,7 @@ pub mod tests {
     let state = State {
         state_hash: "73899d50b4ec5e351b4967e4c4e4a725e0fa3e8ab82d1bb6d3197f22e65f0c97".to_string(),
         state_index:  1,
-        balances: balances,
+        balances,
     };
     assert_eq!(
       state.rolling_hash(),
@@ -199,7 +199,7 @@ pub mod tests {
 
   pub fn create_flux_for_test(slot: u32, slot_index: u32) -> PendingFlux {
       PendingFlux {
-          slot_index: slot_index,
+          slot_index,
           slot,
           account_id: 1,
           token_id: 1,


### PR DESCRIPTION
Im just getting comfortable with the rust code so that I can start writing the simple solver and e2e-test for running an auction.

There were a few warnings and errors that my IDE brought up while I was reading through. The lest obvious one was the implementation ordering of the SnappContract trait (which warned should be in the same order as declared). 

Another place where my IDE provides a very strict warning is here is in `driver/src/contract.rs`

https://github.com/gnosis/dex-services/blob/b43e7dae6c48e4f3c9df115ca506257b41c32ccc/driver/src/contract.rs#L165-L166

Where it says "cannot assign field of immutable binding". The IDE suggested to make the opt mutable, so I have... Please let me know if this is alright with ya'll.

![Screenshot 2019-04-02 at 2 39 48 PM](https://user-images.githubusercontent.com/11778116/55403105-5d746100-5555-11e9-8681-b6928a99ed64.png)



