### PR TITLE
Use npx for truffle instead of global system one

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,22 +66,22 @@ In order to setup some testing accounts and make the first deposits (from accoun
 
 ```bash
 cd dex-contracts
-truffle exec scripts/setup_environment.js
-truffle exec scripts/deposit.js 1 1 18
-truffle exec scripts/wait_seconds.js 181
+npx truffle exec scripts/setup_environment.js
+npx truffle exec scripts/deposit.js 1 1 18
+npx truffle exec scripts/wait_seconds.js 181
 ```
 
 To claim back the deposit, submit a withdraw request:
 
 ```bash
-truffle exec scripts/request_withdraw.js 1 1 18
+npx truffle exec scripts/request_withdraw.js 1 1 18
 ```
 
 After 20 blocks have passed, the driver will apply the state transition and you should be able to claim back your funds:
 
 ```bash
-truffle exec scripts/wait_seconds.js 181
-truffle exec scripts/claim_withdraw.js 0 1 1
+npx truffle exec scripts/wait_seconds.js 181
+npx truffle exec scripts/claim_withdraw.js 0 1 1
 ```
 
 Tests
@@ -120,7 +120,7 @@ Troubleshooting
 If you have built the docker landscape before, and there are updates to the smart contracts submodule (*dex-contracts/*), you have to rebuild your docker environment, for them to be picked up:
 
 ```bash
-cd dex-contracts && rm -rf build && truffle compile && cd ..
+cd dex-contracts && rm -rf build && npx truffle compile && cd ..
 docker-compose build truffle
 ```
 

--- a/test/e2e-tests-auction.sh
+++ b/test/e2e-tests-auction.sh
@@ -4,7 +4,7 @@ cd dex-contracts
 source ../test/utils.sh
 
 step "Setup" \
-"truffle exec scripts/setup_environment.js 6"
+"npx truffle exec scripts/setup_environment.js 6"
 
 EXPECTED_AUCTION=0
 
@@ -12,23 +12,23 @@ step "Ensure no orders yet in auction slot 1" \
 "mongo dfusion2 --eval \"db.orders.find({'auctionId': ${EXPECTED_AUCTION}}).size()\" | grep -w 0"
 
 step "Make sure we have enough balances for the trades" \
-"truffle exec scripts/deposit.js 0 2 300 && \
- truffle exec scripts/deposit.js 1 1 300 && \
- truffle exec scripts/deposit.js 2 2 200 && \
- truffle exec scripts/deposit.js 3 1 300 && \
- truffle exec scripts/deposit.js 4 0 300 && \
- truffle exec scripts/deposit.js 5 0 300"
+"npx truffle exec scripts/deposit.js 0 2 300 && \
+ npx truffle exec scripts/deposit.js 1 1 300 && \
+ npx truffle exec scripts/deposit.js 2 2 200 && \
+ npx truffle exec scripts/deposit.js 3 1 300 && \
+ npx truffle exec scripts/deposit.js 4 0 300 && \
+ npx truffle exec scripts/deposit.js 5 0 300"
 
 step "Advance time to apply deposits" \
-"truffle exec scripts/wait_seconds.js 181"
+"npx truffle exec scripts/wait_seconds.js 181"
 
 step "Place 6 orders in current Auction" \
-"truffle exec scripts/sell_order.js 0 1 2 12 12 && \
- truffle exec scripts/sell_order.js 1 2 1 2.2 2 && \
- truffle exec scripts/sell_order.js 2 0 2 150 10 && \
- truffle exec scripts/sell_order.js 3 0 1 180 15 && \
- truffle exec scripts/sell_order.js 4 1 0 4 52  && \
- truffle exec scripts/sell_order.js 5 2 0 20 280"
+"npx truffle exec scripts/sell_order.js 0 1 2 12 12 && \
+ npx truffle exec scripts/sell_order.js 1 2 1 2.2 2 && \
+ npx truffle exec scripts/sell_order.js 2 0 2 150 10 && \
+ npx truffle exec scripts/sell_order.js 3 0 1 180 15 && \
+ npx truffle exec scripts/sell_order.js 4 1 0 4 52  && \
+ npx truffle exec scripts/sell_order.js 5 2 0 20 280"
 
 step_with_retry "[theGraph]: SellOrder was added to graph db - accountId 5's sellOrder === 280" \
 "source ../test/utils.sh && query_graphql \
@@ -45,11 +45,11 @@ step_with_retry "sellAmount for accountId = 5 is 280000000000000000000" \
 "mongo dfusion2 --eval \"db.orders.findOne({'auctionId': ${EXPECTED_AUCTION}, 'accountId': 5}).sellAmount\" | grep -w 280000000000000000000"
 
 step "Advance time to apply auction" \
-"truffle exec scripts/wait_seconds.js 181"
+"npx truffle exec scripts/wait_seconds.js 181"
 
 EXPECTED_HASH="2b87dc830d051be72f4adcc3677daadab2f3f2253e9da51d803faeb0daa1532f"
 step_with_retry "Test balances have been updated" \
-"truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
+"npx truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
 
 step_with_retry "Account 4 has now 4 of token 1" \
 "mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[121]\" | grep -w 4000000000000000000"

--- a/test/e2e-tests-deposit-withdraw.sh
+++ b/test/e2e-tests-deposit-withdraw.sh
@@ -4,14 +4,14 @@ cd dex-contracts
 source ../test/utils.sh
 
 step "Setup" \
-"truffle exec scripts/setup_environment.js 6"
+"npx truffle exec scripts/setup_environment.js 6"
 
 ###############
 # Deposit Tests
 ###############
 
 step "Deposit 18 of token 2 for user 2" \
-"truffle exec scripts/deposit.js 2 2 18"
+"npx truffle exec scripts/deposit.js 2 2 18"
 
 step_with_retry "Deposit was added to graph db" \
 "source ../test/utils.sh && query_graphql \
@@ -22,12 +22,12 @@ step_with_retry "Deposit was added to graph db" \
     }\" | grep 18000000000000000000"
 
 step "Advance time to finalize batch" \
-"truffle exec scripts/wait_seconds.js 181"
+"npx truffle exec scripts/wait_seconds.js 181"
 
 EXPECTED_HASH="73815c173218e6025f7cb12d0add44354c4671e261a34a360943007ff6ac7af5"
 
 step_with_retry "Check contract updated" \
-"truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
+"npx truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
 
 step_with_retry "Check mongo db updated" \
 "mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '${EXPECTED_HASH}'}).balances[62]\" | grep -w 18000000000000000000"
@@ -45,7 +45,7 @@ step_with_retry "Check graph db updated" \
 ################
 
 step "Request withdraw of 18 of token 2 by account 2" \
-    "truffle exec scripts/request_withdraw.js 2 2 18"
+    "npx truffle exec scripts/request_withdraw.js 2 2 18"
 
 step_with_retry "Withdraw was added to graph db" \
 "source ../test/utils.sh && query_graphql \
@@ -55,17 +55,17 @@ step_with_retry "Withdraw was added to graph db" \
         } \
     }\" | grep 18000000000000000000"
 
-step "wait till withdraw slot becomes inactive" "truffle exec scripts/wait_seconds.js 181"
+step "wait till withdraw slot becomes inactive" "npx truffle exec scripts/wait_seconds.js 181"
 
 EXPECTED_HASH="7b738197bfe79b6d394499b0cac0186cdc2f65ae2239f2e9e3c698709c80cb67"
 
 step_with_retry "Check contract updated" \
-"truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
+"npx truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
 
 step_with_retry "Check mongo db updated" \
  "mongo dfusion2 --eval \"db.accounts.findOne({'stateHash': '$EXPECTED_HASH'}).balances[62]\" | grep -w 0"
 
 # Should now be able to claim withdraw and see a balance change
 step "Claim Withdraw" \
-"truffle exec scripts/claim_withdraw.js 0 2 2 | grep \"Success! Balance of token 2 before claim: 282000000000000000000, after claim: 300000000000000000000\""
+"npx truffle exec scripts/claim_withdraw.js 0 2 2 | grep \"Success! Balance of token 2 before claim: 282000000000000000000, after claim: 300000000000000000000\""
 

--- a/test/e2e-tests-standing-order.sh
+++ b/test/e2e-tests-standing-order.sh
@@ -4,48 +4,48 @@ cd dex-contracts
 source ../test/utils.sh
 
 step "Setup" \
-"truffle exec scripts/setup_environment.js 6"
+"npx truffle exec scripts/setup_environment.js 6"
 
 step "Ensure sufficient Balances" \
-"truffle exec scripts/deposit.js 0 2 300 && \
- truffle exec scripts/deposit.js 1 1 300 && \
- truffle exec scripts/wait_seconds.js 181"
+"npx truffle exec scripts/deposit.js 0 2 300 && \
+ npx truffle exec scripts/deposit.js 1 1 300 && \
+ npx truffle exec scripts/wait_seconds.js 181"
 
 step "Place Sell Order" \
-"truffle exec scripts/sell_order.js 1 2 1 1 1"
+"npx truffle exec scripts/sell_order.js 1 2 1 1 1"
 
 step "Place standing order in current Auction" \
-"truffle exec scripts/standing_order.js 0 1 2 1 1"
+"npx truffle exec scripts/standing_order.js 0 1 2 1 1"
 
 step_with_retry "Check standing order has been recorded" \
 "mongo dfusion2 --eval \"db.standing_orders.findOne({accountId:0, batchIndex:0, orders: [ { buyToken:1, sellToken:2, buyAmount:'1000000000000000000', sellAmount:'1000000000000000000' }]})\" | grep ObjectId"
 
 step "Advance time to apply auction" \
-"truffle exec scripts/wait_seconds.js 181"
+"npx truffle exec scripts/wait_seconds.js 181"
 
 step_with_retry "Assert Standing order account traded" \
 "mongo dfusion2 --eval \"db.accounts.findOne({'stateIndex': 2}).balances[1]\" | grep -2 1000000000000000000"
 
 step "Place matching sell order for standing order" \
-"truffle exec scripts/sell_order.js 1 2 1 1 1"
+"npx truffle exec scripts/sell_order.js 1 2 1 1 1"
 
 step "Advance time to apply auction" \
-"truffle exec scripts/wait_seconds.js 181"
+"npx truffle exec scripts/wait_seconds.js 181"
 
 step_with_retry "Make sure standing order is still traded" \
 "mongo dfusion2 --eval \"db.accounts.findOne({'stateIndex': 3}).balances[1]\" | grep -2 2000000000000000000"
 
 step "Update standing order" \
-"truffle exec scripts/standing_order.js 0 1 2 1 2"
+"npx truffle exec scripts/standing_order.js 0 1 2 1 2"
 
 step "Cancel standing order in same batch (make sure only cancel gets processed)" \
-"truffle exec scripts/standing_order.js 0 0 0 0 0"
+"npx truffle exec scripts/standing_order.js 0 0 0 0 0"
 
 step "Place matching sell order for standing order" \
-"truffle exec scripts/sell_order.js 1 2 1 1 1"
+"npx truffle exec scripts/sell_order.js 1 2 1 1 1"
 
 step "Advance time to apply auction" \
-"truffle exec scripts/wait_seconds.js 181"
+"npx truffle exec scripts/wait_seconds.js 181"
 
 step_with_retry "Standing Order was no longer traded" \
 "mongo dfusion2 --eval \"db.accounts.findOne({'stateIndex': 4}).balances[1]\" | grep -2 2000000000000000000"


### PR DESCRIPTION
The services depends on truffle and other dependencies being install globally.

Truffle can have different versions depending on the project, so it's better not to rely on the global truffle and use npx instead.