### PR TITLE
[easy] refactor util functions into traits

### DIFF
--- a/dfusion_rust_core/src/models/flux.rs
+++ b/dfusion_rust_core/src/models/flux.rs
@@ -43,11 +43,11 @@ impl From<Arc<Log>> for PendingFlux {
     fn from(log: Arc<Log>) -> Self {
         let mut bytes: Vec<u8> = log.data.0.clone();
         PendingFlux {
-            account_id: pop_u16_from_log_data(&mut bytes),
-            token_id: pop_u8_from_log_data(&mut bytes),
-            amount: pop_u128_from_log_data(&mut bytes),
-            slot: pop_u256_from_log_data(&mut bytes),
-            slot_index: pop_u16_from_log_data(&mut bytes),
+            account_id: u16::pop_from_log_data(&mut bytes),
+            token_id: u8::pop_from_log_data(&mut bytes),
+            amount: u128::pop_from_log_data(&mut bytes),
+            slot: U256::pop_from_log_data(&mut bytes),
+            slot_index: u16::pop_from_log_data(&mut bytes),
         }
     }
 }
@@ -67,11 +67,11 @@ impl From<Entity> for PendingFlux {
 impl Into<Entity> for PendingFlux {
     fn into(self) -> Entity {
         let mut entity = Entity::new();
-        entity.set("accountId", i32::from(self.account_id));
-        entity.set("tokenId", i32::from(self.token_id));
-        entity.set("amount", to_value(&self.amount));
-        entity.set("slot", to_value(&self.slot));
-        entity.set("slotIndex", i32::from(self.slot_index));
+        entity.set("accountId", self.account_id.to_value());
+        entity.set("tokenId", self.token_id.to_value());
+        entity.set("amount", self.amount.to_value());
+        entity.set("slot", self.slot.to_value());
+        entity.set("slotIndex", self.slot_index.to_value());
         entity
     }
 }

--- a/dfusion_rust_core/src/models/util.rs
+++ b/dfusion_rust_core/src/models/util.rs
@@ -5,34 +5,85 @@ use std::convert::TryFrom;
 use std::str::FromStr;
 use web3::types::{U256, H256};
 
-pub fn pop_u8_from_log_data(bytes: &mut Vec<u8>) -> u8 {
-    pop_u256_from_log_data(bytes).as_u32().try_into().unwrap()
+pub trait PopFromLogData {
+    fn pop_from_log_data(bytes: &mut Vec<u8>) -> Self;
 }
 
-pub fn pop_u16_from_log_data(bytes: &mut Vec<u8>) -> u16 {
-    pop_u256_from_log_data(bytes).as_u32().try_into().unwrap()
+impl PopFromLogData for u8 {
+    fn pop_from_log_data(bytes: &mut Vec<u8>) -> Self {
+        U256::pop_from_log_data(bytes).as_u32().try_into().unwrap()
+    }
 }
 
-pub fn pop_u128_from_log_data(bytes: &mut Vec<u8>) -> u128 {
-    pop_u256_from_log_data(bytes).to_string().parse().unwrap()
+impl PopFromLogData for u16 {
+    fn pop_from_log_data(bytes: &mut Vec<u8>) -> Self {
+        U256::pop_from_log_data(bytes).as_u32().try_into().unwrap()
+    }
 }
 
-pub fn pop_u256_from_log_data(bytes: &mut Vec<u8>) -> U256 {
-    U256::from_big_endian(
-        bytes.drain(0..32).collect::<Vec<u8>>().as_slice()
-    )
+impl PopFromLogData for u128 {
+    fn pop_from_log_data(bytes: &mut Vec<u8>) -> Self {
+        U256::pop_from_log_data(bytes).to_string().parse().unwrap()
+    }
 }
 
-pub fn pop_h256_from_log_data(bytes: &mut Vec<u8>) -> H256 {
-    H256::from(
-        bytes.drain(0..32).collect::<Vec<u8>>().as_slice()
-    )
+impl PopFromLogData for U256 {
+    fn pop_from_log_data(bytes: &mut Vec<u8>) -> Self {
+        U256::from_big_endian(
+            bytes.drain(0..32).collect::<Vec<u8>>().as_slice()
+        )
+    }
 }
 
-pub fn to_value<T: ToString>(value: &T) -> Value {
-    Value::from(
-        BigDecimal::from_str(&value.to_string()).unwrap()
-    )
+impl PopFromLogData for H256 {
+    fn pop_from_log_data(bytes: &mut Vec<u8>) -> Self {
+        H256::from(
+            bytes.drain(0..32).collect::<Vec<u8>>().as_slice()
+        )
+    }
+}
+
+pub trait ToValue {
+    fn to_value(&self) -> Value;
+}
+
+impl ToValue for u8 {
+    fn to_value(&self) -> Value {
+        i32::from(*self).into()
+    }
+}
+
+impl ToValue for u16 {
+    fn to_value(&self) -> Value {
+        i32::from(*self).into()
+    }
+}
+
+impl ToValue for u128 {
+    fn to_value(&self) -> Value {
+        BigDecimal::from_str(&self.to_string()).unwrap().into()
+    }
+}
+
+impl ToValue for U256 {
+    fn to_value(&self) -> Value {
+        BigDecimal::from_str(&self.to_string()).unwrap().into()
+    }
+}
+
+impl ToValue for H256 {
+    fn to_value(&self) -> Value {
+        format!("{:x}", self).into()
+    }
+}
+
+impl ToValue for Vec<u128> {
+    fn to_value(&self) -> Value {
+        self.iter()
+            .map(|balance| balance.to_value())
+            .collect::<Vec<Value>>()
+            .into()
+    }
 }
 
 pub trait EntityParsing {

--- a/listener/src/event_handler/flux_transition_handler.rs
+++ b/listener/src/event_handler/flux_transition_handler.rs
@@ -1,12 +1,12 @@
 use super::*;
 
 use dfusion_core::models::{PendingFlux, AccountState};
-use dfusion_core::models::util::{pop_u8_from_log_data, pop_u256_from_log_data, pop_h256_from_log_data, to_value};
+use dfusion_core::models::util::{PopFromLogData, ToValue};
 
 use graph::components::store::{EntityFilter, Store};
 use graph::data::store::Entity;
 use std::fmt;
-use web3::types::U256;
+use web3::types::{H256, U256};
 
 #[derive(Clone)]
 pub struct FluxTransitionHandler {
@@ -51,10 +51,10 @@ impl EventHandler for FluxTransitionHandler {
         log: Arc<Log>
     ) -> Result<Vec<EntityOperation>, Error> {
         let mut data = log.data.0.clone();
-        let transition_type: FluxTransitionType = pop_u8_from_log_data(&mut data).into();
-        let state_index = pop_u256_from_log_data(&mut data).saturating_sub(U256::one());
-        let new_state_hash = pop_h256_from_log_data(&mut data);
-        let slot = pop_u256_from_log_data(&mut data);
+        let transition_type: FluxTransitionType = u8::pop_from_log_data(&mut data).into();
+        let state_index = U256::pop_from_log_data(&mut data).saturating_sub(U256::one());
+        let new_state_hash = H256::pop_from_log_data(&mut data);
+        let slot = U256::pop_from_log_data(&mut data);
 
         info!(logger, "Received Flux AccountState Transition Event");
 
@@ -69,7 +69,7 @@ impl EventHandler for FluxTransitionHandler {
         match transition_type {
             FluxTransitionType::Deposit => {
                 let deposit_query = util::entity_query(
-                    "Deposit", EntityFilter::Equal("slot".to_string(), to_value(&slot))
+                    "Deposit", EntityFilter::Equal("slot".to_string(), slot.to_value())
                 );
                 let deposits = self.store
                     .find(deposit_query)?
@@ -80,7 +80,7 @@ impl EventHandler for FluxTransitionHandler {
 
                 let mut entity: Entity = account_state.into();
                 // We set the state root as claimed by the event
-                entity.set("id", format!("{:x}", new_state_hash));
+                entity.set("id", new_state_hash.to_value());
                 Ok(vec![
                     EntityOperation::Set {
                         key: util::entity_key("AccountState", &entity),

--- a/listener/src/event_handler/flux_transition_handler.rs
+++ b/listener/src/event_handler/flux_transition_handler.rs
@@ -59,7 +59,7 @@ impl EventHandler for FluxTransitionHandler {
         info!(logger, "Received Flux AccountState Transition Event");
 
         let account_query = util::entity_query(
-            "AccountState", EntityFilter::Equal("stateIndex".to_string(), to_value(&state_index))
+            "AccountState", EntityFilter::Equal("stateIndex".to_string(), state_index.to_value())
         );
         let mut account_state = AccountState::from(self.store
             .find_one(account_query)?


### PR DESCRIPTION
This PR refactors various utility methods, which we defined over the course of the last days to use traits that can be implemented on the underlying data types (rather than naming the functions slightly different).

First, this is a more rusty way of organizing helpers and secondly it increases type safety. Take for example the `to_value` function.

At the moment this was implemented for any T that implements to_string (e.g. U256 & H256). Under the hood it would convert the variable into a Value of subtype BigDecimal (cf. all options [here](https://github.com/graphprotocol/graph-node/blob/792735ffdfa685c9bbec565b4e3802e35f7f0690/graph/src/data/store/mod.rs#L134)).

While this is fine for U256, H256 should instead be converted into a hex formatted string.

Making `to_value` a trait function allows us to be explicit about how we want to implement it for each data type.
Note, that we cannot just reuse the existing [*std::convert::Into*](https://doc.rust-lang.org/std/convert/trait.Into.html) trait since neither `Value`, nor `U256` nor the `Into` trait itself are local to our module (thus we need to define our own).

### Test plan
 
![](https://miro.medium.com/max/1400/1*_XJgkCd4xD5uoDV2TJq-zw.jpeg)
