### PR TITLE
[Fix] Stopping overwritting run.sh

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       driver: "none"
 
   truffle:
-    command: ./run.sh
+    command: /app/run.sh
     build:
       context: .
       dockerfile: docker/truffle/Dockerfile

--- a/docker/truffle/Dockerfile
+++ b/docker/truffle/Dockerfile
@@ -2,7 +2,8 @@ FROM node:10.15-alpine
 
 # Create app directory
 WORKDIR /app/dex-contracts
-COPY dex-contracts docker/truffle/run.sh ./
+COPY dex-contracts ./
+COPY docker/truffle/run.sh /app/run.sh
 
 # Dependencies will Install app dependencies
 RUN apk add --update --no-cache --virtual build-dependencies git python make g++ ca-certificates


### PR DESCRIPTION
Our new logic for ensuring that the contracts within truffle are the same as the current contracts, was overwritting run.sh of the truffle docker.

This was not spotted in the tests, as the tests do not rely on the truffle docker image and do their own migration.

Hope you guys have suggestions for prettier solutions than mine.