### PR TITLE
[Driver] Adding a nonce to the state hash

### DIFF
--- a/driver/src/models/mod.rs
+++ b/driver/src/models/mod.rs
@@ -13,7 +13,7 @@ pub const TOKENS: u8 = 30;
 pub const DB_NAME: &str = "dfusion2";
 
 pub trait RollingHashable {
-    fn rolling_hash(&self) -> H256;
+    fn rolling_hash(&self, nonce: i32) -> H256;
 }
 
 pub trait RootHashable {

--- a/driver/src/models/order.rs
+++ b/driver/src/models/order.rs
@@ -47,8 +47,8 @@ impl From<mongodb::ordered::OrderedDocument> for Order {
 }
 
 impl<T: Serializable> RollingHashable for Vec<T> {
-    fn rolling_hash(&self) -> H256 {
-        self.iter().fold(H256::zero(), |acc, w| iter_hash(w, &acc))
+    fn rolling_hash(&self, nonce: i32) -> H256 {
+        self.iter().fold(H256::from(nonce as u64), |acc, w| iter_hash(w, &acc))
     }
 }
 
@@ -70,7 +70,7 @@ pub mod tests {
     };
 
     assert_eq!(
-    vec![order].rolling_hash(),
+    vec![order].rolling_hash(0),
     H256::from_str(
       "8c253b4588a6d87b02b5f7d1424020b7b5f8c0397e464e087d2830a126d3b699"
       ).unwrap()

--- a/driver/src/models/state.rs
+++ b/driver/src/models/state.rs
@@ -1,4 +1,4 @@
-use byteorder::{LittleEndian, WriteBytesExt};
+use byteorder::{BigEndian, WriteBytesExt};
 use serde_derive::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use web3::types::H256;
@@ -43,11 +43,12 @@ impl State {
 
 impl RollingHashable for State {
   //Todo: Exchange sha with pederson hash
-  fn rolling_hash(&self) -> H256 {
-    let mut hash = vec![0u8; 32];
+  fn rolling_hash(&self, nonce: i32) -> H256 {
+    let mut hash = vec![0u8; 28];
+    hash.write_i32::<BigEndian>(nonce).unwrap();
     for i in &self.balances {
-      let mut bs = [0u8; 32];
-      bs.as_mut().write_u128::<LittleEndian>(*i).unwrap();
+      let mut bs = vec![0u8; 16];
+      bs.write_u128::<BigEndian>(*i).unwrap();
 
       let mut hasher = Sha256::new();
       hasher.input(hash);
@@ -91,20 +92,20 @@ pub mod tests {
         num_tokens: TOKENS,
     };
     assert_eq!(
-      state.rolling_hash(),
+      state.rolling_hash(0),
       H256::from_str(&state.state_hash).unwrap()
     );
 
     // State with single deposit
     balances[62] = 18;
     let state = State {
-        state_hash: "73899d50b4ec5e351b4967e4c4e4a725e0fa3e8ab82d1bb6d3197f22e65f0c97".to_string(),
+        state_hash: "a0cde336d10dbaf3df98ba662bacf25d95062db7b3e0083bd4bad4a6c7a1cd41".to_string(),
         state_index:  1,
         balances,
         num_tokens: TOKENS,
     };
     assert_eq!(
-      state.rolling_hash(),
+      state.rolling_hash(0),
       H256::from_str(&state.state_hash).unwrap()
     );
   }

--- a/driver/src/withdraw_driver.rs
+++ b/driver/src/withdraw_driver.rs
@@ -45,7 +45,7 @@ pub fn run_withdraw_listener<D, C>(db: &D, contract: &C) -> Result<(bool), Drive
             let balances = db.get_current_balances(&state_root)?;
 
             let withdraws = db.get_withdraws_of_slot(slot.low_u32())?;
-            let withdraw_hash = withdraws.rolling_hash();
+            let withdraw_hash = withdraws.rolling_hash(0);
             if withdraw_hash != contract_withdraw_hash {
                 return Err(DriverError::new(
                     &format!("Pending withdraw hash from contract ({}), didn't match the one found in db ({})", 
@@ -55,7 +55,7 @@ pub fn run_withdraw_listener<D, C>(db: &D, contract: &C) -> Result<(bool), Drive
 
             let (updated_balances, valid_withdraws) = apply_withdraws(&balances, &withdraws);
             let withdrawal_merkle_root = withdraws.root_hash(&valid_withdraws);
-            let new_state_root = updated_balances.rolling_hash();
+            let new_state_root = updated_balances.rolling_hash(balances.state_index + 1);
             
             println!("New State_hash is {}, Valid Withdraw Merkle Root is {}", new_state_root, withdrawal_merkle_root);
             contract.apply_withdraws(slot, withdrawal_merkle_root, state_root, new_state_root, contract_withdraw_hash)?;
@@ -94,7 +94,7 @@ mod tests {
         contract.has_withdraw_slot_been_applied.given(slot - 1).will_return(Ok(true));
         contract.creation_timestamp_for_withdraw_slot.given(slot).will_return(Ok(U256::from(10)));
         contract.get_current_block_timestamp.given(()).will_return(Ok(U256::from(200)));
-        contract.withdraw_hash_for_slot.given(slot).will_return(Ok(withdraws.rolling_hash()));
+        contract.withdraw_hash_for_slot.given(slot).will_return(Ok(withdraws.rolling_hash(0)));
         contract.get_current_state_root.given(()).will_return(Ok(state_hash));
         contract.apply_withdraws.given((slot, Any, Any, Any, Any)).will_return(Ok(()));
 
@@ -147,7 +147,7 @@ mod tests {
         contract.creation_timestamp_for_withdraw_slot.given(slot-1).will_return(Ok(U256::from(10)));
 
         contract.get_current_block_timestamp.given(()).will_return(Ok(U256::from(200)));
-        contract.withdraw_hash_for_slot.given(slot-1).will_return(Ok(second_withdraws.rolling_hash()));
+        contract.withdraw_hash_for_slot.given(slot-1).will_return(Ok(second_withdraws.rolling_hash(0)));
 
         contract.get_current_state_root.given(()).will_return(Ok(state_hash));
         contract.apply_withdraws.given((slot - 1, Any, Any, Any, Any)).will_return(Ok(()));
@@ -227,7 +227,7 @@ mod tests {
         contract.has_withdraw_slot_been_applied.given(slot - 1).will_return(Ok(true));
         contract.creation_timestamp_for_withdraw_slot.given(slot).will_return(Ok(U256::from(10)));
         contract.get_current_block_timestamp.given(()).will_return(Ok(U256::from(200)));
-        contract.withdraw_hash_for_slot.given(slot).will_return(Ok(withdraws.rolling_hash()));
+        contract.withdraw_hash_for_slot.given(slot).will_return(Ok(withdraws.rolling_hash(0)));
         contract.get_current_state_root.given(()).will_return(Ok(state_hash));
         contract.apply_withdraws.given((slot, Val(merkle_root), Any, Any, Any)).will_return(Ok(()));
 

--- a/test/e2e-tests-auction.sh
+++ b/test/e2e-tests-auction.sh
@@ -35,7 +35,7 @@ truffle exec scripts/wait_seconds.js 181
 sleep 10
 
 # Test balances have been updated
-EXPECTED_HASH="c4c44a0c0c17022dc987ba8abbc89d0c77d20865d0d61c07f76c889badd708a2"
+EXPECTED_HASH="0e0369b8be154350fd09141a43d90a53427221001ba9fee5c97145e777420944"
 truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}
 
 # Account 4 has now 4 of token 1 

--- a/test/e2e-tests-deposit-withdraw.sh
+++ b/test/e2e-tests-deposit-withdraw.sh
@@ -18,7 +18,7 @@ truffle exec scripts/wait_seconds.js 181
 sleep 10
 
 # Expect that driver has processed deposit slot and ensure updated balances are as expected
-EXPECTED_HASH="a5b2329a51ada3ce2114e2724264cbfd11f5cd63e41c3700c3f88358995b6153"
+EXPECTED_HASH="73815c173218e6025f7cb12d0add44354c4671e261a34a360943007ff6ac7af5"
 truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}
 mongo dfusion2 --eval "db.accounts.findOne({'stateHash': '${EXPECTED_HASH}'}).balances[62]" | grep 18000000000000000000
 
@@ -32,7 +32,7 @@ truffle exec scripts/wait_seconds.js 181
 
 sleep 5
 # Expect that driver has processed withdraw slot and ensure updated balances are as expected
-EXPECTED_HASH="77b01abfbad57cb7a1344b12709603ea3b9ad803ef5ea09814ca212748f54733"
+EXPECTED_HASH="7b738197bfe79b6d394499b0cac0186cdc2f65ae2239f2e9e3c698709c80cb67"
 truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}
 mongo dfusion2 --eval "db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[62]" | grep 0
 


### PR DESCRIPTION
Currently two state roots with the same balances will have the same hash. This can introduce problems as in our data-model we are only filtering by hash in our query and not by the state_index.

One way to solve this is to introduce a nonce into the hash (this way the state_index is part of the entropy of the hash).
Alternatively we could also query both the currentStateRoot as well as the current stateIndex from the smart contract and filter for a combination of state_index and state_hash. However this would require another contract call each time we query for balance state.

One disadvantage of the proposed approach is that the hashes in our e2e tests now depend on the state_index that they'd been applied on. This means that changing the order of the tests or adding another test, might have consequences to all later e2e test hashes.

There are other ways to solve this issue if it becomes problematic (e.g. computing the expected hash as part of the test).