### PR TITLE
[Listener] processing StandingSellOrderBatch events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,6 @@ matrix:
         - cd dex-contracts && retry truffle migrate && cd -
         - sh ./test/e2e-tests-deposit-withdraw.sh
         - sh ./test/e2e-tests-auction.sh
+        - sh ./test/e2e-tests-standing-order.sh
       after_script:
         - docker-compose logs

--- a/event_listener/dfusion_db/database_interface.py
+++ b/event_listener/dfusion_db/database_interface.py
@@ -93,7 +93,7 @@ class MongoDbInterface(DatabaseInterface):
     def write_auction_constants(
             self, num_orders: int, num_reserved_accounts: int, orders_per_reserved_account: int
     ) -> None:
-        self.database.constants.insert([
+        self.db.constants.insert([
             {
                 'name': 'num_orders',
                 'value': num_orders

--- a/event_listener/dfusion_db/database_interface.py
+++ b/event_listener/dfusion_db/database_interface.py
@@ -93,7 +93,7 @@ class MongoDbInterface(DatabaseInterface):
     def write_auction_constants(
             self, num_orders: int, num_reserved_accounts: int, orders_per_reserved_account: int
     ) -> None:
-        self.db.constants.insert([
+        self.database.constants.insert([
             {
                 'name': 'num_orders',
                 'value': num_orders

--- a/event_listener/dfusion_db/database_interface.py
+++ b/event_listener/dfusion_db/database_interface.py
@@ -5,7 +5,7 @@ from typing import List
 from django.conf import settings
 from pymongo import MongoClient
 
-from .models import Deposit, Withdraw, AccountRecord, Order
+from .models import Deposit, Withdraw, AccountRecord, Order, StandingOrder
 
 
 class DatabaseInterface(ABC):
@@ -49,6 +49,9 @@ class DatabaseInterface(ABC):
 
     @abstractmethod
     def get_orders(self, auction_id: int) -> List[Order]: pass
+
+    @abstractmethod
+    def write_standing_order(self, standing_order: StandingOrder) -> None: pass
 
 
 class MongoDbInterface(DatabaseInterface):
@@ -134,3 +137,8 @@ class MongoDbInterface(DatabaseInterface):
 
     def get_orders(self, auction_id: int) -> List[Order]:
         return list(map(Order.from_dictionary, self.database.orders.find({'auctionId': auction_id})))
+
+    def write_standing_order(self, standing_order: StandingOrder) -> None:
+        standing_order_id = self.database.standing_orders.insert_one(standing_order.to_dictionary()).inserted_id
+        self.logger.info(
+            "Successfully included StandingOrder {}".format(standing_order_id))

--- a/event_listener/dfusion_db/generic_event_receiver.py
+++ b/event_listener/dfusion_db/generic_event_receiver.py
@@ -5,7 +5,7 @@ from django_eth_events.chainevents import AbstractEventReceiver
 
 from .snapp_event_receiver import DepositReceiver, StateTransitionReceiver, SnappInitializationReceiver
 from .snapp_event_receiver import WithdrawRequestReceiver, OrderReceiver, AuctionSettlementReceiver
-from .snapp_event_receiver import AuctionInitializationReceiver
+from .snapp_event_receiver import AuctionInitializationReceiver, StandingOrderBatchReceiver
 
 RECEIVER_MAPPING = {
     'Deposit': DepositReceiver(),
@@ -15,6 +15,7 @@ RECEIVER_MAPPING = {
     'SellOrder': OrderReceiver(),
     'AuctionSettlement': AuctionSettlementReceiver(),
     'AuctionInitialization': AuctionInitializationReceiver(),
+    'StandingSellOrderBatch': StandingOrderBatchReceiver(),
 }
 
 

--- a/event_listener/dfusion_db/models.py
+++ b/event_listener/dfusion_db/models.py
@@ -213,11 +213,12 @@ class OrderDetails(NamedTuple):
 class StandingOrder(NamedTuple):
     account_id: int
     batch_index: int
+    valid_from_auction_id: int
     orders: List[OrderDetails]
 
     @classmethod
     def from_dictionary(cls, data: Dict[str, Any]) -> "StandingOrder":
-        event_fields = ('currentBatchIndex', 'accountId', 'packedOrders')
+        event_fields = ('currentBatchIndex', 'accountId', 'packedOrders', 'validFromAuctionId')
         assert all(k in data for k in event_fields), "Unexpected Event Keys: got {}".format(data.keys())
 
         packed_order_str = data['packedOrders']
@@ -225,6 +226,7 @@ class StandingOrder(NamedTuple):
         return StandingOrder(
             int(data['accountId']),
             int(data['currentBatchIndex']),
+            int(data['validFromAuctionId']),
             list(map(OrderDetails.from_bytes, packed_order_array))
         )
 
@@ -232,6 +234,7 @@ class StandingOrder(NamedTuple):
         return {
             'accountId': self.account_id,
             'batchIndex': self.batch_index,
+            'validFromAuctionId': self.valid_from_auction_id,
             'orders': list(map(lambda o: o.to_dictionary(), self.orders))
         }
 

--- a/event_listener/dfusion_db/snapp_event_receiver.py
+++ b/event_listener/dfusion_db/snapp_event_receiver.py
@@ -3,7 +3,8 @@ from abc import ABC, abstractmethod
 from typing import Dict, Any, Union, List, Optional
 
 from .database_interface import DatabaseInterface, MongoDbInterface
-from .models import Deposit, StateTransition, TransitionType, Withdraw, AccountRecord, Order, AuctionSettlement
+from .models import Deposit, StateTransition, TransitionType, Withdraw, AccountRecord, Order, AuctionSettlement,\
+    StandingOrder
 
 
 class SnappEventListener(ABC):
@@ -169,3 +170,11 @@ class AuctionSettlementReceiver(SnappEventListener):
 
         new_account_record = AccountRecord(settlement.state_index, settlement.state_hash, balances)
         self.database.write_account_state(new_account_record)
+
+
+class StandingOrderBatchReceiver(SnappEventListener):
+    def save(self, event: Dict[str, Any], block_info: Dict[str, Any]) -> None:
+        self.save_parsed(StandingOrder.from_dictionary(event))
+
+    def save_parsed(self, standing_order: StandingOrder) -> None:
+        self.database.write_standing_order(standing_order)

--- a/event_listener/dfusion_db/tests/models_test.py
+++ b/event_listener/dfusion_db/tests/models_test.py
@@ -275,15 +275,16 @@ class StateTransitionTest(unittest.TestCase):
 
 class StandingOrderTest(unittest.TestCase):
     def test_from_dict(self) -> None:
-        first_order_detail = '01' + '02' + '00' * 11 + '03' + '00' * 11 + '04'
-        second_order_detail = '05' + '06' + '00' * 11 + '07' + '00' * 11 + '08'
+        first_order_detail = '00' * 11 + '03' + '00' * 11 + '04' + '02' + '01'
+        second_order_detail = '00' * 11 + '07' + '00' * 11 + '08' + '06' + '05' 
         standing_order_dict = {
             'accountId': 1,
             'currentBatchIndex': 2,
-            'orders': [first_order_detail, second_order_detail]
+            'validFromAuctionId': 3,
+            'packedOrders': first_order_detail + second_order_detail
         }
         expected = StandingOrder(
-            1, 2, [OrderDetails(1, 2, 3, 4), OrderDetails(5, 6, 7, 8)]
+            1, 2, 3, [OrderDetails(1, 2, 3, 4), OrderDetails(5, 6, 7, 8)]
         )
         parsed = StandingOrder.from_dictionary(standing_order_dict)
         self.assertEqual(expected, parsed)
@@ -293,16 +294,18 @@ class StandingOrderTest(unittest.TestCase):
             standing_order_dict = {
                 'accountId': 1,
                 'currentBatchIndex': 2,
+                'validFromAuctionId': 3
             }
             StandingOrder.from_dictionary(standing_order_dict)
 
     def test_to_dict(self) -> None:
         order = StandingOrder(
-            1, 2, [OrderDetails(1, 2, 3, 4), OrderDetails(5, 6, 7, 8)]
+            1, 2, 3, [OrderDetails(1, 2, 3, 4), OrderDetails(5, 6, 7, 8)]
         )
         expected = {
             'accountId': 1,
             'batchIndex': 2,
+            'validFromAuctionId': 3,
             'orders': [
                 {
                     'buyToken': 1,

--- a/event_listener/dfusion_db/tests/models_test.py
+++ b/event_listener/dfusion_db/tests/models_test.py
@@ -1,6 +1,6 @@
 import unittest
 from ..models import AccountRecord, AuctionResults, AuctionSettlement
-from ..models import Deposit, Order, StateTransition, TransitionType, Withdraw
+from ..models import Deposit, Order, StateTransition, TransitionType, Withdraw, StandingOrder, OrderDetails
 from ..exceptions import EventParseError
 
 
@@ -271,3 +271,51 @@ class StateTransitionTest(unittest.TestCase):
                 "slot": "fart",
             }
             StateTransition.from_dictionary(bad_transition_dict)
+
+
+class StandingOrderTest(unittest.TestCase):
+    def test_from_dict(self) -> None:
+        first_order_detail = '01' + '02' + '00' * 11 + '03' + '00' * 11 + '04'
+        second_order_detail = '05' + '06' + '00' * 11 + '07' + '00' * 11 + '08'
+        standing_order_dict = {
+            'accountId': 1,
+            'currentBatchIndex': 2,
+            'orders': [first_order_detail, second_order_detail]
+        }
+        expected = StandingOrder(
+            1, 2, [OrderDetails(1, 2, 3, 4), OrderDetails(5, 6, 7, 8)]
+        )
+        parsed = StandingOrder.from_dictionary(standing_order_dict)
+        self.assertEqual(expected, parsed)
+
+    def test_from_dict_failure(self) -> None:
+        with self.assertRaises(AssertionError):
+            standing_order_dict = {
+                'accountId': 1,
+                'currentBatchIndex': 2,
+            }
+            StandingOrder.from_dictionary(standing_order_dict)
+
+    def test_to_dict(self) -> None:
+        order = StandingOrder(
+            1, 2, [OrderDetails(1, 2, 3, 4), OrderDetails(5, 6, 7, 8)]
+        )
+        expected = {
+            'accountId': 1,
+            'batchIndex': 2,
+            'orders': [
+                {
+                    'buyToken': 1,
+                    'sellToken': 2,
+                    'buyAmount': '3',
+                    'sellAmount': '4',
+                },
+                {
+                    'buyToken': 5,
+                    'sellToken': 6,
+                    'buyAmount': '7',
+                    'sellAmount': '8',
+                }
+            ]
+        }
+        self.assertEqual(expected, order.to_dictionary())

--- a/event_listener/dfusion_db/tests/models_test.py
+++ b/event_listener/dfusion_db/tests/models_test.py
@@ -276,7 +276,7 @@ class StateTransitionTest(unittest.TestCase):
 class StandingOrderTest(unittest.TestCase):
     def test_from_dict(self) -> None:
         first_order_detail = '00' * 11 + '03' + '00' * 11 + '04' + '02' + '01'
-        second_order_detail = '00' * 11 + '07' + '00' * 11 + '08' + '06' + '05' 
+        second_order_detail = '00' * 11 + '07' + '00' * 11 + '08' + '06' + '05'
         standing_order_dict = {
             'accountId': 1,
             'currentBatchIndex': 2,

--- a/event_listener/dfusion_db/tests/snapp_event_receiver_test.py
+++ b/event_listener/dfusion_db/tests/snapp_event_receiver_test.py
@@ -354,6 +354,6 @@ class StandingOrderBatchReceiverTest(unittest.TestCase):
     def test_writes_order() -> None:
         database = Mock()
         receiver = StandingOrderBatchReceiver(database)
-        order = StandingOrder(1, 2, [])
+        order = StandingOrder(1, 2, 3, [])
         receiver.save_parsed(order)
         database.write_standing_order.assert_called_with(order)

--- a/event_listener/dfusion_db/tests/snapp_event_receiver_test.py
+++ b/event_listener/dfusion_db/tests/snapp_event_receiver_test.py
@@ -1,10 +1,10 @@
 import unittest
 from unittest.mock import Mock
 from typing import List
-from ..snapp_event_receiver import DepositReceiver, OrderReceiver, SnappInitializationReceiver
-from ..snapp_event_receiver import WithdrawRequestReceiver, StateTransitionReceiver
-from ..snapp_event_receiver import AuctionSettlementReceiver, AuctionInitializationReceiver
-from ..models import Deposit, StateTransition, TransitionType, Withdraw, AccountRecord, Order
+from ..snapp_event_receiver import DepositReceiver, OrderReceiver, SnappInitializationReceiver, \
+    WithdrawRequestReceiver, StateTransitionReceiver, AuctionSettlementReceiver, AuctionInitializationReceiver, \
+    StandingOrderBatchReceiver
+from ..models import Deposit, StateTransition, TransitionType, Withdraw, AccountRecord, Order, StandingOrder
 
 EMPTY_STATE_HASH = "0x00000000000000000000000000000000000000000000000000000000000000"
 
@@ -346,3 +346,14 @@ class AuctionInitializationReceiverTest(unittest.TestCase):
         # Bad Key
         with self.assertRaises(AssertionError):
             receiver.save({"badKey": 1}, block_info={})
+
+
+class StandingOrderBatchReceiverTest(unittest.TestCase):
+
+    @staticmethod
+    def test_writes_order() -> None:
+        database = Mock()
+        receiver = StandingOrderBatchReceiver(database)
+        order = StandingOrder(1, 2, [])
+        receiver.save_parsed(order)
+        database.write_standing_order.assert_called_with(order)

--- a/test/e2e-tests-standing-order.sh
+++ b/test/e2e-tests-standing-order.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+cd dex-contracts/
+
+# Place standing order in current Auction (accountId, buyToken, sellToken, minBuy, maxSell)
+truffle exec scripts/standing_order.js 0 1 2 12 12
+
+# Check standing order has been recorded
+retry -t 5 "mongo dfusion2 --eval \"db.standing_orders.findOne({accountId:0, batchIndex:1, orders: [ { buyToken:1, sellToken:2, buyAmount:'12000000000000000000', sellAmount:'12000000000000000000' }]})\" | grep ObjectId"


### PR DESCRIPTION
This PR contains logic for processing *StandingSellOrderBatch* events. It depends on https://github.com/gnosis/dex-contracts/pull/97 and assumes that the order details are emitted as blobs.

For now it relies on unit tests to ensure functionality is correct.

## Test Plan
Once depending PR is landed, update submodule and run placeStandingOrder script. Observe that standing orders are added to the database.