### PR TITLE
[The Graph] Postgres db interface implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,7 +514,12 @@ dependencies = [
  "array-macro 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
+<<<<<<< HEAD
  "mock-it 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+=======
+ "graph-node-reader 0.13.2",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+>>>>>>> DbInterface implementation based on the Graph
  "mongodb 0.3.12 (git+https://github.com/mongodb-labs/mongo-rust-driver-prototype?rev=9203ec3216976cfbfddb07856b25d061965810af)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1357,6 +1362,7 @@ dependencies = [
  "graph-core 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
  "graph-datasource-ethereum 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
  "graph-mock 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
+ "graph-node-reader 0.13.2",
  "graph-server-http 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
  "graph-server-websocket 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
  "graph-store-postgres 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,7 +514,7 @@ dependencies = [
  "array-macro 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
- "graph-node-reader 0.13.2 (git+https://github.com/fleupold/graph-node-reader)",
+ "graph-node-reader 0.13.2 (git+https://github.com/fleupold/graph-node-reader?tag=v0.13.2)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mock-it 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mongodb 0.3.12 (git+https://github.com/mongodb-labs/mongo-rust-driver-prototype?rev=9203ec3216976cfbfddb07856b25d061965810af)",
@@ -955,7 +955,7 @@ dependencies = [
 [[package]]
 name = "graph-node-reader"
 version = "0.13.2"
-source = "git+https://github.com/fleupold/graph-node-reader#df5c4d499d655d3e5e6b860773a7ee89bb2e415d"
+source = "git+https://github.com/fleupold/graph-node-reader?tag=v0.13.2#df5c4d499d655d3e5e6b860773a7ee89bb2e415d"
 dependencies = [
  "diesel 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel-derive-enum 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1370,7 +1370,7 @@ dependencies = [
  "graph-core 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
  "graph-datasource-ethereum 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
  "graph-mock 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
- "graph-node-reader 0.13.2 (git+https://github.com/fleupold/graph-node-reader)",
+ "graph-node-reader 0.13.2 (git+https://github.com/fleupold/graph-node-reader?tag=v0.13.2)",
  "graph-server-http 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
  "graph-server-websocket 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
  "graph-store-postgres 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
@@ -3582,7 +3582,7 @@ dependencies = [
 "checksum graph-datasource-ethereum 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)" = "<none>"
 "checksum graph-graphql 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)" = "<none>"
 "checksum graph-mock 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)" = "<none>"
-"checksum graph-node-reader 0.13.2 (git+https://github.com/fleupold/graph-node-reader)" = "<none>"
+"checksum graph-node-reader 0.13.2 (git+https://github.com/fleupold/graph-node-reader?tag=v0.13.2)" = "<none>"
 "checksum graph-runtime-derive 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)" = "<none>"
 "checksum graph-runtime-wasm 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)" = "<none>"
 "checksum graph-server-http 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)" = "<none>"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,12 +514,9 @@ dependencies = [
  "array-macro 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
-<<<<<<< HEAD
- "mock-it 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-=======
  "graph-node-reader 0.13.2",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
->>>>>>> DbInterface implementation based on the Graph
+ "mock-it 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mongodb 0.3.12 (git+https://github.com/mongodb-labs/mongo-rust-driver-prototype?rev=9203ec3216976cfbfddb07856b25d061965810af)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,7 +514,7 @@ dependencies = [
  "array-macro 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
- "graph-node-reader 0.13.2",
+ "graph-node-reader 0.13.2 (git+https://github.com/fleupold/graph-node-reader)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mock-it 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mongodb 0.3.12 (git+https://github.com/mongodb-labs/mongo-rust-driver-prototype?rev=9203ec3216976cfbfddb07856b25d061965810af)",
@@ -955,6 +955,17 @@ dependencies = [
 [[package]]
 name = "graph-node-reader"
 version = "0.13.2"
+source = "git+https://github.com/fleupold/graph-node-reader#df5c4d499d655d3e5e6b860773a7ee89bb2e415d"
+dependencies = [
+ "diesel 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel-derive-enum 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel-dynamic-schema 1.0.0 (git+https://github.com/diesel-rs/diesel-dynamic-schema?rev=a8ec4fb1)",
+ "graph 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
+]
+
+[[package]]
+name = "graph-node-reader"
+version = "0.13.2"
 dependencies = [
  "diesel 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel-derive-enum 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1359,7 +1370,7 @@ dependencies = [
  "graph-core 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
  "graph-datasource-ethereum 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
  "graph-mock 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
- "graph-node-reader 0.13.2",
+ "graph-node-reader 0.13.2 (git+https://github.com/fleupold/graph-node-reader)",
  "graph-server-http 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
  "graph-server-websocket 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
  "graph-store-postgres 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
@@ -3571,6 +3582,7 @@ dependencies = [
 "checksum graph-datasource-ethereum 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)" = "<none>"
 "checksum graph-graphql 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)" = "<none>"
 "checksum graph-mock 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)" = "<none>"
+"checksum graph-node-reader 0.13.2 (git+https://github.com/fleupold/graph-node-reader)" = "<none>"
 "checksum graph-runtime-derive 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)" = "<none>"
 "checksum graph-runtime-wasm 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)" = "<none>"
 "checksum graph-server-http 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)" = "<none>"

--- a/dfusion_rust_core/Cargo.toml
+++ b/dfusion_rust_core/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2018"
 array-macro = "1.0.4"
 byteorder = "1.3.1"
 graph = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }
+graph-node-reader = { path = "../graph_node_reader" }
+lazy_static = "1.2.0"
 mock-it = "0.2.0"
 mongodb = { git = "https://github.com/mongodb-labs/mongo-rust-driver-prototype", rev = "9203ec3216976cfbfddb07856b25d061965810af"}
 serde_derive = "1.0"

--- a/dfusion_rust_core/Cargo.toml
+++ b/dfusion_rust_core/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 array-macro = "1.0.4"
 byteorder = "1.3.1"
 graph = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }
-graph-node-reader = { git = "https://github.com/fleupold/graph-node-reader" }
+graph-node-reader = { git = "https://github.com/fleupold/graph-node-reader", tag = "v0.13.2" }
 lazy_static = "1.2.0"
 mock-it = "0.2.0"
 mongodb = { git = "https://github.com/mongodb-labs/mongo-rust-driver-prototype", rev = "9203ec3216976cfbfddb07856b25d061965810af"}

--- a/dfusion_rust_core/Cargo.toml
+++ b/dfusion_rust_core/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 array-macro = "1.0.4"
 byteorder = "1.3.1"
 graph = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }
-graph-node-reader = { path = "../graph_node_reader" }
+graph-node-reader = { git = "https://github.com/fleupold/graph-node-reader" }
 lazy_static = "1.2.0"
 mock-it = "0.2.0"
 mongodb = { git = "https://github.com/mongodb-labs/mongo-rust-driver-prototype", rev = "9203ec3216976cfbfddb07856b25d061965810af"}

--- a/dfusion_rust_core/src/database/graph_reader.rs
+++ b/dfusion_rust_core/src/database/graph_reader.rs
@@ -1,0 +1,90 @@
+use super::*;
+use crate::models::util::ToValue;
+use crate::SUBGRAPH_ID;
+
+use graph::components::store::{EntityFilter, EntityQuery, EntityRange};
+
+use graph_node_reader::StoreReader;
+
+pub struct GraphReader {
+    reader: Box<StoreReader>
+}
+
+impl GraphReader {
+    fn get_flux_of_slot(
+        &self,
+        slot: u32,
+        flux: &str,
+    ) -> Result<Vec<models::PendingFlux>, DatabaseError> {
+        let deposit_query = entity_query(
+                    flux, EntityFilter::Equal("slot".to_string(), slot.to_value())
+                );
+        Ok(self.reader
+            .find(deposit_query)
+            .map_err(|e| DatabaseError::chain(ErrorKind::ConnectionError, "Could not execute query", e))?
+            .into_iter()
+            .map(models::PendingFlux::from)
+            .collect::<Vec<models::PendingFlux>>())
+    }
+}
+
+impl DbInterface for GraphReader {
+    fn get_current_balances(
+        &self,
+        current_state_root: &H256,
+    ) -> Result<models::AccountState, DatabaseError> {
+        let account_query = entity_query(
+            "AccountState", EntityFilter::Equal("stateIndex".to_string(), current_state_root.to_value())
+        );
+        Ok(models::AccountState::from(self.reader
+            .find_one(account_query)
+            .map_err(|e| DatabaseError::chain(ErrorKind::ConnectionError, "Could not execute query", e))?
+            .ok_or_else(|| DatabaseError::new(
+                ErrorKind::StateError, 
+                &format!("No state record found for index {}", &current_state_root))
+            )?
+        ))
+    }
+
+    fn get_deposits_of_slot(
+        &self,
+        slot: u32,
+    ) -> Result<Vec<models::PendingFlux>, DatabaseError> {
+        self.get_flux_of_slot(slot, "Deposit")
+    }
+
+    fn get_withdraws_of_slot(
+        &self,
+        slot: u32,
+    ) -> Result<Vec<models::PendingFlux>, DatabaseError> {
+        self.get_flux_of_slot(slot, "Withdraw")
+    }
+
+    fn get_orders_of_slot(
+        &self,
+        _: u32,
+    ) -> Result<Vec<models::Order>, DatabaseError> {
+        unimplemented!()
+    }
+
+    fn get_standing_orders_of_slot(
+        &self,
+        _: u32,
+    ) -> Result<[models::StandingOrder; models::NUM_RESERVED_ACCOUNTS], DatabaseError> {
+        unimplemented!()
+    }
+}
+
+pub fn entity_query(entity_type: &str, filter: EntityFilter) -> EntityQuery {
+    EntityQuery {
+        subgraph_id: SUBGRAPH_ID.clone(),
+        entity_types: vec![entity_type.to_string()],
+        filter: Some(filter),
+        order_by: None,
+        order_direction: None,
+        range: EntityRange {
+            first: None,
+            skip: 0
+        }
+    }
+}

--- a/dfusion_rust_core/src/database/graph_reader.rs
+++ b/dfusion_rust_core/src/database/graph_reader.rs
@@ -54,7 +54,7 @@ impl DbInterface for GraphReader {
         state_root: &H256,
     ) -> Result<models::AccountState, DatabaseError> {
         let account_query = entity_query(
-            "AccountState", EntityFilter::Equal("stateRoot".to_string(), state_root.to_value())
+            "AccountState", EntityFilter::Equal("id".to_string(), state_root.to_value())
         );
         self.get_balances_for_query(account_query)
     }

--- a/dfusion_rust_core/src/database/mod.rs
+++ b/dfusion_rust_core/src/database/mod.rs
@@ -1,12 +1,14 @@
 mod error;
+mod graph_reader;
 
 use web3::types::{H256, U256};
 
 pub use error::*;
+pub use graph_reader::GraphReader;
 use super::models;
 
-pub trait DbInterface {
-    fn get_balances_for_state_root(
+pub trait DbInterface: Send + Sync + 'static {
+    fn get_current_balances(
         &self,
         state_root: &H256,
     ) -> Result<models::AccountState, DatabaseError>;

--- a/dfusion_rust_core/src/database/mod.rs
+++ b/dfusion_rust_core/src/database/mod.rs
@@ -8,7 +8,7 @@ pub use graph_reader::GraphReader;
 use super::models;
 
 pub trait DbInterface: Send + Sync + 'static {
-    fn get_current_balances(
+    fn get_balances_for_state_root(
         &self,
         state_root: &H256,
     ) -> Result<models::AccountState, DatabaseError>;

--- a/dfusion_rust_core/src/database/mod.rs
+++ b/dfusion_rust_core/src/database/mod.rs
@@ -7,7 +7,7 @@ pub use error::*;
 pub use graph_reader::GraphReader;
 use super::models;
 
-pub trait DbInterface: Send + Sync + 'static {
+pub trait DbInterface: Send + Sync {
     fn get_balances_for_state_root(
         &self,
         state_root: &H256,

--- a/dfusion_rust_core/src/lib.rs
+++ b/dfusion_rust_core/src/lib.rs
@@ -1,2 +1,13 @@
 pub mod models;
 pub mod database;
+
+use graph::prelude::SubgraphDeploymentId;
+
+#[macro_use]
+extern crate lazy_static;
+
+pub const SUBGRAPH_NAME: &str = "dfusion";
+
+lazy_static! {
+    static ref SUBGRAPH_ID: SubgraphDeploymentId = SubgraphDeploymentId::new(SUBGRAPH_NAME).unwrap();
+}

--- a/dfusion_rust_core/src/models/util.rs
+++ b/dfusion_rust_core/src/models/util.rs
@@ -59,6 +59,12 @@ impl ToValue for u16 {
     }
 }
 
+impl ToValue for u32 {
+    fn to_value(&self) -> Value {
+        u128::from(self.clone()).to_value()
+    }
+}
+
 impl ToValue for u128 {
     fn to_value(&self) -> Value {
         BigDecimal::from_str(&self.to_string()).unwrap().into()

--- a/dfusion_rust_core/src/models/util.rs
+++ b/dfusion_rust_core/src/models/util.rs
@@ -61,7 +61,7 @@ impl ToValue for u16 {
 
 impl ToValue for u32 {
     fn to_value(&self) -> Value {
-        u128::from(self.clone()).to_value()
+        u128::from(*self).to_value()
     }
 }
 

--- a/listener/Cargo.toml
+++ b/listener/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 graph-core = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }
 graph = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }
 graph-datasource-ethereum = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }
-graph-node-reader = { git = "https://github.com/fleupold/graph-node-reader" }
+graph-node-reader = { git = "https://github.com/fleupold/graph-node-reader", tag = "v0.13.2" }
 graph-store-postgres = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }
 graph-server-http = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }
 graph-server-websocket = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }

--- a/listener/Cargo.toml
+++ b/listener/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 graph-core = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }
 graph = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }
 graph-datasource-ethereum = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }
+graph-node-reader = { path = "../graph_node_reader" }
 graph-store-postgres = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }
 graph-server-http = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }
 graph-server-websocket = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }

--- a/listener/Cargo.toml
+++ b/listener/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 graph-core = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }
 graph = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }
 graph-datasource-ethereum = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }
-graph-node-reader = { path = "../graph_node_reader" }
+graph-node-reader = { git = "https://github.com/fleupold/graph-node-reader" }
 graph-store-postgres = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }
 graph-server-http = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }
 graph-server-websocket = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }

--- a/listener/src/event_handler/flux_transition_handler.rs
+++ b/listener/src/event_handler/flux_transition_handler.rs
@@ -1,6 +1,5 @@
 use super::*;
 
-use dfusion_core::models::{PendingFlux, AccountState};
 use dfusion_core::models::util::{PopFromLogData, ToValue};
 use dfusion_core::database::DbInterface;
 
@@ -58,27 +57,21 @@ impl EventHandler for FluxTransitionHandler {
 
         info!(logger, "Received Flux AccountState Transition Event");
 
-        //TODO this needs to use stateIndex
         let mut account_state = self.store
-            .get_current_balances(&H256::zero())
+            .get_balances_for_state_index(&state_index)
             .map_err(|e| failure::err_msg(format!("{}", e)))?;
 
         match transition_type {
             FluxTransitionType::Deposit => {
                 let deposits = self.store
-                    .get_deposits_of_slot(slot.low_u32())
+                    .get_deposits_of_slot(&slot)
                     .map_err(|e| failure::err_msg(format!("{}", e)))?;
                 account_state.apply_deposits(&deposits);
             },
             FluxTransitionType::Withdraw => {
-                let withdraw_query = util::entity_query(
-                    "Withdraw", EntityFilter::Equal("slot".to_string(), slot.to_value())
-                );
                 let withdraws = self.store
-                    .find(withdraw_query)?
-                    .into_iter()
-                    .map(PendingFlux::from)
-                    .collect::<Vec<PendingFlux>>();
+                    .get_withdraws_of_slot(&slot)
+                    .map_err(|e| failure::err_msg(format!("{}", e)))?;
                 account_state.apply_withdraws(&withdraws);
             }
         }
@@ -97,22 +90,18 @@ impl EventHandler for FluxTransitionHandler {
 #[cfg(test)]
 pub mod test {
     use super::*;
-    use graph_mock::MockStore;
+    use dfusion_core::database::tests::DbInterfaceMock;
+    use dfusion_core::database::*;
+    use dfusion_core::models::{PendingFlux, AccountState};
     use web3::types::{Bytes, H256};
 
     #[test]
     fn test_applies_deposits_existing_state() {
-        let schema = util::test::fake_schema();
-        let store = Arc::new(MockStore::new(vec![(schema.id.clone(), schema)]));
-        let handler = FluxTransitionHandler::new(store.clone());
+        let store = Arc::new(DbInterfaceMock::new());
 
         // Add previous account state and pending deposits into Store
         let existing_state = AccountState::new(H256::zero(), U256::zero(), vec![0, 0, 0, 0], 1);
-        let entity = existing_state.into();
-        store.apply_entity_operations(vec![EntityOperation::Set {
-            key: util::entity_key("AccountState", &entity),
-            data: entity
-        }], None).unwrap();
+        store.get_balances_for_state_index.given(U256::zero()).will_return(Ok(existing_state));
 
         let first_deposit = PendingFlux {
             slot_index: 0,
@@ -121,12 +110,6 @@ pub mod test {
             token_id: 0,
             amount: 10,
         };
-        let mut entity: Entity = first_deposit.into();
-        entity.set("id", "1");
-        store.apply_entity_operations(vec![EntityOperation::Set {
-            key: util::entity_key("Deposit", &entity),
-            data: entity
-        }], None).unwrap();
 
         let second_deposit = PendingFlux {
             slot_index: 1,
@@ -135,14 +118,10 @@ pub mod test {
             token_id: 0,
             amount: 10,
         };
-        let mut entity: Entity = second_deposit.into();
-        entity.set("id", "2");
-        store.apply_entity_operations(vec![EntityOperation::Set {
-            key: util::entity_key("Deposit", &entity),
-            data: entity
-        }], None).unwrap();
+        store.get_deposits_of_slot.given(U256::zero()).will_return(Ok(vec![first_deposit, second_deposit]));
 
         // Process event
+        let handler = FluxTransitionHandler::new(store);
         let log = create_state_transition_event(FluxTransitionType::Deposit, 1, H256::from(1), 0);
         let result = handler.process_event(
             util::test::logger(), 
@@ -160,13 +139,15 @@ pub mod test {
     }
 
     #[test]
-    fn test_fails_if_state_does_not_exist() {
-        let schema = util::test::fake_schema();
-        let store = Arc::new(MockStore::new(vec![(schema.id.clone(), schema)]));
-        let handler = FluxTransitionHandler::new(store.clone());
+    fn test_apply_deposit_fails_if_state_does_not_exist() {
+        let store = Arc::new(DbInterfaceMock::new());
 
         // No data in store
+        store.get_balances_for_state_index.given(U256::zero()).will_return(Err(
+            DatabaseError::new(ErrorKind::StateError, "No State found"))
+        );
 
+        let handler = FluxTransitionHandler::new(store);
         let log = create_state_transition_event(FluxTransitionType::Deposit, 1, H256::from(1), 0);
         let result = handler.process_event(
             util::test::logger(), 
@@ -179,9 +160,7 @@ pub mod test {
 
     #[test]
     fn test_applies_withdraws_existing_state() {
-        let schema = util::test::fake_schema();
-        let store = Arc::new(MockStore::new(vec![(schema.id.clone(), schema)]));
-        let handler = FluxTransitionHandler::new(store.clone());
+        let store = Arc::new(DbInterfaceMock::new());
 
         // Add previous account state and pending withdraws into Store
         let existing_state = AccountState::new(
@@ -190,11 +169,8 @@ pub mod test {
             vec![10, 20, 0, 0],
             1
         );
-        let entity = existing_state.into();
-        store.apply_entity_operations(vec![EntityOperation::Set {
-            key: util::entity_key("AccountState", &entity),
-            data: entity
-        }], None).unwrap();
+        store.get_balances_for_state_index.given(U256::zero()).will_return(Ok(existing_state));
+
         let first_withdraw = PendingFlux {
             slot_index: 0,
             slot: U256::zero(),
@@ -202,13 +178,6 @@ pub mod test {
             token_id: 0,
             amount: 10,
         };
-        let mut entity: Entity = first_withdraw.into();
-        entity.set("id", "1");
-        store.apply_entity_operations(vec![EntityOperation::Set {
-            key: util::entity_key("Withdraw", &entity),
-            data: entity
-        }], None).unwrap();
-
         let second_withdraw = PendingFlux {
             slot_index: 1,
             slot: U256::zero(),
@@ -216,13 +185,6 @@ pub mod test {
             token_id: 0,
             amount: 10,
         };
-        let mut entity: Entity = second_withdraw.into();
-        entity.set("id", "2");
-        store.apply_entity_operations(vec![EntityOperation::Set {
-            key: util::entity_key("Withdraw", &entity),
-            data: entity
-        }], None).unwrap();
-
         let invalid_withdraw = PendingFlux {
             slot_index: 1,
             slot: U256::zero(),
@@ -230,14 +192,15 @@ pub mod test {
             token_id: 1,
             amount: 10,
         };
-        let mut entity: Entity = invalid_withdraw.into();
-        entity.set("id", "3");
-        store.apply_entity_operations(vec![EntityOperation::Set {
-            key: util::entity_key("Withdraw", &entity),
-            data: entity
-        }], None).unwrap();
+        
+        store.get_withdraws_of_slot.given(U256::zero()).will_return(Ok(vec![
+            first_withdraw,
+            second_withdraw,
+            invalid_withdraw,
+        ]));
 
         // Process event
+        let handler = FluxTransitionHandler::new(store);
         let log = create_state_transition_event(
             FluxTransitionType::Withdraw,
             1,

--- a/listener/src/event_handler/flux_transition_handler.rs
+++ b/listener/src/event_handler/flux_transition_handler.rs
@@ -101,7 +101,9 @@ pub mod test {
 
         // Add previous account state and pending deposits into Store
         let existing_state = AccountState::new(H256::zero(), U256::zero(), vec![0, 0, 0, 0], 1);
-        store.get_balances_for_state_index.given(U256::zero()).will_return(Ok(existing_state));
+        store.get_balances_for_state_index
+            .given(U256::zero())
+            .will_return(Ok(existing_state));
 
         let first_deposit = PendingFlux {
             slot_index: 0,
@@ -118,7 +120,9 @@ pub mod test {
             token_id: 0,
             amount: 10,
         };
-        store.get_deposits_of_slot.given(U256::zero()).will_return(Ok(vec![first_deposit, second_deposit]));
+        store.get_deposits_of_slot
+            .given(U256::zero())
+            .will_return(Ok(vec![first_deposit, second_deposit]));
 
         // Process event
         let handler = FluxTransitionHandler::new(store);
@@ -143,9 +147,9 @@ pub mod test {
         let store = Arc::new(DbInterfaceMock::new());
 
         // No data in store
-        store.get_balances_for_state_index.given(U256::zero()).will_return(Err(
-            DatabaseError::new(ErrorKind::StateError, "No State found"))
-        );
+        store.get_balances_for_state_index
+            .given(U256::zero())
+            .will_return(Err(DatabaseError::new(ErrorKind::StateError, "No State found")));
 
         let handler = FluxTransitionHandler::new(store);
         let log = create_state_transition_event(FluxTransitionType::Deposit, 1, H256::from(1), 0);
@@ -169,7 +173,9 @@ pub mod test {
             vec![10, 20, 0, 0],
             1
         );
-        store.get_balances_for_state_index.given(U256::zero()).will_return(Ok(existing_state));
+        store.get_balances_for_state_index
+            .given(U256::zero())
+            .will_return(Ok(existing_state));
 
         let first_withdraw = PendingFlux {
             slot_index: 0,
@@ -193,11 +199,13 @@ pub mod test {
             amount: 10,
         };
         
-        store.get_withdraws_of_slot.given(U256::zero()).will_return(Ok(vec![
-            first_withdraw,
-            second_withdraw,
-            invalid_withdraw,
-        ]));
+        store.get_withdraws_of_slot
+            .given(U256::zero())
+            .will_return(Ok(vec![
+                first_withdraw,
+                second_withdraw,
+                invalid_withdraw,
+            ]));
 
         // Process event
         let handler = FluxTransitionHandler::new(store);

--- a/listener/src/event_handler/util.rs
+++ b/listener/src/event_handler/util.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use graph::components::store::{EntityFilter, EntityKey, EntityQuery, EntityRange};
+use graph::components::store::EntityKey;
 use graph::data::store::Entity;
 use web3::types::Log;
 
@@ -19,20 +19,6 @@ pub fn entity_key(entity_type: &str, entity: &Entity) -> EntityKey {
         entity_id: entity.get("id")
             .and_then(|v| v.clone().as_string())
             .unwrap(),
-    }
-}
-
-pub fn entity_query(entity_type: &str, filter: EntityFilter) -> EntityQuery {
-    EntityQuery {
-        subgraph_id: SUBGRAPH_ID.clone(),
-        entity_types: vec![entity_type.to_string()],
-        filter: Some(filter),
-        order_by: None,
-        order_direction: None,
-        range: EntityRange {
-            first: None,
-            skip: 0
-        }
     }
 }
 

--- a/listener/src/event_handler/util.rs
+++ b/listener/src/event_handler/util.rs
@@ -24,18 +24,12 @@ pub fn entity_key(entity_type: &str, entity: &Entity) -> EntityKey {
 
 #[cfg(test)]
 pub mod test {
-    use super::*;
     use graph::components::ethereum::EthereumBlock;
-    use graph::data::schema::Schema;
     use slog::Logger;
     use web3::types::{Block, Bytes, H2048, H256, H160, Transaction, U256};
 
     pub fn logger() -> Logger {
         Logger::root(slog::Discard, o!())
-    }
-
-    pub fn fake_schema() -> Schema {
-        Schema::parse("scalar Foo", SUBGRAPH_ID.clone()).unwrap()
     }
 
     pub fn fake_tx() -> Transaction {

--- a/listener/src/main.rs
+++ b/listener/src/main.rs
@@ -151,7 +151,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
 
     let store = Arc::new(DieselStore::new(
         StoreConfig {
-            postgres_url,
+            postgres_url: postgres_url.clone(),
             network_name: network_name.clone(),
             start_block: 0,
         },
@@ -183,7 +183,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
     );
 
     let store_reader = GraphNodeReader::new(postgres_url, &logger);
-    let database = Arc::new(GraphReader { reader: Box::new(store_reader) });
+    let database = Arc::new(GraphReader::new(Box::new(store_reader)));
     let subgraph_instance_manager = SubgraphInstanceManager::new(
         &logger_factory,
         store.clone(),

--- a/listener/src/main.rs
+++ b/listener/src/main.rs
@@ -41,15 +41,18 @@ use graph_store_postgres::{Store as DieselStore, StoreConfig};
 use runtime_host::RustRuntimeHostBuilder;
 use link_resolver::LocalLinkResolver;
 
+use dfusion_core::SUBGRAPH_NAME;
+use dfusion_core::database::GraphReader;
+
+use graph_node_reader::Store as GraphNodeReader;
+
 lazy_static! {
     static ref ANCESTOR_COUNT: u64 = 50;
     static ref REORG_THRESHOLD: u64 = 50;
     static ref BLOCK_POLLING_INTERVAL: Duration = Duration::from_millis(1000);
     
     static ref NODE_ID: NodeId = NodeId::new("default").unwrap();
-    static ref SUBGRAPH_NAME: SubgraphName = SubgraphName::new("dfusion").unwrap();
-    static ref SUBGRAPH_ID: SubgraphDeploymentId = SubgraphDeploymentId::new("dfusion").unwrap();
-
+    static ref SUBGRAPH_ID: SubgraphDeploymentId = SubgraphDeploymentId::new(SUBGRAPH_NAME).unwrap();
 }
 
 fn main() {
@@ -179,10 +182,12 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
         *REORG_THRESHOLD,
     );
 
+    let store_reader = GraphNodeReader::new(postgres_url, &logger);
+    let database = Arc::new(GraphReader { reader: Box::new(store_reader) });
     let subgraph_instance_manager = SubgraphInstanceManager::new(
         &logger_factory,
         store.clone(),
-        RustRuntimeHostBuilder::new(store.clone()),
+        RustRuntimeHostBuilder::new(database),
         block_stream_builder,
     );
     
@@ -210,12 +215,13 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
         SubgraphVersionSwitchingMode::Instant
     ));
 
+    let subgraph_name = SubgraphName::new("dfusion").unwrap();
     tokio::spawn(	
         subgraph_registrar
-            .create_subgraph(SUBGRAPH_NAME.clone())
+            .create_subgraph(subgraph_name.clone())
             .then( move |_| {
                 subgraph_registrar.create_subgraph_version(
-                    SUBGRAPH_NAME.clone(), SUBGRAPH_ID.clone(), NODE_ID.clone()
+                    subgraph_name, SUBGRAPH_ID.clone(), NODE_ID.clone()
                 )
                 .then(|result| {	
                     result.expect("Failed to create subgraph");

--- a/listener/src/main.rs
+++ b/listener/src/main.rs
@@ -215,7 +215,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
         SubgraphVersionSwitchingMode::Instant
     ));
 
-    let subgraph_name = SubgraphName::new("dfusion").unwrap();
+    let subgraph_name = SubgraphName::new(SUBGRAPH_NAME).unwrap();
     tokio::spawn(	
         subgraph_registrar
             .create_subgraph(subgraph_name.clone())

--- a/listener/src/runtime_host.rs
+++ b/listener/src/runtime_host.rs
@@ -4,9 +4,10 @@ use slog::Logger;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use dfusion_core::database::DbInterface;
+
 use graph::components::ethereum::{EthereumCall, EthereumBlockTriggerType, EthereumBlock};
 use graph::components::subgraph::{RuntimeHost as RuntimeHostTrait, RuntimeHostBuilder, BlockState};
-use graph::components::store::Store;
 
 use graph::data::subgraph::{DataSource, SubgraphDeploymentId};
 
@@ -28,11 +29,11 @@ fn register_event(handlers: &mut HandlerMap, name: &str, handler: Box<dyn EventH
 
 #[derive(Clone)]
 pub struct RustRuntimeHostBuilder {
-    store: Arc<Store>
+    store: Arc<DbInterface>
 }
 
 impl RustRuntimeHostBuilder {
-    pub fn new(store: Arc<Store>) -> Self {
+    pub fn new(store: Arc<DbInterface>) -> Self {
         RustRuntimeHostBuilder {
             store
         }
@@ -57,7 +58,7 @@ pub struct RustRuntimeHost {
 }
 
 impl RustRuntimeHost {
-    fn new(store: Arc<Store>) -> Self {
+    fn new(store: Arc<DbInterface>) -> Self {
         let mut handlers = HashMap::new();
         register_event(
             &mut handlers,


### PR DESCRIPTION
This PR implements the DBInterface trait for the postgres backed graph reader. Once fully implemented, the driver should be able to switch from MongoDB to Postgres DB by just instantiating the other implementation [here](https://github.com/gnosis/dex-services/blob/master/driver/src/bin/main.rs#L18).

For now, I'm using this component in the existing graph listeners that are reading state from the database. I'd hope we can use the same component in the AuctionApplication handler that @bh2smith is working on. This will require finishing the two remaining unimplemented methods.

### Test Plan

Make sure E2E tests covering the exiting graph listeners are still running. 

Also, for withdraw & deposit tests we can already make the adjustment outlined above and have the driver use the graph listener instead of the python one.