### PR TITLE
[TheGraph] applyDepositHandler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
           - $HOME/.nvm/versions/node/v8.12.0/lib/node_modules
           - dex-contracts/node_modules/
       before_install:
-        - npm install -g truffle
+        - npm install -g truffle node-jq
         - sudo sh -c "curl https://raw.githubusercontent.com/kadwanev/retry/a1b1826bdb0a78189d5c70c858dc676f5133b1d7/retry -o /usr/local/bin/retry && chmod +x /usr/local/bin/retry"
       install:
         - git submodule update --init

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,6 +937,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "graph-mock"
+version = "0.13.2"
+source = "git+https://github.com/graphprotocol/graph-node?tag=v0.13.2#602fba1af5322ceeb58cc09c7120bdacbaa5cbea"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "graph 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
+ "graph-graphql 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
+ "graphql-parser 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "graph-runtime-derive"
 version = "0.13.2"
 source = "git+https://github.com/graphprotocol/graph-node?tag=v0.13.2#602fba1af5322ceeb58cc09c7120bdacbaa5cbea"
@@ -1332,6 +1345,7 @@ dependencies = [
  "graph 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
  "graph-core 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
  "graph-datasource-ethereum 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
+ "graph-mock 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
  "graph-server-http 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
  "graph-server-websocket 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
  "graph-store-postgres 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
@@ -3436,7 +3450,7 @@ name = "yaml-rust"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
@@ -3542,6 +3556,7 @@ dependencies = [
 "checksum graph-core 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)" = "<none>"
 "checksum graph-datasource-ethereum 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)" = "<none>"
 "checksum graph-graphql 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)" = "<none>"
+"checksum graph-mock 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)" = "<none>"
 "checksum graph-runtime-derive 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)" = "<none>"
 "checksum graph-runtime-wasm 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)" = "<none>"
 "checksum graph-server-http 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)" = "<none>"

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ truffle exec scripts/claim_withdraw.js 1 3 3
 Tests
 ========
 
+You need the following dependencies installed locally in order to run the e2e tests:
+- [mongo-cli](https://docs.mongodb.com/manual/installation/)
+- [jq](https://stedolan.github.io/jq/)
+
 For end-to-end tests, run from the project root:
 
 ```bash

--- a/dfusion_rust_core/src/models/flux.rs
+++ b/dfusion_rust_core/src/models/flux.rs
@@ -1,11 +1,11 @@
 use byteorder::{BigEndian, WriteBytesExt};
-use graph::data::store::{Entity};
+use graph::data::store::Entity;
 use serde_derive::{Deserialize, Serialize};
 use std::sync::Arc;
 use web3::types::{H256, U256, Log};
 
 use crate::models::{Serializable, RootHashable, merkleize};
-use super::util::{pop_u8_from_log_data, pop_u16_from_log_data, pop_u128_from_log_data, pop_u256_from_log_data, to_value};
+use super::util::*;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug, Ord, PartialOrd, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -48,6 +48,18 @@ impl From<Arc<Log>> for PendingFlux {
             amount: pop_u128_from_log_data(&mut bytes),
             slot: pop_u256_from_log_data(&mut bytes),
             slot_index: pop_u16_from_log_data(&mut bytes),
+        }
+    }
+}
+
+impl From<Entity> for PendingFlux {
+    fn from(entity: Entity) -> Self {
+        PendingFlux {
+            account_id: u16::from_entity(&entity, "accountId"),
+            token_id: u8::from_entity(&entity, "tokenId"),
+            amount: u128::from_entity(&entity, "amount"),
+            slot: U256::from_entity(&entity, "slot"),
+            slot_index: u16::from_entity(&entity, "slotIndex"),
         }
     }
 }
@@ -156,7 +168,7 @@ pub mod unit_test {
   }
 
   #[test]
-  fn test_to_entity() {
+  fn test_to_and_from_entity() {
       let flux = PendingFlux {
             account_id: 1,
             token_id: 1,
@@ -172,6 +184,7 @@ pub mod unit_test {
         entity.set("slot", BigDecimal::from(0));
         entity.set("slotIndex", 0);
 
-        assert_eq!(entity, flux.into());
+        assert_eq!(entity, flux.clone().into());
+        assert_eq!(flux, PendingFlux::from(entity));
   }
 }

--- a/dfusion_rust_core/src/models/mod.rs
+++ b/dfusion_rust_core/src/models/mod.rs
@@ -2,7 +2,7 @@ pub mod state;
 pub mod flux;
 pub mod order;
 pub mod standing_order;
-mod util;
+pub mod util;
 
 pub use crate::models::state::State;
 pub use crate::models::flux::PendingFlux;

--- a/dfusion_rust_core/src/models/util.rs
+++ b/dfusion_rust_core/src/models/util.rs
@@ -44,8 +44,8 @@ impl EntityParsing for u8 {
         u8::try_from(entity
             .get(field)
             .and_then(|value| value.clone().as_int())
-            .expect(&format!("Couldn't get field {} as uint", field))
-        ).expect(&format!("Couldn't cast {} from i32 to u8", field))
+            .unwrap_or_else(|| panic!("Couldn't get field {} as uint", field))
+        ).unwrap_or_else(|_| panic!("Couldn't cast {} from i32 to u8", field))
     }
 }
 
@@ -54,8 +54,8 @@ impl EntityParsing for u16 {
         u16::try_from(entity
             .get(field)
             .and_then(|value| value.clone().as_int())
-            .expect(&format!("Couldn't get field {} as uint", field))
-        ).expect(&format!("Couldn't cast {} from i32 to u16", field))
+            .unwrap_or_else(|| panic!("Couldn't get field {} as uint", field))
+        ).unwrap_or_else(|_| panic!("Couldn't cast {} from i32 to u16", field))
     }
 }
 
@@ -65,8 +65,8 @@ impl EntityParsing for u128 {
             .get(field)
             .and_then(|value| value.clone().as_big_decimal())
             .map(|decimal| decimal.to_string())
-            .expect(&format!("Couldn't get field {} as big decimal", field))
-        ).expect(&format!("Couldn't cast {} from string to u128", field))
+            .unwrap_or_else(|| panic!("Couldn't get field {} as big decimal", field))
+        ).unwrap_or_else(|_| panic!("Couldn't cast {} from string to u128", field))
     }
 }
 
@@ -76,8 +76,8 @@ impl EntityParsing for U256 {
             .get(field)
             .and_then(|value| value.clone().as_big_decimal())
             .map(|decimal| decimal.to_string())
-            .expect(&format!("Couldn't get field {} as big decimal", field))
-        ).expect(&format!("Couldn't cast {} from string to U256", field))
+            .unwrap_or_else(|| panic!("Couldn't get field {} as big decimal", field))
+        ).unwrap_or_else(|_| panic!("Couldn't cast {} from string to U256", field))
     }
 }
 
@@ -86,8 +86,8 @@ impl EntityParsing for H256 {
         H256::from_str(&entity
             .get(field)
             .and_then(|value| value.clone().as_string())
-            .expect(&format!("Couldn't get field {} as string", field))
-        ).expect(&format!("Couldn't cast {} from string to H256", field))
+            .unwrap_or_else(|| panic!("Couldn't get field {} as string", field))
+        ).unwrap_or_else(|_| panic!("Couldn't cast {} from string to H256", field))
     }
 }
 
@@ -102,7 +102,7 @@ impl EntityParsing for Vec<u128> {
                         &value.clone()
                             .as_big_decimal()
                             .map(|decimal| decimal.to_string())
-                            .expect(&format!("Couldn't convert value {} to big decimal", &value))
+                            .unwrap_or_else(|| panic!("Couldn't convert value {} to big decimal", &value))
                     ).unwrap_or_else(|_| panic!("Couldn't parse value {} to u128", &value)))
                 .collect::<Vec<u128>>()
             ).unwrap_or_else(|| panic!("Couldn't get field {} as list", field))

--- a/dfusion_rust_core/src/models/util.rs
+++ b/dfusion_rust_core/src/models/util.rs
@@ -1,6 +1,7 @@
 use std::convert::TryInto;
 use graph::bigdecimal::BigDecimal;
-use graph::data::store::Value;
+use graph::data::store::{Entity, Value};
+use std::convert::TryFrom;
 use std::str::FromStr;
 use web3::types::{U256, H256};
 
@@ -32,4 +33,78 @@ pub fn to_value<T: ToString>(value: &T) -> Value {
     Value::from(
         BigDecimal::from_str(&value.to_string()).unwrap()
     )
+}
+
+pub trait EntityParsing {
+    fn from_entity(entity: &Entity, field: &str) -> Self;
+}
+
+impl EntityParsing for u8 {
+    fn from_entity(entity: &Entity, field: &str) -> Self {
+        u8::try_from(entity
+            .get(field)
+            .and_then(|value| value.clone().as_int())
+            .expect(&format!("Couldn't get field {} as uint", field))
+        ).expect(&format!("Couldn't cast {} from i32 to u8", field))
+    }
+}
+
+impl EntityParsing for u16 {
+    fn from_entity(entity: &Entity, field: &str) -> Self {
+        u16::try_from(entity
+            .get(field)
+            .and_then(|value| value.clone().as_int())
+            .expect(&format!("Couldn't get field {} as uint", field))
+        ).expect(&format!("Couldn't cast {} from i32 to u16", field))
+    }
+}
+
+impl EntityParsing for u128 {
+    fn from_entity(entity: &Entity, field: &str) -> Self {
+        u128::from_str(&entity
+            .get(field)
+            .and_then(|value| value.clone().as_big_decimal())
+            .map(|decimal| decimal.to_string())
+            .expect(&format!("Couldn't get field {} as big decimal", field))
+        ).expect(&format!("Couldn't cast {} from string to u128", field))
+    }
+}
+
+impl EntityParsing for U256 {
+    fn from_entity(entity: &Entity, field: &str) -> Self {
+        U256::from_str(&entity
+            .get(field)
+            .and_then(|value| value.clone().as_big_decimal())
+            .map(|decimal| decimal.to_string())
+            .expect(&format!("Couldn't get field {} as big decimal", field))
+        ).expect(&format!("Couldn't cast {} from string to U256", field))
+    }
+}
+
+impl EntityParsing for H256 {
+    fn from_entity(entity: &Entity, field: &str) -> Self {
+        H256::from_str(&entity
+            .get(field)
+            .and_then(|value| value.clone().as_string())
+            .expect(&format!("Couldn't get field {} as string", field))
+        ).expect(&format!("Couldn't cast {} from string to H256", field))
+    }
+}
+
+impl EntityParsing for Vec<u128> {
+    fn from_entity(entity: &Entity, field: &str) -> Self {
+        entity
+            .get(field)
+            .and_then(|value| value.clone().as_list())
+            .map(|list| list
+                .into_iter()
+                .map(|value| u128::from_str(
+                        &value.clone()
+                            .as_big_decimal()
+                            .map(|decimal| decimal.to_string())
+                            .expect(&format!("Couldn't convert value {} to big decimal", &value))
+                    ).unwrap_or_else(|_| panic!("Couldn't parse value {} to u128", &value)))
+                .collect::<Vec<u128>>()
+            ).unwrap_or_else(|| panic!("Couldn't get field {} as list", field))
+    }
 }

--- a/listener/Cargo.toml
+++ b/listener/Cargo.toml
@@ -28,3 +28,6 @@ serde_yaml = "0.7"
 slog = "2.2.3"
 tiny-keccak = "1.4.2"
 web3 = { git = "https://github.com/graphprotocol/rust-web3", branch = "trace-struct-pre-ethereum-types" }
+
+[dev-dependencies]
+graph-mock = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }

--- a/listener/src/event_handler/deposit_handler.rs
+++ b/listener/src/event_handler/deposit_handler.rs
@@ -36,7 +36,7 @@ impl EventHandler for DepositHandler {
         
         Ok(vec![
             EntityOperation::Set {
-                key: util::entity_key("Deposit", &entity_id),
+                key: util::entity_key("Deposit", &entity),
                 data: entity
             }
         ])

--- a/listener/src/event_handler/flux_transition_handler.rs
+++ b/listener/src/event_handler/flux_transition_handler.rs
@@ -1,0 +1,209 @@
+use super::*;
+
+use dfusion_core::models::{PendingFlux, State};
+use dfusion_core::models::util::{pop_u8_from_log_data, pop_u256_from_log_data, pop_h256_from_log_data, to_value};
+
+use graph::components::store::{EntityFilter, Store};
+use graph::data::store::Entity;
+use std::fmt;
+use web3::types::U256;
+
+#[derive(Clone)]
+pub struct FluxTransitionHandler {
+    store: Arc<Store>,
+}
+
+impl FluxTransitionHandler {
+    pub fn new(store: Arc<Store>) -> Self {
+        FluxTransitionHandler{
+            store
+        }
+    }
+}
+
+impl Debug for FluxTransitionHandler {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "FluxTransitionHandler")
+    }
+}
+
+enum FluxTransitionType {
+    Deposit = 0,
+    Withdraw = 1,
+}
+
+impl From<u8> for FluxTransitionType {
+    fn from(tranition_type: u8) -> Self {
+        match tranition_type {
+            0 => FluxTransitionType::Deposit,
+            1 => FluxTransitionType::Withdraw,
+            _ => panic!("Unknown transition type: {}", tranition_type),
+        }
+    }
+}
+
+impl EventHandler for FluxTransitionHandler {
+    fn process_event(
+        &self,
+        logger: Logger,
+        _block: Arc<EthereumBlock>,
+        _transaction: Arc<Transaction>,
+        log: Arc<Log>
+    ) -> Result<Vec<EntityOperation>, Error> {
+        let mut data = log.data.0.clone();
+        let transition_type: FluxTransitionType = pop_u8_from_log_data(&mut data).into();
+        let state_index = pop_u256_from_log_data(&mut data).saturating_sub(U256::one());
+        let new_state_hash = pop_h256_from_log_data(&mut data);
+        let slot = pop_u256_from_log_data(&mut data);
+
+        info!(logger, "Received Flux State Transition Event");
+
+        let account_query = util::entity_query(
+            "AccountState", EntityFilter::Equal("stateIndex".to_string(), to_value(&state_index))
+        );
+        let mut account_state = State::from(self.store
+            .find_one(account_query)?
+            .ok_or_else(|| failure::err_msg(format!("No state record found for index {}", &state_index)))?
+        );
+
+        match transition_type {
+            FluxTransitionType::Deposit => {
+                let deposit_query = util::entity_query(
+                    "Deposit", EntityFilter::Equal("slot".to_string(), to_value(&slot))
+                );
+                let deposits = self.store
+                    .find(deposit_query)?
+                    .into_iter()
+                    .map(PendingFlux::from)
+                    .collect::<Vec<PendingFlux>>();
+                account_state.apply_deposits(&deposits);
+
+                let mut entity: Entity = account_state.into();
+                // We set the state root as claimed by the event
+                entity.set("id", format!("{:x}", new_state_hash));
+                Ok(vec![
+                    EntityOperation::Set {
+                        key: util::entity_key("AccountState", &entity),
+                        data: entity
+                    }
+                ])
+            },
+            FluxTransitionType::Withdraw => {
+                warn!(logger, "Withdraw handling not yet implementd");
+                Ok(vec![])
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+    use graph_mock::MockStore;
+    use web3::types::{Bytes, H256};
+
+    #[test]
+    fn test_applies_deposits_existing_state() {
+        let schema = util::test::fake_schema();
+        let store = Arc::new(MockStore::new(vec![(schema.id.clone(), schema)]));
+        let handler = FluxTransitionHandler::new(store.clone());
+
+        // Add previous account state and pending deposits into Store
+        let existing_state = State::new(H256::zero(), U256::zero(), vec![0, 0, 0, 0], 1);
+        let entity = existing_state.into();
+        store.apply_entity_operations(vec![EntityOperation::Set {
+            key: util::entity_key("AccountState", &entity),
+            data: entity
+        }], None).unwrap();
+
+        let first_deposit = PendingFlux {
+            slot_index: 0,
+            slot: U256::zero(),
+            account_id: 0,
+            token_id: 0,
+            amount: 10,
+        };
+        let mut entity: Entity = first_deposit.into();
+        entity.set("id", "1");
+        store.apply_entity_operations(vec![EntityOperation::Set {
+            key: util::entity_key("Deposit", &entity),
+            data: entity
+        }], None).unwrap();
+
+        let second_deposit = PendingFlux {
+            slot_index: 1,
+            slot: U256::zero(),
+            account_id: 1,
+            token_id: 0,
+            amount: 10,
+        };
+        let mut entity: Entity = second_deposit.into();
+        entity.set("id", "2");
+        store.apply_entity_operations(vec![EntityOperation::Set {
+            key: util::entity_key("Deposit", &entity),
+            data: entity
+        }], None).unwrap();
+
+        // Process event
+        let log = create_state_transition_event(FluxTransitionType::Deposit, 1, H256::from(1), 0);
+        let result = handler.process_event(
+            util::test::logger(), 
+            Arc::new(util::test::fake_block()),
+            Arc::new(util::test::fake_tx()), 
+            log
+        );
+        let expected_new_state = State::new(H256::from(1), U256::one(), vec![10, 10, 0, 0], 1);
+
+        assert!(result.is_ok());
+        match result.unwrap().pop().unwrap() {
+            EntityOperation::Set { key: _, data } => assert_eq!(State::from(data), expected_new_state),
+            _ => assert!(false)
+        }
+    }
+
+    #[test]
+    fn test_fails_if_state_does_not_exist() {
+        let schema = util::test::fake_schema();
+        let store = Arc::new(MockStore::new(vec![(schema.id.clone(), schema)]));
+        let handler = FluxTransitionHandler::new(store.clone());
+
+        // No data in store
+
+        let log = create_state_transition_event(FluxTransitionType::Deposit, 1, H256::from(1), 0);
+        let result = handler.process_event(
+            util::test::logger(), 
+            Arc::new(util::test::fake_block()),
+            Arc::new(util::test::fake_tx()), 
+            log
+        );
+        assert!(result.is_err());
+    }
+
+    fn create_state_transition_event(
+        transition_type: FluxTransitionType, 
+        new_state_index: u8, 
+        new_state_root: H256,
+        applied_slot: u8
+    ) -> Arc<Log> {
+        let bytes: Vec<Vec<u8>> = vec![
+            /* transition_type */ vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, transition_type as u8],
+            /* new_state_index */ vec![ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, new_state_index],
+            /* new_state_hash */ new_state_root[..].to_vec(),
+            /* applied_slot */ vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, applied_slot],
+        ];
+
+        Arc::new(Log {
+            address: 1.into(),
+            topics: vec![],
+            data: Bytes(bytes.iter().flat_map(|i| i.iter()).cloned().collect()),
+            block_hash: Some(2.into()),
+            block_number: Some(1.into()),
+            transaction_hash: Some(3.into()),
+            transaction_index: Some(0.into()),
+            log_index: Some(0.into()),
+            transaction_log_index: Some(0.into()),
+            log_type: None,
+            removed: None,
+        })
+    }
+}

--- a/listener/src/event_handler/initialization_handler.rs
+++ b/listener/src/event_handler/initialization_handler.rs
@@ -2,7 +2,7 @@ use super::*;
 
 use dfusion_core::models::State;
 
-use graph::data::store::{Entity};
+use graph::data::store::Entity;
 
 #[derive(Debug, Clone)]
 pub struct InitializationHandler {}
@@ -21,12 +21,7 @@ impl EventHandler for InitializationHandler {
         
         Ok(vec![
             EntityOperation::Set {
-                key: util::entity_key(
-                    "AccountState", 
-                    &entity.get("id")
-                        .and_then(|v| v.clone().as_string())
-                        .unwrap()
-                ),
+                key: util::entity_key("AccountState", &entity),
                 data: entity
             }
         ])

--- a/listener/src/event_handler/mod.rs
+++ b/listener/src/event_handler/mod.rs
@@ -14,6 +14,9 @@ pub use deposit_handler::DepositHandler;
 mod initialization_handler;
 pub use initialization_handler::InitializationHandler;
 
+mod flux_transition_handler;
+pub use flux_transition_handler::FluxTransitionHandler;
+
 mod util;
 
 pub trait EventHandler: Send + Sync + Debug {

--- a/listener/src/event_handler/util.rs
+++ b/listener/src/event_handler/util.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
-use graph::components::store::EntityKey;
+use graph::components::store::{EntityFilter, EntityKey, EntityQuery, EntityRange};
+use graph::data::store::Entity;
 use web3::types::Log;
 
 use crate::SUBGRAPH_ID;
@@ -11,10 +12,88 @@ pub fn entity_id_from_log(log: &Arc<Log>) -> String {
     )
 }
 
-pub fn entity_key(entity_type: &str, entity_id: &str) -> EntityKey {
+pub fn entity_key(entity_type: &str, entity: &Entity) -> EntityKey {
     EntityKey {
         subgraph_id: SUBGRAPH_ID.clone(),
         entity_type: entity_type.to_string(),
-        entity_id: entity_id.to_string(),
+        entity_id: entity.get("id")
+            .and_then(|v| v.clone().as_string())
+            .unwrap(),
+    }
+}
+
+pub fn entity_query(entity_type: &str, filter: EntityFilter) -> EntityQuery {
+    EntityQuery {
+        subgraph_id: SUBGRAPH_ID.clone(),
+        entity_types: vec![entity_type.to_string()],
+        filter: Some(filter),
+        order_by: None,
+        order_direction: None,
+        range: EntityRange {
+            first: None,
+            skip: 0
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+    use graph::components::ethereum::EthereumBlock;
+    use graph::data::schema::Schema;
+    use slog::Logger;
+    use web3::types::{Block, Bytes, H2048, H256, H160, Transaction, U256};
+
+    pub fn logger() -> Logger {
+        Logger::root(slog::Discard, o!())
+    }
+
+    pub fn fake_schema() -> Schema {
+        Schema::parse("scalar Foo", SUBGRAPH_ID.clone()).unwrap()
+    }
+
+    pub fn fake_tx() -> Transaction {
+        Transaction {
+            hash: H256::zero(),
+            nonce: U256::zero(),
+            block_hash: None,
+            block_number: None,
+            transaction_index: None,
+            from: H160::zero(),
+            to: None,
+            value: U256::zero(),
+            gas_price: U256::zero(),
+            gas: U256::zero(),
+            input: Bytes(vec![]),
+        }
+    }
+
+    pub fn fake_block() -> EthereumBlock{
+        EthereumBlock {
+            block: Block {
+                hash: None,
+                parent_hash: H256::zero(),
+                uncles_hash: H256::zero(),
+                author: H160::zero(),
+                state_root: H256::zero(),
+                transactions_root: H256::zero(),
+                receipts_root: H256::zero(),
+                number: None,
+                gas_used: U256::zero(),
+                gas_limit: U256::zero(),
+                extra_data: Bytes(vec![]),
+                logs_bloom: H2048::zero(),
+                timestamp: U256::zero(),
+                difficulty: U256::zero(),
+                total_difficulty: U256::zero(),
+                seal_fields: vec![],
+                uncles: vec![],
+                transactions: vec![],
+                size: None,
+                mix_hash: None,
+                nonce: None,
+            },
+            transaction_receipts: vec![],
+        }
     }
 }

--- a/listener/src/main.rs
+++ b/listener/src/main.rs
@@ -182,7 +182,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
     let subgraph_instance_manager = SubgraphInstanceManager::new(
         &logger_factory,
         store.clone(),
-        RustRuntimeHostBuilder {},
+        RustRuntimeHostBuilder::new(store.clone()),
         block_stream_builder,
     );
     

--- a/listener/subgraph_definition/dfusion
+++ b/listener/subgraph_definition/dfusion
@@ -20,5 +20,7 @@ dataSources:
           handler: rust
         - event: SnappInitialization(bytes32,uint8,uint16)
           handler: rust
+        - event: StateTransition(uint8,uint256,bytes32,uint256)
+          handler: rust
       file: 
         /: rustHandler.wasm

--- a/test/e2e-tests-deposit-withdraw.sh
+++ b/test/e2e-tests-deposit-withdraw.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Make sure jq is installed (retry doesn't give a good error message at the moment)
+jq --version
+
 cd dex-contracts
 truffle exec scripts/setup_environment.js 6
 


### PR DESCRIPTION
Apologies for the large PR, I already extracted the reorg of driver logic into the shared library in a separate PR but it still turned out quite big. I guess I could factor each of the things that's going on here into separate PRs which by themselves wouldn't make a ton of sense. Let me know if you prefer that.

What's going on here?

1. We register the event and event handler
2. We provide conversion methods to parse an Entity (read result from the GraphStore) into the respective data models (State, PendingFlux)
3. We implement the FluxTransitionHandler for deposits (withdraws will be handled later)
4. Unit + E2E tests

### Test Plan

Run the docker-compose in one terminal. Run the `e2e-tests-deposit-withdraw.sh` in another (after `truffle migrate`). At the end run the following query in the graphiql interface (localhost:8000):

```
query {
  accountStates {
    id
    numTokens 
  } 
}
```

You can also query for balances if you are ready to scroll a lot.