### PR TITLE
[Listener] Use Result object as solution attribute of Settlement

### DIFF
--- a/event_listener/dfusion_db/models.py
+++ b/event_listener/dfusion_db/models.py
@@ -143,7 +143,7 @@ class AuctionResults(NamedTuple):
     sell_amounts: List[int]
 
     @classmethod
-    def from_bytes(cls, byte_str: str, num_tokens) -> "AuctionResults":
+    def from_bytes(cls, byte_str: str, num_tokens: int) -> "AuctionResults":
         # TODO - pass num_orders (as read from DB for solution verification)
         hex_str_array = [byte_str[i: i+24] for i in range(0, len(byte_str), 24)]
         byte_array = list(map(lambda t: int(t, 16), hex_str_array))

--- a/event_listener/dfusion_db/snapp_event_receiver.py
+++ b/event_listener/dfusion_db/snapp_event_receiver.py
@@ -142,7 +142,9 @@ class OrderReceiver(SnappEventListener):
 
 class AuctionSettlementReceiver(SnappEventListener):
     def save(self, event: Dict[str, Any], block_info: Dict[str, Any]) -> None:
-        self.save_parsed(AuctionSettlement.from_dictionary(event))
+        self.save_parsed(
+            AuctionSettlement.from_dictionary(event, self.database.get_num_tokens())
+        )
 
     def save_parsed(self, settlement: AuctionSettlement) -> None:
         try:
@@ -157,7 +159,7 @@ class AuctionSettlementReceiver(SnappEventListener):
 
         orders = self.database.get_orders(settlement.auction_id)
         num_tokens = self.database.get_num_tokens()
-        solution = settlement.serialize_solution(num_tokens)
+        solution = settlement.prices_and_volumes
 
         buy_amounts = solution.buy_amounts
         sell_amounts = solution.sell_amounts

--- a/event_listener/dfusion_db/tests/models_test.py
+++ b/event_listener/dfusion_db/tests/models_test.py
@@ -166,35 +166,33 @@ class AccountRecordTest(unittest.TestCase):
 
 
 class AuctionResultsTest(unittest.TestCase):
-    def test_from_dictionary(self) -> None:
-        auction_result_dict = {
-            "prices": [1, 2, 3],
-            "buy_amounts": [1, 3, 5],
-            "sell_amounts": [0, 2, 4]
-        }
-        expected_res = AuctionResults([1, 2, 3], [1, 3, 5], [0, 2, 4])
 
-        self.assertEqual(expected_res, AuctionResults.from_dictionary(auction_result_dict))
-
-    def test_from_dict_fail_insufficient_keys(self) -> None:
-        with self.assertRaises(AssertionError):
-            AuctionResults.from_dictionary({
-                "prices": [1, 2, 3],
-                "BAD_KEY": [1, 3, 5],
-                "sell_amounts": [0, 2, 4],
-            })
+    def test_from_bytes(self) -> None:
+        price_strings = list(map(lambda x: str(x).rjust(24, "0"), [1, 2, 3]))
+        amount_strings = list(map(lambda x: str(x).rjust(24, "0"), [1, 2, 3, 4]))
+        solution_bytes = "".join(price_strings) + "".join(amount_strings)
+        solution = AuctionResults.from_bytes(solution_bytes, 3)
+        self.assertEqual(solution.prices, [1, 2, 3], "Solution's prices unexpected")
+        self.assertEqual(solution.buy_amounts, [1, 3], "Solution's buy amounts unexpected")
+        self.assertEqual(solution.sell_amounts, [2, 4], "Solution's sell amounts unexpected")
 
 
 class AuctionSettlementTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.num_tokens = 3
+        self.solution_bytes = "0" * 24 * self.num_tokens + "0" * 24 * 2
+        self.results = AuctionResults.from_bytes(self.solution_bytes, self.num_tokens)
+
     def test_from_dict(self) -> None:
         settlement_dict = {
             "auctionId": 1,
             "stateIndex": 2,
             "stateHash": "hash",
-            "pricesAndVolumes": "hashed_bytes",
+            "pricesAndVolumes": self.solution_bytes,
         }
-        expected = AuctionSettlement(1, 2, "hash", "hashed_bytes")
-        self.assertEqual(expected, AuctionSettlement.from_dictionary(settlement_dict))
+
+        expected = AuctionSettlement(1, 2, "hash", self.results)
+        self.assertEqual(expected, AuctionSettlement.from_dictionary(settlement_dict, self.num_tokens))
 
     def test_from_dict_failure(self) -> None:
         with self.assertRaises(AssertionError):
@@ -203,36 +201,7 @@ class AuctionSettlementTest(unittest.TestCase):
                 "stateIndex": 2,
                 "stateHash": "hash",
                 "pricesAndVolumes": "hashed_bytes",
-            })
-
-    def test_to_dict(self) -> None:
-        rec = AuctionSettlement(1, 2, "hash", "hashed_bytes")
-        expected = {
-            "auctionId": 1,
-            "stateIndex": 2,
-            "stateHash": "hash",
-            "pricesAndVolumes": "hashed_bytes",
-        }
-        self.assertEqual(expected, AuctionSettlement.to_dictionary(rec))
-
-    def test_serialize_solution(self) -> None:
-        num_tokens = 3
-
-        settlement = AuctionSettlement(1, 2, "hash", "0x" + "0" * 24 * num_tokens + "0" * 24 * 2)
-
-        serialized_solution = settlement.serialize_solution(num_tokens)
-        self.assertEqual([0, 0, 0], serialized_solution.prices)
-        self.assertEqual([0], serialized_solution.buy_amounts)
-        self.assertEqual([0], serialized_solution.sell_amounts)
-
-    def test_serialize_solution_warning(self) -> None:
-        num_tokens = 3
-        settlement = AuctionSettlement(1, 2, "hash", "0x" + "0" * 24 * num_tokens + "0" * 24 * 3)
-
-        serialized_solution = settlement.serialize_solution(num_tokens)
-        self.assertEqual([0, 0, 0], serialized_solution.prices)
-        self.assertEqual([0, 0], serialized_solution.buy_amounts)
-        self.assertEqual([0], serialized_solution.sell_amounts)
+            }, self.num_tokens)
 
 
 class StateTransitionTest(unittest.TestCase):

--- a/event_listener/dfusion_db/tests/snapp_event_receiver_test.py
+++ b/event_listener/dfusion_db/tests/snapp_event_receiver_test.py
@@ -5,6 +5,8 @@ from ..snapp_event_receiver import WithdrawRequestReceiver, StateTransitionRecei
 from ..models import Deposit, StateTransition, TransitionType, Withdraw, AccountRecord, Order
 from typing import List
 
+EMPTY_STATE_HASH = "0x00000000000000000000000000000000000000000000000000000000000000"
+
 
 class DepositReceiverTest(unittest.TestCase):
     @staticmethod
@@ -227,24 +229,24 @@ class StateTransitionReceiverTest(unittest.TestCase):
 
 class SnappInitializationReceiverTest(unittest.TestCase):
 
-    def setUp(self) -> None:
-        self.dummy_state = "0x00000000000000000000000000000000000000000000000000000000000000"
-        self.num_tokens = 2
-        self.num_accounts = 3
-
-    def test_generic_save(self) -> None:
+    @staticmethod
+    def test_generic_save() -> None:
         database = Mock()
         receiver = SnappInitializationReceiver(database)
 
+        num_tokens = 2
+        num_accounts = 3
+
         event = {
-            "stateHash": self.dummy_state,
-            "maxTokens": self.num_tokens,
-            "maxAccounts": self.num_accounts
+            "stateHash": EMPTY_STATE_HASH,
+            "maxTokens": num_tokens,
+            "maxAccounts": num_accounts
         }
         receiver.save(event, block_info={})
+
         database.write_constants.assert_called_with(2, 3)
-        database.write_account_state(
-            AccountRecord(0, self.dummy_state, [0 for _ in range(self.num_tokens * self.num_accounts)]))
+        database.write_account_state.assert_called_with(
+            AccountRecord(0, EMPTY_STATE_HASH, [0 for _ in range(num_tokens * num_accounts)]))
 
     @staticmethod
     def test_create_empty_balances() -> None:
@@ -259,14 +261,13 @@ class SnappInitializationReceiverTest(unittest.TestCase):
 
 
 class AuctionSettlementReceiverTest(unittest.TestCase):
-    def setUp(self) -> None:
-        self.num_tokens = 2
-        self.num_accounts = 2
-        self.dummy_state_hash = "0x00000000000000000000000000000000000000000000000000000000000000"
-        self.old_balances = [42] * self.num_accounts * self.num_tokens
-        self.dummy_account_record = AccountRecord(1, self.dummy_state_hash, self.old_balances)
 
-    def test_save(self) -> None:
+    @staticmethod
+    def test_save() -> None:
+        num_tokens = 2
+        num_accounts = 2
+        old_balances = [42] * num_accounts * num_tokens
+        dummy_account_record = AccountRecord(1, EMPTY_STATE_HASH, old_balances)
 
         def int_list_to_hex_bytes(arr: List[int], num_bits: int) -> str:
             assert (num_bits % 4 == 0)
@@ -304,16 +305,16 @@ class AuctionSettlementReceiverTest(unittest.TestCase):
         event = {
             "auctionId": 1,
             "stateIndex": 2,
-            "stateHash": self.dummy_state_hash,
+            "stateHash": EMPTY_STATE_HASH,
             "pricesAndVolumes": encoded_solution
         }
 
-        database.get_account_state.return_value = self.dummy_account_record
+        database.get_account_state.return_value = dummy_account_record
         database.get_orders.return_value = orders
-        database.get_num_tokens.return_value = self.num_tokens
+        database.get_num_tokens.return_value = num_tokens
         receiver.save(event, block_info={})
 
         new_balances = [42 - 10, 42 + 16, 42 + 10, 42 - 16]
 
-        new_account_record = AccountRecord(2, self.dummy_state_hash, new_balances)
+        new_account_record = AccountRecord(2, EMPTY_STATE_HASH, new_balances)
         database.write_account_state.assert_called_with(new_account_record)


### PR DESCRIPTION
Previously, there was a silly `serialize_solution` (meant to be `deserialize_solution`) function inside the Auction Settlement class which was being called every time we wanted to access the solution in a "human readable format". More naturally, it should be converted into an Auction Result object immediately upon the event emission.

This involved some changes to the unit testing, but overall makes for a much easier Listener environment. 

Note that this will likely conflict with changes found in branch #98, but these can be resolved at a later state. 