### PR TITLE
[TheGraph] Withdraw Listener

### DIFF
--- a/listener/src/event_handler/mod.rs
+++ b/listener/src/event_handler/mod.rs
@@ -11,6 +11,9 @@ use web3::types::{Log, Transaction};
 mod deposit_handler;
 pub use deposit_handler::DepositHandler;
 
+mod withdraw_handler;
+pub use withdraw_handler::WithdrawHandler;
+
 mod initialization_handler;
 pub use initialization_handler::InitializationHandler;
 

--- a/listener/src/event_handler/withdraw_handler.rs
+++ b/listener/src/event_handler/withdraw_handler.rs
@@ -30,8 +30,6 @@ impl EventHandler for WithdrawHandler {
         info!(logger, "Processing Withdraw {:?}", &flux);
 
         let mut entity: Entity = flux.into();
-        // We do not care about the ID inside the flux data model,
-        // so we have to set them later.
         entity.set("id", &entity_id);
 
         Ok(vec![

--- a/listener/src/event_handler/withdraw_handler.rs
+++ b/listener/src/event_handler/withdraw_handler.rs
@@ -1,0 +1,44 @@
+use failure::Error;
+use slog::Logger;
+use std::sync::Arc;
+
+use dfusion_core::models::PendingFlux;
+
+use graph::components::ethereum::EthereumBlock;
+use graph::components::store::EntityOperation;
+use graph::data::store::{Entity};
+
+use web3::types::{Log, Transaction};
+
+use super::EventHandler;
+use super::util;
+
+#[derive(Debug, Clone)]
+pub struct WithdrawHandler {}
+
+impl EventHandler for WithdrawHandler {
+    fn process_event(
+        &self,
+        logger: Logger,
+        _block: Arc<EthereumBlock>,
+        _transaction: Arc<Transaction>,
+        log: Arc<Log>
+    ) -> Result<Vec<EntityOperation>, Error> {
+        let entity_id = util::entity_id_from_log(&log);
+        let flux = PendingFlux::from(log);
+
+        info!(logger, "Processing Withdraw {:?}", &flux);
+
+        let mut entity: Entity = flux.into();
+        // We do not care about the ID inside the flux data model,
+        // so we have to set them later.
+        entity.set("id", &entity_id);
+
+        Ok(vec![
+            EntityOperation::Set {
+                key: util::entity_key("Withdraw", &entity),
+                data: entity
+            }
+        ])
+    }
+}

--- a/listener/src/runtime_host.rs
+++ b/listener/src/runtime_host.rs
@@ -76,7 +76,7 @@ impl RustRuntimeHost {
         );
         register_event(
             &mut handlers,
-            "WithdrawRequest(uint16,uint8,uint128,uint,uint16)",
+            "WithdrawRequest(uint16,uint8,uint128,uint256,uint16)",
             Box::new(WithdrawHandler {})
         );
         RustRuntimeHost {

--- a/listener/src/runtime_host.rs
+++ b/listener/src/runtime_host.rs
@@ -14,7 +14,7 @@ use tiny_keccak::keccak256;
 
 use web3::types::{Log, Transaction, H256};
 
-use crate::event_handler::{EventHandler, DepositHandler, InitializationHandler, FluxTransitionHandler};
+use crate::event_handler::{EventHandler, DepositHandler, InitializationHandler, FluxTransitionHandler, WithdrawHandler};
 
 type HandlerMap = HashMap<H256, Box<dyn EventHandler>>;
 
@@ -73,6 +73,11 @@ impl RustRuntimeHost {
             &mut handlers,
             "StateTransition(uint8,uint256,bytes32,uint256)",
             Box::new(FluxTransitionHandler::new(store))
+        );
+        register_event(
+            &mut handlers,
+            "WithdrawRequest(uint16,uint8,uint128,uint,uint16)",
+            Box::new(WithdrawHandler {})
         );
         RustRuntimeHost {
             handlers

--- a/listener/subgraph_definition/dfusion
+++ b/listener/subgraph_definition/dfusion
@@ -22,5 +22,7 @@ dataSources:
           handler: rust
         - event: StateTransition(uint8,uint256,bytes32,uint256)
           handler: rust
+        - event WithdrawRequest(uint16,uint8,uint128,uint,uint16)
+          handler: rust
       file: 
         /: rustHandler.wasm

--- a/listener/subgraph_definition/dfusion
+++ b/listener/subgraph_definition/dfusion
@@ -22,7 +22,7 @@ dataSources:
           handler: rust
         - event: StateTransition(uint8,uint256,bytes32,uint256)
           handler: rust
-        - event WithdrawRequest(uint16,uint8,uint128,uint,uint16)
+        - event WithdrawRequest(uint16,uint8,uint128,uint256,uint16)
           handler: rust
       file: 
         /: rustHandler.wasm

--- a/listener/subgraph_definition/dfusion
+++ b/listener/subgraph_definition/dfusion
@@ -22,7 +22,7 @@ dataSources:
           handler: rust
         - event: StateTransition(uint8,uint256,bytes32,uint256)
           handler: rust
-        - event WithdrawRequest(uint16,uint8,uint128,uint256,uint16)
+        - event: WithdrawRequest(uint16,uint8,uint128,uint256,uint16)
           handler: rust
       file: 
         /: rustHandler.wasm

--- a/listener/subgraph_definition/schema.graphql
+++ b/listener/subgraph_definition/schema.graphql
@@ -13,3 +13,12 @@ type AccountState @entity {
     balances: [BigInt]!
     numTokens: Int!
 }
+
+type Withdraw @entity {
+    id: ID!
+    accountId: Int!
+    tokenId: Int!
+    amount: BigInt!
+    slot: BigInt!
+    slotIndex: Int!
+}

--- a/test/e2e-tests-deposit-withdraw.sh
+++ b/test/e2e-tests-deposit-withdraw.sh
@@ -42,6 +42,15 @@ retry -t 5 "source ../test/utils.sh && query_graphql \
 
 # Request withdraw of 18 of token 2 by account 2 and wait till withdraw slot becomes inactive.
 truffle exec scripts/request_withdraw.js 2 2 18
+
+# check that withdraw was added to the database
+retry -t 5 "source ../test/utils.sh && query_graphql \
+    'query { \
+        withdraws(where: { accountId: 2}) { \
+            amount \
+        } \
+    }' | grep 18000000000000000000"
+
 truffle exec scripts/wait_seconds.js 181
 
 # Expect that driver has processed withdraw slot and ensure updated balances are as expected

--- a/test/e2e-tests-deposit-withdraw.sh
+++ b/test/e2e-tests-deposit-withdraw.sh
@@ -46,6 +46,15 @@ step_with_retry "Check graph db updated" \
 
 step "Request withdraw of 18 of token 2 by account 2" \
     "truffle exec scripts/request_withdraw.js 2 2 18"
+
+step_with_retry "Withdraw was added to graph db" \
+"source ../test/utils.sh && query_graphql \
+    \"query { \
+        withdraws(where: { accountId: 2}) { \
+            amount \
+        } \
+    }\" | grep 18000000000000000000"
+
 step "wait till withdraw slot becomes inactive" "truffle exec scripts/wait_seconds.js 181"
 
 EXPECTED_HASH="7b738197bfe79b6d394499b0cac0186cdc2f65ae2239f2e9e3c698709c80cb67"


### PR DESCRIPTION
Closes #197 

It worked! Purpose of this PR is to get the withdraw requests into the graph listener!

**Test Plan:**

In one terminal run:
```
docker-compose down && docker-compose up graph-listener
```
In another one run:
```
cd dex-contracts
truffle migrate
truffle exec scripts/setup_environment.js
truffle exec scripts/request_withdraw.js 1 1 1
```

Watch the logs for the following:

```
graph-listener_1  | Jul 27 01:01:30.973 INFO Processing Withdraw PendingFlux { slot_index: 0, slot: 0, account_id: 1, token_id: 1, amount: 1000000000000000000 }, block_hash: 0x1012e3332887b81c8d8076d046f89ab0fe2f50a80d894271a225e76fb9d22f2b, block_number: 38, subgraph_id: dfusion, component: SubgraphInstanceManager
```

or open a browser at `localhost:8000` and type the following query:
```
query {
  withdraws {
    id
    amount
    slot
    tokenId
    slotIndex
    accountId
  } 
}
```

PS - @josojo helped here (pair programming)... also our only mistake was a colon in the schema file!
