### PR TITLE
[Listener] Write init constants to DB

### DIFF
--- a/event_listener/dfusion_db/database_interface.py
+++ b/event_listener/dfusion_db/database_interface.py
@@ -25,7 +25,9 @@ class DatabaseInterface(ABC):
     def write_snapp_constants(self, num_tokens: int, num_accounts: int) -> None: pass
 
     @abstractmethod
-    def write_auction_constants(self, num_orders: int) -> None: pass
+    def write_auction_constants(
+        self, num_orders: int, num_reserved_accounts: int, orders_per_reserved_account: int
+    ) -> None: pass
 
     @abstractmethod
     def get_account_state(self, index: int) -> AccountRecord: pass
@@ -88,11 +90,23 @@ class MongoDbInterface(DatabaseInterface):
             }
         ])
 
-    def write_auction_constants(self, num_orders: int) -> None:
-        self.db.constants.insert_one({
-            'name': 'num_orders',
-            'value': num_orders
-        })
+    def write_auction_constants(
+        self, num_orders: int, num_reserved_accounts: int, orders_per_reserved_account: int
+    ) -> None:
+        self.db.constants.insert([
+            {
+                'name': 'num_orders',
+                'value': num_orders
+            },
+            {
+                'name': 'num_reserved_accounts',
+                'value': num_reserved_accounts
+            },
+            {
+                'name': 'orders_per_reserved_account',
+                'value': orders_per_reserved_account
+            },
+        ])
 
     def get_account_state(self, index: int) -> AccountRecord:
         record = self.db.accounts.find_one({'stateIndex': index})

--- a/event_listener/dfusion_db/snapp_event_receiver.py
+++ b/event_listener/dfusion_db/snapp_event_receiver.py
@@ -118,11 +118,15 @@ class AuctionInitializationReceiver(SnappEventListener):
     def save(self, event: Dict[str, Any], block_info: Dict[str, Any]) -> None:
 
         # Verify integrity of post data
-        assert event.keys() == {'maxOrders'}, "Unexpected Event Keys"
+        assert event.keys() == {'maxOrders', 'numReservedAccounts', 'ordersPerReservedAccount'}, "Unexpected Event Keys"
         assert isinstance(event['maxOrders'], int), "maxOrders has unexpected value"
+        assert isinstance(event['numReservedAccounts'], int), "maxOrders has unexpected value"
+        assert isinstance(event['ordersPerReservedAccount'], int), "maxOrders has unexpected value"
 
         try:
-            self.database.write_auction_constants(event['maxOrders'])
+            self.database.write_auction_constants(
+                event['maxOrders'], event['numReservedAccounts'], event['ordersPerReservedAccount']
+            )
             logging.info(
                 "Successfully included Snapp Auction constant(s)")
         except Exception as exc:

--- a/event_listener/dfusion_db/tests/snapp_event_receiver_test.py
+++ b/event_listener/dfusion_db/tests/snapp_event_receiver_test.py
@@ -330,12 +330,10 @@ class AuctionInitializationReceiverTest(unittest.TestCase):
         database = Mock()
         receiver = AuctionInitializationReceiver(database)
 
-        num_orders = 2
-
-        event = {"maxOrders": num_orders}
+        event = {"maxOrders": 2, 'numReservedAccounts': 1, 'ordersPerReservedAccount': 1}
         receiver.save(event, block_info={})
 
-        database.write_auction_constants.assert_called_with(num_orders)
+        database.write_auction_constants.assert_called_with(2, 1, 1)
 
     def test_unexpected_save(self) -> None:
         database = Mock()


### PR DESCRIPTION
As title. This PR also updates the contracts to use the most recent version.

### Test plan:
```
git submodule update
cd dex-contracts
rm -r build
truffle build
cd ../
docker-compose build truffle
docker-compose up
```

Open localhost:3000 in a browser and see that constants table has new entries.