### PR TITLE
GraphNode reader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
       before_script:
         - rustup component add clippy
       script:
-        - cargo clippy --all -- -D warnings
+        - cargo clippy --all --exclude graph-node-reader -- -D warnings
         - cargo check --verbose --all
         - cargo test --verbose --all
     - language: python

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,6 +950,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "graph-node-reader"
+version = "0.13.2"
+dependencies = [
+ "diesel 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel-derive-enum 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel-dynamic-schema 1.0.0 (git+https://github.com/diesel-rs/diesel-dynamic-schema?rev=a8ec4fb1)",
+ "graph 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
+]
+
+[[package]]
 name = "graph-runtime-derive"
 version = "0.13.2"
 source = "git+https://github.com/graphprotocol/graph-node?tag=v0.13.2#602fba1af5322ceeb58cc09c7120bdacbaa5cbea"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 
 members = [
+    "graph_node_reader",
     "dfusion_rust_core",
     "driver",
     "listener",

--- a/docker/rust/Dockerfile
+++ b/docker/rust/Dockerfile
@@ -13,6 +13,7 @@ ENV PYTHONPATH ${PYTHONPATH}:/app/batchauctions/
 COPY dex-contracts/build dex-contracts/build
 
 # Copy and build code
+COPY graph_node_reader ./graph_node_reader
 COPY dfusion_rust_core ./dfusion_rust_core
 COPY driver ./driver
 COPY listener ./listener

--- a/graph_node_reader/Cargo.toml
+++ b/graph_node_reader/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "graph-node-reader"
+version = "0.13.2"
+edition = "2018"
+
+[dependencies]
+diesel = { version = "1.3.2", features = ["postgres", "serde_json", "numeric", "r2d2"] }
+# We use diesel-dynamic-schema straight from git as the project has not
+# made a release as a crate yet
+diesel-dynamic-schema = { git = "https://github.com/diesel-rs/diesel-dynamic-schema", rev="a8ec4fb1" }
+diesel-derive-enum = { version = "0.4", features = ["postgres"] }
+graph = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }

--- a/graph_node_reader/src/entities.rs
+++ b/graph_node_reader/src/entities.rs
@@ -1,0 +1,551 @@
+//! Support for the management of the schemas and tables we create in
+//! the database for each deployment. The Postgres schemas for each
+//! deployment/subgraph are tracked in the `deployment_schemas` table.
+//!
+//! The functions in this module are very low-level and should only be used
+//! directly by the Postgres store, and nowhere else. At the same time, all
+//! manipulation of entities in the database should go through this module
+//! to make it easier to handle future schema changes
+
+// We use Diesel's dynamic table support for querying the entities and history
+// tables of a subgraph. Unfortunately, this support is not good enough for
+// modifying data, and we fall back to generating literal SQL queries for that.
+// For the `entities` table of the subgraph of subgraphs, we do map the table
+// statically and use it in some cases to bridge the gap between dynamic and
+// static table support, in particular in the update operation for entities.
+// Diesel deeply embeds the assumption that all schema is known at compile time;
+// for example, the column for a dynamic table can not implement
+// `diesel::query_source::Column` since that must carry the column name as a
+// constant. As a consequence, a lot of Diesel functionality is not available
+// for dynamic tables.
+
+use diesel::deserialize::QueryableByName;
+use diesel::dsl::{any, sql};
+use diesel::pg::{Pg, PgConnection};
+use diesel::sql_types::{Jsonb, Nullable, Text};
+use diesel::BoolExpressionMethods;
+use diesel::ExpressionMethods;
+use diesel::{debug_query};
+use diesel::{OptionalExtension, QueryDsl, RunQueryDsl};
+use diesel_dynamic_schema::{schema, Column, Table as DynamicTable};
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use graph::prelude::{
+    format_err, EntityFilter, QueryExecutionError, StoreError, SubgraphDeploymentId,
+};
+use graph::serde_json;
+
+use crate::filter::store_filter;
+
+/// Marker trait for tables that store entities
+pub(crate) trait EntitySource {}
+
+// The entities and related tables in the public schema. We put them in
+// this module to make sure that nobody else gets access to them. All access
+// to these tables must go through functions in this module.
+mod public {
+    use diesel::sql_types::Varchar;
+
+    table! {
+        entities (id, subgraph, entity) {
+            id -> Varchar,
+            subgraph -> Varchar,
+            entity -> Varchar,
+            data -> Jsonb,
+            event_source -> Varchar,
+        }
+    }
+
+    table! {
+        entity_history (id) {
+            id -> Integer,
+            // This is a BigInt in the database, but if we mark it that
+            // diesel won't let us join event_meta_data and entity_history
+            // Since event_meta_data.id is Integer, it shouldn't matter
+            // that we call it Integer here
+            event_id -> Integer,
+            entity_id -> Varchar,
+            subgraph -> Varchar,
+            entity -> Varchar,
+            data_before -> Nullable<Jsonb>,
+            data_after -> Nullable<Jsonb>,
+            op_id -> SmallInt,
+            reversion -> Bool,
+        }
+    }
+
+    table! {
+        event_meta_data (id) {
+            id -> Integer,
+            db_transaction_id -> BigInt,
+            db_transaction_time -> Timestamp,
+            source -> Nullable<Varchar>,
+        }
+    }
+
+    joinable!(entity_history -> event_meta_data (event_id));
+    allow_tables_to_appear_in_same_query!(entity_history, event_meta_data);
+
+    /// We support different storage schemes per subgraph. This enum is used
+    /// to track which scheme a given subgraph uses and corresponds to the
+    /// `deployment_schema_version` type in the database.
+    ///
+    /// The column `deployment_schemas.version` stores that information for
+    /// each subgraph. Subgraphs that use the `Public` scheme have their
+    /// entities stored in the monolithic `public.entities` table, subgraphs
+    /// that store their entities and history in a dedicated database schema
+    /// are marked with version `Split`.
+    ///
+    /// Migrating a subgraph amounts to changing the storage scheme for that
+    /// subgraph from one version to another. Whether a subgraph scheme needs
+    /// migrating is determined by `Table::needs_migrating`, the migration
+    /// machinery is kicked off with a call to `Connection::migrate`
+    #[derive(DbEnum, Debug, Clone)]
+    pub enum DeploymentSchemaVersion {
+        Public,
+        Split,
+    }
+
+    /// Migrating a subgraph is broken into two steps: in the first step, the
+    /// schema for the new storage scheme is put into place; in the second
+    /// step data is moved from the old storage scheme to the new one. These
+    /// two steps happen in separate database transactions, since the first
+    /// step takes fairly strong locks, that can block other database work.
+    /// In the case of the `Public -> Split` migration, the schema changes
+    /// take a lock on `event_meta_data`, which, if held for too long, ends up
+    /// blocking any write access to the `public.entities` table because of
+    /// the way in which history is recorded. The second step, moving data,
+    /// only requires relatively weak locks that do not block write activity
+    /// to rows in `public.entities` that are not affected by the migration
+    /// of a different subgraph.
+    ///
+    /// The `Ready` state indicates that the subgraph is ready to use the
+    /// storage scheme indicated by `deployment_schemas.version`. After the
+    /// first step of the migration has been done, the `version` field remains
+    /// unchanged, but we indicate that we have put the new schema in place by
+    /// setting the state to `Tables`. At the end of the second migration
+    /// step, we change the `version` to the new version, and set the state to
+    /// `Ready` to indicate that the subgraph can now be used with the new
+    /// storage scheme.
+    #[derive(DbEnum, Debug, Clone)]
+    pub enum DeploymentSchemaState {
+        Ready,
+        Tables,
+    }
+
+    table! {
+        deployment_schemas(id) {
+            id -> Integer,
+            subgraph -> Text,
+            name -> Text,
+            /// The subgraph storage scheme used for this subgraph
+            version -> crate::entities::public::DeploymentSchemaVersionMapping,
+            /// Whether this subgraph is in the process of being migrated to
+            /// a new storage scheme. This column functions as a lock (or
+            /// semaphore) and is used to limit the number of subgraphs that
+            /// are being migrated at any given time. The details of handling
+            /// this lock are in `Connection::should_migrate`
+            migrating -> Bool,
+            /// Track which step of a subgraph migration has been done
+            state -> crate::entities::public::DeploymentSchemaStateMapping,
+        }
+    }
+
+    // Migrate entities storage to a split entities table, one stored proc
+    // for each migration step
+    sql_function!(fn migrate_entities_tables(schema_name: Varchar, schema_version: DeploymentSchemaVersionMapping, subgraph: Varchar));
+    sql_function!(fn migrate_entities_data(schema_name: Varchar, schema_version: DeploymentSchemaVersionMapping, subgraph: Varchar) -> Integer);
+}
+
+// The entities table for the subgraph of subgraphs.
+mod subgraphs {
+    table! {
+        subgraphs.entities (entity, id) {
+            entity -> Varchar,
+            id -> Varchar,
+            data -> Jsonb,
+            event_source -> Varchar,
+        }
+    }
+
+    table! {
+        subgraphs.entity_history (id) {
+            id -> Integer,
+            // This is a BigInt in the database, but if we mark it that
+            // diesel won't let us join event_meta_data and entity_history
+            // Since event_meta_data.id is Integer, it shouldn't matter
+            // that we call it Integer here
+            event_id -> Integer,
+            subgraph -> Varchar,
+            entity -> Varchar,
+            entity_id -> Varchar,
+            data_before -> Nullable<Jsonb>,
+            op_id -> SmallInt,
+            reversion -> Bool,
+        }
+    }
+
+    // NOTE: This is a duplicate of the `event_meta_data` in `public`. It exists
+    // only so we can link from the subgraphs.entity_history table to
+    // public.event_meta_data.
+    table! {
+        event_meta_data (id) {
+            id -> Integer,
+            db_transaction_id -> BigInt,
+            db_transaction_time -> Timestamp,
+            source -> Nullable<Varchar>,
+        }
+    }
+
+    joinable!(entity_history -> event_meta_data (event_id));
+    allow_tables_to_appear_in_same_query!(entity_history, event_meta_data);
+}
+
+impl EntitySource for self::public::entities::table {}
+
+impl EntitySource for self::subgraphs::entities::table {}
+
+// This is a bit weak, as any DynamicTable<String> is now an EntitySource
+impl EntitySource for DynamicTable<String> {}
+
+use public::deployment_schemas;
+
+/// Information about the database schema that stores the entities for a
+/// subgraph. The schemas are versioned by subgraph, which makes it possible
+/// to migrate subgraphs one at a time to newer storage schemes. Migrations
+/// are split into two stages to make sure that intrusive locks are
+/// only held a very short amount of time. The overall goal is to pause
+/// indexing (write activity) for a subgraph while we migrate, but keep it
+/// possible to query the subgraph, and not affect other subgraph's operation.
+///
+/// When writing a migration, the following guidelines should be followed:
+/// - each migration can only affect a single subgraph, and must not interfere
+///   with the working of any other subgraph
+/// - writing to the subgraph will be paused while the migration is running
+/// - each migration step is run in its own database transaction
+#[derive(Queryable, QueryableByName, Debug)]
+#[table_name = "deployment_schemas"]
+struct Schema {
+    id: i32,
+    subgraph: String,
+    name: String,
+    /// The version currently in use. While we are migrating, the version
+    /// will remain at the old version until the new version is ready to use.
+    /// Migrations should update this field as the very last operation they
+    /// perform.
+    version: public::DeploymentSchemaVersion,
+    /// True if the subgraph is currently running a migration. The `migrating`
+    /// flags in the `deployment_schemas` table act as a semaphore that limits
+    /// the number of subgraphs that can undergo a migration at the same time.
+    migrating: bool,
+    /// Track which parts of a migration have already been performed. The
+    /// `Ready` state means no work to get to the next version has been done
+    /// yet. A migration will first perform a transaction that purely does DDL;
+    /// since that generally requires fairly strong locks but is fast, that
+    /// is done in its own transaction. Once we have done the necessary DDL,
+    /// the state goes to `Tables`. The final state of the migration is
+    /// copying data, which can be very slow, but should not require intrusive
+    /// locks. When the data is in place, the migration updates `version` to
+    /// the new version we migrated to, and sets the state to `Ready`
+    state: public::DeploymentSchemaState,
+}
+
+type EntityColumn<ST> = Column<DynamicTable<String>, String, ST>;
+
+/// A table representing a split entities table, i.e. a setup where
+/// a subgraph deployment's entities are split into their own schema rather
+/// than residing in the entities table in the `public` database schema
+#[derive(Debug, Clone)]
+pub(crate) struct SplitTable {
+    /// The name of the database schema
+    schema: String,
+    /// The subgraph id
+    subgraph: SubgraphDeploymentId,
+    table: DynamicTable<String>,
+    id: EntityColumn<diesel::sql_types::Text>,
+    entity: EntityColumn<diesel::sql_types::Text>,
+    data: EntityColumn<diesel::sql_types::Jsonb>,
+    event_source: EntityColumn<diesel::sql_types::Text>,
+}
+
+/// Helper struct to support a custom query for entity history
+#[derive(Debug, Queryable)]
+struct RawHistory {
+    id: i32,
+    entity: String,
+    entity_id: String,
+    data: Option<serde_json::Value>,
+    // The operation that lead to this history record
+    // 0 = INSERT, 1 = UPDATE, 2 = DELETE
+    op: i16,
+}
+
+impl QueryableByName<Pg> for RawHistory {
+    // Extract one RawHistory entry from the database. The names of the columns
+    // must follow exactly the names used in the queries in revert_block
+    fn build<R: diesel::row::NamedRow<Pg>>(row: &R) -> diesel::deserialize::Result<Self> {
+        Ok(RawHistory {
+            id: row.get("id")?,
+            entity: row.get("entity")?,
+            entity_id: row.get("entity_id")?,
+            data: row.get::<Nullable<Jsonb>, _>("data_before")?,
+            op: row.get("op_id")?,
+        })
+    }
+}
+
+/// Represents a subgraph, and how it is stored in the database. The
+/// implementation of this enum masks which scheme is used to the rest of
+/// the code.
+#[derive(Clone, Debug)]
+pub(crate) enum Table {
+    Public(SubgraphDeploymentId),
+    Split(SplitTable),
+}
+
+/// A connection into the database to handle entities which caches the
+/// mapping to actual database tables. Instances of this struct must not be
+/// cached across transactions as we do not track possible changes to
+/// entity storage, such as migrating a subgraph from the monolithic
+/// entities table to a split entities table
+pub(crate) struct Connection<'a> {
+    pub conn: &'a PgConnection,
+    tables: RefCell<HashMap<SubgraphDeploymentId, Table>>,
+}
+
+impl<'a> Connection<'a> {
+    pub(crate) fn new(conn: &'a PgConnection) -> Connection<'a> {
+        Connection {
+            conn,
+            tables: RefCell::new(HashMap::new()),
+        }
+    }
+
+    /// Return a table for the subgraph
+    fn table(&self, subgraph: &SubgraphDeploymentId) -> Result<Table, StoreError> {
+        let mut tables = self.tables.borrow_mut();
+
+        match tables.get(subgraph) {
+            Some(table) => Ok(table.clone()),
+            None => {
+                let table = Table::new(self.conn, subgraph)?;
+                tables.insert(subgraph.clone(), table.clone());
+                Ok(table)
+            }
+        }
+    }
+
+    pub(crate) fn find(
+        &self,
+        subgraph: &SubgraphDeploymentId,
+        entity: &String,
+        id: &String,
+    ) -> Result<Option<serde_json::Value>, StoreError> {
+        let table = self.table(subgraph)?;
+        table.find(self.conn, entity, id)
+    }
+
+    pub(crate) fn query(
+        &self,
+        subgraph: &SubgraphDeploymentId,
+        entity_types: Vec<String>,
+        filter: Option<EntityFilter>,
+        order: Option<(String, &str, &str)>,
+        first: Option<u32>,
+        skip: u32,
+    ) -> Result<Vec<(serde_json::Value, String)>, QueryExecutionError> {
+        let table = self.table(subgraph)?;
+        table.query(self.conn, entity_types, filter, order, first, skip)
+    }
+}
+
+// Find the database schema for `subgraph`. If no explicit schema exists,
+// return `None`.
+fn find_schema(
+    conn: &diesel::pg::PgConnection,
+    subgraph: &SubgraphDeploymentId,
+) -> Result<Option<Schema>, StoreError> {
+    Ok(deployment_schemas::table
+        .filter(deployment_schemas::subgraph.eq(subgraph.to_string()))
+        .first::<Schema>(conn)
+        .optional()?)
+}
+
+impl SplitTable {
+    fn new(sc: String, subgraph: SubgraphDeploymentId) -> Self {
+        let table = schema(sc.clone()).table("entities".to_owned());
+        let id = table.column::<Text, _>("id".to_string());
+        let entity = table.column::<Text, _>("entity".to_string());
+        let data = table.column::<Jsonb, _>("data".to_string());
+        let event_source = table.column::<Text, _>("event_source".to_string());
+
+        SplitTable {
+            schema: sc,
+            subgraph: subgraph,
+            table,
+            id,
+            entity,
+            data,
+            event_source,
+        }
+    }
+}
+
+impl Table {
+
+    /// Look up the schema for `subgraph` and return its entity table.
+    /// Returns an error if `subgraph` does not have an entry in
+    /// `deployment_schemas`, which can only happen if `create_schema` was not
+    /// called for that `subgraph`
+    fn new(conn: &PgConnection, subgraph: &SubgraphDeploymentId) -> Result<Self, StoreError> {
+        use public::DeploymentSchemaVersion as V;
+
+        let schema = find_schema(conn, subgraph)?
+            .ok_or_else(|| StoreError::Unknown(format_err!("unknown subgraph {}", subgraph)))?;
+        let table = match schema.version {
+            V::Public => Table::Public(subgraph.clone()),
+            V::Split => Table::Split(SplitTable::new(schema.name, subgraph.clone())),
+        };
+        Ok(table)
+    }
+
+    fn find(
+        &self,
+        conn: &PgConnection,
+        entity: &str,
+        id: &String,
+    ) -> Result<Option<serde_json::Value>, StoreError> {
+        match self {
+            Table::Public(subgraph) => Ok(public::entities::table
+                .find((id, subgraph.to_string(), entity))
+                .select(public::entities::data)
+                .first::<serde_json::Value>(conn)
+                .optional()?),
+            Table::Split(entities) => {
+                let entities = entities.clone();
+                Ok(entities
+                    .table
+                    .filter(entities.entity.eq(entity).and(entities.id.eq(id)))
+                    .select(entities.data)
+                    .first::<serde_json::Value>(conn)
+                    .optional()?)
+            }
+        }
+    }
+
+    /// order is a tuple (attribute, cast, direction)
+    fn query(
+        &self,
+        conn: &PgConnection,
+        entity_types: Vec<String>,
+        filter: Option<EntityFilter>,
+        order: Option<(String, &str, &str)>,
+        first: Option<u32>,
+        skip: u32,
+    ) -> Result<Vec<(serde_json::Value, String)>, QueryExecutionError> {
+        match self {
+            Table::Public(subgraph) => {
+                // Create base boxed query; this will be added to based on the
+                // query parameters provided
+                let mut query = public::entities::table
+                    .filter(public::entities::entity.eq(any(entity_types)))
+                    .filter(public::entities::subgraph.eq(subgraph.to_string()))
+                    .select((public::entities::data, public::entities::entity))
+                    .into_boxed::<Pg>();
+
+                // Add specified filter to query
+                if let Some(filter) = filter {
+                    query =
+                        store_filter::<public::entities::table, _>(query, filter).map_err(|e| {
+                            QueryExecutionError::FilterNotSupportedError(
+                                format!("{}", e.value),
+                                e.filter,
+                            )
+                        })?;
+                }
+
+                // Add order by filters to query
+                if let Some((attribute, cast, direction)) = order {
+                    query = query.order(
+                        sql::<Text>("(data ->")
+                            .bind::<Text, _>(attribute)
+                            .sql("->> 'data')")
+                            .sql(cast)
+                            .sql(" ")
+                            .sql(direction)
+                            .sql(" NULLS LAST"),
+                    );
+                }
+
+                // Add range filter to query
+                if let Some(first) = first {
+                    query = query.limit(first as i64);
+                }
+                if skip > 0 {
+                    query = query.offset(skip as i64);
+                }
+
+                let query_debug_info = debug_query(&query).to_string();
+
+                // Process results; deserialize JSON data
+                query
+                    .load::<(serde_json::Value, String)>(conn)
+                    .map_err(|e| {
+                        QueryExecutionError::ResolveEntitiesError(format!(
+                            "{}, query = {:?}",
+                            e, query_debug_info
+                        ))
+                    })
+            }
+            Table::Split(entities) => {
+                let entities = entities.clone();
+
+                let mut query = entities
+                    .table
+                    .filter((&entities.entity).eq(any(entity_types)))
+                    .select((&entities.data, &entities.entity))
+                    .into_boxed::<Pg>();
+
+                if let Some(filter) = filter {
+                    query = store_filter(query, filter).map_err(|e| {
+                        QueryExecutionError::FilterNotSupportedError(
+                            format!("{}", e.value),
+                            e.filter,
+                        )
+                    })?;
+                }
+
+                if let Some((attribute, cast, direction)) = order {
+                    query = query.order(
+                        sql::<Text>("(data ->")
+                            .bind::<Text, _>(attribute)
+                            .sql("->> 'data')")
+                            .sql(cast)
+                            .sql(" ")
+                            .sql(direction)
+                            .sql(" NULLS LAST"),
+                    );
+                }
+
+                if let Some(first) = first {
+                    query = query.limit(first as i64);
+                }
+                if skip > 0 {
+                    query = query.offset(skip as i64);
+                }
+
+                let query_debug_info = debug_query(&query).to_string();
+
+                query
+                    .load::<(serde_json::Value, String)>(conn)
+                    .map_err(|e| {
+                        QueryExecutionError::ResolveEntitiesError(format!(
+                            "{}, query = {:?}",
+                            e, query_debug_info
+                        ))
+                    })
+            }
+        }
+    }
+}

--- a/graph_node_reader/src/filter.rs
+++ b/graph_node_reader/src/filter.rs
@@ -1,0 +1,395 @@
+use diesel::dsl::{self, sql};
+use diesel::pg::Pg;
+use diesel::prelude::*;
+use diesel::query_builder::BoxedSelectStatement;
+use diesel::serialize::ToSql;
+use diesel::sql_types::{Array, Bool, Double, HasSqlType, Integer, Numeric, Text};
+use std::str::FromStr;
+
+use graph::components::store::EntityFilter;
+use graph::data::store::*;
+use graph::prelude::{BigDecimal, BigInt};
+use graph::serde_json;
+
+use crate::entities::EntitySource;
+use crate::sql_value::SqlValue;
+
+#[derive(Debug)]
+pub(crate) struct UnsupportedFilter {
+    pub filter: String,
+    pub value: Value,
+}
+
+type FilterExpression<QS> = Box<BoxableExpression<QS, Pg, SqlType = Bool>>;
+
+trait IntoFilter<QS> {
+    fn into_filter(self, attribute: String, op: &str) -> FilterExpression<QS>;
+}
+
+impl<QS> IntoFilter<QS> for String {
+    fn into_filter(self, attribute: String, op: &str) -> FilterExpression<QS> {
+        Box::new(
+            sql("data -> ")
+                .bind::<Text, _>(attribute)
+                .sql("->> 'data'")
+                .sql(op)
+                .bind::<Text, _>(self),
+        ) as FilterExpression<QS>
+    }
+}
+
+impl<QS> IntoFilter<QS> for f64 {
+    fn into_filter(self, attribute: String, op: &str) -> FilterExpression<QS> {
+        Box::new(
+            sql("(data -> ")
+                .bind::<Text, _>(attribute)
+                .sql("->> 'data')::float")
+                .sql(op)
+                .bind::<Double, _>(self),
+        ) as FilterExpression<QS>
+    }
+}
+
+impl<QS> IntoFilter<QS> for i32 {
+    fn into_filter(self, attribute: String, op: &str) -> FilterExpression<QS> {
+        Box::new(
+            sql("(data -> ")
+                .bind::<Text, _>(attribute)
+                .sql("->> 'data')::int")
+                .sql(op)
+                .bind::<Integer, _>(self),
+        ) as FilterExpression<QS>
+    }
+}
+
+impl<QS> IntoFilter<QS> for bool {
+    fn into_filter(self, attribute: String, op: &str) -> FilterExpression<QS> {
+        Box::new(
+            sql("(data -> ")
+                .bind::<Text, _>(attribute)
+                .sql("->> 'data')::boolean")
+                .sql(op)
+                .bind::<Bool, _>(self),
+        ) as FilterExpression<QS>
+    }
+}
+
+impl<QS> IntoFilter<QS> for BigInt {
+    fn into_filter(self, attribute: String, op: &str) -> FilterExpression<QS> {
+        Box::new(
+            sql("(data -> ")
+                .bind::<Text, _>(attribute)
+                .sql("->> 'data')::numeric")
+                .sql(op)
+                // Using `BigDecimal::new(query_value.0, 0)` results in a
+                // mismatch of `bignum` versions, go through the string
+                // representation to work around that.
+                .bind::<Numeric, _>(BigDecimal::from_str(&self.to_string()).unwrap()),
+        ) as FilterExpression<QS>
+    }
+}
+
+impl<QS> IntoFilter<QS> for BigDecimal {
+    fn into_filter(self, attribute: String, op: &str) -> FilterExpression<QS> {
+        Box::new(
+            sql("(data -> ")
+                .bind::<Text, _>(attribute)
+                .sql("->> 'data')::numeric")
+                .sql(op)
+                .bind::<Numeric, _>(self),
+        ) as FilterExpression<QS>
+    }
+}
+
+trait IntoArrayFilter<QS, T>
+where
+    T: 'static,
+{
+    fn into_array_filter<U>(
+        self,
+        attribute: String,
+        op: &str,
+        coercion: &str,
+    ) -> FilterExpression<QS>
+    where
+        T: ToSql<U, Pg>,
+        U: 'static,
+        Pg: HasSqlType<U>;
+}
+
+impl<QS> IntoArrayFilter<QS, SqlValue> for Vec<SqlValue> {
+    fn into_array_filter<U>(
+        self,
+        attribute: String,
+        op: &str,
+        coercion: &str,
+    ) -> FilterExpression<QS>
+    where
+        SqlValue: ToSql<U, Pg>,
+        U: 'static,
+        Pg: HasSqlType<U>,
+    {
+        Box::new(
+            sql("(data -> ")
+                .bind::<Text, _>(attribute)
+                .sql("->> 'data')")
+                .sql(coercion)
+                .sql(op)
+                .sql("(")
+                .bind::<Array<U>, _>(self)
+                .sql(")"),
+        ) as FilterExpression<QS>
+    }
+}
+
+/// Adds `filter` to a `SELECT data FROM entities` statement.
+pub(crate) fn store_filter<QS, ST>(
+    query: BoxedSelectStatement<ST, QS, Pg>,
+    filter: EntityFilter,
+) -> Result<BoxedSelectStatement<ST, QS, Pg>, UnsupportedFilter>
+where
+    QS: EntitySource + 'static,
+{
+    Ok(query.filter(build_filter(filter)?))
+}
+
+pub(crate) fn build_filter<QS>(
+    filter: EntityFilter,
+) -> Result<FilterExpression<QS>, UnsupportedFilter>
+where
+    QS: EntitySource + 'static,
+{
+    use self::EntityFilter::*;
+
+    let false_expr = Box::new(false.into_sql::<Bool>()) as FilterExpression<QS>;
+    let true_expr = Box::new(true.into_sql::<Bool>()) as FilterExpression<QS>;
+
+    match filter {
+        And(filters) => filters.into_iter().try_fold(true_expr, |p, filter| {
+            build_filter(filter)
+                .map(|filter_expr| Box::new(p.and(filter_expr)) as FilterExpression<QS>)
+        }),
+
+        Or(filters) => filters.into_iter().try_fold(false_expr, |p, filter| {
+            build_filter(filter)
+                .map(|filter_expr| Box::new(p.or(filter_expr)) as FilterExpression<QS>)
+        }),
+
+        Contains(..) | NotContains(..) => {
+            let (attribute, contains, op, value) = match filter {
+                EntityFilter::Contains(attribute, value) => (attribute, true, " LIKE ", value),
+                EntityFilter::NotContains(attribute, value) => {
+                    (attribute, false, " NOT LIKE ", value)
+                }
+                _ => unreachable!(),
+            };
+
+            match value {
+                Value::String(s) => Ok(s.into_filter(attribute, op)),
+                Value::Bytes(b) => Ok(b.to_string().into_filter(attribute, op)),
+                Value::List(lst) => {
+                    let s = serde_json::to_string(&lst).expect("failed to serialize list value");
+                    let predicate = sql("data -> ")
+                        .bind::<Text, _>(attribute)
+                        .sql("-> 'data' @> ")
+                        .bind::<Text, _>(s)
+                        .sql("::jsonb");
+                    if contains {
+                        Ok(Box::new(predicate) as FilterExpression<QS>)
+                    } else {
+                        Ok(Box::new(dsl::not(predicate)) as FilterExpression<QS>)
+                    }
+                }
+                Value::Null
+                | Value::BigDecimal(_)
+                | Value::Int(_)
+                | Value::Bool(_)
+                | Value::BigInt(_) => {
+                    return Err(UnsupportedFilter {
+                        filter: if contains { "contains" } else { "not_contains" }.to_owned(),
+                        value,
+                    });
+                }
+            }
+        }
+
+        Equal(..) | Not(..) => {
+            let (attribute, op, is_negated, value) = match filter {
+                Equal(attribute, value) => (attribute, " = ", false, value),
+                Not(attribute, value) => (attribute, " != ", true, value),
+                _ => unreachable!(),
+            };
+
+            match value {
+                Value::BigInt(n) => Ok(n.into_filter(attribute, op)),
+                Value::Bool(b) => Ok(b.into_filter(attribute, op)),
+                Value::Bytes(b) => Ok(b.to_string().into_filter(attribute, op)),
+                Value::BigDecimal(n) => Ok(n.into_filter(attribute, op)),
+                Value::Int(n) => Ok(n.into_filter(attribute, op)),
+                Value::List(lst) => {
+                    // In order to compare lists, we have to coerce the database value to jsonb
+                    let s = serde_json::to_string(&lst).expect("failed to serialize list value");
+                    Ok(Box::new(
+                        sql("(")
+                            .sql("data -> ")
+                            .bind::<Text, _>(attribute)
+                            .sql("-> 'data'")
+                            .sql(")::jsonb")
+                            .sql(op)
+                            .bind::<Text, _>(s)
+                            .sql("::jsonb"),
+                    ))
+                }
+                Value::Null => Ok(if is_negated {
+                    // Value is not null if the property is present ("IS NOT NULL") and is not a
+                    // value of the 'Null' type.
+                    Box::new(
+                        sql("data -> ")
+                            .bind::<Text, _>(attribute.clone())
+                            .sql(" IS NOT NULL ")
+                            .and(
+                                sql("data -> ")
+                                    .bind::<Text, _>(attribute)
+                                    .sql(" ->> 'type' != 'Null' "),
+                            ),
+                    )
+                } else {
+                    // Value is null if the property is missing ("IS NULL") or is present but is a
+                    // value of the 'Null' type.
+                    Box::new(
+                        sql("data -> ")
+                            .bind::<Text, _>(attribute.clone())
+                            .sql(" IS NULL ")
+                            .or(sql("data -> ")
+                                .bind::<Text, _>(attribute)
+                                .sql(" ->> 'type' = 'Null' ")),
+                    )
+                }),
+                Value::String(s) => Ok(s.into_filter(attribute, op)),
+            }
+        }
+
+        GreaterThan(..) | LessThan(..) | GreaterOrEqual(..) | LessOrEqual(..) => {
+            let (attribute, op, value) = match filter {
+                GreaterThan(attribute, value) => (attribute, " > ", value),
+                LessThan(attribute, value) => (attribute, " < ", value),
+                GreaterOrEqual(attribute, value) => (attribute, " >= ", value),
+                LessOrEqual(attribute, value) => (attribute, " <= ", value),
+                _ => unreachable!(),
+            };
+
+            match value {
+                Value::BigInt(n) => Ok(n.into_filter(attribute, op)),
+                Value::BigDecimal(n) => Ok(n.into_filter(attribute, op)),
+                Value::Int(n) => Ok(n.into_filter(attribute, op)),
+                Value::String(s) => Ok(s.into_filter(attribute, op)),
+                Value::Bool(_) | Value::Bytes(_) | Value::List(_) | Value::Null => {
+                    return Err(UnsupportedFilter {
+                        filter: op.to_owned(),
+                        value,
+                    });
+                }
+            }
+        }
+
+        In(attribute, values) => {
+            if values.is_empty() {
+                return Ok(false_expr);
+            }
+            let op = " = ANY ";
+
+            match values[0] {
+                Value::BigInt(_) | Value::BigDecimal(_) => Ok(SqlValue::new_array(values)
+                    .into_array_filter::<Numeric>(attribute, op, "::numeric")),
+                Value::Bool(_) => Ok(SqlValue::new_array(values).into_array_filter::<Bool>(
+                    attribute,
+                    op,
+                    "::boolean",
+                )),
+                Value::Bytes(_) => {
+                    Ok(SqlValue::new_array(values).into_array_filter::<Text>(attribute, op, ""))
+                }
+                Value::Int(_) => Ok(SqlValue::new_array(values)
+                    .into_array_filter::<Integer>(attribute, op, "::int")),
+                Value::String(_) => {
+                    Ok(SqlValue::new_array(values).into_array_filter::<Text>(attribute, op, ""))
+                }
+                Value::List(_) | Value::Null => {
+                    return Err(UnsupportedFilter {
+                        filter: "in".to_owned(),
+                        value: Value::List(values),
+                    });
+                }
+            }
+        }
+
+        NotIn(attribute, values) => {
+            if values.is_empty() {
+                return Ok(true_expr);
+            }
+
+            build_filter(And(values
+                .into_iter()
+                .map(|value| Not(attribute.clone(), value))
+                .collect()))
+        }
+
+        StartsWith(..) | NotStartsWith(..) => {
+            let (attribute, op, value) = match filter {
+                StartsWith(attribute, value) => (attribute, " LIKE ", value),
+                NotStartsWith(attribute, value) => (attribute, " NOT LIKE ", value),
+                _ => unreachable!(),
+            };
+
+            match value {
+                Value::String(s) => Ok(format!("{}%", s).into_filter(attribute, op)),
+                Value::Bool(_)
+                | Value::BigInt(_)
+                | Value::Bytes(_)
+                | Value::BigDecimal(_)
+                | Value::Int(_)
+                | Value::List(_)
+                | Value::Null => {
+                    return Err(UnsupportedFilter {
+                        filter: if op == " LIKE " {
+                            "starts_with"
+                        } else {
+                            "not_starts_with"
+                        }
+                        .to_owned(),
+                        value,
+                    });
+                }
+            }
+        }
+
+        EndsWith(..) | NotEndsWith(..) => {
+            let (attribute, op, value) = match filter {
+                EndsWith(attribute, value) => (attribute, " LIKE ", value),
+                NotEndsWith(attribute, value) => (attribute, " NOT LIKE ", value),
+                _ => unreachable!(),
+            };
+
+            match value {
+                Value::String(s) => Ok(format!("%{}", s).into_filter(attribute, op)),
+                Value::Bool(_)
+                | Value::BigInt(_)
+                | Value::Bytes(_)
+                | Value::BigDecimal(_)
+                | Value::Int(_)
+                | Value::List(_)
+                | Value::Null => {
+                    return Err(UnsupportedFilter {
+                        filter: if op == " LIKE " {
+                            "ends_with"
+                        } else {
+                            "not_ends_with"
+                        }
+                        .to_owned(),
+                        value,
+                    });
+                }
+            }
+        }
+    }
+}

--- a/graph_node_reader/src/lib.rs
+++ b/graph_node_reader/src/lib.rs
@@ -1,0 +1,12 @@
+#[macro_use]
+extern crate diesel;
+extern crate diesel_dynamic_schema;
+#[macro_use]
+extern crate diesel_derive_enum;
+
+mod entities;
+mod filter;
+mod sql_value;
+
+pub mod store;
+pub use self::store::{Store, StoreReader};

--- a/graph_node_reader/src/sql_value.rs
+++ b/graph_node_reader/src/sql_value.rs
@@ -1,0 +1,55 @@
+use diesel::pg::Pg;
+use diesel::serialize::{self, Output, ToSql};
+use diesel::sql_types::{Bool, Integer, Numeric, Text};
+use std::io::Write;
+
+use graph::data::store::Value;
+
+#[derive(Clone, Debug, PartialEq, AsExpression)]
+pub struct SqlValue(Value);
+
+impl SqlValue {
+    pub fn new_array(values: Vec<Value>) -> Vec<Self> {
+        values.into_iter().map(SqlValue).collect()
+    }
+}
+
+impl ToSql<Bool, Pg> for SqlValue {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
+        match self.0 {
+            Value::Bool(ref b) => <bool as ToSql<Bool, Pg>>::to_sql(&b, out),
+            _ => panic!("Failed to convert non-boolean attribute value to boolean in SQL"),
+        }
+    }
+}
+
+impl ToSql<Integer, Pg> for SqlValue {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
+        match self.0 {
+            Value::Int(ref i) => <i32 as ToSql<Integer, Pg>>::to_sql(&i, out),
+            _ => panic!("Failed to convert non-int attribute value to int in SQL"),
+        }
+    }
+}
+
+impl ToSql<Numeric, Pg> for SqlValue {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
+        match &self.0 {
+            Value::BigDecimal(d) => <_ as ToSql<Numeric, Pg>>::to_sql(&d, out),
+            Value::BigInt(number) => {
+                <_ as ToSql<Numeric, Pg>>::to_sql(&number.clone().to_big_decimal(0.into()), out)
+            }
+            _ => panic!("Failed to convert attribute value to bigint in SQL"),
+        }
+    }
+}
+
+impl ToSql<Text, Pg> for SqlValue {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
+        match self.0 {
+            Value::String(ref s) => <String as ToSql<Text, Pg>>::to_sql(&s, out),
+            Value::Bytes(ref h) => <String as ToSql<Text, Pg>>::to_sql(&h.to_string(), out),
+            _ => panic!("Failed to convert attribute value to String or Bytes in SQL"),
+        }
+    }
+}

--- a/graph_node_reader/src/store.rs
+++ b/graph_node_reader/src/store.rs
@@ -1,0 +1,207 @@
+use diesel::pg::PgConnection;
+use diesel::r2d2::{self, ConnectionManager, Pool, PooledConnection};
+use std::time::{Duration, Instant};
+
+use graph::prelude::*;
+use graph::serde_json;
+use graph::util::security::SafeDisplay;
+
+use crate::entities as e;
+
+/// A Store based on Diesel and Postgres.
+pub struct Store {
+    logger: Logger,
+    // listen to StoreEvents generated when applying entity operations
+    conn: Pool<ConnectionManager<PgConnection>>,
+}
+
+impl Store {
+    pub fn new(
+        postgres_url: String,
+        logger: &Logger,
+    ) -> Self {
+        // Create a store-specific logger
+        let logger = logger.new(o!("component" => "Store"));
+
+        #[derive(Debug)]
+        struct ErrorHandler(Logger);
+        impl r2d2::HandleError<r2d2::Error> for ErrorHandler {
+            fn handle_error(&self, error: r2d2::Error) {
+                error!(self.0, "Postgres connection error"; "error" => error.to_string())
+            }
+        }
+        let error_handler = Box::new(ErrorHandler(logger.clone()));
+
+        // Connect to Postgres
+        let conn_manager = ConnectionManager::new(postgres_url.as_str());
+        let pool = Pool::builder()
+            .error_handler(error_handler)
+            // Set the time we wait for a connection to 6h. The default is 30s
+            // which can be too little if database connections are highly
+            // contended; if we don't get a connection within the timeout,
+            // ultimately subgraphs get marked as failed. This effectively
+            // turns off this timeout and makes it possible that work needing
+            // a database connection blocks for a very long time
+            .connection_timeout(Duration::from_secs(6 * 60 * 60))
+            .build(conn_manager)
+            .unwrap();
+        info!(
+            logger,
+            "Connected to Postgres";
+            "url" => SafeDisplay(postgres_url.as_str())
+        );
+
+        // Create the store
+        let store = Store {
+            logger: logger.clone(),
+            conn: pool,
+        };
+        // Return the store
+        store
+    }
+
+    /// Gets an entity from Postgres.
+    fn get_entity(
+        &self,
+        conn: &e::Connection,
+        op_subgraph: &SubgraphDeploymentId,
+        op_entity: &String,
+        op_id: &String,
+    ) -> Result<Option<Entity>, QueryExecutionError> {
+        match conn.find(op_subgraph, op_entity, op_id).map_err(|e| {
+            QueryExecutionError::ResolveEntityError(
+                op_subgraph.clone(),
+                op_entity.clone(),
+                op_id.clone(),
+                format!("{}", e),
+            )
+        })? {
+            Some(json) => {
+                let mut value = serde_json::from_value::<Entity>(json).map_err(|e| {
+                    QueryExecutionError::ResolveEntityError(
+                        op_subgraph.clone(),
+                        op_entity.clone(),
+                        op_id.clone(),
+                        format!("Invalid entity: {}", e),
+                    )
+                })?;
+                value.set("__typename", op_entity);
+                Ok(Some(value))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn execute_query(
+        &self,
+        conn: &e::Connection,
+        query: EntityQuery,
+    ) -> Result<Vec<Entity>, QueryExecutionError> {
+        // Add order by filters to query
+        let order = match query.order_by {
+            Some((attribute, value_type)) => {
+                let direction = query
+                    .order_direction
+                    .map(|direction| match direction {
+                        EntityOrder::Ascending => "ASC",
+                        EntityOrder::Descending => "DESC",
+                    })
+                    .unwrap_or("ASC");
+                let cast_type = match value_type {
+                    ValueType::BigInt | ValueType::BigDecimal => "::numeric",
+                    ValueType::Boolean => "::boolean",
+                    ValueType::Bytes => "",
+                    ValueType::ID => "",
+                    ValueType::Int => "::bigint",
+                    ValueType::String => "",
+                    ValueType::List => {
+                        return Err(QueryExecutionError::OrderByNotSupportedForType(
+                            "List".to_string(),
+                        ));
+                    }
+                };
+                Some((attribute, cast_type, direction))
+            }
+            None => None,
+        };
+
+        // Process results; deserialize JSON data
+        conn.query(
+            &query.subgraph_id,
+            query.entity_types,
+            query.filter,
+            order,
+            query.range.first,
+            query.range.skip,
+        )
+        .map(|values| {
+            values
+                .into_iter()
+                .map(|(value, entity_type)| {
+                    let parse_error_msg = format!("Error parsing entity JSON: {:?}", value);
+                    let mut value =
+                        serde_json::from_value::<Entity>(value).expect(&parse_error_msg);
+                    value.set("__typename", entity_type);
+                    value
+                })
+                .collect()
+        })
+    }
+
+    fn get_conn(&self) -> Result<PooledConnection<ConnectionManager<PgConnection>>, Error> {
+        let start_time = Instant::now();
+        let conn = self.conn.get();
+        let wait = start_time.elapsed();
+        if wait > Duration::from_millis(10) {
+            warn!(self.logger, "Possible contention in DB connection pool";
+                               "wait_ms" => wait.as_millis())
+        }
+        conn.map_err(Error::from)
+    }
+}
+
+/// Common trait for store implementations.
+pub trait StoreReader: Send + Sync + 'static {
+    /// Looks up an entity using the given store key.
+    fn get(&self, key: EntityKey) -> Result<Option<Entity>, QueryExecutionError>;
+
+    /// Queries the store for entities that match the store query.
+    fn find(&self, query: EntityQuery) -> Result<Vec<Entity>, QueryExecutionError>;
+
+    /// Queries the store for a single entity matching the store query.
+    fn find_one(&self, query: EntityQuery) -> Result<Option<Entity>, QueryExecutionError>;
+}
+
+impl StoreReader for Store {
+
+    fn get(&self, key: EntityKey) -> Result<Option<Entity>, QueryExecutionError> {
+        let conn = self
+            .get_conn()
+            .map_err(|e| QueryExecutionError::StoreError(e.into()))?;
+        let conn = e::Connection::new(&conn);
+        self.get_entity(&conn, &key.subgraph_id, &key.entity_type, &key.entity_id)
+    }
+
+    fn find(&self, query: EntityQuery) -> Result<Vec<Entity>, QueryExecutionError> {
+        let conn = self
+            .get_conn()
+            .map_err(|e| QueryExecutionError::StoreError(e.into()))?;
+        let conn = e::Connection::new(&conn);
+        self.execute_query(&conn, query)
+    }
+
+    fn find_one(&self, mut query: EntityQuery) -> Result<Option<Entity>, QueryExecutionError> {
+        query.range = EntityRange::first(1);
+
+        let conn = self
+            .get_conn()
+            .map_err(|e| QueryExecutionError::StoreError(e.into()))?;
+        let conn = e::Connection::new(&conn);
+
+        let mut results = self.execute_query(&conn, query)?;
+        match results.len() {
+            0 | 1 => Ok(results.pop()),
+            n => panic!("find_one query found {} results", n),
+        }
+    }
+}


### PR DESCRIPTION
At the moment, the only way to interact with the low level postgres representation from The Graph is via the [Store trait](https://github.com/graphprotocol/graph-node/blob/master/graph/src/components/store.rs#L650).

This trait is very elaborative in that it not only handles both read and write operations, it also covers both chain related storage as well as entity related storage.

The only thing we are interested on the driver side (and long term also on the listener side) is to read Entities. This means, we don't want to setup the entire dependency graph that the main graph component requires (GQL adapter, ethereum adapter, etc), but instead want to be able to instantiate a reader component just from a postgres connection (with a read-only user).

This PR takes the large store component from the graph repo and removes all write and chain related parts, leaving only a simple interface to query entities (code is copied). This interface will be used to implement database access inside the driver.

Long term, it would be nice if we could push such a separation of concerns inside the graph's main repository as their monolithic storage design seems quite inflexible.


### TestPlan

Make sure we can instantiate a version of this reader in the driver's main function just using a postgres connection.