### PR TITLE
Migrate apply_withdraws into dfusion core

### DIFF
--- a/dfusion_rust_core/src/models/account_state.rs
+++ b/dfusion_rust_core/src/models/account_state.rs
@@ -51,6 +51,19 @@ impl AccountState {
         self.state_index = self.state_index.saturating_add(U256::one());
         self.state_hash = self.rolling_hash(self.state_index.low_u32());
     }
+
+    pub fn apply_withdraws(&mut self, withdraws: &[PendingFlux]) -> Vec<bool> {
+        let mut valid_withdraws = vec![];
+        for withdraw in withdraws {
+            if self.read_balance(withdraw.token_id, withdraw.account_id) >= withdraw.amount {
+                self.decrement_balance(withdraw.token_id, withdraw.account_id, withdraw.amount);
+                valid_withdraws.push(true);
+            } else {
+                valid_withdraws.push(false);
+            }
+        }
+        valid_withdraws
+    }
 }
 
 impl RollingHashable for AccountState {

--- a/dfusion_rust_core/src/models/account_state.rs
+++ b/dfusion_rust_core/src/models/account_state.rs
@@ -62,6 +62,8 @@ impl AccountState {
                 valid_withdraws.push(false);
             }
         }
+        self.state_index = self.state_index.saturating_add(U256::one());
+        self.state_hash = self.rolling_hash(self.state_index.low_u32());
         valid_withdraws
     }
 }

--- a/driver/src/withdraw_driver.rs
+++ b/driver/src/withdraw_driver.rs
@@ -3,56 +3,42 @@ use crate::contract::SnappContract;
 use crate::error::DriverError;
 use crate::util::{find_first_unapplied_slot, can_process, hash_consistency_check};
 
-use dfusion_core::models::{RollingHashable, RootHashable, PendingFlux, AccountState};
+use dfusion_core::models::{RollingHashable, RootHashable};
 
-fn apply_withdraws(
-    state: &AccountState,
-    withdraws: &[PendingFlux],
-) -> (AccountState, Vec<bool>) {
-    let mut state = state.clone();  // TODO - does this really need to be cloned
-    let mut valid_withdraws = vec![];
-    for w in withdraws {
-        if state.read_balance(w.token_id, w.account_id) >= w.amount {
-            state.decrement_balance(w.token_id, w.account_id, w.amount);
-            valid_withdraws.push(true);
-        } else {
-            valid_withdraws.push(false);
-        }
-    }
-    (state, valid_withdraws)
-}
-
-pub fn run_withdraw_listener<D, C>(db: &D, contract: &C) -> Result<(bool), DriverError> 
-    where   D: DbInterface,
-            C: SnappContract
+pub fn run_withdraw_listener<D, C>(db: &D, contract: &C) -> Result<(bool), DriverError>
+    where D: DbInterface,
+          C: SnappContract
 {
     let withdraw_slot = contract.get_current_withdraw_slot()?;
 
     info!("Current top withdraw_slot is {:?}", withdraw_slot);
     let slot = find_first_unapplied_slot(
-        withdraw_slot, 
-        &|i| contract.has_withdraw_slot_been_applied(i)
+        withdraw_slot,
+        &|i| contract.has_withdraw_slot_been_applied(i),
     )?;
     if slot <= withdraw_slot {
         info!("Highest unprocessed withdraw_slot is {:?}", slot);
         if can_process(slot, contract,
-            &|i| contract.creation_timestamp_for_withdraw_slot(i)
+                       &|i| contract.creation_timestamp_for_withdraw_slot(i),
         )? {
             info!("Processing withdraw_slot {:?}", slot);
             let state_root = contract.get_current_state_root()?;
             let contract_withdraw_hash = contract.withdraw_hash_for_slot(slot)?;
-            let balances = db.get_current_balances(&state_root)?;
+            let mut balances = db.get_current_balances(&state_root)?;
 
             let withdraws = db.get_withdraws_of_slot(slot.low_u32())?;
             let withdraw_hash = withdraws.rolling_hash(0);
             hash_consistency_check(withdraw_hash, contract_withdraw_hash, "withdraw")?;
 
-            let (updated_balances, valid_withdraws) = apply_withdraws(&balances, &withdraws);
+            let valid_withdraws = balances.apply_withdraws(&withdraws);
             let withdrawal_merkle_root = withdraws.root_hash(&valid_withdraws);
-            let new_state_root = updated_balances.rolling_hash(balances.state_index.low_u32() + 1);
-            
-            info!("New AccountState hash is {}, Valid Withdraw Merkle Root is {}", new_state_root, withdrawal_merkle_root);
-            contract.apply_withdraws(slot, withdrawal_merkle_root, state_root, new_state_root, contract_withdraw_hash)?;
+
+            info!(
+                "New AccountState hash is {}, Valid Withdraw Merkle Root is {}",
+                balances.state_hash,
+                withdrawal_merkle_root
+            );
+            contract.apply_withdraws(slot, withdrawal_merkle_root, state_root, balances.state_hash, contract_withdraw_hash)?;
             return Ok(true);
         } else {
             info!("Need to wait before processing withdraw_slot {:?}", slot);
@@ -66,17 +52,17 @@ mod tests {
     use super::*;
     use crate::contract::tests::SnappContractMock;
     use dfusion_core::models::flux::tests::create_flux_for_test;
-    use dfusion_core::models::TOKENS;
+    use dfusion_core::models::{AccountState, PendingFlux, TOKENS};
     use crate::db_interface::tests::DbInterfaceMock;
     use mock_it::Matcher::*;
     use web3::types::{H256, U256};
-    use crate::error::{ErrorKind};
+    use crate::error::ErrorKind;
 
     #[test]
     fn applies_current_state_if_unapplied_and_enough_blocks_passed() {
         let slot = U256::from(1);
         let state_hash = H256::zero();
-        let withdraws = vec![create_flux_for_test(1,1), create_flux_for_test(1,2)];
+        let withdraws = vec![create_flux_for_test(1, 1), create_flux_for_test(1, 2)];
         let state = AccountState::new(
             state_hash,
             U256::one(),
@@ -118,7 +104,7 @@ mod tests {
         let contract = SnappContractMock::new();
         contract.get_current_withdraw_slot.given(()).will_return(Ok(slot));
         contract.has_withdraw_slot_been_applied.given(slot).will_return(Ok(false));
-        contract.has_withdraw_slot_been_applied.given(slot-1).will_return(Ok(true));
+        contract.has_withdraw_slot_been_applied.given(slot - 1).will_return(Ok(true));
 
         contract.creation_timestamp_for_withdraw_slot.given(slot).will_return(Ok(U256::from(10)));
         contract.get_current_block_timestamp.given(()).will_return(Ok(U256::from(11)));
@@ -131,8 +117,8 @@ mod tests {
     fn applies_all_unapplied_states_before_current() {
         let slot = U256::from(1);
         let state_hash = H256::zero();
-        let first_withdraws = vec![create_flux_for_test(0,1), create_flux_for_test(0,2)];
-        let second_withdraws = vec![create_flux_for_test(1,1), create_flux_for_test(1,2)];
+        let first_withdraws = vec![create_flux_for_test(0, 1), create_flux_for_test(0, 2)];
+        let second_withdraws = vec![create_flux_for_test(1, 1), create_flux_for_test(1, 2)];
 
         let contract = SnappContractMock::new();
         contract.get_current_withdraw_slot.given(()).will_return(Ok(slot));
@@ -140,10 +126,10 @@ mod tests {
         contract.has_withdraw_slot_been_applied.given(slot).will_return(Ok(false));
         contract.has_withdraw_slot_been_applied.given(slot - 1).will_return(Ok(false));
 
-        contract.creation_timestamp_for_withdraw_slot.given(slot-1).will_return(Ok(U256::from(10)));
+        contract.creation_timestamp_for_withdraw_slot.given(slot - 1).will_return(Ok(U256::from(10)));
 
         contract.get_current_block_timestamp.given(()).will_return(Ok(U256::from(200)));
-        contract.withdraw_hash_for_slot.given(slot-1).will_return(Ok(second_withdraws.rolling_hash(0)));
+        contract.withdraw_hash_for_slot.given(slot - 1).will_return(Ok(second_withdraws.rolling_hash(0)));
 
         contract.get_current_state_root.given(()).will_return(Ok(state_hash));
         contract.apply_withdraws.given((slot - 1, Any, Any, Any, Any)).will_return(Ok(()));
@@ -158,7 +144,7 @@ mod tests {
         let db = DbInterfaceMock::new();
         db.get_withdraws_of_slot.given(0).will_return(Ok(first_withdraws));
         db.get_current_balances.given(state_hash).will_return(Ok(state));
-        
+
         assert_eq!(run_withdraw_listener(&db, &contract), Ok(true));
         assert_eq!(run_withdraw_listener(&db, &contract), Ok(true));
     }
@@ -168,7 +154,7 @@ mod tests {
         let slot = U256::from(1);
         let state_hash = H256::zero();
 
-        let withdraws = vec![create_flux_for_test(1,1), create_flux_for_test(1,2)];
+        let withdraws = vec![create_flux_for_test(1, 1), create_flux_for_test(1, 2)];
 
         let state = AccountState::new(
             state_hash,
@@ -184,7 +170,7 @@ mod tests {
 
         contract.creation_timestamp_for_withdraw_slot.given(slot).will_return(Ok(U256::from(10)));
         contract.get_current_block_timestamp.given(()).will_return(Ok(U256::from(200)));
-        
+
         contract.withdraw_hash_for_slot.given(slot).will_return(Ok(H256::zero()));
         contract.get_current_state_root.given(()).will_return(Ok(state_hash));
 
@@ -200,7 +186,7 @@ mod tests {
     fn skips_invalid_balances_in_applied_merkle_tree() {
         let slot = U256::from(1);
         let state_hash = H256::zero();
-        let withdraws = vec![create_flux_for_test(1,1), PendingFlux {
+        let withdraws = vec![create_flux_for_test(1, 1), PendingFlux {
             slot_index: 2,
             slot: U256::one(),
             account_id: 0,

--- a/test/e2e-tests-deposit-withdraw.sh
+++ b/test/e2e-tests-deposit-withdraw.sh
@@ -50,7 +50,7 @@ step "Request withdraw of 18 of token 2 by account 2" \
 step_with_retry "Withdraw was added to graph db" \
 "source ../test/utils.sh && query_graphql \
     \"query { \
-        withdraws(where: { accountId: 2}) { \
+        withdraws(where: { accountId: 2 }) { \
             amount \
         } \
     }\" | grep 18000000000000000000"


### PR DESCRIPTION
The is a Pre-step to ensuring the event listener processes state transitions for withdrawals. 

**Test Plan**

End-2-end tests not breaking should suffice here.