### PR TITLE
[E2E Tests] Improving print statements for easier debugging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
         # driver/listener require compiled contracts
         - cd dex-contracts && truffle compile && cd -
         - docker-compose up -d driver listener graph-listener | while read line ; do echo "$(date)| $line"; done; # prints timestamps for profiling
-        - cd dex-contracts && retry truffle migrate && cd -
+        - cd dex-contracts && sleep 1 && truffle migrate && cd -
       script:
         - sh ./test/e2e-tests-deposit-withdraw.sh
         - sh ./test/restart-containers.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ matrix:
           - dex-contracts/node_modules/
       before_install:
         - npm install -g truffle node-jq
-        - sudo sh -c "curl https://raw.githubusercontent.com/kadwanev/retry/a1b1826bdb0a78189d5c70c858dc676f5133b1d7/retry -o /usr/local/bin/retry && chmod +x /usr/local/bin/retry"
       install:
         - git submodule update --init
         - npm install -C dex-contracts

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,10 @@ matrix:
         - docker-compose up -d driver listener graph-listener | while read line ; do echo "$(date)| $line"; done; # prints timestamps for profiling
         - cd dex-contracts && sleep 1 && truffle migrate && cd -
       script:
-        - sh ./test/e2e-tests-deposit-withdraw.sh
-        - sh ./test/restart-containers.sh
-        - sh ./test/e2e-tests-auction.sh
-        - sh ./test/restart-containers.sh
-        - sh ./test/e2e-tests-standing-order.sh
+        - ./test/e2e-tests-deposit-withdraw.sh
+        - ./test/restart-containers.sh
+        - ./test/e2e-tests-auction.sh
+        - ./test/restart-containers.sh
+        - ./test/e2e-tests-standing-order.sh
       after_failure:
         - docker-compose logs

--- a/test/e2e-tests-auction.sh
+++ b/test/e2e-tests-auction.sh
@@ -1,42 +1,47 @@
 #!/bin/bash
-set -e
 
 cd dex-contracts
-truffle exec scripts/setup_environment.js 6
+source ../test/utils.sh
+
+step "Setup" \
+"truffle exec scripts/setup_environment.js 6"
 
 EXPECTED_AUCTION=0
 
-# Ensure no orders yet in auction slot 1
-mongo dfusion2 --eval "db.orders.find({'auctionId': ${EXPECTED_AUCTION}}).size()" | grep -w 0
+step "Ensure no orders yet in auction slot 1" \
+"mongo dfusion2 --eval \"db.orders.find({'auctionId': ${EXPECTED_AUCTION}}).size()\" | grep -w 0"
 
-# Make sure we have enough balances for the trades
-truffle exec scripts/deposit.js 0 2 300
-truffle exec scripts/deposit.js 1 1 300
-truffle exec scripts/deposit.js 2 2 200
-truffle exec scripts/deposit.js 3 1 300
-truffle exec scripts/deposit.js 4 0 300
-truffle exec scripts/deposit.js 5 0 300
+step "Make sure we have enough balances for the trades" \
+"truffle exec scripts/deposit.js 0 2 300 && \
+ truffle exec scripts/deposit.js 1 1 300 && \
+ truffle exec scripts/deposit.js 2 2 200 && \
+ truffle exec scripts/deposit.js 3 1 300 && \
+ truffle exec scripts/deposit.js 4 0 300 && \
+ truffle exec scripts/deposit.js 5 0 300"
 
-# Place 6 orders in current Auction (accountId, buyToken, sellToken, minBuy, maxSell)
-truffle exec scripts/sell_order.js 0 1 2 12 12
-truffle exec scripts/sell_order.js 1 2 1 2.2 2
-truffle exec scripts/sell_order.js 2 0 2 150 10
-truffle exec scripts/sell_order.js 3 0 1 180 15 # executed sell: 4
-truffle exec scripts/sell_order.js 4 1 0 4 52 # executed sell: 52
-truffle exec scripts/sell_order.js 5 2 0 20 280
+step "Place 6 orders in current Auction" \
+"truffle exec scripts/sell_order.js 0 1 2 12 12 && \
+ truffle exec scripts/sell_order.js 1 2 1 2.2 2 && \
+ truffle exec scripts/sell_order.js 2 0 2 150 10 && \
+ truffle exec scripts/sell_order.js 3 0 1 180 15 && \
+ truffle exec scripts/sell_order.js 4 1 0 4 52  && \
+ truffle exec scripts/sell_order.js 5 2 0 20 280"
 
-# Test Listener: There are now 6 orders in auction slot 1 and sellAmount for accountId = 5 is 280000000000000000000
-retry -t 5 "mongo dfusion2 --eval \"db.orders.find({'auctionId': ${EXPECTED_AUCTION}}).size()\" | grep -w 6"
-retry -t 5 "mongo dfusion2 --eval \"db.orders.findOne({'auctionId': ${EXPECTED_AUCTION}, 'accountId': 5}).sellAmount\" | grep -w 280000000000000000000"
+step_with_retry "Test Listener: There are now 6 orders in auction slot 1" \
+"mongo dfusion2 --eval \"db.orders.find({'auctionId': ${EXPECTED_AUCTION}}).size()\" | grep -w 6"
 
-truffle exec scripts/wait_seconds.js 181
+step_with_retry "sellAmount for accountId = 5 is 280000000000000000000" \
+"mongo dfusion2 --eval \"db.orders.findOne({'auctionId': ${EXPECTED_AUCTION}, 'accountId': 5}).sellAmount\" | grep -w 280000000000000000000"
 
-# Test balances have been updated
+step "Advance time to apply auction" \
+"truffle exec scripts/wait_seconds.js 181"
+
 EXPECTED_HASH="2b87dc830d051be72f4adcc3677daadab2f3f2253e9da51d803faeb0daa1532f"
-retry -t 5 "truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
+step_with_retry "Test balances have been updated" \
+"truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
 
-# Account 4 has now 4 of token 1 
-retry -t 5 "mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[121]\" | grep -w 4000000000000000000"
+step_with_retry "Account 4 has now 4 of token 1" \
+"mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[121]\" | grep -w 4000000000000000000"
 
-# Account 3 has now 52 of token 0
-retry -t 5 "mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[90]\" | grep -2 52000000000000000000"
+step_with_retry "Account 3 has now 52 of token 0" \
+"mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[90]\" | grep -2 52000000000000000000"

--- a/test/e2e-tests-deposit-withdraw.sh
+++ b/test/e2e-tests-deposit-withdraw.sh
@@ -1,53 +1,62 @@
 #!/bin/bash
-set -e
-
-# Make sure jq is installed (retry doesn't give a good error message at the moment)
-jq --version
 
 cd dex-contracts
-truffle exec scripts/setup_environment.js 6
+source ../test/utils.sh
+
+step "Setup" \
+"truffle exec scripts/setup_environment.js 6"
 
 ###############
 # Deposit Tests
 ###############
 
-# checks state after first new deposit round with a deposit of 18 from account 2 and token 2
-truffle exec scripts/deposit.js 2 2 18
+step "Deposit 18 of token 2 for user 2" \
+"truffle exec scripts/deposit.js 2 2 18"
 
-# check that deposit was added to the database
-retry -t 5 "source ../test/utils.sh && query_graphql \
-    'query { \
+step_with_retry "Deposit was added to graph db" \
+"source ../test/utils.sh && query_graphql \
+    \"query { \
         deposits(where: { accountId: 2}) { \
             amount \
         } \
-    }' | grep 18000000000000000000"
+    }\" | grep 18000000000000000000"
 
-# Wait till previous deposit slot becomes inactive
-truffle exec scripts/wait_seconds.js 181
+step "Advance time to finalize batch" \
+"truffle exec scripts/wait_seconds.js 181"
 
-# Expect that driver has processed deposit slot and ensure updated balances are as expected
 EXPECTED_HASH="73815c173218e6025f7cb12d0add44354c4671e261a34a360943007ff6ac7af5"
-retry -t 5 "truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
-retry -t 5 "mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '${EXPECTED_HASH}'}).balances[62]\" | grep -w 18000000000000000000"
-retry -t 5 "source ../test/utils.sh && query_graphql \
-    'query { \
+
+step_with_retry "Check contract updated" \
+"truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
+
+step_with_retry "Check mongo db updated" \
+"mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '${EXPECTED_HASH}'}).balances[62]\" | grep -w 18000000000000000000"
+
+step_with_retry "Check graph db updated" \
+"source ../test/utils.sh && query_graphql \
+    \"query { \
         accountStates(where: {id: \\\"${EXPECTED_HASH}\\\"}) {\
             balances \
         } \
-    }' | jq .data.accountStates[0].balances[62] | grep -w 18000000000000000000"
+    }\" | jq .data.accountStates[0].balances[62] | grep -w 18000000000000000000"
 
 ################
 # Withdraw Tests
 ################
 
-# Request withdraw of 18 of token 2 by account 2 and wait till withdraw slot becomes inactive.
-truffle exec scripts/request_withdraw.js 2 2 18
-truffle exec scripts/wait_seconds.js 181
+step "Request withdraw of 18 of token 2 by account 2" \
+    "truffle exec scripts/request_withdraw.js 2 2 18"
+step "wait till withdraw slot becomes inactive" "truffle exec scripts/wait_seconds.js 181"
 
-# Expect that driver has processed withdraw slot and ensure updated balances are as expected
 EXPECTED_HASH="7b738197bfe79b6d394499b0cac0186cdc2f65ae2239f2e9e3c698709c80cb67"
-retry -t 5 "truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
-retry -t 5 "mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[62]\" | grep -w 0"
+
+step_with_retry "Check contract updated" \
+"truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
+
+step_with_retry "Check mongo db updated" \
+ "mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[62]\" | grep -w 0"
 
 # Should now be able to claim withdraw and see a balance change
-truffle exec scripts/claim_withdraw.js 0 2 2 | grep "Success! Balance of token 2 before claim: 282000000000000000000, after claim: 300000000000000000000"
+step "Claim Withdraw" \
+"truffle exec scripts/claim_withdraw.js 0 2 2 | grep \"Success! Balance of token 2 before claim: 282000000000000000000, after claim: 300000000000000000000\""
+

--- a/test/restart-containers.sh
+++ b/test/restart-containers.sh
@@ -6,4 +6,4 @@ docker-compose up -d mongo
 docker-compose rm -sf ganache-cli
 docker-compose up -d ganache-cli
 docker-compose restart listener
-cd dex-contracts && retry truffle migrate && cd -
+cd dex-contracts && sleep 1 && truffle migrate && cd -

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -1,7 +1,66 @@
+RED="\033[1;31m"
+GREEN="\033[1;32m"
+NOCOLOR="\033[0m"
+
+CHECKMARK="\xE2\x9C\x94"
+CROSS="\xE2\x9D\x8C"
+
 query_graphql() {
-    curl -s \
+    echo "{ \"query\": \"" > query
+    echo ${1//\"/\\\"} >> query
+    echo "\" }" >> query
+    result=$(curl -s \
         -X POST \
         -H "Content-Type: application/json" \
-        --data "{ \"query\": \" $1 \" }" \
-        http://localhost:8000/subgraphs/name/dfusion
+        --data @query \
+        http://localhost:8000/subgraphs/name/dfusion)
+    rm query
+    echo $result
+}
+# Takes two arguments
+# 1) a string describing the step
+# 2) the command to execute
+step() {
+    with_backoff "$1" "$2" 0 0
+}
+
+# Same as above, but retries up to 5 times
+step_with_retry() {
+    with_backoff "$1" "$2" 5 .3
+}
+
+# Takes four arguments
+# $1 - description of the command
+# $2 - command to be executed
+# $3 - remaining retries
+# $4 - backoff time
+function with_backoff {
+    local description=$1
+    local cmd=$2
+    local remaining=$3
+    local backoff=$4
+
+    unset e
+    
+    bash -c "$cmd" &> output.txt
+    if [[ $? == 0 ]]
+    then
+      echo -e "$GREEN$CHECKMARK $description $NOCOLOR"
+      rm output.txt
+    else
+        if [[ $remaining == 0 ]]
+        then
+            echo -e "$RED$CROSS $1 $NOCOLOR"
+            echo "Command: $cmd"
+            cat output.txt
+            rm output.txt
+            set -e
+            false
+        else
+            sleep $backoff
+            backoff=$(node -pe $4*2)
+            with_backoff "$description" "$cmd" $(( remaining - 1 )) $backoff
+        fi
+    fi
+
 }


### PR DESCRIPTION
At the moment our E2E tests have a pretty messy output and it's hard to tell why and in which step a test is failing.

This PR makes it so that each command in an e2e test has en explicit description of its purpose (at the moment this is already the implicitly the case with comments inside the bash script).
The e2e test will then run all steps, printing their description with a ✅ if successful and printing it with a ❌ plus the error message and other output if not successful.

This should hopefully make it easier to see where in the tests we are having a problem.

As a side effect we also get rid of the external retry binary we had been using.

### Test Plan

Check out travis for hopefully pretty prints