### PR TITLE
Remove `set -e` in travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ matrix:
         - docker-compose up -d ganache-cli driver listener | while read line ; do echo "$(date)| $line"; done; # prints timestamps for profiling
         - cd dex-contracts && retry truffle migrate && cd -
       script:
-        - set -e # make this script fail as soon as any individual command fail
         - sh ./test/e2e-tests-deposit-withdraw.sh
         - sh ./test/restart-containers.sh
         - sh ./test/e2e-tests-auction.sh

--- a/test/e2e-tests-deposit-withdraw.sh
+++ b/test/e2e-tests-deposit-withdraw.sh
@@ -28,7 +28,7 @@ truffle exec scripts/request_withdraw.js 2 2 18
 truffle exec scripts/wait_seconds.js 181
 
 # Expect that driver has processed withdraw slot and ensure updated balances are as expected
-EXPECTED_HASH="7b738197bfe79b6d394499b0cac0186cdc2f65ae2239f2e9e3c698709c80cb67"
+EXPECTED_HASH="7b738197bfe79b6d394499b0cac0186cdc2f65ae2239f2e9e3c698709c80cb67_BREAK"
 retry -t 5 "truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
 retry -t 5 "mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[62]\" | grep -w 0"
 

--- a/test/e2e-tests-deposit-withdraw.sh
+++ b/test/e2e-tests-deposit-withdraw.sh
@@ -28,7 +28,7 @@ truffle exec scripts/request_withdraw.js 2 2 18
 truffle exec scripts/wait_seconds.js 181
 
 # Expect that driver has processed withdraw slot and ensure updated balances are as expected
-EXPECTED_HASH="7b738197bfe79b6d394499b0cac0186cdc2f65ae2239f2e9e3c698709c80cb67_BREAK"
+EXPECTED_HASH="7b738197bfe79b6d394499b0cac0186cdc2f65ae2239f2e9e3c698709c80cb67"
 retry -t 5 "truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
 retry -t 5 "mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[62]\" | grep -w 0"
 


### PR DESCRIPTION
We still don't see the error logs when a travis build fails (e.g. https://travis-ci.org/gnosis/dex-services/jobs/560457456).

This is critical to find the reason for our flakyness. I believe that the reason could be the `set -e` command inside the script, which I assume makes travis immediately stop the build and all future commands.

Running an expectedly failing build to verify.