### PR TITLE
[Easy] Update django version to address security warning

### DIFF
--- a/event_listener/requirements.txt
+++ b/event_listener/requirements.txt
@@ -1,4 +1,4 @@
-Django==2.1.5
+Django==2.1.7
 django-environ==0.4.5
 django-eth-events==3.0.5
 django-model-utils==3.1.2


### PR DESCRIPTION
Turns out Django 2.1.0 - 2.1.6 have a moderate security vulnerability, This change should make the  [warning](https://github.com/gnosis/dex-services/network/alert/event_listener/requirements.txt/django/open) go away.