### PR TITLE
Creating base images to improve build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ matrix:
       sudo: required
       cache: 
         directories:
-          - .cache
           - $HOME/.nvm/versions/node/v8.12.0/lib/node_modules
           - dex-contracts/node_modules/
       before_install:
@@ -43,7 +42,3 @@ matrix:
         - sh ./test/e2e-tests-auction.sh
       after_script:
         - docker-compose logs
-      before_cache:
-        # Save caches from docker images
-        - docker cp $(docker ps -lqf "name=dex-services_driver"):/app/driver/target/ . && tar -zcf .cache/target_cache.tar.gz target/
-        - docker cp $(docker ps -lqf "name=dex-services_listener"):/usr/local/lib/python3.6/site-packages/ . && tar -zcf .cache/pip_cache.tar.gz site-packages/

--- a/docker/driver/Dockerfile
+++ b/docker/driver/Dockerfile
@@ -1,12 +1,4 @@
-FROM fleupold/dfusion-solver-base:v2
-
-RUN apt-get update \ 
-    && apt-get install -y --no-install-recommends curl ssh git libc-dev gcc openssl pkg-config libssl-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-#Install Rust
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-RUN ln -s $HOME/.cargo/bin/* /usr/bin/
+FROM gnosispm/dfusion-driver-base
 
 # Copy requirements and install
 WORKDIR /app/driver

--- a/docker/driver/Dockerfile
+++ b/docker/driver/Dockerfile
@@ -3,7 +3,7 @@ FROM gnosispm/dfusion-driver-base
 # Copy requirements and install
 WORKDIR /app/driver
 COPY driver/Cargo.toml ./
-RUN mkdir src && touch src/lib.rs && cargo build
+RUN cargo build
 
 # Install solver if specified
 ARG use_solver

--- a/docker/driver/Dockerfile
+++ b/docker/driver/Dockerfile
@@ -2,7 +2,7 @@ FROM gnosispm/dfusion-driver-base
 
 # Copy requirements and install
 WORKDIR /app/driver
-ADD driver/Cargo.toml .cache/target_cache.tar.gz* ./
+COPY driver/Cargo.toml ./
 RUN mkdir src && touch src/lib.rs && cargo build
 
 # Install solver if specified

--- a/docker/driver/base/Dockerfile
+++ b/docker/driver/base/Dockerfile
@@ -7,3 +7,8 @@ RUN apt-get update \
 #Install Rust
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 RUN ln -s $HOME/.cargo/bin/* /usr/bin/
+
+# Copy requirements and install
+WORKDIR /app/driver
+COPY driver/Cargo.toml ./
+RUN mkdir src && touch src/lib.rs && cargo build

--- a/docker/driver/base/Dockerfile
+++ b/docker/driver/base/Dockerfile
@@ -1,0 +1,9 @@
+FROM fleupold/dfusion-solver-base:v2
+
+RUN apt-get update \ 
+    && apt-get install -y --no-install-recommends curl ssh git libc-dev gcc openssl pkg-config libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+#Install Rust
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+RUN ln -s $HOME/.cargo/bin/* /usr/bin/

--- a/docker/event_listener/Dockerfile
+++ b/docker/event_listener/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim-stretch
+FROM gnosispm/dfusion-event-listener-base
 
 ENV PYTHONUNBUFFERED 1
 WORKDIR /app
@@ -7,9 +7,6 @@ WORKDIR /app
 ADD README.md .cache/pip_cache.tar.gz* /usr/local/lib/python3.6/
 
 COPY event_listener/requirements.txt event_listener/
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends build-essential libssl-dev \
-    && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir -r event_listener/requirements.txt 
+RUN pip install --no-cache-dir -r event_listener/requirements.txt 
 
 ENV PYTHONPATH=/app/

--- a/docker/event_listener/Dockerfile
+++ b/docker/event_listener/Dockerfile
@@ -1,12 +1,4 @@
 FROM gnosispm/dfusion-event-listener-base
 
-ENV PYTHONUNBUFFERED 1
-WORKDIR /app
-
-# Restore cache if available (at least one sourcefile is needed, therefore use README in case cache doesn't exist)
-ADD README.md .cache/pip_cache.tar.gz* /usr/local/lib/python3.6/
-
 COPY event_listener/requirements.txt event_listener/
 RUN pip install --no-cache-dir -r event_listener/requirements.txt 
-
-ENV PYTHONPATH=/app/

--- a/docker/event_listener/base/Dockerfile
+++ b/docker/event_listener/base/Dockerfile
@@ -3,3 +3,10 @@ FROM python:3.6-slim-stretch
 RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential libssl-dev \
     && rm -rf /var/lib/apt/lists/*
+
+ENV PYTHONUNBUFFERED 1
+WORKDIR /app
+ENV PYTHONPATH=/app/
+
+COPY event_listener/requirements.txt event_listener/
+RUN pip install --no-cache-dir -r event_listener/requirements.txt 

--- a/docker/event_listener/base/Dockerfile
+++ b/docker/event_listener/base/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.6-slim-stretch
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential libssl-dev \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Extracting code independent base configuration for docker images into a separate images, which I pushed to docker hub.

Ideally this should reduce the amount of time travis takes to build our containers.