### PR TITLE
[Driver] Making sure our models don't know about price finding internals

### DIFF
--- a/driver/src/deposit_driver.rs
+++ b/driver/src/deposit_driver.rs
@@ -82,6 +82,7 @@ mod tests {
             format!("{:x}", state_hash),
             1,
             vec![100; (models::TOKENS * 2) as usize],
+            models::TOKENS,
         );
 
         let contract = SnappContractMock::new();
@@ -110,6 +111,7 @@ mod tests {
             format!("{:x}", state_hash),
             1,
             vec![100; (models::TOKENS * 2) as usize],
+            models::TOKENS,
         );
 
         let contract = SnappContractMock::new();
@@ -137,6 +139,7 @@ mod tests {
             format!("{:x}", state_hash),
             1,
             vec![100; (models::TOKENS * 2) as usize],
+            models::TOKENS,
         );
 
         let contract = SnappContractMock::new();
@@ -179,6 +182,7 @@ mod tests {
             format!("{:x}", state_hash),
             1,
             vec![100; (models::TOKENS * 2) as usize],
+            models::TOKENS,
         );
 
         let db = DbInterfaceMock::new();
@@ -199,6 +203,7 @@ mod tests {
             format!("{:x}", state_hash),
             1,
             vec![100; (models::TOKENS * 2) as usize],
+            models::TOKENS,
         );
 
         let contract = SnappContractMock::new();

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -144,7 +144,8 @@ pub mod tests {
         let state = State::new(
             "test".to_string(),
             0,
-            vec![200; (TOKENS * 2) as usize]
+            vec![200; (TOKENS * 2) as usize],
+            TOKENS,
         );
         let orders = vec![
             Order {
@@ -174,7 +175,8 @@ pub mod tests {
         let state = State::new(
             "test".to_string(),
             0,
-            vec![200; (TOKENS * 2) as usize]
+            vec![200; (TOKENS * 2) as usize],
+            TOKENS,
         );
         let orders = vec![
             Order {
@@ -204,7 +206,8 @@ pub mod tests {
         let state = State::new(
             "test".to_string(),
             0,
-            vec![200; (TOKENS * 2) as usize]
+            vec![200; (TOKENS * 2) as usize],
+            TOKENS,
         );
         let orders = vec![
             Order {
@@ -234,7 +237,8 @@ pub mod tests {
         let state = State::new(
             "test".to_string(),
             0,
-            vec![200; (TOKENS * 6) as usize]
+            vec![200; (TOKENS * 6) as usize],
+            TOKENS,
         );
         let orders = vec![
             Order {
@@ -296,7 +300,8 @@ pub mod tests {
         let state = State::new(
             "test".to_string(),
             0,
-            vec![0; (TOKENS * 2) as usize]
+            vec![0; (TOKENS * 2) as usize],
+            TOKENS,
         );
         let orders = vec![
             Order {
@@ -326,7 +331,8 @@ pub mod tests {
         let state = State::new(
             "test".to_string(),
             0,
-            vec![200; (TOKENS * 2) as usize]
+            vec![200; (TOKENS * 2) as usize],
+            TOKENS,
         );
         let orders = vec![
             Order {

--- a/driver/src/withdraw_driver.rs
+++ b/driver/src/withdraw_driver.rs
@@ -85,6 +85,7 @@ mod tests {
             format!("{:x}", state_hash),
             1,
             vec![100; (models::TOKENS * 2) as usize],
+            models::TOKENS,
         );
 
         let contract = SnappContractMock::new();
@@ -155,6 +156,7 @@ mod tests {
             format!("{:x}", state_hash),
             1,
             vec![100; (models::TOKENS * 2) as usize],
+            models::TOKENS,
         );
 
         let db = DbInterfaceMock::new();
@@ -176,6 +178,7 @@ mod tests {
             format!("{:x}", state_hash),
             1,
             vec![100; (models::TOKENS * 2) as usize],
+            models::TOKENS,
         );
 
         let contract = SnappContractMock::new();
@@ -212,6 +215,7 @@ mod tests {
             format!("{:x}", state_hash),
             1,
             vec![100; (models::TOKENS * 2) as usize],
+            models::TOKENS,
         );
         state.decrement_balance(1, 0, 100);
 


### PR DESCRIPTION
I didn't like that our models "know" (as in import a dependency) about how the price finding decides to serialize account balances when it passes input data to the python solver (by exposing the ought to be private `accountId` and `tokenId` methods). This is an implementation detail to the linear optimization solver that should not be leaked to the basic data model.

I also didn't like that `State` had to know about `Solution` (in order to update balances it took a reference to the `Solution` object). While we could argue that `Solution` is a basic data model that should be moved into the models submodule (instead of being in price_finding as it is right now), there is no need for the two to be coupled. `update_balances` can be a free method on the order_processor, which already has to know about both `Solution` and `State`.

This PR moves the code back and cleans up the imports.

In order to allow simpler unit testing (e.g. not having to create 1k * 30 balances for each state) I made the `num_tokens` an ivar on the State object. This allows more concise testing.

**Test Plan**

```
cargo test
e2e test
```