### PR TITLE
#83 - Store all large integers in DB as string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ matrix:
       script:
         - cd dex-contracts && truffle migrate && cd -
         - sh ./test/e2e-tests-deposit.sh
-        - sh ./test/e2e-tests-auction.sh
         - sh ./test/e2e-tests-withdraw.sh
+        - sh ./test/e2e-tests-auction.sh
       after_script:
         - docker-compose logs
       before_cache:

--- a/driver/src/db_interface.rs
+++ b/driver/src/db_interface.rs
@@ -86,11 +86,7 @@ impl DbInterface for MongoDB {
                 &format!("Expected to find a single unique state, found {}", docs.len()), ErrorKind::StateError)
             );
         }
-
-        let json: String = serde_json::to_string(&docs[0])?;
-
-        let deserialized: models::State = serde_json::from_str(&json)?;
-        Ok(deserialized)
+        Ok(models::State::from(docs.pop().unwrap()))
     }
 
     fn get_deposits_of_slot(

--- a/event_listener/dfusion_db/database_interface.py
+++ b/event_listener/dfusion_db/database_interface.py
@@ -53,14 +53,7 @@ class MongoDbInterface(DatabaseInterface):
         self.logger = logging.getLogger(__name__)
 
     def write_deposit(self, deposit: Deposit) -> None:
-        event = {
-            "accountId": deposit.account_id,
-            "tokenId": deposit.token_id,
-            "amount": deposit.amount,
-            "slot": deposit.slot,
-            "slotIndex": deposit.slot_index
-        }
-        deposit_id = self.db.deposits.insert_one(event).inserted_id
+        deposit_id = self.db.deposits.insert_one(deposit.to_dictionary()).inserted_id
         self.logger.info(
             "Successfully included Deposit - {}".format(deposit_id))
 
@@ -72,15 +65,10 @@ class MongoDbInterface(DatabaseInterface):
     def update_withdraw(self, old: Withdraw, new: Withdraw) -> None:
         self.db.withdraws.replace_one({'_id': old.id}, new.to_dictionary())
         self.logger.info(
-            "Successfully included Withdraw - {}".format(old.id))
+            "Successfully updated Withdraw - {}".format(old.id))
 
     def write_account_state(self, account_record: AccountRecord) -> None:
-        record = {
-            "stateIndex": account_record.state_index,
-            "stateHash": account_record.state_hash,
-            "balances": account_record.balances
-        }
-        self.db.accounts.insert_one(record)
+        self.db.accounts.insert_one(account_record.to_dictionary())
 
     def write_constants(self, num_tokens: int, num_accounts: int) -> None:
         self.db.constants.insert_one({

--- a/event_listener/dfusion_db/database_interface.py
+++ b/event_listener/dfusion_db/database_interface.py
@@ -78,7 +78,7 @@ class MongoDbInterface(DatabaseInterface):
 
     def get_account_state(self, index: int) -> AccountRecord:
         record = self.db.accounts.find_one({'stateIndex': index})
-        return AccountRecord(record["stateIndex"], record["stateHash"], record["balances"])
+        return AccountRecord(record["stateIndex"], record["stateHash"], list(map(int, record["balances"])))
 
     def get_deposits(self, slot: int) -> List[Deposit]:
         return list(map(lambda d: Deposit.from_dictionary(d), self.db.deposits.find({'slot': slot})))

--- a/event_listener/dfusion_db/models.py
+++ b/event_listener/dfusion_db/models.py
@@ -29,7 +29,7 @@ class StateTransition(NamedTuple):
 class Deposit(NamedTuple):
     account_id: int
     token_id: int
-    amount: int
+    amount: str
     slot: int
     slot_index: int
 
@@ -40,7 +40,7 @@ class Deposit(NamedTuple):
         return Deposit(
             int(data['accountId']),
             int(data['tokenId']),
-            int(data['amount']),
+            data['amount'],
             int(data['slot']),
             int(data['slotIndex'])
         )
@@ -49,7 +49,7 @@ class Deposit(NamedTuple):
 class Withdraw(NamedTuple):
     account_id: int
     token_id: int
-    amount: int
+    amount: str
     slot: int
     slot_index: int
     valid: bool = False
@@ -62,7 +62,7 @@ class Withdraw(NamedTuple):
         return Withdraw(
             int(data['accountId']),
             int(data['tokenId']),
-            int(data['amount']),
+            data['amount'],
             int(data['slot']),
             int(data['slotIndex']),
             bool(data.get('valid', False)),
@@ -83,7 +83,7 @@ class Withdraw(NamedTuple):
 class AccountRecord(NamedTuple):
     state_index: int
     state_hash: str
-    balances: List[int]
+    balances: List[str]
 
 
 class Order(NamedTuple):
@@ -92,8 +92,8 @@ class Order(NamedTuple):
     account_id: int
     buy_token: int
     sell_token: int
-    buy_amount: int
-    sell_amount: int
+    buy_amount: str
+    sell_amount: str
 
     @classmethod
     def from_dictionary(cls, data: Dict[str, Any]) -> "Order":
@@ -105,8 +105,8 @@ class Order(NamedTuple):
             int(data['accountId']),
             int(data['buyToken']),
             int(data['sellToken']),
-            int(data['buyAmount']),
-            int(data['sellAmount']),
+            data['buyAmount'],
+            data['sellAmount'],
         )
 
     def to_dictionary(self) -> Dict[str, Any]:

--- a/event_listener/dfusion_db/models.py
+++ b/event_listener/dfusion_db/models.py
@@ -29,7 +29,7 @@ class StateTransition(NamedTuple):
 class Deposit(NamedTuple):
     account_id: int
     token_id: int
-    amount: str
+    amount: int
     slot: int
     slot_index: int
 
@@ -40,16 +40,25 @@ class Deposit(NamedTuple):
         return Deposit(
             int(data['accountId']),
             int(data['tokenId']),
-            data['amount'],
+            int(data['amount']),
             int(data['slot']),
             int(data['slotIndex'])
         )
+
+    def to_dictionary(self):
+        return {
+            "accountId": self.account_id,
+            "tokenId": self.token_id,
+            "amount": str(self.amount),
+            "slot": self.slot,
+            "slotIndex": self.slot_index
+        }
 
 
 class Withdraw(NamedTuple):
     account_id: int
     token_id: int
-    amount: str
+    amount: int
     slot: int
     slot_index: int
     valid: bool = False
@@ -62,7 +71,7 @@ class Withdraw(NamedTuple):
         return Withdraw(
             int(data['accountId']),
             int(data['tokenId']),
-            data['amount'],
+            int(data['amount']),
             int(data['slot']),
             int(data['slotIndex']),
             bool(data.get('valid', False)),
@@ -73,7 +82,7 @@ class Withdraw(NamedTuple):
         return {
             "accountId": self.account_id,
             "tokenId": self.token_id,
-            "amount": self.amount,
+            "amount": str(self.amount),
             "slot": self.slot,
             "slotIndex": self.slot_index,
             "valid": self.valid
@@ -83,7 +92,14 @@ class Withdraw(NamedTuple):
 class AccountRecord(NamedTuple):
     state_index: int
     state_hash: str
-    balances: List[str]
+    balances: List[int]
+
+    def to_dictionary(self):
+        return {
+            "stateIndex": self.state_index,
+            "stateHash": self.state_hash,
+            "balances": list(map(str, self.balances))
+        }
 
 
 class Order(NamedTuple):
@@ -92,8 +108,8 @@ class Order(NamedTuple):
     account_id: int
     buy_token: int
     sell_token: int
-    buy_amount: str
-    sell_amount: str
+    buy_amount: int
+    sell_amount: int
 
     @classmethod
     def from_dictionary(cls, data: Dict[str, Any]) -> "Order":
@@ -105,8 +121,8 @@ class Order(NamedTuple):
             int(data['accountId']),
             int(data['buyToken']),
             int(data['sellToken']),
-            data['buyAmount'],
-            data['sellAmount'],
+            int(data['buyAmount']),
+            int(data['sellAmount']),
         )
 
     def to_dictionary(self) -> Dict[str, Any]:
@@ -116,6 +132,6 @@ class Order(NamedTuple):
             "accountId": self.account_id,
             "buyToken": self.buy_token,
             "sellToken": self.sell_token,
-            "buyAmount": self.buy_amount,
-            "sellAmount": self.sell_amount
+            "buyAmount": str(self.buy_amount),
+            "sellAmount": str(self.sell_amount)
         }

--- a/event_listener/dfusion_db/models.py
+++ b/event_listener/dfusion_db/models.py
@@ -45,7 +45,7 @@ class Deposit(NamedTuple):
             int(data['slotIndex'])
         )
 
-    def to_dictionary(self):
+    def to_dictionary(self) -> Dict[str, Any]:
         return {
             "accountId": self.account_id,
             "tokenId": self.token_id,
@@ -94,7 +94,7 @@ class AccountRecord(NamedTuple):
     state_hash: str
     balances: List[int]
 
-    def to_dictionary(self):
+    def to_dictionary(self) -> Dict[str, Any]:
         return {
             "stateIndex": self.state_index,
             "stateHash": self.state_hash,

--- a/event_listener/dfusion_db/snapp_event_receiver.py
+++ b/event_listener/dfusion_db/snapp_event_receiver.py
@@ -43,8 +43,7 @@ class StateTransitionReceiver(SnappEventListener):
                 "Failed to record StateTransition [{}] - {}".format(exc, transition))
 
     def __update_accounts(self, transition: StateTransition) -> None:
-        balances = self.database.get_account_state(
-            transition.state_index - 1).balances.copy()
+        balances = self.database.get_account_state(transition.state_index - 1).balances.copy()
         num_tokens = self.database.get_num_tokens()
         for datum in self.__get_data_to_apply(transition):
             # Balances are stored as [b(a1, t1), b(a1, t2), ... b(a1, T), b(a2, t1), ...]

--- a/test/e2e-tests-auction.sh
+++ b/test/e2e-tests-auction.sh
@@ -18,9 +18,9 @@ truffle exec scripts/sell_order.js 6 3 1 20 280
 
 sleep 5
 
-# Test Listener: There are now 6 orders in auction slot 1 and sellAmount for accountId = 6 is 280
+# Test Listener: There are now 6 orders in auction slot 1 and sellAmount for accountId = 6 is 280000000000000000000
 mongo dfusion2 --eval "db.orders.find({'auctionId': ${EXPECTED_AUCTION}}).size()" | grep 6
-mongo dfusion2 --eval "db.orders.findOne({'auctionId': ${EXPECTED_AUCTION}, 'accountId': 6}).sellAmount" | grep 280
+mongo dfusion2 --eval "db.orders.findOne({'auctionId': ${EXPECTED_AUCTION}, 'accountId': 6}).sellAmount" | grep 280000000000000000000
 
 truffle exec scripts/mine_blocks.js 21
 

--- a/test/e2e-tests-deposit.sh
+++ b/test/e2e-tests-deposit.sh
@@ -12,5 +12,5 @@ truffle exec scripts/mine_blocks.js 21
 sleep 5
 
 EXPECTED_HASH="73899d50b4ec5e351b4967e4c4e4a725e0fa3e8ab82d1bb6d3197f22e65f0c97"
-truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}
-mongo dfusion2 --eval "db.accounts.findOne({'stateHash': '${EXPECTED_HASH}'}).balances[62]" | grep 18
+truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep $EXPECTED_HASH
+mongo dfusion2 --eval "db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[62]" | grep 18

--- a/test/e2e-tests-deposit.sh
+++ b/test/e2e-tests-deposit.sh
@@ -11,6 +11,6 @@ truffle exec scripts/mine_blocks.js 21
 
 sleep 5
 
-EXPECTED_HASH="73899d50b4ec5e351b4967e4c4e4a725e0fa3e8ab82d1bb6d3197f22e65f0c97"
-truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep $EXPECTED_HASH
-mongo dfusion2 --eval "db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[62]" | grep 18
+EXPECTED_HASH="a5b2329a51ada3ce2114e2724264cbfd11f5cd63e41c3700c3f88358995b6153"
+truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}
+mongo dfusion2 --eval "db.accounts.findOne({'stateHash': '${EXPECTED_HASH}'}).balances[62]" | grep 18000000000000000000

--- a/test/e2e-tests-withdraw.sh
+++ b/test/e2e-tests-withdraw.sh
@@ -10,7 +10,7 @@ sleep 5
 truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot'
 
 EXPECTED_HASH="77b01abfbad57cb7a1344b12709603ea3b9ad803ef5ea09814ca212748f54733"
-truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}
-mongo dfusion2 --eval "db.accounts.findOne({'stateHash': '${EXPECTED_HASH}'}).balances[62]" | grep 0
+truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep $EXPECTED_HASH
+mongo dfusion2 --eval "db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[62]" | grep 0
 
 truffle exec scripts/claim_withdraw.js 1 3 3 | grep "Success! Balance of token 3 before claim: 82, after claim: 100"

--- a/test/e2e-tests-withdraw.sh
+++ b/test/e2e-tests-withdraw.sh
@@ -10,7 +10,7 @@ sleep 5
 truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot'
 
 EXPECTED_HASH="77b01abfbad57cb7a1344b12709603ea3b9ad803ef5ea09814ca212748f54733"
-truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep $EXPECTED_HASH
+truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}
 mongo dfusion2 --eval "db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[62]" | grep 0
 
-truffle exec scripts/claim_withdraw.js 1 3 3 | grep "Success! Balance of token 3 before claim: 82, after claim: 100"
+truffle exec scripts/claim_withdraw.js 1 3 3 | grep "Success! Balance of token 3 before claim: 82000000000000000000, after claim: 100000000000000000000"


### PR DESCRIPTION
1. Event Listener to write Strings to DB for all "large integers" (i.e. > 64 bits). Only change required here is to update the `to_dictionary` function for each model (since these dictionaries are what is written to the DB). Its really nice that we don't have to change the model definitions!

2. Driver will have to implement a different `from` method as which parses these amounts as strings
