### PR TITLE
[trouble-shooting, just to explain my issue] Dirty solution with old web3 lib

### DIFF
--- a/driver/src/deposit_driver.rs
+++ b/driver/src/deposit_driver.rs
@@ -47,7 +47,7 @@ pub fn run_deposit_listener<D, C>(db: &D, contract: &C) -> Result<(bool), Driver
             let new_state_root = updated_balances.rolling_hash(balances.state_index + 1);
             
             info!("New State_hash is {}", new_state_root);
-            contract.apply_deposits(slot, state_root, new_state_root, contract_deposit_hash)?;
+            contract.apply_deposits(slot + 10, state_root, new_state_root, contract_deposit_hash)?;
             return Ok(true);
         } else {
             info!("Need to wait before processing deposit_slot {:?}", slot);

--- a/driver/src/error.rs
+++ b/driver/src/error.rs
@@ -30,7 +30,7 @@ impl From<std::io::Error> for DriverError {
 }
 impl From<web3::contract::Error> for DriverError {
     fn from(error: web3::contract::Error) -> Self {
-        DriverError::new(error.description(), ErrorKind::ContractError)
+        DriverError::new(&format!("{}", error), ErrorKind::JsonError)  
     }
 }
 impl From<web3::Error> for DriverError {


### PR DESCRIPTION
The code from this PR is based on the old web3 lib and prints extensive, but dirty error messages:
```
driver_1       | 2019-06-18 07:55:18,368 ERROR [driver] Deposit_driver error: RPC error: Error { code: ServerError(-32000), message: "VM Exception while processing transaction: revert Requested deposit slot does not exist", data: Some(Object({"0x29fb9f50f466e7a698101a0dcbf3286e66867728b2da81077e004742020759a4": Object({"error": String("revert"), "program_counter": Number(4776), "return": String("0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000025526571756573746564206465706f73697420736c6f7420646f6573206e6f74206578697374000000000000000000000000000000000000000000000000000000"), "reason": String("Requested deposit slot does not exist")}), "stack": String("o: VM Exception while processing transaction: revert Requested deposit slot does not exist\n    at Function.o.fromResults (/app/ganache-core.docker.cli.js:10:82299)\n    at /app/ganache-core.docker.cli.js:47:151756\n    at /app/ganache-core.docker.cli.js:47:128087\n    at b (/app/ganache-core.docker.cli.js:47:127744)\n    at /app/ganache-core.docker.cli.js:47:127797\n    at t.default (/app/ganache-core.docker.cli.js:52:259867)\n    at /app/ganache-core.docker.cli.js:47:128711\n    at _.n.emit (/app/ganache-core.docker.cli.js:61:1071339)\n    at /app/ganache-core.docker.cli.js:61:1710136\n    at /app/ganache-core.docker.cli.js:61:1710159\n    at /app/ganache-core.docker.cli.js:61:359815\n    at /app/ganache-core.docker.cli.js:2:69007\n    at i (/app/ganache-core.docker.cli.js:2:84062)\n    at /app/ganache-core.docker.cli.js:2:64530\n    at process._tickCallback (internal/process/next_tick.js:61:11)"), "name": String("o")})) }
```
The error messages is coming from the fact that I increased the slot index during apply_deposits