### PR TITLE
Move Solution into shared models library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,16 +965,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "graph-node-reader"
-version = "0.13.2"
-dependencies = [
- "diesel 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel-derive-enum 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel-dynamic-schema 1.0.0 (git+https://github.com/diesel-rs/diesel-dynamic-schema?rev=a8ec4fb1)",
- "graph 0.13.2 (git+https://github.com/graphprotocol/graph-node?tag=v0.13.2)",
-]
-
-[[package]]
 name = "graph-runtime-derive"
 version = "0.13.2"
 source = "git+https://github.com/graphprotocol/graph-node?tag=v0.13.2#602fba1af5322ceeb58cc09c7120bdacbaa5cbea"

--- a/dfusion_rust_core/src/models/mod.rs
+++ b/dfusion_rust_core/src/models/mod.rs
@@ -1,12 +1,14 @@
 pub mod account_state;
 pub mod flux;
 pub mod order;
+pub mod solution;
 pub mod standing_order;
 pub mod util;
 
 pub use crate::models::account_state::AccountState;
 pub use crate::models::flux::PendingFlux;
 pub use crate::models::order::Order;
+pub use crate::models::solution::Solution;
 pub use crate::models::standing_order::StandingOrder;
 pub use crate::models::order::BatchInformation;
 
@@ -34,6 +36,10 @@ pub trait RootHashable {
 
 pub trait Serializable {
     fn bytes(&self) -> Vec<u8>;
+}
+
+pub trait Deserializable {
+    fn from_bytes(bytes: Vec<u8>) -> Self;
 }
 
 fn merkleize(leafs: Vec<Vec<u8>>) -> H256 {

--- a/dfusion_rust_core/src/models/order.rs
+++ b/dfusion_rust_core/src/models/order.rs
@@ -1,4 +1,4 @@
-use byteorder::{BigEndian, WriteBytesExt, ByteOrder};
+use byteorder::{BigEndian, WriteBytesExt};
 use graph::data::store::Entity;
 use serde_derive::{Deserialize};
 use std::sync::Arc;
@@ -105,22 +105,6 @@ impl From<Entity> for Order {
             sell_amount: u128::from_entity(&entity, "sellAmount"),
         }
     }
-}
-
-fn get_amount_from_slice(bytes: &[u8]) -> [u8; 12] {
-    let mut bytes_12 = [0u8; 12];
-    bytes_12.copy_from_slice(bytes);
-
-    bytes_12
-}
-
-fn read_amount(bytes: &[u8; 12]) -> u128 {    
-    let bytes = [0u8, 0u8, 0u8, 0u8].iter()
-        .chain(bytes.iter())
-        .cloned()
-        .collect::<Vec<u8>>();
-
-    BigEndian::read_u128(bytes.as_slice())
 }
 
 impl From<mongodb::ordered::OrderedDocument> for Order {

--- a/dfusion_rust_core/src/models/solution.rs
+++ b/dfusion_rust_core/src/models/solution.rs
@@ -12,12 +12,12 @@ pub struct Solution {
 }
 
 impl Solution {
-    pub fn trivial() -> Self {
+    pub fn trivial(num_orders: usize) -> Self {
         Solution {
             surplus: Some(U256::zero()),
             prices: vec![0; TOKENS as usize],
-            executed_sell_amounts: vec![],
-            executed_buy_amounts: vec![],
+            executed_sell_amounts: vec![0; num_orders],
+            executed_buy_amounts: vec![0; num_orders],
         }
     }
 }
@@ -42,7 +42,7 @@ impl Deserializable for Solution {
     fn from_bytes(mut bytes: Vec<u8>) -> Self {
         let volumes = bytes.split_off(TOKENS as usize * 12);
         let prices = bytes
-            .chunks(12)
+            .chunks_exact(12)
             .map(|chunk| {
                 util::read_amount(
                     &util::get_amount_from_slice(chunk)
@@ -52,7 +52,7 @@ impl Deserializable for Solution {
 
         let mut executed_sell_amounts: Vec<u128> = vec![];
         let mut executed_buy_amounts: Vec<u128> = vec![];
-        volumes.chunks(2 * 12)
+        volumes.chunks_exact(2 * 12)
             .for_each(|chunk| {
                 executed_buy_amounts.push(util::read_amount(
                     &util::get_amount_from_slice(&chunk[0..12])
@@ -87,5 +87,18 @@ pub mod unit_test {
         let parsed_solution = Solution::from_bytes(bytes);
 
         assert_eq!(solution, parsed_solution);
+    }
+
+    #[test]
+    fn test_deserialize_e2e_example() {
+        let bytes = vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let parsed_solution = Solution::from_bytes(bytes);
+        let expected = Solution {
+            surplus: None,
+            prices: vec![1, 10u128.pow(18), 10u128.pow(18), 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            executed_sell_amounts: vec![10u128.pow(18), 10u128.pow(18)],
+            executed_buy_amounts: vec![10u128.pow(18), 10u128.pow(18)],
+        };
+        assert_eq!(parsed_solution, expected);
     }
 }

--- a/dfusion_rust_core/src/models/solution.rs
+++ b/dfusion_rust_core/src/models/solution.rs
@@ -1,0 +1,91 @@
+use super::*;
+use web3::types::U256;
+
+use std::iter::once;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Solution {
+    pub surplus: Option<U256>,
+    pub prices: Vec<u128>,
+    pub executed_sell_amounts: Vec<u128>,
+    pub executed_buy_amounts: Vec<u128>,
+}
+
+impl Solution {
+    pub fn trivial() -> Self {
+        Solution {
+            surplus: Some(U256::zero()),
+            prices: vec![0; TOKENS as usize],
+            executed_sell_amounts: vec![],
+            executed_buy_amounts: vec![],
+        }
+    }
+}
+
+impl Serializable for Solution {
+    fn bytes(&self) -> Vec<u8> {
+        let alternating_buy_sell_amounts: Vec<u128> = self.executed_buy_amounts
+            .iter()
+            .zip(self.executed_sell_amounts.iter())
+            .flat_map(|tup| once(tup.0).chain(once(tup.1)))
+            .cloned()
+            .collect();
+        [&self.prices, &alternating_buy_sell_amounts]
+            .iter()
+            .flat_map(|list| list.iter())
+            .flat_map(Serializable::bytes)
+            .collect()
+    }
+}
+
+impl Deserializable for Solution {
+    fn from_bytes(mut bytes: Vec<u8>) -> Self {
+        let volumes = bytes.split_off(TOKENS as usize * 12);
+        let prices = bytes
+            .chunks(12)
+            .map(|chunk| {
+                util::read_amount(
+                    &util::get_amount_from_slice(chunk)
+                )
+            })
+            .collect();
+
+        let mut executed_sell_amounts: Vec<u128> = vec![];
+        let mut executed_buy_amounts: Vec<u128> = vec![];
+        volumes.chunks(2 * 12)
+            .for_each(|chunk| {
+                executed_buy_amounts.push(util::read_amount(
+                    &util::get_amount_from_slice(&chunk[0..12])
+                ));
+                executed_sell_amounts.push(util::read_amount(
+                    &util::get_amount_from_slice(&chunk[12..24])
+                ));
+            });
+        Solution {
+            surplus: None,
+            prices,
+            executed_sell_amounts,
+            executed_buy_amounts,
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod unit_test {
+    use super::*;
+
+    #[test]
+    fn test_serialize_deserialize() {
+        let solution = Solution {
+            surplus: None,
+            prices: vec![42; TOKENS as usize],
+            executed_sell_amounts: vec![1, 2, 3],
+            executed_buy_amounts: vec![4, 5, 6],
+        };
+
+        let bytes = solution.bytes();
+        let parsed_solution = Solution::from_bytes(bytes);
+
+        assert_eq!(solution, parsed_solution);
+    }
+}

--- a/dfusion_rust_core/src/models/util.rs
+++ b/dfusion_rust_core/src/models/util.rs
@@ -1,3 +1,4 @@
+use byteorder::{BigEndian, ByteOrder};
 use std::convert::TryInto;
 use graph::bigdecimal::BigDecimal;
 use graph::data::store::{Entity, Value};
@@ -164,4 +165,20 @@ impl EntityParsing for Vec<u128> {
                 .collect::<Vec<u128>>()
             ).unwrap_or_else(|| panic!("Couldn't get field {} as list", field))
     }
+}
+
+pub fn get_amount_from_slice(bytes: &[u8]) -> [u8; 12] {
+    let mut bytes_12 = [0u8; 12];
+    bytes_12.copy_from_slice(bytes);
+
+    bytes_12
+}
+
+pub fn read_amount(bytes: &[u8; 12]) -> u128 {    
+    let bytes = [0u8, 0u8, 0u8, 0u8].iter()
+        .chain(bytes.iter())
+        .cloned()
+        .collect::<Vec<u8>>();
+
+    BigEndian::read_u128(bytes.as_slice())
 }

--- a/driver/src/order_driver.rs
+++ b/driver/src/order_driver.rs
@@ -57,11 +57,11 @@ pub fn run_order_listener<D, C>(
             let solution = if !orders.is_empty() {
                 price_finder.find_prices(&orders, &state).unwrap_or_else(|e| {
                     error!("Error computing result: {}\n Falling back to trivial solution", e);
-                    Solution::trivial()
+                    Solution::trivial(orders.len())
                 })
             } else {
                 warn!("No orders in batch. Falling back to trivial solution");
-                Solution::trivial()
+                Solution::trivial(orders.len())
             };
 
             // Compute updated balances

--- a/driver/src/price_finding/mod.rs
+++ b/driver/src/price_finding/mod.rs
@@ -5,6 +5,5 @@ pub mod naive_solver;
 pub mod price_finder_interface;
 
 pub use crate::price_finding::price_finder_interface::PriceFinding;
-pub use crate::price_finding::price_finder_interface::Solution;
 pub use crate::price_finding::linear_optimization_price_finder::LinearOptimisationPriceFinder;
 pub use crate::price_finding::naive_solver::NaiveSolver;

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -1,10 +1,10 @@
 use web3::types::U256;
 
-use dfusion_core::models::{Order, AccountState, TOKENS};
+use dfusion_core::models::{Order, AccountState, Solution, TOKENS};
 
 use crate::price_finding::error::PriceFindingError;
 
-use super::price_finder_interface::{PriceFinding, Solution};
+use super::price_finder_interface::PriceFinding;
 
 pub enum OrderPairType {
     LhsFullyFilled,
@@ -134,7 +134,7 @@ impl PriceFinding for NaiveSolver {
             }
         }
         let solution = Solution {
-            surplus: total_surplus,
+            surplus: Some(total_surplus),
             prices,
             executed_sell_amounts: exec_sell_amount,
             executed_buy_amounts: exec_buy_amount,
@@ -178,7 +178,7 @@ pub mod tests {
         ];
         let mut solver = NaiveSolver{};
         let res = solver.find_prices(&orders, &state);
-        assert_eq!(U256::from(16), res.unwrap().surplus);
+        assert_eq!(Some(U256::from(16)), res.unwrap().surplus);
     }
 
     #[test]
@@ -209,7 +209,7 @@ pub mod tests {
         ];
         let mut solver = NaiveSolver{};
         let res = solver.find_prices(&orders, &state);
-        assert_eq!(U256::from(16), res.unwrap().surplus);
+        assert_eq!(Some(U256::from(16)), res.unwrap().surplus);
     }
 
     #[test]
@@ -240,7 +240,7 @@ pub mod tests {
         ];
         let mut solver = NaiveSolver{};
         let res = solver.find_prices(&orders, &state);
-        assert_eq!(U256::from(116), res.unwrap().surplus);
+        assert_eq!(Some(U256::from(116)), res.unwrap().surplus);
     }
 
     #[test]
@@ -303,7 +303,7 @@ pub mod tests {
         ];
         let mut solver = NaiveSolver{};
         let res = solver.find_prices(&orders, &state);
-        assert_eq!(U256::from(16), res.unwrap().surplus);
+        assert_eq!(Some(U256::from(16)), res.unwrap().surplus);
     }
 
     #[test]
@@ -334,7 +334,7 @@ pub mod tests {
         ];
         let mut solver = NaiveSolver{};
         let res = solver.find_prices(&orders, &state);
-        assert_eq!(U256::from(0), res.unwrap().surplus);
+        assert_eq!(Some(U256::from(0)), res.unwrap().surplus);
     }
 
     #[test]
@@ -365,6 +365,6 @@ pub mod tests {
         ];
         let mut solver = NaiveSolver{};
         let res = solver.find_prices(&orders, &state);
-        assert_eq!(U256::from(0), res.unwrap().surplus);
+        assert_eq!(Some(U256::from(0)), res.unwrap().surplus);
     }
 }


### PR DESCRIPTION
#220 is introducing a new data type - AuctionResults. Really, this should be reusing the existing solution struct. The struct already defines how it is serialized into a bytes array and only misses the inverse deserialize method.

However, at the moment this struct only available in the driver project.

This PR moves the struct into the shared core library and implements the deserialization method (including a unit test)

### TestPlan

CI and make sure the deserialize method can be used in #220 