### PR TITLE
[theGraph/dfusion Model] Order Extend

### DIFF
--- a/dfusion_rust_core/src/models/order.rs
+++ b/dfusion_rust_core/src/models/order.rs
@@ -11,8 +11,8 @@ use super::util::*;
 #[derive(Debug, Clone, Deserialize, Eq, Ord, PartialEq, PartialOrd)]
 #[serde(rename_all = "camelCase")]
 pub struct Order {
-    pub slot: U256,
-    pub slot_index: u16,
+    pub slot: Option<U256>,
+    pub slot_index: Option<u16>,
     pub account_id: u16,
     pub sell_token: u8,
     pub buy_token: u8,
@@ -42,13 +42,13 @@ impl From<Arc<Log>> for Order {
     fn from(log: Arc<Log>) -> Self {
         let mut bytes: Vec<u8> = log.data.0.clone();
         Order {
-            slot: U256::pop_from_log_data(&mut bytes),
-            slot_index: u16::pop_from_log_data(&mut bytes),
+            slot: Some(U256::pop_from_log_data(&mut bytes)),
+            slot_index: Some(u16::pop_from_log_data(&mut bytes)),
             account_id: u16::pop_from_log_data(&mut bytes),
-            sell_token: u8::pop_from_log_data(&mut bytes),
             buy_token: u8::pop_from_log_data(&mut bytes),
-            sell_amount: u128::pop_from_log_data(&mut bytes),
+            sell_token: u8::pop_from_log_data(&mut bytes),
             buy_amount: u128::pop_from_log_data(&mut bytes),
+            sell_amount: u128::pop_from_log_data(&mut bytes),
         }
     }
 }
@@ -56,13 +56,13 @@ impl From<Arc<Log>> for Order {
 impl From<Entity> for Order {
     fn from(entity: Entity) -> Self {
         Order {
-            slot: U256::from_entity(&entity, "auctionId"),
-            slot_index: u16::from_entity(&entity, "slotIndex"),
+            slot: Some(U256::from_entity(&entity, "auctionId")),
+            slot_index: Some(u16::from_entity(&entity, "slotIndex")),
             account_id: u16::from_entity(&entity, "accountId"),
-            sell_token: u8::from_entity(&entity, "sellToken"),
             buy_token: u8::from_entity(&entity, "buyToken"),
-            sell_amount: u128::from_entity(&entity, "sellAmount"),
+            sell_token: u8::from_entity(&entity, "sellToken"),
             buy_amount: u128::from_entity(&entity, "buyAmount"),
+            sell_amount: u128::from_entity(&entity, "sellAmount"),
         }
     }
 }
@@ -70,8 +70,8 @@ impl From<Entity> for Order {
 impl From<mongodb::ordered::OrderedDocument> for Order {
     fn from(document: mongodb::ordered::OrderedDocument) -> Self {
         Order {
-            slot: U256::from(document.get_i32("slot").unwrap()),
-            slot_index: document.get_i32("slotIndex").unwrap() as u16,
+            slot: None,
+            slot_index: None,
             account_id: document.get_i32("accountId").unwrap() as u16,
             buy_token: document.get_i32("buyToken").unwrap() as u8,
             sell_token: document.get_i32("sellToken").unwrap() as u8,
@@ -84,13 +84,13 @@ impl From<mongodb::ordered::OrderedDocument> for Order {
 impl Into<Entity> for Order {
     fn into(self) -> Entity {
         let mut entity = Entity::new();
-        entity.set("slot", self.slot.to_value());
-        entity.set("slotIndex", self.slot_index.to_value());
+        entity.set("slot", self.slot.unwrap().to_value());
+        entity.set("slotIndex", self.slot_index.unwrap().to_value());
         entity.set("accountId", self.account_id.to_value());
         entity.set("buyToken", self.buy_token.to_value());
         entity.set("sellToken", self.sell_token.to_value());
-        entity.set("sellAmount", self.sell_amount.to_value());
         entity.set("buyAmount", self.buy_amount.to_value());
+        entity.set("sellAmount", self.sell_amount.to_value());
         entity
     }
 }
@@ -105,13 +105,13 @@ pub mod tests {
     use super::*;
     pub fn create_order_for_test() -> Order {
       Order {
+          slot: Some(U256::zero()),
+          slot_index: Some(0),
           account_id: 1,
-          sell_token: 2,
           buy_token: 3,
-          sell_amount: 4,
+          sell_token: 2,
           buy_amount: 5,
-          slot: U256::zero(),
-          slot_index: 0,
+          sell_amount: 4,
       }
   }
 }
@@ -125,13 +125,13 @@ pub mod unit_test {
   #[test]
   fn test_order_rolling_hash() {
     let order = Order {
+      slot: Some(U256::zero()),
+      slot_index: Some(0),
       account_id: 1,
-      sell_token: 2,
       buy_token: 3,
-      sell_amount: 4,
+      sell_token: 2,
       buy_amount: 5,
-      slot: U256::zero(),
-      slot_index: 0,
+      sell_amount: 4,
     };
 
     assert_eq!(

--- a/dfusion_rust_core/src/models/order.rs
+++ b/dfusion_rust_core/src/models/order.rs
@@ -56,7 +56,7 @@ impl From<Arc<Log>> for Order {
 impl From<Entity> for Order {
     fn from(entity: Entity) -> Self {
         Order {
-            slot: U256::from_entity(&entity, "slot"),
+            slot: U256::from_entity(&entity, "auctionId"),
             slot_index: u16::from_entity(&entity, "slotIndex"),
             account_id: u16::from_entity(&entity, "accountId"),
             sell_token: u8::from_entity(&entity, "sellToken"),

--- a/dfusion_rust_core/src/models/standing_order.rs
+++ b/dfusion_rust_core/src/models/standing_order.rs
@@ -57,8 +57,8 @@ impl From<mongodb::ordered::OrderedDocument> for StandingOrder {
                 .iter()
                 .map(|raw_order| raw_order.as_document().unwrap())
                 .map(|order_doc| super::Order {
-                        slot: order_doc.get_str("slot").unwrap().parse().unwrap(),
-                        slot_index: order_doc.get_i32("slot_index").unwrap() as u16,
+                        slot: None,
+                        slot_index: None,
                         account_id,
                         buy_token: order_doc.get_i32("buyToken").unwrap() as u8,
                         sell_token: order_doc.get_i32("sellToken").unwrap() as u8,

--- a/dfusion_rust_core/src/models/standing_order.rs
+++ b/dfusion_rust_core/src/models/standing_order.rs
@@ -57,6 +57,8 @@ impl From<mongodb::ordered::OrderedDocument> for StandingOrder {
                 .iter()
                 .map(|raw_order| raw_order.as_document().unwrap())
                 .map(|order_doc| super::Order {
+                        slot: order_doc.get_str("slot").unwrap().parse().unwrap(),
+                        slot_index: order_doc.get_i32("slot_index").unwrap() as u16,
                         account_id,
                         buy_token: order_doc.get_i32("buyToken").unwrap() as u8,
                         sell_token: order_doc.get_i32("sellToken").unwrap() as u8,
@@ -91,6 +93,8 @@ pub mod tests {
 
   pub fn create_order_for_test() -> models::Order {
       models::Order {
+          slot: U256::zero(),
+          slot_index: 0,
           account_id: 1,
           sell_token: 2,
           buy_token: 3,

--- a/driver/src/order_driver.rs
+++ b/driver/src/order_driver.rs
@@ -339,6 +339,8 @@ mod tests {
             executed_buy_amounts: vec![1, 1],
         };
         let order_1 = Order{
+          slot: U256::zero(),
+          slot_index: 0,
           account_id: 1,
           sell_token: 0,
           buy_token: 1,
@@ -346,6 +348,8 @@ mod tests {
           buy_amount: 5,
         };
         let order_2 = Order{
+          slot: U256::zero(),
+          slot_index: 0,
           account_id: 0,
           sell_token: 1,
           buy_token: 0,

--- a/driver/src/price_finding/linear_optimization_price_finder.rs
+++ b/driver/src/price_finding/linear_optimization_price_finder.rs
@@ -227,6 +227,8 @@ pub mod tests {
     #[test]
     fn test_serialize_order() {
         let order = models::Order {
+            slot: U256::zero(),
+            slot_index: 0,
             account_id: 0,
             sell_token: 1,
             buy_token: 2,

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -160,6 +160,8 @@ pub mod tests {
         );
         let orders = vec![
             Order {
+                slot: U256::zero(),
+                slot_index: 0,
                 account_id: 1,
                 sell_token: 1,
                 buy_token: 2,
@@ -167,6 +169,8 @@ pub mod tests {
                 buy_amount: 4,
             },
             Order {
+                slot: U256::zero(),
+                slot_index: 1,
                 account_id: 0,
                 sell_token: 2,
                 buy_token: 1,
@@ -189,6 +193,8 @@ pub mod tests {
         );
         let orders = vec![
             Order {
+                slot: U256::zero(),
+                slot_index: 0,
                 account_id: 0,
                 sell_token: 2,
                 buy_token: 1,
@@ -196,6 +202,8 @@ pub mod tests {
                 buy_amount: 180,
             },
             Order {
+                slot: U256::zero(),
+                slot_index: 1,
                 account_id: 1,
                 sell_token: 1,
                 buy_token: 2,
@@ -218,6 +226,8 @@ pub mod tests {
         );
         let orders = vec![
             Order {
+                slot: U256::zero(),
+                slot_index: 0,
                 account_id: 0,
                 sell_token: 2,
                 buy_token: 1,
@@ -225,6 +235,8 @@ pub mod tests {
                 buy_amount: 10,
             },
             Order {
+                slot: U256::zero(),
+                slot_index: 1,
                 account_id: 1,
                 sell_token: 1,
                 buy_token: 2,
@@ -247,6 +259,8 @@ pub mod tests {
         );
         let orders = vec![
             Order {
+                slot: U256::zero(),
+                slot_index: 0,
                 account_id: 0,
                 sell_token: 3,
                 buy_token: 2,
@@ -254,6 +268,8 @@ pub mod tests {
                 buy_amount: 12,
             },
             Order {
+                slot: U256::zero(),
+                slot_index: 1,
                 account_id: 1,
                 sell_token: 2,
                 buy_token: 3,
@@ -261,6 +277,8 @@ pub mod tests {
                 buy_amount: 22,
             },
             Order {
+                slot: U256::zero(),
+                slot_index: 2,
                 account_id: 2,
                 sell_token: 3,
                 buy_token: 1,
@@ -268,6 +286,8 @@ pub mod tests {
                 buy_amount: 150,
             },
             Order {
+                slot: U256::zero(),
+                slot_index: 3,
                 account_id: 3,
                 sell_token: 2,
                 buy_token: 1,
@@ -275,6 +295,8 @@ pub mod tests {
                 buy_amount: 180,
             },
             Order {
+                slot: U256::zero(),
+                slot_index: 4,
                 account_id: 4,
                 sell_token: 1,
                 buy_token: 2,
@@ -282,6 +304,8 @@ pub mod tests {
                 buy_amount: 4,
             },
             Order {
+                slot: U256::zero(),
+                slot_index: 5,
                 account_id: 5,
                 sell_token: 1,
                 buy_token: 3,
@@ -304,6 +328,8 @@ pub mod tests {
         );
         let orders = vec![
             Order {
+                slot: U256::zero(),
+                slot_index: 0,
                 account_id: 1,
                 sell_token: 1,
                 buy_token: 2,
@@ -311,6 +337,8 @@ pub mod tests {
                 buy_amount: 4,
             },
             Order {
+                slot: U256::zero(),
+                slot_index: 1,
                 account_id: 0,
                 sell_token: 2,
                 buy_token: 1,
@@ -333,6 +361,8 @@ pub mod tests {
         );
         let orders = vec![
             Order {
+                slot: U256::zero(),
+                slot_index: 0,
                 account_id: 1,
                 sell_token: 1,
                 buy_token: 2,
@@ -340,6 +370,8 @@ pub mod tests {
                 buy_amount: 4,
             },
             Order {
+                slot: U256::zero(),
+                slot_index: 1,
                 account_id: 0,
                 sell_token: 2,
                 buy_token: 1,


### PR DESCRIPTION
Would fix #202 

Extension of Order model to include:
1. `slot`
2. `slot_index`