### PR TITLE
Minor changes to the db interface

### DIFF
--- a/dfusion_rust_core/src/database/mod.rs
+++ b/dfusion_rust_core/src/database/mod.rs
@@ -1,30 +1,34 @@
 mod error;
 
-use web3::types::H256;
+use web3::types::{H256, U256};
 
 pub use error::*;
 use super::models;
 
 pub trait DbInterface {
-    fn get_current_balances(
+    fn get_balances_for_state_root(
         &self,
-        current_state_root: &H256,
+        state_root: &H256,
+    ) -> Result<models::AccountState, DatabaseError>;
+    fn get_balances_for_state_index(
+        &self,
+        state_index: &U256,
     ) -> Result<models::AccountState, DatabaseError>;
     fn get_deposits_of_slot(
         &self,
-        slot: u32,
+        slot: &U256,
     ) -> Result<Vec<models::PendingFlux>, DatabaseError>;
     fn get_withdraws_of_slot(
         &self,
-        slot: u32,
+        slot: &U256,
     ) -> Result<Vec<models::PendingFlux>, DatabaseError>;
     fn get_orders_of_slot(
         &self,
-        slot: u32,
+        slot: &U256,
     ) -> Result<Vec<models::Order>, DatabaseError>;
     fn get_standing_orders_of_slot(
         &self,
-        slot: u32,
+        slot: &U256,
     ) -> Result<[models::StandingOrder; models::NUM_RESERVED_ACCOUNTS], DatabaseError>;
 }
 
@@ -36,17 +40,19 @@ pub mod tests {
 
     #[derive(Clone)]
     pub struct DbInterfaceMock {
-        pub get_current_balances: Mock<H256, Result<models::AccountState, DatabaseError>>,
-        pub get_deposits_of_slot: Mock<u32, Result<Vec<models::PendingFlux>, DatabaseError>>,
-        pub get_withdraws_of_slot: Mock<u32, Result<Vec<models::PendingFlux>, DatabaseError>>,
-        pub get_orders_of_slot: Mock<u32, Result<Vec<models::Order>, DatabaseError>>,
-        pub get_standing_orders_of_slot: Mock<u32, Result<[models::StandingOrder; models::NUM_RESERVED_ACCOUNTS], DatabaseError>>,
+        pub get_balances_for_state_root: Mock<H256, Result<models::AccountState, DatabaseError>>,
+        pub get_balances_for_state_index: Mock<U256, Result<models::AccountState, DatabaseError>>,
+        pub get_deposits_of_slot: Mock<U256, Result<Vec<models::PendingFlux>, DatabaseError>>,
+        pub get_withdraws_of_slot: Mock<U256, Result<Vec<models::PendingFlux>, DatabaseError>>,
+        pub get_orders_of_slot: Mock<U256, Result<Vec<models::Order>, DatabaseError>>,
+        pub get_standing_orders_of_slot: Mock<U256, Result<[models::StandingOrder; models::NUM_RESERVED_ACCOUNTS], DatabaseError>>,
     }
 
     impl DbInterfaceMock {
         pub fn new() -> DbInterfaceMock {
             DbInterfaceMock {
-                get_current_balances: Mock::new(Err(DatabaseError::new(ErrorKind::Unknown, "Unexpected call to get_current_balances"))),
+                get_balances_for_state_root: Mock::new(Err(DatabaseError::new(ErrorKind::Unknown, "Unexpected call to get_balances_for_state_root"))),
+                get_balances_for_state_index: Mock::new(Err(DatabaseError::new(ErrorKind::Unknown, "Unexpected call to get_balances_for_state_root"))),
                 get_deposits_of_slot: Mock::new(Err(DatabaseError::new(ErrorKind::Unknown, "Unexpected call to get_deposits_of_slot"))),
                 get_withdraws_of_slot: Mock::new(Err(DatabaseError::new(ErrorKind::Unknown, "Unexpected call to get_withdraws_of_slot"))),
                 get_orders_of_slot: Mock::new(Err(DatabaseError::new(ErrorKind::Unknown, "Unexpected call to get_withdraws_of_slot"))),
@@ -62,35 +68,41 @@ pub mod tests {
     }
 
     impl DbInterface for DbInterfaceMock {
-        fn get_current_balances(
+        fn get_balances_for_state_root(
             &self,
-            current_state_root: &H256,
+            state_root: &H256,
         ) -> Result<models::AccountState, DatabaseError> {
-            self.get_current_balances.called(*current_state_root)  // https://github.com/intellij-rust/intellij-rust/issues/3164
+            self.get_balances_for_state_root.called(*state_root)  // https://github.com/intellij-rust/intellij-rust/issues/3164
+        }
+        fn get_balances_for_state_index(
+            &self,
+            state_index: &U256,
+        ) -> Result<models::AccountState, DatabaseError> {
+            self.get_balances_for_state_index.called(*state_index)
         }
         fn get_deposits_of_slot(
             &self,
-            slot: u32,
+            slot: &U256,
         ) -> Result<Vec<models::PendingFlux>, DatabaseError> {
-            self.get_deposits_of_slot.called(slot)
+            self.get_deposits_of_slot.called(*slot)
         }
         fn get_withdraws_of_slot(
             &self,
-            slot: u32,
+            slot: &U256,
         ) -> Result<Vec<models::PendingFlux>, DatabaseError> {
-            self.get_withdraws_of_slot.called(slot)
+            self.get_withdraws_of_slot.called(*slot)
         }
         fn get_orders_of_slot(
             &self,
-            slot: u32,
+            slot: &U256,
         ) -> Result<Vec<models::Order>, DatabaseError> {
-            self.get_orders_of_slot.called(slot)
+            self.get_orders_of_slot.called(*slot)
         }
         fn get_standing_orders_of_slot(
             &self,
-            slot: u32,
+            slot: &U256,
         ) -> Result<[models::StandingOrder; models::NUM_RESERVED_ACCOUNTS], DatabaseError> {
-            self.get_standing_orders_of_slot.called(slot)
+            self.get_standing_orders_of_slot.called(*slot)
         }
     }
 }

--- a/driver/src/deposit_driver.rs
+++ b/driver/src/deposit_driver.rs
@@ -24,9 +24,9 @@ pub fn run_deposit_listener<D, C>(db: &D, contract: &C) -> Result<(bool), Driver
             info!("Processing deposit_slot {:?}", slot);
             let state_root = contract.get_current_state_root()?;
             let contract_deposit_hash = contract.deposit_hash_for_slot(slot)?;
-            let mut balances = db.get_current_balances(&state_root)?;
+            let mut balances = db.get_balances_for_state_root(&state_root)?;
 
-            let deposits = db.get_deposits_of_slot(slot.low_u32())?;
+            let deposits = db.get_deposits_of_slot(&slot)?;
             let deposit_hash = deposits.rolling_hash(0);
             hash_consistency_check(deposit_hash, contract_deposit_hash, "deposit")?;
 
@@ -78,8 +78,8 @@ mod tests {
         contract.apply_deposits.given((slot, Any, Any, Any)).will_return(Ok(()));
 
         let db = DbInterfaceMock::new();
-        db.get_deposits_of_slot.given(1).will_return(Ok(deposits));
-        db.get_current_balances.given(state_hash).will_return(Ok(state));
+        db.get_deposits_of_slot.given(U256::one()).will_return(Ok(deposits));
+        db.get_balances_for_state_root.given(state_hash).will_return(Ok(state));
 
         assert_eq!(run_deposit_listener(&db, &contract), Ok(true));
     }
@@ -106,7 +106,7 @@ mod tests {
         contract.deposit_hash_for_slot.given(slot + 1).will_return(Ok(H256::zero()));
 
         let db = DbInterfaceMock::new();
-        db.get_current_balances.given(state_hash).will_return(Ok(state));
+        db.get_balances_for_state_root.given(state_hash).will_return(Ok(state));
 
         assert_eq!(run_deposit_listener(&db, &contract), Ok(false));
     }
@@ -135,7 +135,7 @@ mod tests {
         contract.deposit_hash_for_slot.given(slot).will_return(Ok(deposits.rolling_hash(0)));
 
         let db = DbInterfaceMock::new();
-        db.get_current_balances.given(state_hash).will_return(Ok(state));
+        db.get_balances_for_state_root.given(state_hash).will_return(Ok(state));
 
         assert_eq!(run_deposit_listener(&db, &contract), Ok(false));
     }
@@ -168,8 +168,8 @@ mod tests {
         );
 
         let db = DbInterfaceMock::new();
-        db.get_deposits_of_slot.given(0).will_return(Ok(first_deposits));
-        db.get_current_balances.given(state_hash).will_return(Ok(state));
+        db.get_deposits_of_slot.given(U256::zero()).will_return(Ok(first_deposits));
+        db.get_balances_for_state_root.given(state_hash).will_return(Ok(state));
         
         assert_eq!(run_deposit_listener(&db, &contract), Ok(true));
     }
@@ -200,8 +200,8 @@ mod tests {
         contract.get_current_state_root.given(()).will_return(Ok(state_hash));
 
         let db = DbInterfaceMock::new();
-        db.get_deposits_of_slot.given(1).will_return(Ok(deposits));
-        db.get_current_balances.given(state_hash).will_return(Ok(state));
+        db.get_deposits_of_slot.given(U256::one()).will_return(Ok(deposits));
+        db.get_balances_for_state_root.given(state_hash).will_return(Ok(state));
 
         let error = run_deposit_listener(&db, &contract).expect_err("Expected Error");
         assert_eq!(error.kind, ErrorKind::StateError);

--- a/driver/src/mongo_db.rs
+++ b/driver/src/mongo_db.rs
@@ -95,7 +95,7 @@ impl DbInterface for MongoDB {
         &self,
         state_index: &U256,
     ) -> Result<models::AccountState, DatabaseError> {
-        let query = doc!{ "stateIndex" => state_index.to_string() };
+        let query = doc!{ "stateIndex" => state_index.low_u64() };
         info!("Querying stateIndex: {}", query);
         self.get_balances_for_query(query)
     }
@@ -104,7 +104,7 @@ impl DbInterface for MongoDB {
         &self,
         slot: &U256,
     ) -> Result<Vec<models::PendingFlux>, DatabaseError> {
-        let query = doc!{ "slot" => slot.to_string() };
+        let query = doc!{ "slot" => slot.low_u64() };
         self.get_items_from_query(query, "deposits")
     }
 
@@ -112,7 +112,7 @@ impl DbInterface for MongoDB {
         &self,
         slot: &U256,
     ) -> Result<Vec<models::PendingFlux>, DatabaseError> {
-        let query = doc!{ "slot" => slot.to_string() };
+        let query = doc!{ "slot" => slot.low_u64() };
         self.get_items_from_query(query, "withdraws")
     }
 
@@ -120,7 +120,7 @@ impl DbInterface for MongoDB {
         &self,
         slot: &U256,
     ) -> Result<Vec<models::Order>, DatabaseError> {
-        let query = doc!{ "auctionId" => slot.to_string() };
+        let query = doc!{ "auctionId" => slot.low_u64() };
         self.get_items_from_query(query, "orders")
     }
     fn get_standing_orders_of_slot(
@@ -128,7 +128,7 @@ impl DbInterface for MongoDB {
         slot: &U256,
     ) -> Result<[models::StandingOrder; models::NUM_RESERVED_ACCOUNTS], DatabaseError> {
         let pipeline = vec![
-            doc!{"$match" => (doc!{"validFromAuctionId" => (doc!{ "$lte" => slot.to_string()})})},
+            doc!{"$match" => (doc!{"validFromAuctionId" => (doc!{ "$lte" => slot.low_u64()})})},
             doc!{"$sort" => (doc!{"validFromAuctionId" => -1, "_id" => -1})},
             doc!{"$group" => (doc!{"_id" => "$accountId", "orders" => (doc!{"$first" =>"$orders" }), "batchIndex" => (doc!{"$first" => "$batchIndex" })})}
         ];

--- a/driver/src/order_driver.rs
+++ b/driver/src/order_driver.rs
@@ -34,13 +34,13 @@ pub fn run_order_listener<D, C>(
             info!("Processing auction slot {:?}", slot);
             let state_root = contract.get_current_state_root()?;
             let non_reserved_orders_hash_from_contract = contract.order_hash_for_slot(slot)?;
-            let mut state = db.get_current_balances(&state_root)?;
+            let mut state = db.get_balances_for_state_root(&state_root)?;
 
-            let mut orders = db.get_orders_of_slot(slot.low_u32())?;
+            let mut orders = db.get_orders_of_slot(&slot)?;
             let non_reserved_orders_hash = orders.rolling_hash(0);
             hash_consistency_check(non_reserved_orders_hash, non_reserved_orders_hash_from_contract, "non-reserved-orders")?;
 
-            let standing_orders = db.get_standing_orders_of_slot(slot.low_u32())?;
+            let standing_orders = db.get_standing_orders_of_slot(&slot)?;
             
             orders.extend(standing_orders
                 .iter()
@@ -140,9 +140,9 @@ mod tests {
         contract.apply_auction.given((slot, Any, Any, Any, Any, Any)).will_return(Ok(()));
         let standing_orders = StandingOrder::empty_array();
         let db = DbInterfaceMock::new();
-        db.get_orders_of_slot.given(1).will_return(Ok(orders.clone()));
-        db.get_standing_orders_of_slot.given(1).will_return(Ok(standing_orders));
-        db.get_current_balances.given(state_hash).will_return(Ok(state.clone()));
+        db.get_orders_of_slot.given(U256::one()).will_return(Ok(orders.clone()));
+        db.get_standing_orders_of_slot.given(U256::one()).will_return(Ok(standing_orders));
+        db.get_balances_for_state_root.given(state_hash).will_return(Ok(state.clone()));
 
         let mut pf = PriceFindingMock::new();
         let expected_solution = Solution {
@@ -216,9 +216,9 @@ mod tests {
         );
         let standing_orders = StandingOrder::empty_array();
         let db = DbInterfaceMock::new();
-        db.get_orders_of_slot.given(0).will_return(Ok(first_orders.clone()));
-        db.get_standing_orders_of_slot.given(0).will_return(Ok(standing_orders));
-        db.get_current_balances.given(state_hash).will_return(Ok(state.clone()));
+        db.get_orders_of_slot.given(U256::zero()).will_return(Ok(first_orders.clone()));
+        db.get_standing_orders_of_slot.given(U256::zero()).will_return(Ok(standing_orders));
+        db.get_balances_for_state_root.given(state_hash).will_return(Ok(state.clone()));
 
         let mut pf = PriceFindingMock::new();
         let expected_solution = Solution {
@@ -259,8 +259,8 @@ mod tests {
         contract.get_current_state_root.given(()).will_return(Ok(state_hash));
 
         let db = DbInterfaceMock::new();
-        db.get_orders_of_slot.given(1).will_return(Ok(orders.clone()));
-        db.get_current_balances.given(state_hash).will_return(Ok(state.clone()));
+        db.get_orders_of_slot.given(U256::one()).will_return(Ok(orders.clone()));
+        db.get_balances_for_state_root.given(state_hash).will_return(Ok(state.clone()));
 
         let mut pf = PriceFindingMock::new();
 
@@ -297,9 +297,9 @@ mod tests {
         let mut standing_orders = StandingOrder::empty_array();
         standing_orders[1] = standing_order.clone();
         let db = DbInterfaceMock::new();
-        db.get_orders_of_slot.given(1).will_return(Ok(vec![]));
-        db.get_standing_orders_of_slot.given(1).will_return(Ok(standing_orders.clone()));
-        db.get_current_balances.given(state_hash).will_return(Ok(state.clone()));
+        db.get_orders_of_slot.given(U256::one()).will_return(Ok(vec![]));
+        db.get_standing_orders_of_slot.given(U256::one()).will_return(Ok(standing_orders.clone()));
+        db.get_balances_for_state_root.given(state_hash).will_return(Ok(state.clone()));
 
         let mut pf = PriceFindingMock::new();
         pf.find_prices

--- a/driver/src/withdraw_driver.rs
+++ b/driver/src/withdraw_driver.rs
@@ -24,9 +24,9 @@ pub fn run_withdraw_listener<D, C>(db: &D, contract: &C) -> Result<(bool), Drive
             info!("Processing withdraw_slot {:?}", slot);
             let state_root = contract.get_current_state_root()?;
             let contract_withdraw_hash = contract.withdraw_hash_for_slot(slot)?;
-            let mut balances = db.get_current_balances(&state_root)?;
+            let mut balances = db.get_balances_for_state_root(&state_root)?;
 
-            let withdraws = db.get_withdraws_of_slot(slot.low_u32())?;
+            let withdraws = db.get_withdraws_of_slot(&slot)?;
             let withdraw_hash = withdraws.rolling_hash(0);
             hash_consistency_check(withdraw_hash, contract_withdraw_hash, "withdraw")?;
 
@@ -81,8 +81,8 @@ mod tests {
         contract.apply_withdraws.given((slot, Any, Any, Any, Any)).will_return(Ok(()));
 
         let db = DbInterfaceMock::new();
-        db.get_withdraws_of_slot.given(1).will_return(Ok(withdraws));
-        db.get_current_balances.given(state_hash).will_return(Ok(state));
+        db.get_withdraws_of_slot.given(U256::one()).will_return(Ok(withdraws));
+        db.get_balances_for_state_root.given(state_hash).will_return(Ok(state));
 
         assert_eq!(run_withdraw_listener(&db, &contract), Ok(true));
     }
@@ -142,8 +142,8 @@ mod tests {
         );
 
         let db = DbInterfaceMock::new();
-        db.get_withdraws_of_slot.given(0).will_return(Ok(first_withdraws));
-        db.get_current_balances.given(state_hash).will_return(Ok(state));
+        db.get_withdraws_of_slot.given(U256::zero()).will_return(Ok(first_withdraws));
+        db.get_balances_for_state_root.given(state_hash).will_return(Ok(state));
 
         assert_eq!(run_withdraw_listener(&db, &contract), Ok(true));
         assert_eq!(run_withdraw_listener(&db, &contract), Ok(true));
@@ -175,8 +175,8 @@ mod tests {
         contract.get_current_state_root.given(()).will_return(Ok(state_hash));
 
         let db = DbInterfaceMock::new();
-        db.get_withdraws_of_slot.given(1).will_return(Ok(withdraws));
-        db.get_current_balances.given(state_hash).will_return(Ok(state));
+        db.get_withdraws_of_slot.given(U256::one()).will_return(Ok(withdraws));
+        db.get_balances_for_state_root.given(state_hash).will_return(Ok(state));
 
         let error = run_withdraw_listener(&db, &contract).expect_err("Expected Error");
         assert_eq!(error.kind, ErrorKind::StateError);
@@ -214,8 +214,8 @@ mod tests {
         contract.apply_withdraws.given((slot, Val(merkle_root), Any, Any, Any)).will_return(Ok(()));
 
         let db = DbInterfaceMock::new();
-        db.get_withdraws_of_slot.given(1).will_return(Ok(withdraws));
-        db.get_current_balances.given(state_hash).will_return(Ok(state));
+        db.get_withdraws_of_slot.given(U256::one()).will_return(Ok(withdraws));
+        db.get_balances_for_state_root.given(state_hash).will_return(Ok(state));
 
         assert_eq!(run_withdraw_listener(&db, &contract), Ok(true));
     }


### PR DESCRIPTION
This PR adds a method to obtain the AccountState by state index (previously only possible by state root). This is needed in the listener whenever we apply a state transition.

I also cleaned up the interface to use the full width U256 instead of using only the low u32 of our slot/state index.

### Test Plan

CI