### PR TITLE
[Listener] enforce proper linting

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,0 +1,3 @@
+[pep8]
+ignore = E701,E704
+max-line-length = 120

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
       script:
         - pytest --cov=event_listener/dfusion_db/ --cov-report term-missing
         - mypy event_listener/dfusion_db/ --ignore-missing-imports --strict
+        - pep8 --config .pep8 event_listener/dfusion_db/
+        - pylint --errors-only event_listener/dfusion_db/
     - language: generic
       dist: xenial
       sudo: required

--- a/event_listener/dfusion_db/models.py
+++ b/event_listener/dfusion_db/models.py
@@ -152,7 +152,7 @@ class AuctionResults(NamedTuple):
         buy_amounts = volumes[0::2]  # Even elements
         sell_amounts = volumes[1::2]  # Odd elements
 
-        logging.debug("Prices: {}\nBuy Amounts: {}\n Sell Amounts: {}", prices, buy_amounts, sell_amounts)
+        logging.debug("Prices: {}\nBuy Amounts: {}\n Sell Amounts: {}".format(prices, buy_amounts, sell_amounts))
 
         assert len(buy_amounts) == len(sell_amounts), "Unequal buy-sell amounts {}-{}".format(buy_amounts, sell_amounts)
         assert len(buy_amounts) <= num_orders, "Solution data contains more execution volumes than orders"

--- a/event_listener/dfusion_db/snapp_event_receiver.py
+++ b/event_listener/dfusion_db/snapp_event_receiver.py
@@ -23,10 +23,7 @@ class DepositReceiver(SnappEventListener):
         self.save_parsed(Deposit.from_dictionary(event))
 
     def save_parsed(self, deposit: Deposit) -> None:
-        try:
-            self.database.write_deposit(deposit)
-        except Exception as exc:
-            logging.critical("Failed to record Deposit [{}] - {}".format(exc, deposit))
+        self.database.write_deposit(deposit)
 
 
 class StateTransitionReceiver(SnappEventListener):
@@ -34,11 +31,8 @@ class StateTransitionReceiver(SnappEventListener):
         self.save_parsed(StateTransition.from_dictionary(event))
 
     def save_parsed(self, transition: StateTransition) -> None:
-        try:
-            self.__update_accounts(transition)
-            logging.info("Successfully updated state and balances")
-        except Exception as exc:
-            logging.critical("Failed to record StateTransition [{}] - {}".format(exc, transition))
+        self.__update_accounts(transition)
+        logging.info("Successfully updated state and balances")
 
     def __update_accounts(self, transition: StateTransition) -> None:
         balances = self.database.get_account_state(transition.state_index - 1).balances.copy()
@@ -101,11 +95,7 @@ class SnappInitializationReceiver(SnappEventListener):
         assert isinstance(event['maxTokens'], int), "maxTokens has unexpected value"
         assert isinstance(event['maxAccounts'], int), "maxAccounts has unexpected value"
 
-        try:
-            self.initialize_accounts(event['maxTokens'], event['maxAccounts'], state_hash)
-        except Exception as exc:
-            logging.critical(
-                "Failed to record SnappInitialization [{}] - {}".format(exc, event))
+        self.initialize_accounts(event['maxTokens'], event['maxAccounts'], state_hash)
 
     def initialize_accounts(self, num_tokens: int, num_accounts: int, state_hash: str) -> None:
         account_record = AccountRecord(0, state_hash, [0 for _ in range(num_tokens * num_accounts)])
@@ -123,15 +113,11 @@ class AuctionInitializationReceiver(SnappEventListener):
         assert isinstance(event['numReservedAccounts'], int), "maxOrders has unexpected value"
         assert isinstance(event['ordersPerReservedAccount'], int), "maxOrders has unexpected value"
 
-        try:
-            self.database.write_auction_constants(
-                event['maxOrders'], event['numReservedAccounts'], event['ordersPerReservedAccount']
-            )
-            logging.info(
-                "Successfully included Snapp Auction constant(s)")
-        except Exception as exc:
-            logging.critical(
-                "Failed to record AuctionInitialization [{}] - {}".format(exc, event))
+        self.database.write_auction_constants(
+            event['maxOrders'], event['numReservedAccounts'], event['ordersPerReservedAccount']
+        )
+        logging.info(
+            "Successfully included Snapp Auction constant(s)")
 
 
 class WithdrawRequestReceiver(SnappEventListener):
@@ -139,11 +125,7 @@ class WithdrawRequestReceiver(SnappEventListener):
         self.save_parsed(Withdraw.from_dictionary(event))
 
     def save_parsed(self, withdraw: Withdraw) -> None:
-        try:
-            self.database.write_withdraw(withdraw)
-        except Exception as exc:
-            logging.critical(
-                "Failed to record Deposit [{}] - {}".format(exc, withdraw))
+        self.database.write_withdraw(withdraw)
 
 
 class OrderReceiver(SnappEventListener):
@@ -151,11 +133,7 @@ class OrderReceiver(SnappEventListener):
         self.save_parsed(Order.from_dictionary(event))
 
     def save_parsed(self, order: Order) -> None:
-        try:
-            self.database.write_order(order)
-        except Exception as exc:
-            logging.critical(
-                "Failed to record Order [{}] - {}".format(exc, order))
+        self.database.write_order(order)
 
 
 class AuctionSettlementReceiver(SnappEventListener):
@@ -169,11 +147,7 @@ class AuctionSettlementReceiver(SnappEventListener):
         )
 
     def save_parsed(self, settlement: AuctionSettlement) -> None:
-        try:
-            self.__update_accounts(settlement)
-        except Exception as exc:
-            logging.critical(
-                "Failed to record Settlement [{}] - {}".format(exc, settlement))
+        self.__update_accounts(settlement)
 
     def __update_accounts(self, settlement: AuctionSettlement) -> None:
         state = self.database.get_account_state(settlement.state_index - 1)

--- a/event_listener/dfusion_db/tests/snapp_event_receiver_test.py
+++ b/event_listener/dfusion_db/tests/snapp_event_receiver_test.py
@@ -1,10 +1,10 @@
 import unittest
 from unittest.mock import Mock
+from typing import List
 from ..snapp_event_receiver import DepositReceiver, OrderReceiver, SnappInitializationReceiver
 from ..snapp_event_receiver import WithdrawRequestReceiver, StateTransitionReceiver
 from ..snapp_event_receiver import AuctionSettlementReceiver, AuctionInitializationReceiver
 from ..models import Deposit, StateTransition, TransitionType, Withdraw, AccountRecord, Order
-from typing import List
 
 EMPTY_STATE_HASH = "0x00000000000000000000000000000000000000000000000000000000000000"
 
@@ -272,7 +272,7 @@ class AuctionSettlementReceiverTest(unittest.TestCase):
         dummy_account_record = AccountRecord(1, EMPTY_STATE_HASH, old_balances)
 
         def int_list_to_hex_bytes(arr: List[int], num_bits: int) -> str:
-            assert (num_bits % 4 == 0)
+            assert num_bits % 4 == 0
             hex_length = num_bits // 4
             return "".join(map(lambda t: str(hex(t))[2:].rjust(hex_length, "0"), arr))
 

--- a/event_listener/requirements.txt
+++ b/event_listener/requirements.txt
@@ -8,7 +8,7 @@ web3==4.8.2
 flake8==3.7.5
 flake8-mypy==17.8.0
 pep8==1.7.1
-pylint==2.1.1
+pylint==2.3.0
 pytest==4.2.0
 pytest-cov==2.6.1
 kombu==4.4.0

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,8 @@
+[FORMAT]
+max-line-length=120
+
+[MESSAGES CONTROL]
+disable=
+    logging-format-interpolation,
+    missing-docstring,
+    multiple-statements,

--- a/pylintrc
+++ b/pylintrc
@@ -1,8 +1,562 @@
-[FORMAT]
-max-line-length=120
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
 
 [MESSAGES CONTROL]
-disable=
-    logging-format-interpolation,
-    missing-docstring,
-    multiple-statements,
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        locally-enabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape,
+        missing-docstring,
+        multiple-statements,
+        logging-format-interpolation
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package..
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=120
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           v,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement.
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception".
+overgeneral-exceptions=Exception


### PR DESCRIPTION
This PR makes it so that linter errors are actually going to break travis. I went ahead and created config files for both pep and pylint. @bh2smith feel free to add whatever rules your IDE thinks we should enforce.

This makes it so that we don't regular cleanup diffs by our [Putzfee](https://bilder.kalaydo.de/kalaydo/images/2018/11/04/16/aaa68d0d/medium_image_0.jpg?lastModified=1541346025000) but instead can encourage everyone to only submit clean code in the first place.

### Testplan
```
pep8 --config .pep8 event_listener/dfusion_db/
pylint --errors-only event_listener/dfusion_db/
```