### PR TITLE
Reading from an ENV var and deciding which solver to use

### DIFF
--- a/docker/driver/Dockerfile
+++ b/docker/driver/Dockerfile
@@ -19,6 +19,7 @@ WORKDIR /app
 COPY docker/driver/clone_solver.sh docker/driver/clone_solver.sh
 COPY .ssh/ .ssh/
 RUN if [ "$use_solver" = 1 ]; then docker/driver/clone_solver.sh; else echo "Not installing solver"; fi
+ENV LINEAR_OPTIMIZATION_SOLVER $use_solver
 ENV PYTHONPATH ${PYTHONPATH}:/app/batchauctions/
 
 # Copy smart contract build artefacts

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -12,7 +12,7 @@ use crate::contract::SnappContractImpl;
 use crate::db_interface::MongoDB;
 use crate::deposit_driver::run_deposit_listener;
 use crate::order_driver::run_order_listener;
-use crate::price_finding::naive_solver::NaiveSolver;
+use crate::price_finding::PriceFinding;
 use crate::withdraw_driver::run_withdraw_listener;
 
 pub mod contract;
@@ -29,7 +29,7 @@ mod util;
 pub fn run_driver_components(
     db: &MongoDB,
     contract: &SnappContractImpl, 
-    price_finder: &mut NaiveSolver,
+    price_finder: &mut Box<PriceFinding>,
 ) -> () {
     if let Err(e) = run_deposit_listener(db, contract) {
         println!("Deposit_driver error: {}", e);

--- a/driver/src/price_finding/mod.rs
+++ b/driver/src/price_finding/mod.rs
@@ -1,8 +1,10 @@
 
-pub mod price_finder_interface;
-pub mod linear_optimization_price_finder;
 pub mod error;
+pub mod linear_optimization_price_finder;
+pub mod naive_solver;
+pub mod price_finder_interface;
 
 pub use crate::price_finding::price_finder_interface::PriceFinding;
 pub use crate::price_finding::price_finder_interface::Solution;
-pub mod naive_solver;
+pub use crate::price_finding::linear_optimization_price_finder::LinearOptimisationPriceFinder;
+pub use crate::price_finding::naive_solver::NaiveSolver;


### PR DESCRIPTION
In case we build docker with `--build-arg use_solver=1`, this PR will make it so that we use the sophisticated solver. In all other cases (e.g. travis) we will use the naive solver.