### PR TITLE
[Listener] Consider standing orders when computing balance after AuctionSettlement

### DIFF
--- a/event_listener/dfusion_db/database_interface.py
+++ b/event_listener/dfusion_db/database_interface.py
@@ -140,7 +140,7 @@ class MongoDbInterface(DatabaseInterface):
 
         pipeline = [
             {"$match": {"validFromAuctionId": {"$lte": auction_id}}},
-            {"$sort": {"validFromAuctionId": -1}},
+            {"$sort": {"validFromAuctionId": -1, "_id": -1}},
             {"$group": {
                 "_id": "$accountId",
                 "batchIndex": {"$first": "$batchIndex"},

--- a/event_listener/dfusion_db/database_interface.py
+++ b/event_listener/dfusion_db/database_interface.py
@@ -136,7 +136,22 @@ class MongoDbInterface(DatabaseInterface):
             "Successfully included Order - {}".format(order_id))
 
     def get_orders(self, auction_id: int) -> List[Order]:
-        return list(map(Order.from_dictionary, self.database.orders.find({'auctionId': auction_id})))
+        orders = list(map(Order.from_dictionary, self.database.orders.find({'auctionId': auction_id})))
+
+        pipeline = [
+            {"$match": {"validFromAuctionId": {"$lte": auction_id}}},
+            {"$sort": {"validFromAuctionId": -1}},
+            {"$group": {
+                "_id": "$accountId",
+                "batchIndex": {"$first": "$batchIndex"},
+                "validFromAuctionId": {"$first": "$validFromAuctionId"},
+                "orders": {"$first": "$orders"}
+            }}
+        ]
+        standing_orders = list(map(StandingOrder.from_db_dictionary, self.database.standing_orders.aggregate(pipeline)))
+        for standing_order in standing_orders:
+            orders += standing_order.get_orders()
+        return orders
 
     def write_standing_order(self, standing_order: StandingOrder) -> None:
         standing_order_id = self.database.standing_orders.insert_one(standing_order.to_dictionary()).inserted_id

--- a/event_listener/dfusion_db/tests/models_test.py
+++ b/event_listener/dfusion_db/tests/models_test.py
@@ -322,3 +322,21 @@ class StandingOrderTest(unittest.TestCase):
             ]
         }
         self.assertEqual(expected, order.to_dictionary())
+
+    def test_from_db_dict(self) -> None:
+        standing_order_dict = {
+            "_id": 0,
+            "batchIndex": 1,
+            "validFromAuctionId": 2,
+            "orders": [{
+                "buyToken": 1,
+                "sellToken": 2,
+                "buyAmount": "1000000000000000000",
+                "sellAmount": "1000000000000000000"
+            }]
+        }
+        expected = StandingOrder(
+            0, 1, 2, [OrderDetails(1, 2, 1000000000000000000, 1000000000000000000)]
+        )
+        parsed = StandingOrder.from_db_dictionary(standing_order_dict)
+        self.assertEqual(expected, parsed)


### PR DESCRIPTION
When computing the updated balances after auction settlement, we now also need to consider the standing orders that were valid at the given time.

### Test plan
Unit test + e2e test in next PR