### PR TITLE
[Listener] Auction Settlement

### DIFF
--- a/event_listener/dfusion_db/generic_event_receiver.py
+++ b/event_listener/dfusion_db/generic_event_receiver.py
@@ -3,8 +3,8 @@ from typing import Any, Dict
 
 from django_eth_events.chainevents import AbstractEventReceiver
 
-from .snapp_event_receiver import DepositReceiver, StateTransitionReceiver, \
-    SnappInitializationReceiver, WithdrawRequestReceiver, OrderReceiver
+from .snapp_event_receiver import DepositReceiver, StateTransitionReceiver, SnappInitializationReceiver
+from .snapp_event_receiver import WithdrawRequestReceiver, OrderReceiver, AuctionSettlementReceiver
 
 RECEIVER_MAPPING = {
     'Deposit': DepositReceiver(),
@@ -12,6 +12,7 @@ RECEIVER_MAPPING = {
     'StateTransition': StateTransitionReceiver(),
     'SnappInitialization': SnappInitializationReceiver(),
     'SellOrder': OrderReceiver(),
+    'AuctionSettlement': AuctionSettlementReceiver(),
 }
 
 

--- a/event_listener/dfusion_db/models.py
+++ b/event_listener/dfusion_db/models.py
@@ -141,7 +141,7 @@ class AuctionSettlement(NamedTuple):
     auction_id: int
     state_index: int
     state_hash: str
-    prices_and_volumes: str  # Stored as Hex String
+    prices_and_volumes: str  # Emitted as Hex String
 
     @classmethod
     def from_dictionary(cls, data: Dict[str, Any]) -> "AuctionSettlement":
@@ -162,14 +162,14 @@ class AuctionSettlement(NamedTuple):
             "pricesAndVolumes": self.prices_and_volumes,
         }
 
-    def serialize_solution(self) -> "AuctionResults":
+    def serialize_solution(self, num_tokens: int) -> "AuctionResults":
         """Transform Byte Code for prices_and_volumes into Prices & TradeExecution objects"""
         logging.info("Serializing Auction Results (from bytecode)")
         tmp = self.prices_and_volumes[2:]
         hex_str_array = [tmp[i] + tmp[i + 1] for i in range(0, len(tmp), 2)]
         byte_array = list(map(lambda t: int(t, 16), hex_str_array))
 
-        prices, volumes = byte_array[:30], byte_array[30:]
+        prices, volumes = byte_array[:num_tokens], byte_array[num_tokens:]
         buy_amounts = volumes[0::2]  # Even elements
         sell_amounts = volumes[1::2]  # Odd elements
 

--- a/event_listener/dfusion_db/models.py
+++ b/event_listener/dfusion_db/models.py
@@ -1,3 +1,4 @@
+import logging
 from enum import Enum
 from typing import NamedTuple, Dict, Any, List, Optional
 
@@ -36,7 +37,7 @@ class Deposit(NamedTuple):
     @classmethod
     def from_dictionary(cls, data: Dict[str, Any]) -> "Deposit":
         event_fields = ('accountId', 'tokenId', 'amount', 'slot', 'slotIndex')
-        assert all(k in data for k in event_fields), "Unexpected Event Keys"
+        assert all(k in data for k in event_fields), "Unexpected Event Keys: got {}".format(data.keys())
         return Deposit(
             int(data['accountId']),
             int(data['tokenId']),
@@ -67,7 +68,7 @@ class Withdraw(NamedTuple):
     @classmethod
     def from_dictionary(cls, data: Dict[str, Any]) -> "Withdraw":
         event_fields = ('accountId', 'tokenId', 'amount', 'slot', 'slotIndex')
-        assert all(k in data for k in event_fields), "Unexpected Event Keys"
+        assert all(k in data for k in event_fields), "Unexpected Event Keys: got {}".format(data.keys())
         return Withdraw(
             int(data['accountId']),
             int(data['tokenId']),
@@ -114,7 +115,7 @@ class Order(NamedTuple):
     @classmethod
     def from_dictionary(cls, data: Dict[str, Any]) -> "Order":
         event_fields = ('auctionId', 'slotIndex', 'accountId', 'buyToken', 'sellToken', 'buyAmount', 'sellAmount')
-        assert all(k in data for k in event_fields), "Unexpected Event Keys"
+        assert all(k in data for k in event_fields), "Unexpected Event Keys: got {}".format(data.keys())
         return Order(
             int(data['auctionId']),
             int(data['slotIndex']),
@@ -134,4 +135,41 @@ class Order(NamedTuple):
             "sellToken": self.sell_token,
             "buyAmount": str(self.buy_amount),
             "sellAmount": str(self.sell_amount)
+        }
+
+
+class AuctionSettlement(NamedTuple):
+    auction_id: int
+    state_index: int
+    state_hash: str
+    prices_and_volumes: bytes
+
+    @classmethod
+    def from_dictionary(cls, data: Dict[str, Any]) -> "AuctionSettlement":
+        event_fields = ('auctionId', 'stateIndex', 'stateHash', 'pricesAndVolumes')
+        assert all(k in data for k in event_fields), "Unexpected Event Keys: got {}".format(data.keys())
+        return AuctionSettlement(
+            int(data['auctionId']),
+            int(data['slotIndex']),
+            str(data['stateHash']),
+            bytes(data['pricesAndVolumes']),
+        )
+
+    def to_dictionary(self) -> Dict[str, Any]:
+        return {
+            "auctionId": self.auction_id,
+            "slotIndex": self.state_index,
+            "stateHash": self.state_hash,
+            "pricesAndVolumes": self.prices_and_volumes,
+        }
+
+    def serialize_solution(self) -> Dict[str, List[int]]:
+        """Transform Byte Code for prices_and_volumes into Prices & TradeExecution objects"""
+        logging.info("Serializing Auction Results (from bytecode)")
+
+        logging.warning("serialize_solution not yet implemented, returning empty results")
+        return {
+            "prices": [],
+            "exec_buy_amounts": [],
+            "exec_sell_amounts": [],
         }

--- a/event_listener/dfusion_db/models.py
+++ b/event_listener/dfusion_db/models.py
@@ -189,8 +189,9 @@ class AuctionResults(NamedTuple):
     def from_dictionary(cls, data: Dict[str, List[int]]) -> "AuctionResults":
         event_fields = ('prices', 'buy_amounts', 'sell_amounts')
         assert all(k in data for k in event_fields), "Unexpected keys. Got {}".format(data.keys())
+
         return AuctionResults(
             data["prices"],
-            data["exec_buy_amounts"],
-            data["exec_sell_amounts"]
+            data["buy_amounts"],
+            data["sell_amounts"]
         )

--- a/event_listener/dfusion_db/models.py
+++ b/event_listener/dfusion_db/models.py
@@ -183,7 +183,7 @@ class AuctionSettlement(NamedTuple):
         """Transform Byte Code for prices_and_volumes into Prices & TradeExecution objects"""
         logging.info("Serializing Auction Results (from bytecode)")
         tmp = self.prices_and_volumes[2:]
-        hex_str_array = [tmp[i] + tmp[i + 1] for i in range(0, len(tmp), 2)]
+        hex_str_array = [tmp[i: i+24] for i in range(0, len(tmp), 24)]
         byte_array = list(map(lambda t: int(t, 16), hex_str_array))
 
         prices, volumes = byte_array[:num_tokens], byte_array[num_tokens:]

--- a/event_listener/dfusion_db/models.py
+++ b/event_listener/dfusion_db/models.py
@@ -142,7 +142,7 @@ class AuctionSettlement(NamedTuple):
     auction_id: int
     state_index: int
     state_hash: str
-    prices_and_volumes: bytes
+    prices_and_volumes: str  # Stored as Hex String
 
     @classmethod
     def from_dictionary(cls, data: Dict[str, Any]) -> "AuctionSettlement":
@@ -152,7 +152,7 @@ class AuctionSettlement(NamedTuple):
             int(data['auctionId']),
             int(data['slotIndex']),
             str(data['stateHash']),
-            bytes(data['pricesAndVolumes']),
+            str(data['pricesAndVolumes']),
         )
 
     def to_dictionary(self) -> Dict[str, Any]:
@@ -166,10 +166,16 @@ class AuctionSettlement(NamedTuple):
     def serialize_solution(self) -> Dict[str, List[int]]:
         """Transform Byte Code for prices_and_volumes into Prices & TradeExecution objects"""
         logging.info("Serializing Auction Results (from bytecode)")
+        tmp = self.prices_and_volumes[2:]
+        hex_str_array = [tmp[i] + tmp[i+1] for i in range(0,len(tmp), 2)]
+        byte_array = list(map(lambda t: int(t, 16), hex_str_array))
 
-        logging.warning("serialize_solution not yet implemented, returning empty results")
+        prices, volumes = byte_array[:30], byte_array[30:]
+        buy_amounts = volumes[0::2]   # Even elements
+        sell_amounts = volumes[1::2]  # Odd elements
+
         return {
-            "prices": [],
-            "exec_buy_amounts": [],
-            "exec_sell_amounts": [],
+            "prices": prices,
+            "exec_buy_amounts": buy_amounts,
+            "exec_sell_amounts": sell_amounts,
         }

--- a/event_listener/dfusion_db/models.py
+++ b/event_listener/dfusion_db/models.py
@@ -163,7 +163,7 @@ class AuctionSettlement(NamedTuple):
             "pricesAndVolumes": self.prices_and_volumes,
         }
 
-    def serialize_solution(self) -> Dict[str, List[int]]:
+    def serialize_solution(self) -> "AuctionResults":
         """Transform Byte Code for prices_and_volumes into Prices & TradeExecution objects"""
         logging.info("Serializing Auction Results (from bytecode)")
         tmp = self.prices_and_volumes[2:]
@@ -174,8 +174,24 @@ class AuctionSettlement(NamedTuple):
         buy_amounts = volumes[0::2]  # Even elements
         sell_amounts = volumes[1::2]  # Odd elements
 
-        return {
+        return AuctionResults.from_dictionary({
             "prices": prices,
-            "exec_buy_amounts": buy_amounts,
-            "exec_sell_amounts": sell_amounts,
-        }
+            "buy_amounts": buy_amounts,
+            "sell_amounts": sell_amounts,
+        })
+
+
+class AuctionResults(NamedTuple):
+    prices: List[int]
+    buy_amounts: List[int]
+    sell_amounts: List[int]
+
+    @classmethod
+    def from_dictionary(cls, data: Dict[str, List[int]]) -> "AuctionResults":
+        event_fields = ('prices', 'buy_amounts', 'sell_amounts')
+        assert all(k in data for k in event_fields), "Unexpected keys. Got {}".format(data.keys())
+        return AuctionResults(
+            data["prices"],
+            data["exec_buy_amounts"],
+            data["exec_sell_amounts"]
+        )

--- a/event_listener/dfusion_db/models.py
+++ b/event_listener/dfusion_db/models.py
@@ -6,7 +6,6 @@ from typing import NamedTuple, Dict, Any, List, Optional
 class TransitionType(Enum):
     Deposit = 0
     Withdraw = 1
-    Auction = 2
 
 
 class StateTransition(NamedTuple):

--- a/event_listener/dfusion_db/models.py
+++ b/event_listener/dfusion_db/models.py
@@ -182,6 +182,8 @@ class AuctionSettlement(NamedTuple):
     def serialize_solution(self, num_tokens: int) -> AuctionResults:
         """Transform Byte Code for prices_and_volumes into Prices & TradeExecution objects"""
         logging.info("Serializing Auction Results (from bytecode)")
+
+        # TODO - pass num_orders (as read from DB for solution verification)
         tmp = self.prices_and_volumes[2:]
         hex_str_array = [tmp[i: i+24] for i in range(0, len(tmp), 24)]
         byte_array = list(map(lambda t: int(t, 16), hex_str_array))
@@ -191,6 +193,7 @@ class AuctionSettlement(NamedTuple):
         sell_amounts = volumes[1::2]  # Odd elements
 
         if len(buy_amounts) != len(sell_amounts):
+            # TODO - assert that buy and sell amounts have same length and are less than num_orders
             logging.warning("Solution data is not correct!")
 
         return AuctionResults.from_dictionary({

--- a/event_listener/dfusion_db/models.py
+++ b/event_listener/dfusion_db/models.py
@@ -150,7 +150,7 @@ class AuctionSettlement(NamedTuple):
         assert all(k in data for k in event_fields), "Unexpected Event Keys: got {}".format(data.keys())
         return AuctionSettlement(
             int(data['auctionId']),
-            int(data['slotIndex']),
+            int(data['stateIndex']),
             str(data['stateHash']),
             str(data['pricesAndVolumes']),
         )
@@ -158,7 +158,7 @@ class AuctionSettlement(NamedTuple):
     def to_dictionary(self) -> Dict[str, Any]:
         return {
             "auctionId": self.auction_id,
-            "slotIndex": self.state_index,
+            "stateIndex": self.state_index,
             "stateHash": self.state_hash,
             "pricesAndVolumes": self.prices_and_volumes,
         }

--- a/event_listener/dfusion_db/models.py
+++ b/event_listener/dfusion_db/models.py
@@ -167,11 +167,11 @@ class AuctionSettlement(NamedTuple):
         """Transform Byte Code for prices_and_volumes into Prices & TradeExecution objects"""
         logging.info("Serializing Auction Results (from bytecode)")
         tmp = self.prices_and_volumes[2:]
-        hex_str_array = [tmp[i] + tmp[i+1] for i in range(0,len(tmp), 2)]
+        hex_str_array = [tmp[i] + tmp[i + 1] for i in range(0, len(tmp), 2)]
         byte_array = list(map(lambda t: int(t, 16), hex_str_array))
 
         prices, volumes = byte_array[:30], byte_array[30:]
-        buy_amounts = volumes[0::2]   # Even elements
+        buy_amounts = volumes[0::2]  # Even elements
         sell_amounts = volumes[1::2]  # Odd elements
 
         return {

--- a/event_listener/dfusion_db/models.py
+++ b/event_listener/dfusion_db/models.py
@@ -136,6 +136,7 @@ class Order(NamedTuple):
             "sellAmount": str(self.sell_amount)
         }
 
+
 class AuctionResults(NamedTuple):
     prices: List[int]
     buy_amounts: List[int]

--- a/event_listener/dfusion_db/snapp_event_receiver.py
+++ b/event_listener/dfusion_db/snapp_event_receiver.py
@@ -147,14 +147,13 @@ class AuctionSettlementReceiver(SnappEventListener):
                 "Failed to record Settlement [{}] - {}".format(exc, settlement))
 
     def __update_accounts(self, settlement: AuctionSettlement) -> None:
-        balances = self.database.get_account_state(settlement.state_index - 1).balances.copy()
-        num_tokens = self.database.get_num_tokens()
+        state = self.database.get_account_state(settlement.state_index - 1)
+        new_account_record = AccountRecord(settlement.state_index, settlement.state_hash, state.balances.copy())
+        self.database.write_account_state(new_account_record)
 
         # Apply the balance updates according to settlement.prices_and_volumes
         # Should we bother to fetch the corresponding orders?
         # We can assume the solution took balances into account?
-
-        logging.error()
 
         # for datum in self.__get_data_to_apply(settlement):
         #     # Balances are stored as [b(a1, t1), b(a1, t2), ... b(a1, T), b(a2, t1), ...]

--- a/event_listener/dfusion_db/snapp_event_receiver.py
+++ b/event_listener/dfusion_db/snapp_event_receiver.py
@@ -172,12 +172,3 @@ class AuctionSettlementReceiver(SnappEventListener):
 
         new_account_record = AccountRecord(settlement.state_index, settlement.state_hash, balances)
         self.database.write_account_state(new_account_record)
-
-        # Apply the balance updates according to settlement.prices_and_volumes
-        # Should we bother to fetch the corresponding orders?
-        # We can assume the solution took balances into account?
-        # for datum in self.__get_data_to_apply(settlement):
-        #     # Balances are stored as [b(a1, t1), b(a1, t2), ... b(a1, T), b(a2, t1), ...]
-        #     index = num_tokens * (datum.account_id - 1) + (datum.token_id - 1)
-
-

--- a/event_listener/dfusion_db/snapp_event_receiver.py
+++ b/event_listener/dfusion_db/snapp_event_receiver.py
@@ -156,12 +156,11 @@ class AuctionSettlementReceiver(SnappEventListener):
         balances = state.balances.copy()
 
         orders = self.database.get_orders(settlement.auction_id)
-        solution = settlement.serialize_solution()
+        num_tokens = self.database.get_num_tokens()
+        solution = settlement.serialize_solution(num_tokens)
 
         buy_amounts = solution.buy_amounts
         sell_amounts = solution.sell_amounts
-
-        num_tokens = self.database.get_num_tokens()
 
         for i, order in enumerate(orders):
             buy_index = num_tokens * (order.account_id - 1) + (order.buy_token - 1)

--- a/event_listener/dfusion_db/snapp_event_receiver.py
+++ b/event_listener/dfusion_db/snapp_event_receiver.py
@@ -15,7 +15,7 @@ class SnappEventListener(ABC):
 
     @abstractmethod
     def save(self, event: Dict[str, Any], block_info: Dict[str, Any]) -> None:
-        pass
+        return
 
 
 class DepositReceiver(SnappEventListener):

--- a/event_listener/dfusion_db/snapp_event_receiver.py
+++ b/event_listener/dfusion_db/snapp_event_receiver.py
@@ -154,7 +154,6 @@ class AuctionSettlementReceiver(SnappEventListener):
         # Apply the balance updates according to settlement.prices_and_volumes
         # Should we bother to fetch the corresponding orders?
         # We can assume the solution took balances into account?
-
         # for datum in self.__get_data_to_apply(settlement):
         #     # Balances are stored as [b(a1, t1), b(a1, t2), ... b(a1, T), b(a2, t1), ...]
         #     index = num_tokens * (datum.account_id - 1) + (datum.token_id - 1)

--- a/event_listener/dfusion_db/tests/models_test.py
+++ b/event_listener/dfusion_db/tests/models_test.py
@@ -217,21 +217,22 @@ class AuctionSettlementTest(unittest.TestCase):
 
     def test_serialize_solution(self) -> None:
         num_tokens = 3
-        settlement = AuctionSettlement(1, 2, "hash", "0x010203010203040506")
+
+        settlement = AuctionSettlement(1, 2, "hash", "0x" + "0" * 24 * num_tokens + "0" * 24 * 2)
 
         serialized_solution = settlement.serialize_solution(num_tokens)
-        self.assertEqual([1, 2, 3], serialized_solution.prices)
-        self.assertEqual([1, 3, 5], serialized_solution.buy_amounts)
-        self.assertEqual([2, 4, 6], serialized_solution.sell_amounts)
+        self.assertEqual([0, 0, 0], serialized_solution.prices)
+        self.assertEqual([0], serialized_solution.buy_amounts)
+        self.assertEqual([0], serialized_solution.sell_amounts)
 
     def test_serialize_solution_warning(self) -> None:
         num_tokens = 3
-        settlement = AuctionSettlement(1, 2, "hash", "0x01020301020304050607")
+        settlement = AuctionSettlement(1, 2, "hash", "0x" + "0" * 24 * num_tokens + "0" * 24 * 3)
 
         serialized_solution = settlement.serialize_solution(num_tokens)
-        self.assertEqual([1, 2, 3], serialized_solution.prices)
-        self.assertEqual([1, 3, 5, 7], serialized_solution.buy_amounts)
-        self.assertEqual([2, 4, 6], serialized_solution.sell_amounts)
+        self.assertEqual([0, 0, 0], serialized_solution.prices)
+        self.assertEqual([0, 0], serialized_solution.buy_amounts)
+        self.assertEqual([0], serialized_solution.sell_amounts)
 
 
 class StateTransitionTest(unittest.TestCase):

--- a/event_listener/dfusion_db/tests/models_test.py
+++ b/event_listener/dfusion_db/tests/models_test.py
@@ -115,3 +115,74 @@ class OrderTest(unittest.TestCase):
                 "sellAmount": 7
             })
 
+
+class AccountRecordTest(unittest.TestCase):
+    def test_to_dictionary(self) -> None:
+        rec = AccountRecord(1, 2, [1, 2, 3])
+        expected_dict = {
+            "stateIndex": 1,
+            "stateHash": 2,
+            "balances": ["1", "2", "3"]
+        }
+
+        self.assertEqual(expected_dict, rec.to_dictionary())
+
+
+class AuctionResultsTest(unittest.TestCase):
+    def test_from_dictionary(self) -> None:
+        auction_result_dict = {
+            "prices": [1, 2, 3],
+            "buy_amounts": [1, 3, 5],
+            "sell_amounts": [0, 2, 4]
+        }
+        expected_res = AuctionResults([1, 2, 3], [1, 3, 5], [0, 2, 4])
+
+        self.assertEqual(expected_res, AuctionResults.from_dictionary(auction_result_dict))
+
+    def test_from_dict_fail_insufficient_keys(self) -> None:
+        with self.assertRaises(AssertionError):
+            AuctionResults.from_dictionary({
+                "prices": [1, 2, 3],
+                "BAD_KEY": [1, 3, 5],
+                "sell_amounts": [0, 2, 4],
+            })
+
+
+class AuctionSettlementTest(unittest.TestCase):
+    def test_from_dict(self) -> None:
+        settlement_dict = {
+            "auctionId": 1,
+            "stateIndex": 2,
+            "stateHash": "hash",
+            "pricesAndVolumes": "hashed_bytes",
+        }
+        expected = AuctionSettlement(1, 2, "hash", "hashed_bytes")
+        self.assertEqual(expected, AuctionSettlement.from_dictionary(settlement_dict))
+
+    def test_from_dict_failure(self) -> None:
+        with self.assertRaises(AssertionError):
+            AuctionSettlement.from_dictionary({
+                "BAD_KEY": 1,
+                "stateIndex": 2,
+                "stateHash": "hash",
+                "pricesAndVolumes": "hashed_bytes",
+            })
+
+    def test_to_dict(self) -> None:
+        rec = AuctionSettlement(1, 2, "hash", "hashed_bytes")
+        expected = {
+            "auctionId": 1,
+            "stateIndex": 2,
+            "stateHash": "hash",
+            "pricesAndVolumes": "hashed_bytes",
+        }
+        self.assertEqual(expected, AuctionSettlement.to_dictionary(rec))
+
+    def test_serialize_solution(self) -> None:
+        num_tokens = 3
+        settlement = AuctionSettlement(1, 2, "hash", "0x010203010203040506")
+
+        serialized_solution = settlement.serialize_solution(num_tokens)
+        self.assertEqual([1, 2, 3], serialized_solution.prices)
+        self.assertEqual([1, 3, 5], serialized_solution.buy_amounts)
+        self.assertEqual([2, 4, 6], serialized_solution.sell_amounts)

--- a/event_listener/dfusion_db/tests/models_test.py
+++ b/event_listener/dfusion_db/tests/models_test.py
@@ -1,5 +1,5 @@
 import unittest
-from ..models import Deposit, Withdraw, Order
+from ..models import Deposit, Withdraw, Order, AuctionResults, AccountRecord, AuctionSettlement, StateTransition
 
 
 class DepositTest(unittest.TestCase):
@@ -11,11 +11,11 @@ class DepositTest(unittest.TestCase):
             "slot": 4,
             "slotIndex": 5
         })
-        assert deposit.account_id == 1
-        assert deposit.token_id == 2
-        assert deposit.amount == 3
-        assert deposit.slot == 4
-        assert deposit.slot_index == 5
+        self.assertEqual(1, deposit.account_id)
+        self.assertEqual(2, deposit.token_id)
+        self.assertEqual(3, deposit.amount)
+        self.assertEqual(4, deposit.slot)
+        self.assertEqual(5, deposit.slot_index)
 
     def test_throws_with_missing_key(self) -> None:
         with self.assertRaises(AssertionError):
@@ -46,11 +46,11 @@ class WithdrawTest(unittest.TestCase):
             "slot": 4,
             "slotIndex": 5
         })
-        assert withdraw.account_id == 1
-        assert withdraw.token_id == 2
-        assert withdraw.amount == 3
-        assert withdraw.slot == 4
-        assert withdraw.slot_index == 5
+        self.assertEqual(1, withdraw.account_id)
+        self.assertEqual(2, withdraw.token_id)
+        self.assertEqual(3, withdraw.amount)
+        self.assertEqual(4, withdraw.slot)
+        self.assertEqual(5, withdraw.slot_index)
 
     def test_throws_with_missing_key(self) -> None:
         with self.assertRaises(AssertionError):
@@ -114,3 +114,4 @@ class OrderTest(unittest.TestCase):
                 "buyAmount": 6,
                 "sellAmount": 7
             })
+

--- a/event_listener/dfusion_db/tests/models_test.py
+++ b/event_listener/dfusion_db/tests/models_test.py
@@ -1,5 +1,6 @@
 import unittest
-from ..models import Deposit, Withdraw, Order, AuctionResults, AccountRecord, AuctionSettlement, StateTransition
+from ..models import AccountRecord, AuctionResults, AuctionSettlement
+from ..models import Deposit, Order, StateTransition, TransitionType, Withdraw
 
 
 class DepositTest(unittest.TestCase):
@@ -118,10 +119,10 @@ class OrderTest(unittest.TestCase):
 
 class AccountRecordTest(unittest.TestCase):
     def test_to_dictionary(self) -> None:
-        rec = AccountRecord(1, 2, [1, 2, 3])
+        rec = AccountRecord(1, "Hash", [1, 2, 3])
         expected_dict = {
             "stateIndex": 1,
-            "stateHash": 2,
+            "stateHash": "Hash",
             "balances": ["1", "2", "3"]
         }
 
@@ -186,3 +187,25 @@ class AuctionSettlementTest(unittest.TestCase):
         self.assertEqual([1, 2, 3], serialized_solution.prices)
         self.assertEqual([1, 3, 5], serialized_solution.buy_amounts)
         self.assertEqual([2, 4, 6], serialized_solution.sell_amounts)
+
+
+class StateTransitionTest(unittest.TestCase):
+    def test_from_dict(self) -> None:
+        transition_dict = {
+            "transitionType": TransitionType.Deposit,
+            "stateIndex": 2,
+            "stateHash": "hash",
+            "slot": 1,
+        }
+        expected = StateTransition(TransitionType.Deposit, 2, "hash", 1)
+        self.assertEqual(expected, StateTransition.from_dictionary(transition_dict))
+
+    def test_from_dict_failure(self) -> None:
+        with self.assertRaises(AssertionError):
+            bad_transition_dict = {
+                "BAD_KEY": TransitionType.Deposit,
+                "stateIndex": 2,
+                "stateHash": "hash",
+                "slot": 1,
+            }
+            StateTransition.from_dictionary(bad_transition_dict)

--- a/event_listener/dfusion_db/tests/snapp_event_receiver_test.py
+++ b/event_listener/dfusion_db/tests/snapp_event_receiver_test.py
@@ -1,12 +1,13 @@
 import unittest
 from unittest.mock import Mock
-from ..snapp_event_receiver import WithdrawRequestReceiver, DepositReceiver, StateTransitionReceiver, \
-    SnappInitializationReceiver, OrderReceiver
+from ..snapp_event_receiver import DepositReceiver, OrderReceiver, SnappInitializationReceiver
+from ..snapp_event_receiver import WithdrawRequestReceiver, StateTransitionReceiver
 from ..models import Deposit, StateTransition, TransitionType, Withdraw, AccountRecord, Order
 
 
 class DepositReceiverTest(unittest.TestCase):
-    def test_writes_deposit(self) -> None:
+    @staticmethod
+    def test_writes_deposit() -> None:
         database = Mock()
         receiver = DepositReceiver(database)
         deposit = Deposit(1, 2, 10, 42, 51)
@@ -15,7 +16,8 @@ class DepositReceiverTest(unittest.TestCase):
 
 
 class WithdrawRequestReceiverTest(unittest.TestCase):
-    def test_writes_withdraw(self) -> None:
+    @staticmethod
+    def test_writes_withdraw() -> None:
         database = Mock()
         receiver = WithdrawRequestReceiver(database)
         withdraw = Withdraw(1, 2, 10, 42, 51)
@@ -24,7 +26,8 @@ class WithdrawRequestReceiverTest(unittest.TestCase):
 
 
 class OrderReceiverTest(unittest.TestCase):
-    def test_writes_order(self) -> None:
+    @staticmethod
+    def test_writes_order() -> None:
         database = Mock()
         receiver = OrderReceiver(database)
         order = Order(1, 1, 2, 1, 1, 1, 1)
@@ -33,7 +36,8 @@ class OrderReceiverTest(unittest.TestCase):
 
 
 class StateTransitionReceiverTest(unittest.TestCase):
-    def test_adds_pending_deposits_to_previous_balances(self) -> None:
+    @staticmethod
+    def test_adds_pending_deposits_to_previous_balances() -> None:
         database = Mock()
         receiver = StateTransitionReceiver(database)
         new_state_index = 2
@@ -58,7 +62,8 @@ class StateTransitionReceiverTest(unittest.TestCase):
         new_state = AccountRecord(new_state_index, "new state", new_balances)
         database.write_account_state.assert_called_with(new_state)
 
-    def test_subtracts_pending_withdraws_to_previous_balances(self) -> None:
+    @staticmethod
+    def test_subtracts_pending_withdraws_to_previous_balances() -> None:
         database = Mock()
         receiver = StateTransitionReceiver(database)
         new_state_index = 2
@@ -82,8 +87,9 @@ class StateTransitionReceiverTest(unittest.TestCase):
         new_balances[62] = 37
         new_state = AccountRecord(new_state_index, "new state", new_balances)
         database.write_account_state.assert_called_with(new_state)
-    
-    def test_marks_valid_withdraws_as_valid(self) -> None:
+
+    @staticmethod
+    def test_marks_valid_withdraws_as_valid() -> None:
         database = Mock()
         receiver = StateTransitionReceiver(database)
         new_state_index = 2
@@ -105,7 +111,8 @@ class StateTransitionReceiverTest(unittest.TestCase):
         updated_withdraw1 = withdraw1._replace(valid=True)
         database.update_withdraw.assert_called_once_with(withdraw1, updated_withdraw1)
 
-    def test_skips_deduction_if_not_enough_balance(self) -> None:
+    @staticmethod
+    def test_skips_deduction_if_not_enough_balance() -> None:
         database = Mock()
         receiver = StateTransitionReceiver(database)
         new_state_index = 2
@@ -131,7 +138,9 @@ class StateTransitionReceiverTest(unittest.TestCase):
 
 
 class SnappInitializationReceiverTest(unittest.TestCase):
-    def test_create_empty_balances(self) -> None:
+
+    @staticmethod
+    def test_create_empty_balances() -> None:
         database = Mock()
         receiver = SnappInitializationReceiver(database)
 

--- a/test/e2e-tests-deposit.sh
+++ b/test/e2e-tests-deposit.sh
@@ -9,7 +9,7 @@ truffle exec scripts/setup_environment.js
 truffle exec scripts/deposit.js 3 3 18 
 truffle exec scripts/mine_blocks.js 21
 
-sleep 5
+sleep 10
 
 EXPECTED_HASH="a5b2329a51ada3ce2114e2724264cbfd11f5cd63e41c3700c3f88358995b6153"
 truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}


### PR DESCRIPTION
- Listener should receive Auction Settlement Event, store it in the DB, and update account balances according to the `pricesAndVolumes` emited as part of the event. This involves implementation of

- Auction Settlement model (with same attributes as the event)
- to and from dictionary for DB storage
- serialize solution (byte array to prices and trade executions)
- update balances based on Orders and auction results