### PR TITLE
Refactor data types in rust models to make them consistent with SC

### DIFF
--- a/dfusion_rust_core/src/models/flux.rs
+++ b/dfusion_rust_core/src/models/flux.rs
@@ -1,14 +1,14 @@
 use byteorder::{BigEndian, WriteBytesExt};
 use serde_derive::{Deserialize, Serialize};
-use web3::types::H256;
+use web3::types::{H256, U256};
 
 use crate::models::{Serializable, RootHashable, merkleize};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug, Ord, PartialOrd, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct PendingFlux {
-  pub slot_index: u32,
-  pub slot: u32,
+  pub slot_index: u16,
+  pub slot: U256,
   pub account_id: u16,
   pub token_id: u8,
   pub amount: u128,
@@ -27,8 +27,8 @@ impl Serializable for PendingFlux {
 impl From<mongodb::ordered::OrderedDocument> for PendingFlux {
     fn from(document: mongodb::ordered::OrderedDocument) -> Self {
         PendingFlux {
-            slot_index: document.get_i32("slotIndex").unwrap() as u32,
-            slot: document.get_i32("slot").unwrap() as u32,
+            slot_index: document.get_i32("slotIndex").unwrap() as u16,
+            slot: U256::from(document.get_i32("slot").unwrap()),
             account_id: document.get_i32("accountId").unwrap() as u16,
             token_id: document.get_i32("tokenId").unwrap() as u8,
             amount: document.get_str("amount").unwrap().parse().unwrap(),
@@ -49,10 +49,10 @@ impl RootHashable for Vec<PendingFlux> {
 
 pub mod tests {
     use super::*;
-    pub fn create_flux_for_test(slot: u32, slot_index: u32) -> PendingFlux {
+    pub fn create_flux_for_test(slot: u32, slot_index: u16) -> PendingFlux {
         PendingFlux {
             slot_index,
-            slot,
+            slot: U256::from(slot),
             account_id: 1,
             token_id: 1,
             amount: 10,
@@ -70,7 +70,7 @@ pub mod unit_test {
   fn test_pending_flux_root_hash() {
     let deposit = PendingFlux {
       slot_index: 0,
-      slot: 0,
+      slot: U256::zero(),
       account_id: 3,
       token_id: 3,
       amount: 18,

--- a/dfusion_rust_core/src/models/mod.rs
+++ b/dfusion_rust_core/src/models/mod.rs
@@ -17,7 +17,7 @@ pub const NUM_RESERVED_ACCOUNTS: usize = 50;
 pub const DB_NAME: &str = "dfusion2";
 
 pub trait RollingHashable {
-    fn rolling_hash(&self, nonce: i32) -> H256;
+    fn rolling_hash(&self, nonce: u32) -> H256;
 }
 
 pub trait ConcatenatingHashable {

--- a/dfusion_rust_core/src/models/order.rs
+++ b/dfusion_rust_core/src/models/order.rs
@@ -45,7 +45,7 @@ impl From<mongodb::ordered::OrderedDocument> for Order {
 }
 
 impl<T: Serializable> RollingHashable for Vec<T> {
-    fn rolling_hash(&self, nonce: i32) -> H256 {
+    fn rolling_hash(&self, nonce: u32) -> H256 {
         self.iter().fold(H256::from(nonce as u64), |acc, w| iter_hash(w, &acc))
     }
 }

--- a/dfusion_rust_core/src/models/order.rs
+++ b/dfusion_rust_core/src/models/order.rs
@@ -46,7 +46,7 @@ impl From<mongodb::ordered::OrderedDocument> for Order {
 
 impl<T: Serializable> RollingHashable for Vec<T> {
     fn rolling_hash(&self, nonce: u32) -> H256 {
-        self.iter().fold(H256::from(nonce as u64), |acc, w| iter_hash(w, &acc))
+        self.iter().fold(H256::from(u64::from(nonce)), |acc, w| iter_hash(w, &acc))
     }
 }
 

--- a/dfusion_rust_core/src/models/standing_order.rs
+++ b/dfusion_rust_core/src/models/standing_order.rs
@@ -1,6 +1,6 @@
 use serde_derive::{Deserialize};
 use sha2::{Digest, Sha256};
-use web3::types::H256;
+use web3::types::{H256, U256};
 use crate::models::{ConcatenatingHashable, RollingHashable};
 use crate::models;
 use array_macro::array;
@@ -10,12 +10,12 @@ use array_macro::array;
 #[serde(rename_all = "camelCase")]
 pub struct StandingOrder {
     pub account_id: u16,
-    pub batch_index: u32,
+    pub batch_index: U256,
     orders: Vec<super::Order>,
 }
 
 impl StandingOrder {
-    pub fn new(account_id: u16, batch_index: u32, orders: Vec<super::Order>) -> StandingOrder {
+    pub fn new(account_id: u16, batch_index: U256, orders: Vec<super::Order>) -> StandingOrder {
         StandingOrder { account_id, batch_index, orders }
     }
     pub fn empty_array() -> [models::StandingOrder; models::NUM_RESERVED_ACCOUNTS]{
@@ -29,7 +29,7 @@ impl StandingOrder {
         self.orders.len()
     }
     pub fn empty(account_id: u16) -> StandingOrder {
-        models::StandingOrder::new(account_id, 0, vec![])
+        models::StandingOrder::new(account_id, U256::zero(), vec![])
     }
 }
 
@@ -47,7 +47,7 @@ impl ConcatenatingHashable for [models::StandingOrder; models::NUM_RESERVED_ACCO
 impl From<mongodb::ordered::OrderedDocument> for StandingOrder {
     fn from(document: mongodb::ordered::OrderedDocument) -> Self {
         let account_id = document.get_i32("_id").unwrap() as u16;
-        let batch_index = document.get_i32("batchIndex").unwrap() as u32;
+        let batch_index = U256::from(document.get_i32("batchIndex").unwrap());
         StandingOrder {
             account_id,
             batch_index,
@@ -77,7 +77,7 @@ pub mod tests {
   #[test]
   fn test_concatenating_hash() {
     let standing_order = models::StandingOrder::new(
-        1, 0, vec![create_order_for_test(), create_order_for_test()]
+        1, U256::zero(), vec![create_order_for_test(), create_order_for_test()]
     );
     let mut standing_orders = models::StandingOrder::empty_array();
     standing_orders[1] = standing_order;

--- a/dfusion_rust_core/src/models/state.rs
+++ b/dfusion_rust_core/src/models/state.rs
@@ -1,21 +1,21 @@
 use byteorder::{BigEndian, WriteBytesExt};
 use serde_derive::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use web3::types::H256;
+use web3::types::{H256, U256};
 
 use crate::models::{TOKENS, RollingHashable};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct State {
-    pub state_hash: String,
-    pub state_index: i32,
+    pub state_hash: H256,
+    pub state_index: U256,
     balances: Vec<u128>,
     pub num_tokens: u8,
 }
 
 impl State {
-    pub fn new(state_hash: String, state_index: i32, balances: Vec<u128>, num_tokens: u8) -> Self {
+    pub fn new(state_hash: H256, state_index: U256, balances: Vec<u128>, num_tokens: u8) -> Self {
         State { state_hash, state_index, balances, num_tokens }
     }
     fn balance_index(&self, token_id: u8, account_id: u16) -> usize {
@@ -43,9 +43,9 @@ impl State {
 
 impl RollingHashable for State {
   //Todo: Exchange sha with pederson hash
-  fn rolling_hash(&self, nonce: i32) -> H256 {
+  fn rolling_hash(&self, nonce: u32) -> H256 {
     let mut hash = vec![0u8; 28];
-    hash.write_i32::<BigEndian>(nonce).unwrap();
+    hash.write_u32::<BigEndian>(nonce).unwrap();
     for i in &self.balances {
       let mut bs = vec![0u8; 16];
       bs.write_u128::<BigEndian>(*i).unwrap();
@@ -63,8 +63,11 @@ impl RollingHashable for State {
 impl From<mongodb::ordered::OrderedDocument> for State {
     fn from(document: mongodb::ordered::OrderedDocument) -> Self {
         State {
-            state_hash: document.get_str("stateHash").unwrap().to_owned(),
-            state_index: document.get_i32("stateIndex").unwrap(),
+            state_hash: document.get_str("stateHash")
+                .unwrap()
+                .parse::<H256>()
+                .unwrap(),
+            state_index: U256::from(document.get_i32("stateIndex").unwrap()),
             balances: document.get_array("balances")
                 .unwrap()
                 .iter()
@@ -79,34 +82,35 @@ impl From<mongodb::ordered::OrderedDocument> for State {
 pub mod tests {
   use super::*;
   use web3::types::{H256};
-  use std::str::FromStr;
 
   #[test]
   fn test_state_rolling_hash() {
     // Empty state
     let mut balances = vec![0; 3000];
+    let state_hash = "77b01abfbad57cb7a1344b12709603ea3b9ad803ef5ea09814ca212748f54733".parse::<H256>().unwrap();
     let state = State {
-        state_hash: "77b01abfbad57cb7a1344b12709603ea3b9ad803ef5ea09814ca212748f54733".to_string(),
-        state_index:  1,
+        state_hash: state_hash.clone(),
+        state_index:  U256::one(),
         balances: balances.clone(),
         num_tokens: TOKENS,
     };
     assert_eq!(
       state.rolling_hash(0),
-      H256::from_str(&state.state_hash).unwrap()
+      state_hash
     );
 
     // State with single deposit
     balances[62] = 18;
+    let state_hash = "a0cde336d10dbaf3df98ba662bacf25d95062db7b3e0083bd4bad4a6c7a1cd41".parse::<H256>().unwrap();
     let state = State {
-        state_hash: "a0cde336d10dbaf3df98ba662bacf25d95062db7b3e0083bd4bad4a6c7a1cd41".to_string(),
-        state_index:  1,
+        state_hash: state_hash.clone(),
+        state_index:  U256::one(),
         balances,
         num_tokens: TOKENS,
     };
     assert_eq!(
       state.rolling_hash(0),
-      H256::from_str(&state.state_hash).unwrap()
+      state_hash
     );
   }
 }

--- a/driver/src/deposit_driver.rs
+++ b/driver/src/deposit_driver.rs
@@ -42,7 +42,7 @@ pub fn run_deposit_listener<D, C>(db: &D, contract: &C) -> Result<(bool), Driver
             hash_consistency_check(deposit_hash, contract_deposit_hash, "deposit")?;
 
             let updated_balances = apply_deposits(&balances, &deposits);
-            let new_state_root = updated_balances.rolling_hash(balances.state_index + 1);
+            let new_state_root = updated_balances.rolling_hash(balances.state_index.low_u32() + 1);
             
             info!("New State_hash is {}", new_state_root);
             contract.apply_deposits(slot, state_root, new_state_root, contract_deposit_hash)?;
@@ -73,8 +73,8 @@ mod tests {
         let state_hash = H256::zero();
         let deposits = vec![create_flux_for_test(1,1), create_flux_for_test(1,2)];
         let state = State::new(
-            format!("{:x}", state_hash),
-            1,
+            state_hash,
+            U256::one(),
             vec![100; (models::TOKENS * 2) as usize],
             models::TOKENS,
         );
@@ -102,8 +102,8 @@ mod tests {
         let state_hash = H256::zero();
 
         let state = State::new(
-            format!("{:x}", state_hash),
-            1,
+            state_hash,
+            U256::one(),
             vec![100; (models::TOKENS * 2) as usize],
             models::TOKENS,
         );
@@ -130,8 +130,8 @@ mod tests {
         let deposits = vec![create_flux_for_test(1,1), create_flux_for_test(1,2)];
 
         let state = State::new(
-            format!("{:x}", state_hash),
-            1,
+            state_hash,
+            U256::one(),
             vec![100; (models::TOKENS * 2) as usize],
             models::TOKENS,
         );
@@ -173,8 +173,8 @@ mod tests {
         contract.apply_deposits.given((slot - 1, Any, Any, Any)).will_return(Ok(()));
 
         let state = State::new(
-            format!("{:x}", state_hash),
-            1,
+            state_hash,
+            U256::one(),
             vec![100; (models::TOKENS * 2) as usize],
             models::TOKENS,
         );
@@ -194,8 +194,8 @@ mod tests {
         let deposits = vec![create_flux_for_test(1,1), create_flux_for_test(1,2)];
 
         let state = State::new(
-            format!("{:x}", state_hash),
-            1,
+            state_hash,
+            U256::one(),
             vec![100; (models::TOKENS * 2) as usize],
             models::TOKENS,
         );

--- a/driver/src/order_driver.rs
+++ b/driver/src/order_driver.rs
@@ -76,7 +76,7 @@ pub fn run_order_listener<D, C>(
 
             // Compute updated balances
             update_balances(&mut state, &orders, &solution);
-            let new_state_root = state.rolling_hash(state.state_index + 1);
+            let new_state_root = state.rolling_hash(state.state_index.low_u32() + 1);
             
             info!("New State_hash is {}, Solution: {:?}", new_state_root, solution);
 
@@ -122,8 +122,8 @@ mod tests {
         let state_hash = H256::zero();
         let orders = vec![create_order_for_test(), create_order_for_test()];
         let state = State::new(
-            format!("{:x}", state_hash),
-            1,
+            state_hash,
+            U256::one(),
             vec![100; (TOKENS * 2) as usize],
             TOKENS,
         );
@@ -209,8 +209,8 @@ mod tests {
         contract.apply_auction.given((slot - 1, Any, Any, Any, Any, Any)).will_return(Ok(()));
 
         let state = State::new(
-            format!("{:x}", state_hash),
-            1,
+            state_hash,
+            U256::one(),
             vec![100; (TOKENS * 2) as usize],
             TOKENS,
         );
@@ -241,8 +241,8 @@ mod tests {
         let orders = vec![create_order_for_test(), create_order_for_test()];
 
         let state = State::new(
-            format!("{:x}", state_hash),
-            1,
+            state_hash,
+            U256::one(),
             vec![100; (TOKENS * 2) as usize],
             TOKENS,
         );
@@ -273,12 +273,12 @@ mod tests {
         let slot = U256::from(1);
         let state_hash = H256::zero();
         let standing_order = StandingOrder::new(
-            1, 0, vec![create_order_for_test(), create_order_for_test()]
+            1, U256::zero(), vec![create_order_for_test(), create_order_for_test()]
         );
 
         let state = State::new(
-            format!("{:x}", state_hash),
-            1,
+            state_hash,
+            U256::one(),
             vec![100; (TOKENS * 2) as usize],
             TOKENS,
         );
@@ -312,10 +312,10 @@ mod tests {
     #[test]
     fn test_get_standing_orders_indexes(){
         let standing_order = StandingOrder::new(
-            1, 3, vec![create_order_for_test(), create_order_for_test()]
+            1, U256::from(3), vec![create_order_for_test(), create_order_for_test()]
         );
         let empty_order = StandingOrder::new(
-            0, 0, vec![]
+            0, U256::zero(), vec![]
         );
         let mut standing_orders = vec![empty_order; NUM_RESERVED_ACCOUNTS as usize];
         standing_orders[1] = standing_order.clone();
@@ -327,8 +327,8 @@ mod tests {
     #[test]
     fn test_update_balances(){
         let mut state = State::new(
-            "test".to_string(),
-            0,
+            H256::zero(),
+            U256::one(),
             vec![100; 70],
             TOKENS,
         );

--- a/driver/src/price_finding/linear_optimization_price_finder.rs
+++ b/driver/src/price_finding/linear_optimization_price_finder.rs
@@ -190,12 +190,13 @@ pub mod tests {
 
     use super::*;
     use std::error::Error;
+    use web3::types::H256;
 
     #[test]
     fn test_solver_keeps_prices_from_previous_result() {
         let state = models::State::new(
-            "hash".to_string(),
-            0,
+            H256::zero(),
+            U256::zero(),
             vec![0; 2],
             2
         );
@@ -435,8 +436,8 @@ pub mod tests {
     #[test]
     fn test_serialize_balances() {
         let state = models::State::new(
-            "test".to_string(),
-            0,
+            H256::zero(),
+            U256::zero(),
             vec![100, 200, 300, 400, 500, 600],
             3
         );
@@ -460,8 +461,8 @@ pub mod tests {
     #[should_panic]
     fn test_serialize_balances_with_bad_balance_length() {
         let state = models::State::new(
-            "test".to_string(),
-            0,
+            H256::zero(),
+            U256::zero(),
             vec![100, 200],
             30
         );

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -148,12 +148,13 @@ impl PriceFinding for NaiveSolver {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use web3::types::H256;
 
     #[test]
     fn test_type_ia() {
         let state = State::new(
-            "test".to_string(),
-            0,
+            H256::zero(),
+            U256::zero(),
             vec![200; (TOKENS * 2) as usize],
             TOKENS,
         );
@@ -181,8 +182,8 @@ pub mod tests {
     #[test]
     fn test_type_ib() {
         let state = State::new(
-            "test".to_string(),
-            0,
+            H256::zero(),
+            U256::zero(),
             vec![200; (TOKENS * 2) as usize],
             TOKENS,
         );
@@ -210,8 +211,8 @@ pub mod tests {
     #[test]
     fn test_type_ii() {
         let state = State::new(
-            "test".to_string(),
-            0,
+            H256::zero(),
+            U256::zero(),
             vec![200; (TOKENS * 2) as usize],
             TOKENS,
         );
@@ -239,8 +240,8 @@ pub mod tests {
     #[test]
     fn test_retreth_example() {
         let state = State::new(
-            "test".to_string(),
-            0,
+            H256::zero(),
+            U256::zero(),
             vec![200; (TOKENS * 6) as usize],
             TOKENS,
         );
@@ -296,8 +297,8 @@ pub mod tests {
     #[test]
     fn test_insufficient_balance() {
         let state = State::new(
-            "test".to_string(),
-            0,
+            H256::zero(),
+            U256::zero(),
             vec![0; (TOKENS * 2) as usize],
             TOKENS,
         );
@@ -325,8 +326,8 @@ pub mod tests {
     #[test]
     fn test_no_matches() {
         let state = State::new(
-            "test".to_string(),
-            0,
+            H256::zero(),
+            U256::zero(),
             vec![200; (TOKENS * 2) as usize],
             TOKENS,
         );

--- a/driver/src/withdraw_driver.rs
+++ b/driver/src/withdraw_driver.rs
@@ -49,7 +49,7 @@ pub fn run_withdraw_listener<D, C>(db: &D, contract: &C) -> Result<(bool), Drive
 
             let (updated_balances, valid_withdraws) = apply_withdraws(&balances, &withdraws);
             let withdrawal_merkle_root = withdraws.root_hash(&valid_withdraws);
-            let new_state_root = updated_balances.rolling_hash(balances.state_index + 1);
+            let new_state_root = updated_balances.rolling_hash(balances.state_index.low_u32() + 1);
             
             info!("New State_hash is {}, Valid Withdraw Merkle Root is {}", new_state_root, withdrawal_merkle_root);
             contract.apply_withdraws(slot, withdrawal_merkle_root, state_root, new_state_root, contract_withdraw_hash)?;
@@ -78,8 +78,8 @@ mod tests {
         let state_hash = H256::zero();
         let withdraws = vec![create_flux_for_test(1,1), create_flux_for_test(1,2)];
         let state = State::new(
-            format!("{:x}", state_hash),
-            1,
+            state_hash,
+            U256::one(),
             vec![100; (TOKENS * 2) as usize],
             TOKENS,
         );
@@ -149,8 +149,8 @@ mod tests {
         contract.apply_withdraws.given((slot - 1, Any, Any, Any, Any)).will_return(Ok(()));
 
         let state = State::new(
-            format!("{:x}", state_hash),
-            1,
+            state_hash,
+            U256::one(),
             vec![100; (TOKENS * 2) as usize],
             TOKENS,
         );
@@ -171,8 +171,8 @@ mod tests {
         let withdraws = vec![create_flux_for_test(1,1), create_flux_for_test(1,2)];
 
         let state = State::new(
-            format!("{:x}", state_hash),
-            1,
+            state_hash,
+            U256::one(),
             vec![100; (TOKENS * 2) as usize],
             TOKENS,
         );
@@ -202,14 +202,14 @@ mod tests {
         let state_hash = H256::zero();
         let withdraws = vec![create_flux_for_test(1,1), PendingFlux {
             slot_index: 2,
-            slot: 1,
+            slot: U256::one(),
             account_id: 0,
             token_id: 1,
             amount: 10,
         }];
         let mut state = State::new(
-            format!("{:x}", state_hash),
-            1,
+            state_hash,
+            U256::one(),
             vec![100; (TOKENS * 2) as usize],
             TOKENS,
         );


### PR DESCRIPTION
I noticed that the datatypes we use in our rust models and the datatypes used in the events that the smart contract emits are different. This PR attempts at unifying the two data models.

### Test plan
compilation and rust unit tests.