### PR TITLE
Restart all services in restart-containers.sh

### DIFF
--- a/test/restart-containers.sh
+++ b/test/restart-containers.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-docker-compose rm -sf mongo
-docker-compose up -d mongo
-docker-compose rm -sf ganache-cli
-docker-compose up -d ganache-cli
-docker-compose restart listener
+docker-compose rm -sf
+docker-compose up -d
 cd dex-contracts && wait-port -t 30000 8545 && truffle migrate && cd -

--- a/test/restart-containers.sh
+++ b/test/restart-containers.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 set -e
 
-docker-compose rm -sf
-docker-compose up -d
-cd dex-contracts && wait-port -t 30000 8545 && truffle migrate && cd -
+
+docker-compose rm -sf mongo
+docker-compose up -d mongo
+
+docker-compose rm -sf postgres
+docker-compose up -d postgres
+
+docker-compose rm -sf ganache-cli
+docker-compose up -d ganache-cli
+
+docker-compose restart listener
+docker-compose restart graph-listener
+
+cd dex-contracts && npx wait-port -t 30000 8545 && npx truffle migrate && cd -


### PR DESCRIPTION
Restarting the containers using `test/restart-containers.sh` script won't restart services like `graph-listener`.

Modified the script so all services are restarted, so it takes for example the new mappings/handlers for graph-listener