### PR TITLE
David-Fix: README & .GITIGNORE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ venv.bak/
 .idea
 .vscode
 .DS_Store
+
+# VS
+.history

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ git clone git@github.com:gnosis/dex-services.git
 cd dex-services
 git submodule update --init
 cd dex-contracts 
-npm install && truffle compile 
+npm install && npx truffle compile 
 cd ../
 docker-compose up
 ```


### PR DESCRIPTION
1. `truffle compile` will use global install - `npx truffle compile` uses local version correctly (my install was failing)
2. added `.history` to `.gitignore` for users using it in VS