### PR TITLE
[Easy] showing docker compose logs after failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,5 +48,5 @@ matrix:
         - sh ./test/e2e-tests-auction.sh
         - sh ./test/restart-containers.sh
         - sh ./test/e2e-tests-standing-order.sh
-      after_script:
+      after_failure:
         - docker-compose logs


### PR DESCRIPTION
We are mainly interested in studying the docker logs after travis failures (as we seem to have some flakyness in our e2e tests which we should resolve). At the moment (e.g. https://travis-ci.org/gnosis/dex-services/jobs/559987321) we don't see the logs after failure.