### PR TITLE
[E2E] fix a flaky test

### DIFF
--- a/test/e2e-tests-auction.sh
+++ b/test/e2e-tests-auction.sh
@@ -19,6 +19,9 @@ step "Make sure we have enough balances for the trades" \
  truffle exec scripts/deposit.js 4 0 300 && \
  truffle exec scripts/deposit.js 5 0 300"
 
+step "Advance time to apply deposits" \
+"truffle exec scripts/wait_seconds.js 181"
+
 step "Place 6 orders in current Auction" \
 "truffle exec scripts/sell_order.js 0 1 2 12 12 && \
  truffle exec scripts/sell_order.js 1 2 1 2.2 2 && \


### PR DESCRIPTION
Our current e2e tests are flaky. E.g. check out https://travis-ci.org/gnosis/dex-services/jobs/566931767#L1801 which failed, but re-running it without a change succeeded.

- Reason for the fail was that the solution of applyAuctions only provided 0 executed buy/sell Volume.
- Reason for that is that the stateBalances for all participants were 0 (thus not sufficient balance to make any trade)
- Reason for that is that the deposits hadn't been correctly applied (cf. the temporary `deposit_driver transport error` in line 1794). 

These errors can happen from time to time and a more sophisticated retry strategy in such cases is probably needed. However, the fundamental problem is that deposit application and auction application happen in the same driver runloop.

This PR makes it so that we wait 180s after depositing to let the driver pick up the deposits **before** it processes the auction.

This should make the test pass more reliably.

### Test Plan

Travis