### PR TITLE
206: Slot & Slot Index >> Batch Information optional struct

### DIFF
--- a/dfusion_rust_core/src/models/order.rs
+++ b/dfusion_rust_core/src/models/order.rs
@@ -64,7 +64,7 @@ impl From<Entity> for Order {
     fn from(entity: Entity) -> Self {
         Order {
             batch_information: Some(BatchInformation{
-                slot: U256::from_entity(&entity, "slot"),
+                slot: U256::from_entity(&entity, "auctionId"),
                 slot_index: u16::from_entity(&entity, "slotIndex"),
             }),
             account_id: u16::from_entity(&entity, "accountId"),
@@ -80,7 +80,7 @@ impl From<mongodb::ordered::OrderedDocument> for Order {
     fn from(document: mongodb::ordered::OrderedDocument) -> Self {
         Order {
             batch_information: Some(BatchInformation{
-                slot: U256::from(document.get_i32("slot").unwrap()),
+                slot: U256::from(document.get_i32("auctionId").unwrap()),
                 slot_index: document.get_i32("slotIndex").unwrap() as u16,
             }),
             account_id: document.get_i32("accountId").unwrap() as u16,

--- a/dfusion_rust_core/src/models/order.rs
+++ b/dfusion_rust_core/src/models/order.rs
@@ -64,7 +64,7 @@ impl From<Entity> for Order {
     fn from(entity: Entity) -> Self {
         Order {
             batch_information: Some(BatchInformation{
-                slot: U256::from_entity(&entity, "auctionId"),
+                slot: U256::from_entity(&entity, "slot"),
                 slot_index: u16::from_entity(&entity, "slotIndex"),
             }),
             account_id: u16::from_entity(&entity, "accountId"),
@@ -80,7 +80,7 @@ impl From<mongodb::ordered::OrderedDocument> for Order {
     fn from(document: mongodb::ordered::OrderedDocument) -> Self {
         Order {
             batch_information: Some(BatchInformation{
-                slot: U256::from(document.get_i32("auctionId").unwrap()),
+                slot: U256::from(document.get_i32("slot").unwrap()),
                 slot_index: document.get_i32("slotIndex").unwrap() as u16,
             }),
             account_id: document.get_i32("accountId").unwrap() as u16,

--- a/dfusion_rust_core/src/models/order.rs
+++ b/dfusion_rust_core/src/models/order.rs
@@ -11,8 +11,8 @@ use super::util::*;
 #[derive(Debug, Clone, Deserialize, Eq, Ord, PartialEq, PartialOrd)]
 #[serde(rename_all = "camelCase")]
 pub struct Order {
-    pub slot: U256,
-    pub slot_index: u16,
+    pub slot: Option<U256>,
+    pub slot_index: Option<u16>,
     pub account_id: u16,
     pub sell_token: u8,
     pub buy_token: u8,
@@ -42,13 +42,13 @@ impl From<Arc<Log>> for Order {
     fn from(log: Arc<Log>) -> Self {
         let mut bytes: Vec<u8> = log.data.0.clone();
         Order {
-            slot: U256::pop_from_log_data(&mut bytes),
-            slot_index: u16::pop_from_log_data(&mut bytes),
+            slot: Some(U256::pop_from_log_data(&mut bytes)),
+            slot_index: Some(u16::pop_from_log_data(&mut bytes)),
             account_id: u16::pop_from_log_data(&mut bytes),
-            sell_token: u8::pop_from_log_data(&mut bytes),
             buy_token: u8::pop_from_log_data(&mut bytes),
-            sell_amount: u128::pop_from_log_data(&mut bytes),
+            sell_token: u8::pop_from_log_data(&mut bytes),
             buy_amount: u128::pop_from_log_data(&mut bytes),
+            sell_amount: u128::pop_from_log_data(&mut bytes),
         }
     }
 }
@@ -56,13 +56,13 @@ impl From<Arc<Log>> for Order {
 impl From<Entity> for Order {
     fn from(entity: Entity) -> Self {
         Order {
-            slot: U256::from_entity(&entity, "auctionId"),
-            slot_index: u16::from_entity(&entity, "slotIndex"),
+            slot: Some(U256::from_entity(&entity, "auctionId")),
+            slot_index: Some(u16::from_entity(&entity, "slotIndex")),
             account_id: u16::from_entity(&entity, "accountId"),
-            sell_token: u8::from_entity(&entity, "sellToken"),
             buy_token: u8::from_entity(&entity, "buyToken"),
-            sell_amount: u128::from_entity(&entity, "sellAmount"),
+            sell_token: u8::from_entity(&entity, "sellToken"),
             buy_amount: u128::from_entity(&entity, "buyAmount"),
+            sell_amount: u128::from_entity(&entity, "sellAmount"),
         }
     }
 }
@@ -70,8 +70,8 @@ impl From<Entity> for Order {
 impl From<mongodb::ordered::OrderedDocument> for Order {
     fn from(document: mongodb::ordered::OrderedDocument) -> Self {
         Order {
-            slot: U256::from(document.get_i32("slot").unwrap()),
-            slot_index: document.get_i32("slotIndex").unwrap() as u16,
+            slot: None,
+            slot_index: None,
             account_id: document.get_i32("accountId").unwrap() as u16,
             buy_token: document.get_i32("buyToken").unwrap() as u8,
             sell_token: document.get_i32("sellToken").unwrap() as u8,
@@ -84,13 +84,13 @@ impl From<mongodb::ordered::OrderedDocument> for Order {
 impl Into<Entity> for Order {
     fn into(self) -> Entity {
         let mut entity = Entity::new();
-        entity.set("slot", self.slot.to_value());
-        entity.set("slotIndex", self.slot_index.to_value());
+        entity.set("slot", self.slot.unwrap().to_value());
+        entity.set("slotIndex", self.slot_index.unwrap().to_value());
         entity.set("accountId", self.account_id.to_value());
         entity.set("buyToken", self.buy_token.to_value());
         entity.set("sellToken", self.sell_token.to_value());
-        entity.set("sellAmount", self.sell_amount.to_value());
         entity.set("buyAmount", self.buy_amount.to_value());
+        entity.set("sellAmount", self.sell_amount.to_value());
         entity
     }
 }
@@ -105,13 +105,13 @@ pub mod tests {
     use super::*;
     pub fn create_order_for_test() -> Order {
       Order {
+          slot: Some(U256::zero()),
+          slot_index: Some(0),
           account_id: 1,
-          sell_token: 2,
           buy_token: 3,
-          sell_amount: 4,
+          sell_token: 2,
           buy_amount: 5,
-          slot: U256::zero(),
-          slot_index: 0,
+          sell_amount: 4,
       }
   }
 }
@@ -125,13 +125,13 @@ pub mod unit_test {
   #[test]
   fn test_order_rolling_hash() {
     let order = Order {
+      slot: Some(U256::zero()),
+      slot_index: Some(0),
       account_id: 1,
-      sell_token: 2,
       buy_token: 3,
-      sell_amount: 4,
+      sell_token: 2,
       buy_amount: 5,
-      slot: U256::zero(),
-      slot_index: 0,
+      sell_amount: 4,
     };
 
     assert_eq!(

--- a/dfusion_rust_core/src/models/order.rs
+++ b/dfusion_rust_core/src/models/order.rs
@@ -96,7 +96,7 @@ impl Into<Entity> for Order {
     fn into(self) -> Entity {
         let mut entity = Entity::new();
         if let Some(_batch_info) = self.batch_information {
-            entity.set("slot", _batch_info.slot.to_value());
+            entity.set("auctionId", _batch_info.slot.to_value());
             entity.set("slotIndex", _batch_info.slot_index.to_value());
         }
         entity.set("accountId", self.account_id.to_value());

--- a/dfusion_rust_core/src/models/order.rs
+++ b/dfusion_rust_core/src/models/order.rs
@@ -56,7 +56,7 @@ impl From<Arc<Log>> for Order {
 impl From<Entity> for Order {
     fn from(entity: Entity) -> Self {
         Order {
-            slot: U256::from_entity(&entity, "slot"),
+            slot: U256::from_entity(&entity, "auctionId"),
             slot_index: u16::from_entity(&entity, "slotIndex"),
             account_id: u16::from_entity(&entity, "accountId"),
             sell_token: u8::from_entity(&entity, "sellToken"),

--- a/dfusion_rust_core/src/models/standing_order.rs
+++ b/dfusion_rust_core/src/models/standing_order.rs
@@ -75,8 +75,6 @@ pub mod tests {
   use web3::types::{H256};
   use std::str::FromStr;
 
-  use crate::models::order::BatchInformation;
-
   #[test]
   fn test_concatenating_hash() {
     let standing_order = models::StandingOrder::new(
@@ -94,10 +92,7 @@ pub mod tests {
 
   pub fn create_order_for_test() -> models::Order {
       models::Order {
-          batch_information: Some(BatchInformation{
-            slot: U256::zero(),
-            slot_index: 0,
-          }),
+          batch_information: None,
           account_id: 1,
           sell_token: 2,
           buy_token: 3,

--- a/dfusion_rust_core/src/models/standing_order.rs
+++ b/dfusion_rust_core/src/models/standing_order.rs
@@ -57,8 +57,7 @@ impl From<mongodb::ordered::OrderedDocument> for StandingOrder {
                 .iter()
                 .map(|raw_order| raw_order.as_document().unwrap())
                 .map(|order_doc| super::Order {
-                        slot: None,
-                        slot_index: None,
+                        batch_information: None,
                         account_id,
                         buy_token: order_doc.get_i32("buyToken").unwrap() as u8,
                         sell_token: order_doc.get_i32("sellToken").unwrap() as u8,
@@ -75,6 +74,8 @@ pub mod tests {
   use super::*;
   use web3::types::{H256};
   use std::str::FromStr;
+
+  use crate::models::order::BatchInformation;
 
   #[test]
   fn test_concatenating_hash() {
@@ -93,8 +94,10 @@ pub mod tests {
 
   pub fn create_order_for_test() -> models::Order {
       models::Order {
-          slot: U256::zero(),
-          slot_index: 0,
+          batch_information: Some(BatchInformation{
+            slot: U256::zero(),
+            slot_index: 0,
+          }),
           account_id: 1,
           sell_token: 2,
           buy_token: 3,

--- a/dfusion_rust_core/src/models/standing_order.rs
+++ b/dfusion_rust_core/src/models/standing_order.rs
@@ -57,8 +57,8 @@ impl From<mongodb::ordered::OrderedDocument> for StandingOrder {
                 .iter()
                 .map(|raw_order| raw_order.as_document().unwrap())
                 .map(|order_doc| super::Order {
-                        slot: order_doc.get_str("slot").unwrap().parse().unwrap(),
-                        slot_index: order_doc.get_i32("slot_index").unwrap() as u16,
+                        slot: None,
+                        slot_index: None,
                         account_id,
                         buy_token: order_doc.get_i32("buyToken").unwrap() as u8,
                         sell_token: order_doc.get_i32("sellToken").unwrap() as u8,

--- a/dfusion_rust_core/src/models/standing_order.rs
+++ b/dfusion_rust_core/src/models/standing_order.rs
@@ -57,6 +57,8 @@ impl From<mongodb::ordered::OrderedDocument> for StandingOrder {
                 .iter()
                 .map(|raw_order| raw_order.as_document().unwrap())
                 .map(|order_doc| super::Order {
+                        slot: order_doc.get_str("slot").unwrap().parse().unwrap(),
+                        slot_index: order_doc.get_i32("slot_index").unwrap() as u16,
                         account_id,
                         buy_token: order_doc.get_i32("buyToken").unwrap() as u8,
                         sell_token: order_doc.get_i32("sellToken").unwrap() as u8,
@@ -91,6 +93,8 @@ pub mod tests {
 
   pub fn create_order_for_test() -> models::Order {
       models::Order {
+          slot: U256::zero(),
+          slot_index: 0,
           account_id: 1,
           sell_token: 2,
           buy_token: 3,

--- a/driver/src/order_driver.rs
+++ b/driver/src/order_driver.rs
@@ -339,8 +339,7 @@ mod tests {
             executed_buy_amounts: vec![1, 1],
         };
         let order_1 = Order{
-          slot: U256::zero(),
-          slot_index: 0,
+          batch_information: None,
           account_id: 1,
           sell_token: 0,
           buy_token: 1,
@@ -348,8 +347,7 @@ mod tests {
           buy_amount: 5,
         };
         let order_2 = Order{
-          slot: U256::zero(),
-          slot_index: 0,
+          batch_information: None,
           account_id: 0,
           sell_token: 1,
           buy_token: 0,

--- a/driver/src/order_driver.rs
+++ b/driver/src/order_driver.rs
@@ -339,6 +339,8 @@ mod tests {
             executed_buy_amounts: vec![1, 1],
         };
         let order_1 = Order{
+          slot: U256::zero(),
+          slot_index: 0,
           account_id: 1,
           sell_token: 0,
           buy_token: 1,
@@ -346,6 +348,8 @@ mod tests {
           buy_amount: 5,
         };
         let order_2 = Order{
+          slot: U256::zero(),
+          slot_index: 0,
           account_id: 0,
           sell_token: 1,
           buy_token: 0,

--- a/driver/src/price_finding/linear_optimization_price_finder.rs
+++ b/driver/src/price_finding/linear_optimization_price_finder.rs
@@ -227,8 +227,7 @@ pub mod tests {
     #[test]
     fn test_serialize_order() {
         let order = models::Order {
-            slot: U256::zero(),
-            slot_index: 0,
+            batch_information: None,
             account_id: 0,
             sell_token: 1,
             buy_token: 2,

--- a/driver/src/price_finding/linear_optimization_price_finder.rs
+++ b/driver/src/price_finding/linear_optimization_price_finder.rs
@@ -227,6 +227,8 @@ pub mod tests {
     #[test]
     fn test_serialize_order() {
         let order = models::Order {
+            slot: U256::zero(),
+            slot_index: 0,
             account_id: 0,
             sell_token: 1,
             buy_token: 2,

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -160,6 +160,8 @@ pub mod tests {
         );
         let orders = vec![
             Order {
+                slot: U256::zero(),
+                slot_index: 0,
                 account_id: 1,
                 sell_token: 1,
                 buy_token: 2,
@@ -167,6 +169,8 @@ pub mod tests {
                 buy_amount: 4,
             },
             Order {
+                slot: U256::zero(),
+                slot_index: 1,
                 account_id: 0,
                 sell_token: 2,
                 buy_token: 1,
@@ -189,6 +193,8 @@ pub mod tests {
         );
         let orders = vec![
             Order {
+                slot: U256::zero(),
+                slot_index: 0,
                 account_id: 0,
                 sell_token: 2,
                 buy_token: 1,
@@ -196,6 +202,8 @@ pub mod tests {
                 buy_amount: 180,
             },
             Order {
+                slot: U256::zero(),
+                slot_index: 1,
                 account_id: 1,
                 sell_token: 1,
                 buy_token: 2,
@@ -218,6 +226,8 @@ pub mod tests {
         );
         let orders = vec![
             Order {
+                slot: U256::zero(),
+                slot_index: 0,
                 account_id: 0,
                 sell_token: 2,
                 buy_token: 1,
@@ -225,6 +235,8 @@ pub mod tests {
                 buy_amount: 10,
             },
             Order {
+                slot: U256::zero(),
+                slot_index: 1,
                 account_id: 1,
                 sell_token: 1,
                 buy_token: 2,
@@ -247,6 +259,8 @@ pub mod tests {
         );
         let orders = vec![
             Order {
+                slot: U256::zero(),
+                slot_index: 0,
                 account_id: 0,
                 sell_token: 3,
                 buy_token: 2,
@@ -254,6 +268,8 @@ pub mod tests {
                 buy_amount: 12,
             },
             Order {
+                slot: U256::zero(),
+                slot_index: 1,
                 account_id: 1,
                 sell_token: 2,
                 buy_token: 3,
@@ -261,6 +277,8 @@ pub mod tests {
                 buy_amount: 22,
             },
             Order {
+                slot: U256::zero(),
+                slot_index: 2,
                 account_id: 2,
                 sell_token: 3,
                 buy_token: 1,
@@ -268,6 +286,8 @@ pub mod tests {
                 buy_amount: 150,
             },
             Order {
+                slot: U256::zero(),
+                slot_index: 3,
                 account_id: 3,
                 sell_token: 2,
                 buy_token: 1,
@@ -275,6 +295,8 @@ pub mod tests {
                 buy_amount: 180,
             },
             Order {
+                slot: U256::zero(),
+                slot_index: 4,
                 account_id: 4,
                 sell_token: 1,
                 buy_token: 2,
@@ -282,6 +304,8 @@ pub mod tests {
                 buy_amount: 4,
             },
             Order {
+                slot: U256::zero(),
+                slot_index: 5,
                 account_id: 5,
                 sell_token: 1,
                 buy_token: 3,
@@ -304,6 +328,8 @@ pub mod tests {
         );
         let orders = vec![
             Order {
+                slot: U256::zero(),
+                slot_index: 0,
                 account_id: 1,
                 sell_token: 1,
                 buy_token: 2,
@@ -311,6 +337,8 @@ pub mod tests {
                 buy_amount: 4,
             },
             Order {
+                slot: U256::zero(),
+                slot_index: 1,
                 account_id: 0,
                 sell_token: 2,
                 buy_token: 1,
@@ -333,6 +361,8 @@ pub mod tests {
         );
         let orders = vec![
             Order {
+                slot: U256::zero(),
+                slot_index: 0,
                 account_id: 1,
                 sell_token: 1,
                 buy_token: 2,
@@ -340,6 +370,8 @@ pub mod tests {
                 buy_amount: 4,
             },
             Order {
+                slot: U256::zero(),
+                slot_index: 1,
                 account_id: 0,
                 sell_token: 2,
                 buy_token: 1,

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -160,8 +160,7 @@ pub mod tests {
         );
         let orders = vec![
             Order {
-                slot: U256::zero(),
-                slot_index: 0,
+                batch_information: None,
                 account_id: 1,
                 sell_token: 1,
                 buy_token: 2,
@@ -169,8 +168,7 @@ pub mod tests {
                 buy_amount: 4,
             },
             Order {
-                slot: U256::zero(),
-                slot_index: 1,
+                batch_information: None,
                 account_id: 0,
                 sell_token: 2,
                 buy_token: 1,
@@ -193,8 +191,7 @@ pub mod tests {
         );
         let orders = vec![
             Order {
-                slot: U256::zero(),
-                slot_index: 0,
+                batch_information: None,
                 account_id: 0,
                 sell_token: 2,
                 buy_token: 1,
@@ -202,8 +199,7 @@ pub mod tests {
                 buy_amount: 180,
             },
             Order {
-                slot: U256::zero(),
-                slot_index: 1,
+                batch_information: None,
                 account_id: 1,
                 sell_token: 1,
                 buy_token: 2,
@@ -226,8 +222,7 @@ pub mod tests {
         );
         let orders = vec![
             Order {
-                slot: U256::zero(),
-                slot_index: 0,
+                batch_information: None,
                 account_id: 0,
                 sell_token: 2,
                 buy_token: 1,
@@ -235,8 +230,7 @@ pub mod tests {
                 buy_amount: 10,
             },
             Order {
-                slot: U256::zero(),
-                slot_index: 1,
+                batch_information: None,
                 account_id: 1,
                 sell_token: 1,
                 buy_token: 2,
@@ -259,8 +253,7 @@ pub mod tests {
         );
         let orders = vec![
             Order {
-                slot: U256::zero(),
-                slot_index: 0,
+                batch_information: None,
                 account_id: 0,
                 sell_token: 3,
                 buy_token: 2,
@@ -268,8 +261,7 @@ pub mod tests {
                 buy_amount: 12,
             },
             Order {
-                slot: U256::zero(),
-                slot_index: 1,
+                batch_information: None,
                 account_id: 1,
                 sell_token: 2,
                 buy_token: 3,
@@ -277,8 +269,7 @@ pub mod tests {
                 buy_amount: 22,
             },
             Order {
-                slot: U256::zero(),
-                slot_index: 2,
+                batch_information: None,
                 account_id: 2,
                 sell_token: 3,
                 buy_token: 1,
@@ -286,8 +277,7 @@ pub mod tests {
                 buy_amount: 150,
             },
             Order {
-                slot: U256::zero(),
-                slot_index: 3,
+                batch_information: None,
                 account_id: 3,
                 sell_token: 2,
                 buy_token: 1,
@@ -295,8 +285,7 @@ pub mod tests {
                 buy_amount: 180,
             },
             Order {
-                slot: U256::zero(),
-                slot_index: 4,
+                batch_information: None,
                 account_id: 4,
                 sell_token: 1,
                 buy_token: 2,
@@ -304,8 +293,7 @@ pub mod tests {
                 buy_amount: 4,
             },
             Order {
-                slot: U256::zero(),
-                slot_index: 5,
+                batch_information: None,
                 account_id: 5,
                 sell_token: 1,
                 buy_token: 3,
@@ -328,8 +316,7 @@ pub mod tests {
         );
         let orders = vec![
             Order {
-                slot: U256::zero(),
-                slot_index: 0,
+                batch_information: None,
                 account_id: 1,
                 sell_token: 1,
                 buy_token: 2,
@@ -337,8 +324,7 @@ pub mod tests {
                 buy_amount: 4,
             },
             Order {
-                slot: U256::zero(),
-                slot_index: 1,
+                batch_information: None,
                 account_id: 0,
                 sell_token: 2,
                 buy_token: 1,
@@ -361,8 +347,7 @@ pub mod tests {
         );
         let orders = vec![
             Order {
-                slot: U256::zero(),
-                slot_index: 0,
+                batch_information: None,
                 account_id: 1,
                 sell_token: 1,
                 buy_token: 2,
@@ -370,8 +355,7 @@ pub mod tests {
                 buy_amount: 4,
             },
             Order {
-                slot: U256::zero(),
-                slot_index: 1,
+                batch_information: None,
                 account_id: 0,
                 sell_token: 2,
                 buy_token: 1,

--- a/test/restart-containers.sh
+++ b/test/restart-containers.sh
@@ -6,4 +6,4 @@ docker-compose up -d mongo
 docker-compose rm -sf ganache-cli
 docker-compose up -d ganache-cli
 docker-compose restart listener
-cd dex-contracts && sleep 1 && truffle migrate && cd -
+cd dex-contracts && wait-port -t 30000 8545 && truffle migrate && cd -


### PR DESCRIPTION
Branched off of (now closed) #202 

Closes #203 

As suggested in #203, make `slot` and `slot_index` (optional props) into an optional struct named `batch_information` instead

Fixes tests