### PR TITLE
[E2E] replacing sleep with retry statement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
           - dex-contracts/node_modules/
       before_install:
         - npm install -g truffle
-        - curl https://raw.githubusercontent.com/kadwanev/retry/a1b1826bdb0a78189d5c70c858dc676f5133b1d7/retry -o /usr/local/bin/retry && chmod +x /usr/local/bin/retry
+        - sudo sh -c "curl https://raw.githubusercontent.com/kadwanev/retry/a1b1826bdb0a78189d5c70c858dc676f5133b1d7/retry -o /usr/local/bin/retry && chmod +x /usr/local/bin/retry"
       install:
         - git submodule update --init
         - npm install -C dex-contracts

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,15 +28,15 @@ matrix:
           - dex-contracts/node_modules/
       before_install:
         - npm install -g truffle
+        - curl https://raw.githubusercontent.com/kadwanev/retry/a1b1826bdb0a78189d5c70c858dc676f5133b1d7/retry -o /usr/local/bin/retry && chmod +x /usr/local/bin/retry
       install:
         - git submodule update --init
         - npm install -C dex-contracts
         # driver/listener require compiled contracts
         - cd dex-contracts && truffle compile && cd -
         - docker-compose up -d ganache-cli driver listener | while read line ; do echo "$(date)| $line"; done; # prints timestamps for profiling
-        - sleep 2s
       script:
-        - cd dex-contracts && truffle migrate && cd -
+        - cd dex-contracts && retry truffle migrate && cd -
         - sh ./test/e2e-tests-deposit-withdraw.sh
         - sh ./test/e2e-tests-auction.sh
       after_script:

--- a/test/e2e-tests-auction.sh
+++ b/test/e2e-tests-auction.sh
@@ -25,17 +25,17 @@ truffle exec scripts/sell_order.js 4 1 0 4 52 # executed sell: 52
 truffle exec scripts/sell_order.js 5 2 0 20 280
 
 # Test Listener: There are now 6 orders in auction slot 1 and sellAmount for accountId = 5 is 280000000000000000000
-retry "mongo dfusion2 --eval \"db.orders.find({'auctionId': ${EXPECTED_AUCTION}}).size()\" | grep -w 6"
-retry "mongo dfusion2 --eval \"db.orders.findOne({'auctionId': ${EXPECTED_AUCTION}, 'accountId': 5}).sellAmount\" | grep -w 280000000000000000000"
+retry -t 5 "mongo dfusion2 --eval \"db.orders.find({'auctionId': ${EXPECTED_AUCTION}}).size()\" | grep -w 6"
+retry -t 5 "mongo dfusion2 --eval \"db.orders.findOne({'auctionId': ${EXPECTED_AUCTION}, 'accountId': 5}).sellAmount\" | grep -w 280000000000000000000"
 
 truffle exec scripts/wait_seconds.js 181
 
 # Test balances have been updated
 EXPECTED_HASH="0e0369b8be154350fd09141a43d90a53427221001ba9fee5c97145e777420944"
-retry "truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
+retry -t 5 "truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
 
 # Account 4 has now 4 of token 1 
-retry "mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[121]\" | grep -w 4000000000000000000"
+retry -t 5 "mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[121]\" | grep -w 4000000000000000000"
 
 # Account 3 has now 52 of token 0
-retry "mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[90]\" | grep -2 52000000000000000000"
+retry -t 5 "mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[90]\" | grep -2 52000000000000000000"

--- a/test/e2e-tests-auction.sh
+++ b/test/e2e-tests-auction.sh
@@ -6,7 +6,7 @@ cd dex-contracts/
 EXPECTED_AUCTION=0
 
 # Ensure no orders yet in auction slot 1
-mongo dfusion2 --eval "db.orders.find({'auctionId': ${EXPECTED_AUCTION}}).size()" | grep 0
+mongo dfusion2 --eval "db.orders.find({'auctionId': ${EXPECTED_AUCTION}}).size()" | grep -w 0
 
 # Make sure we have enough balances for the trades
 truffle exec scripts/deposit.js 0 2 300
@@ -24,22 +24,18 @@ truffle exec scripts/sell_order.js 3 0 1 180 15 # executed sell: 4
 truffle exec scripts/sell_order.js 4 1 0 4 52 # executed sell: 52
 truffle exec scripts/sell_order.js 5 2 0 20 280
 
-sleep 5
-
 # Test Listener: There are now 6 orders in auction slot 1 and sellAmount for accountId = 5 is 280000000000000000000
-mongo dfusion2 --eval "db.orders.find({'auctionId': ${EXPECTED_AUCTION}}).size()" | grep 6
-mongo dfusion2 --eval "db.orders.findOne({'auctionId': ${EXPECTED_AUCTION}, 'accountId': 5}).sellAmount" | grep 280000000000000000000
+retry "mongo dfusion2 --eval \"db.orders.find({'auctionId': ${EXPECTED_AUCTION}}).size()\" | grep -w 6"
+retry "mongo dfusion2 --eval \"db.orders.findOne({'auctionId': ${EXPECTED_AUCTION}, 'accountId': 5}).sellAmount\" | grep -w 280000000000000000000"
 
 truffle exec scripts/wait_seconds.js 181
 
-sleep 10
-
 # Test balances have been updated
 EXPECTED_HASH="0e0369b8be154350fd09141a43d90a53427221001ba9fee5c97145e777420944"
-truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}
+retry "truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
 
 # Account 4 has now 4 of token 1 
-mongo dfusion2 --eval "db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[121]" | grep 4000000000000000000
+retry "mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[121]\" | grep -w 4000000000000000000"
 
 # Account 3 has now 52 of token 0
-mongo dfusion2 --eval "db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[90]" | grep 52000000000000000000
+retry "mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[90]\" | grep -2 52000000000000000000"

--- a/test/e2e-tests-deposit-withdraw.sh
+++ b/test/e2e-tests-deposit-withdraw.sh
@@ -17,8 +17,8 @@ truffle exec scripts/wait_seconds.js 181
 
 # Expect that driver has processed deposit slot and ensure updated balances are as expected
 EXPECTED_HASH="73815c173218e6025f7cb12d0add44354c4671e261a34a360943007ff6ac7af5"
-retry "truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
-retry "mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '${EXPECTED_HASH}'}).balances[62]\" | grep -w 18000000000000000000"
+retry -t 5 "truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
+retry -t 5 "mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '${EXPECTED_HASH}'}).balances[62]\" | grep -w 18000000000000000000"
 
 ################
 # Withdraw Tests
@@ -30,8 +30,8 @@ truffle exec scripts/wait_seconds.js 181
 
 # Expect that driver has processed withdraw slot and ensure updated balances are as expected
 EXPECTED_HASH="7b738197bfe79b6d394499b0cac0186cdc2f65ae2239f2e9e3c698709c80cb67"
-retry "truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
-retry "mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[62]\" | grep -w 0"
+retry -t 5 "truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
+retry -t 5 "mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[62]\" | grep -w 0"
 
 # Should now be able to claim withdraw and see a balance change
 truffle exec scripts/claim_withdraw.js 0 2 2 | grep "Success! Balance of token 2 before claim: 282000000000000000000, after claim: 300000000000000000000"

--- a/test/e2e-tests-deposit-withdraw.sh
+++ b/test/e2e-tests-deposit-withdraw.sh
@@ -15,12 +15,10 @@ truffle exec scripts/deposit.js 2 2 18
 # Wait till previous deposit slot becomes inactive
 truffle exec scripts/wait_seconds.js 181
 
-sleep 10
-
 # Expect that driver has processed deposit slot and ensure updated balances are as expected
 EXPECTED_HASH="73815c173218e6025f7cb12d0add44354c4671e261a34a360943007ff6ac7af5"
-truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}
-mongo dfusion2 --eval "db.accounts.findOne({'stateHash': '${EXPECTED_HASH}'}).balances[62]" | grep 18000000000000000000
+retry "truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
+retry "mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '${EXPECTED_HASH}'}).balances[62]\" | grep -w 18000000000000000000"
 
 ################
 # Withdraw Tests
@@ -30,11 +28,10 @@ mongo dfusion2 --eval "db.accounts.findOne({'stateHash': '${EXPECTED_HASH}'}).ba
 truffle exec scripts/request_withdraw.js 2 2 18
 truffle exec scripts/wait_seconds.js 181
 
-sleep 5
 # Expect that driver has processed withdraw slot and ensure updated balances are as expected
 EXPECTED_HASH="7b738197bfe79b6d394499b0cac0186cdc2f65ae2239f2e9e3c698709c80cb67"
-truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}
-mongo dfusion2 --eval "db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[62]" | grep 0
+retry "truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
+retry "mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[62]\" | grep -w 0"
 
 # Should now be able to claim withdraw and see a balance change
 truffle exec scripts/claim_withdraw.js 0 2 2 | grep "Success! Balance of token 2 before claim: 282000000000000000000, after claim: 300000000000000000000"


### PR DESCRIPTION
I'm not entirely sure if this is a much better approach, since it requires a lot of thinking on which commands need to be retried and which ones don't.

Yet, it will make sure that we are not waiting unnecessarily and also not subject to flaky timing issues.

Looking forward to a discussion...

**Testplan**
Install retry and run e2e tests locally:

```
brew pull 27283
brew install retry
echo 'export PATH="/usr/local/opt/gnu-getopt/bin:$PATH"' >> ~/.bash_profile
./test/e2e-tests-deposit-withdraw.sh && ./test/e2e-tests-auction.sh
```

Closes #100 