### PR TITLE
[The Graph] Implementing a runtime to route events to specific handlers

### DIFF
--- a/listener/src/event_handler/mod.rs
+++ b/listener/src/event_handler/mod.rs
@@ -1,0 +1,19 @@
+use failure::Error;
+use slog::Logger;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use graph::components::ethereum::EthereumBlock;
+use graph::components::store::EntityOperation;
+
+use web3::types::{Log, Transaction};
+
+pub trait EventHandler: Send + Sync + Debug {
+    fn process_event(
+        &self,
+        logger: Logger,
+        block: Arc<EthereumBlock>,
+        transaction: Arc<Transaction>,
+        log: Arc<Log>
+    ) -> Result<Vec<EntityOperation>, Error>;
+}

--- a/listener/src/main.rs
+++ b/listener/src/main.rs
@@ -8,6 +8,7 @@ extern crate slog;
 
 mod runtime_host;
 mod link_resolver;
+mod event_handler;
 
 use lazy_static::lazy_static;
 use std::env;
@@ -36,7 +37,7 @@ use graph_server_websocket::SubscriptionServer as GraphQLSubscriptionServer;
 
 use graph_store_postgres::{Store as DieselStore, StoreConfig};
 
-use runtime_host::RustRuntimeHost;
+use runtime_host::RustRuntimeHostBuilder;
 use link_resolver::LocalLinkResolver;
 
 lazy_static! {
@@ -180,7 +181,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
     let subgraph_instance_manager = SubgraphInstanceManager::new(
         &logger_factory,
         store.clone(),
-        RustRuntimeHost {},
+        RustRuntimeHostBuilder {},
         block_stream_builder,
     );
     


### PR DESCRIPTION
This PR implements an interface which each event handler (e.g. Deposit, Withdraw, etc.) will implement. It also implements the RustRuntimeHandler which takes the events that are supposed to be processed according to the subgraph definition and forwards them to the specific event handler.

The next PR will implement the first concrete EventHandler (listening to Deposit events).

### Test Plan

In one console run:

```sh
docker-compose down && docker-compose up graph-listener
```

In another one run:
```sh
cd dex-contracts
truffle migrate
truffle exec scripts/setup_environment.js
truffle exec scripts/deposit.js 1 1 1
```

Observe the following print statements (and that the process no longer crashes)
```
INFO Received event, block_hash: ...
WARN Unhandled event with topic 0xba69…11ee, block_hash: ...
```