### PR TITLE
[The Graph] Adding Initialization event listener

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
         - npm install -C dex-contracts
         # driver/listener require compiled contracts
         - cd dex-contracts && truffle compile && cd -
-        - docker-compose up -d ganache-cli driver listener graph-listener | while read line ; do echo "$(date)| $line"; done; # prints timestamps for profiling
+        - docker-compose up -d driver listener graph-listener | while read line ; do echo "$(date)| $line"; done; # prints timestamps for profiling
         - cd dex-contracts && retry truffle migrate && cd -
       script:
         - sh ./test/e2e-tests-deposit-withdraw.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
         - npm install -C dex-contracts
         # driver/listener require compiled contracts
         - cd dex-contracts && truffle compile && cd -
-        - docker-compose up -d driver listener graph-listener | while read line ; do echo "$(date)| $line"; done; # prints timestamps for profiling
+        - docker-compose up -d ganache-cli driver listener graph-listener | while read line ; do echo "$(date)| $line"; done; # prints timestamps for profiling
         - cd dex-contracts && retry truffle migrate && cd -
       script:
         - sh ./test/e2e-tests-deposit-withdraw.sh

--- a/dfusion_rust_core/src/models/flux.rs
+++ b/dfusion_rust_core/src/models/flux.rs
@@ -1,13 +1,11 @@
 use byteorder::{BigEndian, WriteBytesExt};
-use graph::bigdecimal::BigDecimal;
 use graph::data::store::{Entity};
 use serde_derive::{Deserialize, Serialize};
-use std::str::FromStr;
 use std::sync::Arc;
 use web3::types::{H256, U256, Log};
 
 use crate::models::{Serializable, RootHashable, merkleize};
-use super::util::*;
+use super::util::{pop_u8_from_log_data, pop_u16_from_log_data, pop_u128_from_log_data, pop_u256_from_log_data, to_value};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug, Ord, PartialOrd, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -59,8 +57,8 @@ impl Into<Entity> for PendingFlux {
         let mut entity = Entity::new();
         entity.set("accountId", i32::from(self.account_id));
         entity.set("tokenId", i32::from(self.token_id));
-        entity.set("amount", BigDecimal::from_str(&self.amount.to_string()).unwrap());
-        entity.set("slot", BigDecimal::from_str(&self.slot.to_string()).unwrap());
+        entity.set("amount", to_value(&self.amount));
+        entity.set("slot", to_value(&self.slot));
         entity.set("slotIndex", i32::from(self.slot_index));
         entity
     }
@@ -93,6 +91,7 @@ pub mod tests {
 #[cfg(test)]
 pub mod unit_test {
   use super::*;
+  use graph::bigdecimal::BigDecimal;
   use web3::types::{H256, Bytes};
   use std::str::FromStr;
 

--- a/dfusion_rust_core/src/models/state.rs
+++ b/dfusion_rust_core/src/models/state.rs
@@ -1,9 +1,13 @@
 use byteorder::{BigEndian, WriteBytesExt};
+use graph::data::store::{Entity, Value};
 use serde_derive::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use web3::types::{H256, U256};
+use std::sync::Arc;
+use web3::types::{H256, U256, Log};
 
 use crate::models::{TOKENS, RollingHashable};
+
+use super::util::{pop_u8_from_log_data, pop_u16_from_log_data, pop_h256_from_log_data, to_value};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -63,7 +67,7 @@ impl RollingHashable for State {
 impl From<mongodb::ordered::OrderedDocument> for State {
     fn from(document: mongodb::ordered::OrderedDocument) -> Self {
         State {
-            state_hash: document.get_str("stateHash")
+            state_hash: document.get_str("state_hash")
                 .unwrap()
                 .parse::<H256>()
                 .unwrap(),
@@ -78,10 +82,36 @@ impl From<mongodb::ordered::OrderedDocument> for State {
     }
 }
 
+impl From<Arc<Log>> for State {
+    fn from(log: Arc<Log>) -> Self {
+        let mut bytes: Vec<u8> = log.data.0.clone();
+        let state_hash = pop_h256_from_log_data(&mut bytes);
+        let num_tokens = pop_u8_from_log_data(&mut bytes);
+        let num_accounts = pop_u16_from_log_data(&mut bytes);
+        State {
+            state_hash,
+            state_index: U256::zero(),
+            num_tokens,
+            balances: vec![0; num_tokens as usize * num_accounts as usize]
+        }
+    }
+}
+
+impl Into<Entity> for State {
+    fn into(self) -> Entity {
+        let mut entity = Entity::new();
+        entity.set("id", format!("{:#x}", &self.state_hash));
+        entity.set("stateIndex", to_value(&self.state_index));
+        entity.set("balances", self.balances.iter().map(to_value).collect::<Vec<Value>>());
+        entity.set("numTokens", i32::from(self.num_tokens));
+        entity
+    }
+}
+
 #[cfg(test)]
 pub mod tests {
   use super::*;
-  use web3::types::{H256};
+  use web3::types::{H256, Bytes};
 
   #[test]
   fn test_state_rolling_hash() {
@@ -112,5 +142,57 @@ pub mod tests {
       state.rolling_hash(0),
       state_hash
     );
+  }
+
+    #[test]
+  fn test_from_log() {
+      let bytes: Vec<Vec<u8>> = vec![
+        /* state_hash */ vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        /* num_tokens */ vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 30],
+        /* num_accounts */ vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 100],
+      ];
+
+      let log = Arc::new(Log {
+            address: 1.into(),
+            topics: vec![],
+            data: Bytes(bytes.iter().flat_map(|i| i.iter()).cloned().collect()),
+            block_hash: Some(2.into()),
+            block_number: Some(1.into()),
+            transaction_hash: Some(3.into()),
+            transaction_index: Some(0.into()),
+            log_index: Some(0.into()),
+            transaction_log_index: Some(0.into()),
+            log_type: None,
+            removed: None,
+        });
+
+        let expected_state = State {
+            state_hash: H256::zero(),
+            state_index:  U256::zero(),
+            balances: vec![0; 3000],
+            num_tokens: 30,
+        };
+
+        assert_eq!(expected_state, State::from(log));
+  }
+
+  #[test]
+  fn test_to_entity() {
+        let balances = vec![0, 18, 1];
+
+        let state = State {
+            state_hash: H256::zero(),
+            state_index:  U256::one(),
+            balances: balances.clone(),
+            num_tokens: TOKENS,
+        };
+        
+        let mut entity = Entity::new();
+        entity.set("id", "0x0000000000000000000000000000000000000000000000000000000000000000");
+        entity.set("stateIndex", to_value(&1));
+        entity.set("balances", balances.iter().map(to_value).collect::<Vec<Value>>());
+        entity.set("numTokens", i32::from(TOKENS));
+
+        assert_eq!(entity, state.into());
   }
 }

--- a/dfusion_rust_core/src/models/state.rs
+++ b/dfusion_rust_core/src/models/state.rs
@@ -67,7 +67,7 @@ impl RollingHashable for State {
 impl From<mongodb::ordered::OrderedDocument> for State {
     fn from(document: mongodb::ordered::OrderedDocument) -> Self {
         State {
-            state_hash: document.get_str("state_hash")
+            state_hash: document.get_str("stateHash")
                 .unwrap()
                 .parse::<H256>()
                 .unwrap(),

--- a/dfusion_rust_core/src/models/util.rs
+++ b/dfusion_rust_core/src/models/util.rs
@@ -1,5 +1,8 @@
 use std::convert::TryInto;
-use web3::types::U256;
+use graph::bigdecimal::BigDecimal;
+use graph::data::store::Value;
+use std::str::FromStr;
+use web3::types::{U256, H256};
 
 pub fn pop_u8_from_log_data(bytes: &mut Vec<u8>) -> u8 {
     pop_u256_from_log_data(bytes).as_u32().try_into().unwrap()
@@ -16,5 +19,17 @@ pub fn pop_u128_from_log_data(bytes: &mut Vec<u8>) -> u128 {
 pub fn pop_u256_from_log_data(bytes: &mut Vec<u8>) -> U256 {
     U256::from_big_endian(
         bytes.drain(0..32).collect::<Vec<u8>>().as_slice()
+    )
+}
+
+pub fn pop_h256_from_log_data(bytes: &mut Vec<u8>) -> H256 {
+    H256::from(
+        bytes.drain(0..32).collect::<Vec<u8>>().as_slice()
+    )
+}
+
+pub fn to_value<T: ToString>(value: &T) -> Value {
+    Value::from(
+        BigDecimal::from_str(&value.to_string()).unwrap()
     )
 }

--- a/listener/src/event_handler/initialization_handler.rs
+++ b/listener/src/event_handler/initialization_handler.rs
@@ -1,0 +1,34 @@
+use super::*;
+
+use dfusion_core::models::State;
+
+use graph::data::store::{Entity};
+
+#[derive(Debug, Clone)]
+pub struct InitializationHandler {}
+
+impl EventHandler for InitializationHandler {
+    fn process_event(
+        &self,
+        logger: Logger,
+        _block: Arc<EthereumBlock>,
+        _transaction: Arc<Transaction>,
+        log: Arc<Log>
+    ) -> Result<Vec<EntityOperation>, Error> {
+        info!(logger, "Processing Initialization Event {:?}", &log.data);
+        let state = State::from(log);
+        let entity: Entity = state.into();
+        
+        Ok(vec![
+            EntityOperation::Set {
+                key: util::entity_key(
+                    "AccountState", 
+                    &entity.get("id")
+                        .and_then(|v| v.clone().as_string())
+                        .unwrap()
+                ),
+                data: entity
+            }
+        ])
+    }
+}

--- a/listener/src/event_handler/initialization_handler.rs
+++ b/listener/src/event_handler/initialization_handler.rs
@@ -15,7 +15,7 @@ impl EventHandler for InitializationHandler {
         _transaction: Arc<Transaction>,
         log: Arc<Log>
     ) -> Result<Vec<EntityOperation>, Error> {
-        info!(logger, "Processing Initialization Event {:?}", &log.data);
+        info!(logger, "Processing SnappBase Initialization Event");
         let state = State::from(log);
         let entity: Entity = state.into();
         

--- a/listener/src/event_handler/mod.rs
+++ b/listener/src/event_handler/mod.rs
@@ -11,6 +11,9 @@ use web3::types::{Log, Transaction};
 mod deposit_handler;
 pub use deposit_handler::DepositHandler;
 
+mod initialization_handler;
+pub use initialization_handler::InitializationHandler;
+
 mod util;
 
 pub trait EventHandler: Send + Sync + Debug {

--- a/listener/src/runtime_host.rs
+++ b/listener/src/runtime_host.rs
@@ -13,8 +13,7 @@ use tiny_keccak::keccak256;
 
 use web3::types::{Log, Transaction, H256};
 
-use crate::event_handler::EventHandler;
-use crate::event_handler::DepositHandler;
+use crate::event_handler::{EventHandler, DepositHandler, InitializationHandler};
 
 type HandlerMap = HashMap<H256, Box<dyn EventHandler>>;
 
@@ -52,6 +51,11 @@ impl RustRuntimeHost {
             &mut handlers,
             "Deposit(uint16,uint8,uint128,uint256,uint16)",
             Box::new(DepositHandler {})
+        );
+        register_event(
+            &mut handlers,
+            "SnappInitialization(bytes32,uint8,uint16)",
+            Box::new(InitializationHandler {})
         );
         RustRuntimeHost {
             handlers

--- a/listener/subgraph_definition/dfusion
+++ b/listener/subgraph_definition/dfusion
@@ -18,5 +18,7 @@ dataSources:
       eventHandlers:
         - event: Deposit(uint16,uint8,uint128,uint256,uint16)
           handler: rust
+        - event: SnappInitialization(bytes32,uint8,uint16)
+          handler: rust
       file: 
         /: rustHandler.wasm

--- a/listener/subgraph_definition/schema.graphql
+++ b/listener/subgraph_definition/schema.graphql
@@ -6,3 +6,10 @@ type Deposit @entity {
     slot: BigInt!
     slotIndex: Int!
 }
+
+type AccountState @entity {
+    id: ID!
+    stateIndex: BigInt!
+    balances: [BigInt]!
+    numTokens: Int!
+}

--- a/test/e2e-tests-deposit-withdraw.sh
+++ b/test/e2e-tests-deposit-withdraw.sh
@@ -12,7 +12,7 @@ truffle exec scripts/setup_environment.js 6
 truffle exec scripts/deposit.js 2 2 18
 
 # check that deposit was added to the database
-retry -t 5 "source ../test/utils.sh && query_graphql \"{ deposits(where: { accountId: 2}) { amount } }\"" | grep 18000000000000000000
+retry -t 5 "source ../test/utils.sh && query_graphql \"{ deposits(where: { accountId: 2}) { amount } }\" | grep 18000000000000000000"
 
 # Wait till previous deposit slot becomes inactive
 truffle exec scripts/wait_seconds.js 181


### PR DESCRIPTION
This PR adds a new Graph handler for the SnappBase initialisation event. It creates the genesis state and writes it into the graph database.

### Test Plan

In one terminal run:
```
docker-compose down && docker-compose up graph-listener
```

In another terminal run:
```
cd dex-contracts
truffle migrate
```

See how the event is being handles in the log statements. To verify go to localhost:8000 and run the following query:

```graphql
query {
  accountStates {
    id
    numTokens 
    balances
  } 
}
```