### PR TITLE
[Lint] Several clippy warnings by suggestion

### DIFF
--- a/driver/src/bin/main.rs
+++ b/driver/src/bin/main.rs
@@ -16,7 +16,8 @@ fn main() {
     let db_instance = MongoDB::new(db_host, db_port).unwrap();
     let contract = SnappContractImpl::new().unwrap();
 
-    let solver_env_var = env::var("LINEAR_OPTIMIZATION_SOLVER").unwrap_or("0".to_string());
+    let solver_env_var = env::var("LINEAR_OPTIMIZATION_SOLVER")
+        .unwrap_or_else(|_| "0".to_string());
     let mut price_finder : Box<PriceFinding> = if solver_env_var == "1" {
         Box::new(LinearOptimisationPriceFinder::new())
     } else {

--- a/driver/src/contract.rs
+++ b/driver/src/contract.rs
@@ -93,85 +93,85 @@ impl SnappContract for SnappContractImpl {
                     None => Err(web3::Error::from("Current block not found"))
                 }
             })
-            .map_err(|e| DriverError::from(e))
+            .map_err(DriverError::from)
     }
 
     fn get_current_state_root(&self) -> Result<H256> {
         self.contract.query(
             "getCurrentStateRoot", (), None, Options::default(), None
-        ).wait().map_err(|e| DriverError::from(e))
+        ).wait().map_err(DriverError::from)
     }
 
     fn get_current_deposit_slot(&self) -> Result<U256> {
         self.contract.query(
             "depositIndex", (), None, Options::default(), None
-        ).wait().map_err(|e| DriverError::from(e))
+        ).wait().map_err(DriverError::from)
     }
 
     fn get_current_withdraw_slot(&self) -> Result<U256> {
         self.contract.query(
             "withdrawIndex", (), None, Options::default(), None
-        ).wait().map_err(|e| DriverError::from(e))
+        ).wait().map_err(DriverError::from)
     }
 
     fn get_current_auction_slot(&self) -> Result<U256> {
         self.contract.query(
             "auctionIndex", (), None, Options::default(), None
-        ).wait().map_err(|e| DriverError::from(e))
+        ).wait().map_err(DriverError::from)
     }
 
     fn creation_timestamp_for_deposit_slot(&self, slot: U256) -> Result<U256> {
         self.contract.query(
             "getDepositCreationTimestamp", slot, None, Options::default(), None,
-        ).wait().map_err(|e| DriverError::from(e))
+        ).wait().map_err(DriverError::from)
     }
 
     fn deposit_hash_for_slot(&self, slot: U256) -> Result<H256> {
         self.contract.query(
             "getDepositHash", slot, None, Options::default(), None,
-        ).wait().map_err(|e| DriverError::from(e))
+        ).wait().map_err(DriverError::from)
     }
 
     fn has_deposit_slot_been_applied(&self, slot: U256) -> Result<bool> {
         self.contract.query(
             "hasDepositBeenApplied", slot, None, Options::default(), None,
-        ).wait().map_err(|e| DriverError::from(e))
+        ).wait().map_err(DriverError::from)
     }
 
     fn creation_timestamp_for_withdraw_slot(&self, slot: U256) -> Result<U256> {
         self.contract.query(
             "getWithdrawCreationTimestamp", slot, None, Options::default(), None,
-        ).wait().map_err(|e| DriverError::from(e))
+        ).wait().map_err(DriverError::from)
     }
 
     fn withdraw_hash_for_slot(&self, slot: U256) -> Result<H256> {
         self.contract.query(
             "getWithdrawHash", slot, None, Options::default(), None,
-        ).wait().map_err(|e| DriverError::from(e))
+        ).wait().map_err(DriverError::from)
     }
 
     fn has_withdraw_slot_been_applied(&self, slot: U256) -> Result<bool> {
         self.contract.query(
             "hasWithdrawBeenApplied", slot, None, Options::default(), None,
-        ).wait().map_err(|e| DriverError::from(e))
+        ).wait().map_err(DriverError::from)
     }
 
     fn creation_timestamp_for_auction_slot(&self, slot: U256) -> Result<U256> {
         self.contract.query(
             "getAuctionCreationTimestamp", slot, None, Options::default(), None,
-        ).wait().map_err(|e| DriverError::from(e))
+        ).wait().map_err(DriverError::from)
     }
 
     fn order_hash_for_slot(&self, slot: U256) -> Result<H256> {
         self.contract.query(
             "getOrderHash", slot, None, Options::default(), None,
-        ).wait().map_err(|e| DriverError::from(e))
+        ).wait().map_err(DriverError::from)
     }
 
     fn has_auction_slot_been_applied(&self, slot: U256) -> Result<bool> {
         self.contract.query(
             "hasAuctionBeenApplied", slot, None, Options::default(), None,
-        ).wait().map_err(|e| DriverError::from(e))
+        ).wait().map_err(DriverError::from)
     }
     
     fn apply_deposits(
@@ -187,7 +187,7 @@ impl SnappContract for SnappContractImpl {
                 account,
                 Options::default(),
             ).wait()
-            .map_err(|e| DriverError::from(e))
+            .map_err(DriverError::from)
             .map(|_|())
     }
 
@@ -209,7 +209,7 @@ impl SnappContract for SnappContractImpl {
                     opt.gas = Some(1_000_000.into());
                 }),
             ).wait()
-            .map_err(|e| DriverError::from(e))
+            .map_err(DriverError::from)
             .map(|_|())
     }
 
@@ -224,14 +224,14 @@ impl SnappContract for SnappContractImpl {
             let account = self.account_with_sufficient_balance().ok_or("Not enough balance to send Txs")?;
 
             let mut options = Options::default();
-            options.gas = Some(U256::from(5000000));
+            options.gas = Some(U256::from(5_000_000));
             self.contract.call(
                 "applyAuction",
                 (slot, prev_state, new_state, order_hash, prices_and_volumes),
                 account,
                 options,
             ).wait()
-            .map_err(|e| DriverError::from(e))
+            .map_err(DriverError::from)
             .map(|_|())
     }
 }

--- a/driver/src/db_interface.rs
+++ b/driver/src/db_interface.rs
@@ -82,7 +82,7 @@ impl DbInterface for MongoDB {
         for result in cursor {
             docs.push(result?);
         }
-        if docs.len() == 0 {
+        if docs.is_empty() {
             return Err(DriverError::new(
                 &format!("Expected to find a single unique state, found {}", docs.len()), ErrorKind::StateError)
             );

--- a/driver/src/deposit_driver.rs
+++ b/driver/src/deposit_driver.rs
@@ -6,12 +6,10 @@ use crate::error::{DriverError, ErrorKind};
 use crate::contract::SnappContract;
 use crate::util::{balance_index, find_first_unapplied_slot, can_process};
 
-use web3::types::H256;
-
 
 pub fn apply_deposits(
     state: &models::State,
-    deposits: &Vec<models::PendingFlux>,
+    deposits: &[models::PendingFlux],
 ) -> models::State {
     let mut updated_state = state.clone();
     for i in deposits {
@@ -51,7 +49,7 @@ pub fn run_deposit_listener<D, C>(db: &D, contract: &C) -> Result<(bool), Driver
             }
 
             let updated_balances = apply_deposits(&balances, &deposits);
-            let new_state_root = H256::from(updated_balances.rolling_hash());
+            let new_state_root = updated_balances.rolling_hash();
             
             println!("New State_hash is {}", new_state_root);
             contract.apply_deposits(slot, state_root, new_state_root, contract_deposit_hash)?;
@@ -73,7 +71,7 @@ mod tests {
     use crate::models::tests::create_flux_for_test;
     use crate::db_interface::tests::DbInterfaceMock;
     use mock_it::Matcher::*;
-    use web3::types::U256;
+    use web3::types::{H256, U256};
 
     #[test]
     fn applies_current_state_if_unapplied_and_enough_blocks_passed() {

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -30,7 +30,7 @@ pub fn run_driver_components(
     db: &MongoDB,
     contract: &SnappContractImpl, 
     price_finder: &mut Box<PriceFinding>,
-) -> () {
+) {
     if let Err(e) = run_deposit_listener(db, contract) {
         println!("Deposit_driver error: {}", e);
     }

--- a/driver/src/models.rs
+++ b/driver/src/models.rs
@@ -11,7 +11,7 @@ pub trait RollingHashable {
 }
 
 pub trait RootHashable {
-    fn root_hash(&self, valid_items: &Vec<bool>) -> H256;
+    fn root_hash(&self, valid_items: &[bool]) -> H256;
 }
 
 pub trait Serializable {
@@ -97,7 +97,7 @@ impl<T: Serializable> RollingHashable for Vec<T> {
 }
 
 impl RootHashable for Vec<PendingFlux> {
-    fn root_hash(&self, valid_items: &Vec<bool>) -> H256 {
+    fn root_hash(&self, valid_items: &[bool]) -> H256 {
         assert_eq!(self.len(), valid_items.len());
         let mut withdraw_bytes = vec![vec![0; 32]; 128];
         for (index, _) in valid_items.iter().enumerate().filter(|(_, valid)| **valid) {

--- a/driver/src/order_driver.rs
+++ b/driver/src/order_driver.rs
@@ -6,7 +6,7 @@ use crate::models;
 use crate::price_finding::{PriceFinding, Solution};
 use crate::util;
 
-use web3::types::{H256, U256};
+use web3::types::U256;
 
 pub fn run_order_listener<D, C>(
     db: &D, 
@@ -42,7 +42,7 @@ pub fn run_order_listener<D, C>(
                 ));
             }
 
-            let solution = if orders.len() > 0 {
+            let solution = if !orders.is_empty() {
                 price_finder.find_prices(&orders, &state).unwrap_or_else(|e| {
                     println!("Error computing result: {}\n Falling back to trivial solution", e);
                     Solution {
@@ -62,7 +62,7 @@ pub fn run_order_listener<D, C>(
                 }
             };
             state.balances = compute_updated_balances(&state.balances, &orders, &solution);
-            let new_state_root = H256::from(state.rolling_hash());
+            let new_state_root = state.rolling_hash();
             
             println!("New State_hash is {}, Solution: {:?}", new_state_root, solution);
             contract.apply_auction(slot, state_root, new_state_root, order_hash, solution.bytes())?;
@@ -75,11 +75,11 @@ pub fn run_order_listener<D, C>(
 }
 
 fn compute_updated_balances(
-    balances: &Vec<u128>, 
-    orders: &Vec<Order>, 
+    balances: &[u128],
+    orders: &[Order],
     solution: &Solution
 ) -> Vec<u128> {
-    let mut result = balances.clone();
+    let mut result = balances.to_owned();
     for (index, order) in orders.iter().enumerate() {
         let buy_volume = solution.executed_buy_amounts[index];
         let buy_index = util::balance_index(order.buy_token, order.account_id);
@@ -100,7 +100,7 @@ mod tests {
     use crate::db_interface::tests::DbInterfaceMock;
     use crate::price_finding::price_finder_interface::tests::PriceFindingMock;
     use mock_it::Matcher::*;
-    use web3::types::U256;
+    use web3::types::{H256, U256};
 
     #[test]
     fn computes_updated_balance_on_example_with_equal_buy_and_sell(){

--- a/driver/src/price_finding/linear_optimization_price_finder.rs
+++ b/driver/src/price_finding/linear_optimization_price_finder.rs
@@ -22,10 +22,16 @@ pub struct LinearOptimisationPriceFinder {
     read_output: fn() -> std::io::Result<serde_json::Value>,
 }
 
+impl Default for LinearOptimisationPriceFinder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LinearOptimisationPriceFinder {
     pub fn new() -> Self {
         // All prices are 1 (10**18)
-        return LinearOptimisationPriceFinder {
+        LinearOptimisationPriceFinder {
             num_tokens: models::TOKENS,
             previous_prices: (0..models::TOKENS)
                 .map(|t| (token_id(t), "1000000000000000000".to_string()))
@@ -56,13 +62,16 @@ fn serialize_order(order: &models::Order, id: &str) -> serde_json::Value {
     })
 }
 
-fn serialize_balances(balances: &Vec<u128>, num_tokens: u8) -> serde_json::Value {
-    assert!((balances.len() % num_tokens as usize) == 0, "Balance vector cannot be split into equal accounts");
+fn serialize_balances(balances: &[u128], num_tokens: u8) -> serde_json::Value {
+    assert_eq!(
+        (balances.len() % num_tokens as usize), 0,
+        "Balance vector cannot be split into equal accounts"
+    );
     let mut accounts: HashMap<String, HashMap<String, String>> = HashMap::new();
     let mut current_account = 0;
     for balances_for_current_account in balances.chunks(num_tokens as usize) {
         accounts.insert(account_id(current_account), (0..num_tokens)
-            .map(|t| token_id(t))
+            .map(token_id)
             .zip(balances_for_current_account.iter().map(|b| b.to_string()))
             .collect());
         current_account += 1;
@@ -78,13 +87,14 @@ fn deserialize_result(json: &serde_json::Value, num_tokens: u8) -> Result<(Price
         .map(|(token, price)| price
             .as_str()
             .map(|p| (token.to_owned(), p.to_owned()))
-            .ok_or_else(|| PriceFindingError::new(&format!("Could not convert price to string"), ErrorKind::JsonError))
+            .ok_or_else(|| PriceFindingError::new(
+                &"Could not convert price to string".to_string(), ErrorKind::JsonError))
         )
         .collect::<Result<Prices, PriceFindingError>>()?;
     let prices = (0..num_tokens)
         .map(|t| price_map.get(&token_id(t))
             .ok_or_else(|| PriceFindingError::new(&format!("Token {} not found in price map", t), ErrorKind::JsonError))
-            .and_then(|price| price.parse::<u128>().map_err(|e| PriceFindingError::from(e)))
+            .and_then(|price| price.parse::<u128>().map_err(PriceFindingError::from))
         )
         .collect::<Result<Vec<u128>, PriceFindingError>>()?;
     let orders = json["orders"].as_array().ok_or_else(|| "No 'orders' list in json")?;
@@ -104,8 +114,8 @@ fn deserialize_result(json: &serde_json::Value, num_tokens: u8) -> Result<(Price
         .iter()
         .map(|o| o["execSellAmount"]
             .as_str()
-            .ok_or_else(|| PriceFindingError::new("No 'execSellAmount' field on order",  ErrorKind::JsonError))
-            .and_then(|amount| amount.parse::<u128>().map_err(|e| PriceFindingError::from(e)))
+            .ok_or_else(|| PriceFindingError::new("No 'execSellAmount' field on order", ErrorKind::JsonError))
+            .and_then(|amount| amount.parse::<u128>().map_err(PriceFindingError::from))
         )
         .collect::<Result<Vec<u128>, PriceFindingError>>()?;
     let executed_buy_amounts = orders
@@ -113,7 +123,7 @@ fn deserialize_result(json: &serde_json::Value, num_tokens: u8) -> Result<(Price
         .map(|o| o["execBuyAmount"]
             .as_str()
             .ok_or_else(|| PriceFindingError::new("No 'execBuyAmount' field on order",  ErrorKind::JsonError))
-            .and_then(|amount| amount.parse::<u128>().map_err(|e| PriceFindingError::from(e)))
+            .and_then(|amount| amount.parse::<u128>().map_err(PriceFindingError::from))
         )
         .collect::<Result<Vec<u128>, PriceFindingError>>()?;
     Ok((price_map.to_owned(), Solution {
@@ -127,11 +137,11 @@ fn deserialize_result(json: &serde_json::Value, num_tokens: u8) -> Result<(Price
 impl PriceFinding for LinearOptimisationPriceFinder {
     fn find_prices(
         &mut self, 
-        orders: &Vec<models::Order>, 
+        orders: &[models::Order],
         state: &models::State
     ) -> Result<Solution, PriceFindingError> {
         let token_ids: Vec<String> = (0..self.num_tokens)
-            .map(|t| token_id(t))
+            .map(token_id)
             .collect();
         let orders: Vec<serde_json::Value> = orders
             .iter()

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -61,7 +61,7 @@ pub struct NaiveSolver {}
 impl PriceFinding for NaiveSolver {
     fn find_prices(
         &mut self, 
-        orders: &Vec<Order>, 
+        orders: &[Order],
         state: &State
     ) -> Result<Solution, PriceFindingError> {
         // Initialize trivial solution
@@ -121,7 +121,7 @@ impl PriceFinding for NaiveSolver {
                 total_surplus = x_surplus.checked_add(y_surplus).unwrap();
                 break;
             }
-            if found_flag == true {
+            if found_flag {
                 break;
             }
         }

--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -28,7 +28,7 @@ impl models::Serializable for Solution {
 pub trait PriceFinding {
     fn find_prices(
         &mut self, 
-        orders: &Vec<models::Order>, 
+        orders: &[models::Order],
         state: &models::State
     ) -> Result<Solution, PriceFindingError>;
 }
@@ -56,7 +56,7 @@ pub mod tests {
     impl PriceFinding for PriceFindingMock {
         fn find_prices(
             &mut self, 
-            orders: &Vec<models::Order>, 
+            orders: &[models::Order],
             state: &models::State
         ) -> Result<Solution, PriceFindingError> {
             self.find_prices.called((orders.to_vec(), state.to_owned()))

--- a/driver/src/withdraw_driver.rs
+++ b/driver/src/withdraw_driver.rs
@@ -6,11 +6,9 @@ use crate::contract::SnappContract;
 use crate::error::{DriverError, ErrorKind};
 use crate::util;
 
-use web3::types::H256;
-
 fn apply_withdraws(
     state: &models::State,
-    withdraws: &Vec<models::PendingFlux>,
+    withdraws: &[models::PendingFlux],
 ) -> (models::State, Vec<bool>) {
     let mut state = state.clone();
     let mut valid_withdraws = vec![];
@@ -58,7 +56,7 @@ pub fn run_withdraw_listener<D, C>(db: &D, contract: &C) -> Result<(bool), Drive
 
             let (updated_balances, valid_withdraws) = apply_withdraws(&balances, &withdraws);
             let withdrawal_merkle_root = withdraws.root_hash(&valid_withdraws);
-            let new_state_root = H256::from(updated_balances.rolling_hash());
+            let new_state_root = updated_balances.rolling_hash();
             
             println!("New State_hash is {}, Valid Withdraw Merkle Root is {}", new_state_root, withdrawal_merkle_root);
             contract.apply_withdraws(slot, withdrawal_merkle_root, state_root, new_state_root, contract_withdraw_hash)?;
@@ -77,7 +75,7 @@ mod tests {
     use crate::models::tests::create_flux_for_test;
     use crate::db_interface::tests::DbInterfaceMock;
     use mock_it::Matcher::*;
-    use web3::types::U256;
+    use web3::types::{H256, U256};
 
     #[test]
     fn applies_current_state_if_unapplied_and_enough_blocks_passed() {


### PR DESCRIPTION
## Issue Description

Full report of `clippy` warnings can be found here

https://gist.github.com/bh2smith/af26bb187b1d1dbc1dc3f1963ac84052

Brief summary (i.e. some highlights) of those most commonly fixed

- warning: redundant closure found
```
 | .map_err(|e| DriverError::from(e))
 |          ^^^^^^^^^^^^^^^^^^^^^^^^ help: remove closure as shown: `DriverError::from`
```
- writing `&Vec<_>` instead of `&[_]` involves one more reference and cannot be used with non-Vec-based slices.
```
 | fn serialize_balances(balances: &Vec<u128>, num_tokens: u8) -> serde_json::Value {
 |                                 ^^^^^^^^^^ help: change this to: `&[u128]`
```
- warning: length comparison to zero
```
 | if docs.len() == 0 {
 |    ^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `docs.is_empty()`
```
- warning: identical conversion
```
 | let new_state_root = H256::from(updated_balances.rolling_hash());
 |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `H256::from()`: `updated_balances.rolling_hash()`
 
```

## Test Plan

```sh
git check master
cd driver
cargo clippy
```
Observe the warnings! 

```sh
git check cargo_clippy
cargo clippy
```
Be amazed!