### PR TITLE
[E2E Test] wait up to 30s for ganache to open port

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,14 +31,14 @@ matrix:
           - $HOME/.nvm/versions/node/v8.12.0/lib/node_modules
           - dex-contracts/node_modules/
       before_install:
-        - npm install -g truffle node-jq
+        - npm install -g truffle node-jq wait-port
       install:
         - git submodule update --init
         - npm install -C dex-contracts
         # driver/listener require compiled contracts
         - cd dex-contracts && truffle compile && cd -
         - docker-compose up -d driver listener graph-listener | while read line ; do echo "$(date)| $line"; done; # prints timestamps for profiling
-        - cd dex-contracts && sleep 1 && truffle migrate && cd -
+        - cd dex-contracts && wait-port -t 30000 8545 && truffle migrate && cd -
       script:
         - ./test/e2e-tests-deposit-withdraw.sh
         - ./test/restart-containers.sh

--- a/test/restart-containers.sh
+++ b/test/restart-containers.sh
@@ -6,4 +6,4 @@ docker-compose up -d mongo
 docker-compose rm -sf ganache-cli
 docker-compose up -d ganache-cli
 docker-compose restart listener
-cd dex-contracts && sleep 1 && truffle migrate && cd -
+cd dex-contracts && wait-port -t 30000 8545 && truffle migrate && cd -


### PR DESCRIPTION
Seeing a lot of e2e tests fail because ganache is not yet started (after 1s sleep). 

E.g. https://travis-ci.org/gnosis/dex-services/jobs/565485559

This was introduced in #196 as we got rid of the retry library that was used before. This PR introduces are tool that allows waiting for a port to open (with timeout in ms).

### Test Plan

See travis pass and be no longer flaky.