### PR TITLE
[Easy] adding dyn infront of trait types

### DIFF
--- a/driver/src/bin/main.rs
+++ b/driver/src/bin/main.rs
@@ -20,7 +20,7 @@ fn main() {
 
     let solver_env_var = env::var("LINEAR_OPTIMIZATION_SOLVER")
         .unwrap_or_else(|_| "0".to_string());
-    let mut price_finder : Box<PriceFinding> = if solver_env_var == "1" {
+    let mut price_finder : Box<dyn PriceFinding> = if solver_env_var == "1" {
         Box::new(LinearOptimisationPriceFinder::new())
     } else {
         Box::new(NaiveSolver {})

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -31,7 +31,7 @@ mod util;
 pub fn run_driver_components(
     db: &MongoDB,
     contract: &SnappContractImpl, 
-    price_finder: &mut Box<PriceFinding>,
+    price_finder: &mut Box<dyn PriceFinding>,
 ) {
     if let Err(e) = run_deposit_listener(db, contract) {
         error!("Deposit_driver error: {}", e);

--- a/driver/src/order_driver.rs
+++ b/driver/src/order_driver.rs
@@ -11,7 +11,7 @@ use web3::types::{U256, U128};
 pub fn run_order_listener<D, C>(
     db: &D, 
     contract: &C, 
-    price_finder: &mut Box<PriceFinding>
+    price_finder: &mut Box<dyn PriceFinding>
 ) -> Result<bool, DriverError>
     where   D: DbInterface,
             C: SnappContract,
@@ -153,7 +153,7 @@ mod tests {
             executed_buy_amounts: vec![0, 2],
         };
         pf.find_prices.given((orders, state)).will_return(Ok(expected_solution));
-        let mut pf_box : Box<PriceFinding> = Box::new(pf);
+        let mut pf_box : Box<dyn PriceFinding> = Box::new(pf);
 
         assert_eq!(run_order_listener(&db, &contract, &mut pf_box), Ok(true));
     }
@@ -166,7 +166,7 @@ mod tests {
         contract.has_auction_slot_been_applied.given(slot).will_return(Ok(true));
 
         let db = DbInterfaceMock::new();
-        let mut pf : Box<PriceFinding> = Box::new(PriceFindingMock::new());
+        let mut pf : Box<dyn PriceFinding> = Box::new(PriceFindingMock::new());
         assert_eq!(run_order_listener(&db, &contract, &mut pf), Ok(false));
     }
 
@@ -182,7 +182,7 @@ mod tests {
         contract.get_current_block_timestamp.given(()).will_return(Ok(U256::from(11)));
 
         let db = DbInterfaceMock::new();
-        let mut pf : Box<PriceFinding> = Box::new(PriceFindingMock::new());
+        let mut pf : Box<dyn PriceFinding> = Box::new(PriceFindingMock::new());
         assert_eq!(run_order_listener(&db, &contract, &mut pf), Ok(false));
     }
 
@@ -230,7 +230,7 @@ mod tests {
         };
         pf.find_prices.given((first_orders, state)).will_return(Ok(expected_solution));
 
-        let mut pf_box : Box<PriceFinding> = Box::new(pf);
+        let mut pf_box : Box<dyn PriceFinding> = Box::new(pf);
 
         assert_eq!(run_order_listener(&db, &contract, &mut pf_box), Ok(true));
         assert_eq!(run_order_listener(&db, &contract, &mut pf_box), Ok(true));
@@ -265,7 +265,7 @@ mod tests {
         db.get_orders_of_slot.given(1).will_return(Ok(orders.clone()));
         db.get_current_balances.given(state_hash).will_return(Ok(state.clone()));
 
-        let mut pf : Box<PriceFinding> = Box::new(PriceFindingMock::new());
+        let mut pf : Box<dyn PriceFinding> = Box::new(PriceFindingMock::new());
 
         let error = run_order_listener(&db, &contract, &mut pf).expect_err("Expected Error");
         assert_eq!(error.kind, ErrorKind::StateError);
@@ -306,7 +306,7 @@ mod tests {
         pf.find_prices
             .given((standing_order.get_orders().clone(), state))
             .will_return(Err(PriceFindingError::from("Trivial solution is fine")));
-        let mut pf_box : Box<PriceFinding> = Box::new(pf);
+        let mut pf_box : Box<dyn PriceFinding> = Box::new(pf);
 
         assert_eq!(run_order_listener(&db, &contract, &mut pf_box), Ok(true));
     }

--- a/driver/src/util.rs
+++ b/driver/src/util.rs
@@ -6,7 +6,7 @@ use web3::types::{H256, U256};
 
 pub fn find_first_unapplied_slot(
     upper_bound: U256,
-    has_slot_been_applied: Box<&Fn(U256) -> Result<bool, DriverError>>,
+    has_slot_been_applied: Box<&dyn Fn(U256) -> Result<bool, DriverError>>,
 ) -> Result<U256, DriverError> {
     if upper_bound == U256::max_value() {
         return Ok(U256::zero());
@@ -41,7 +41,7 @@ pub fn hash_consistency_check(
 pub fn can_process<C>(
     slot: U256,
     contract: &C,
-    creation_block: Box<&Fn(U256) -> Result<U256, DriverError>>,
+    creation_block: Box<&dyn Fn(U256) -> Result<U256, DriverError>>,
 ) -> Result<bool, DriverError>
 where
     C: SnappContract,


### PR DESCRIPTION
Removing a bunch of 

```
warning: trait objects without an explicit `dyn` are deprecated
```

on the newest rust version.

## Test plan
Compile without warnings.