### PR TITLE
[Easy] Run cargo fmt

### DIFF
--- a/dfusion_rust_core/src/database/error.rs
+++ b/dfusion_rust_core/src/database/error.rs
@@ -16,29 +16,22 @@ pub enum ErrorKind {
 
 impl fmt::Display for DatabaseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f,"Database Error: [{}]", self.details)
+        write!(f, "Database Error: [{}]", self.details)
     }
 }
 
 impl DatabaseError {
-    pub fn new(
-        kind: ErrorKind, 
-        description: &str, 
-    ) -> Self {
+    pub fn new(kind: ErrorKind, description: &str) -> Self {
         DatabaseError {
             details: description.to_string(),
-            kind
+            kind,
         }
     }
 
-    pub fn chain<T: fmt::Display>(
-        kind: ErrorKind, 
-        description: &str, 
-        underlying_error: T
-    ) -> Self {
+    pub fn chain<T: fmt::Display>(kind: ErrorKind, description: &str, underlying_error: T) -> Self {
         DatabaseError {
             details: format!("{} - {}", description, underlying_error),
-            kind
+            kind,
         }
     }
 }

--- a/dfusion_rust_core/src/database/mod.rs
+++ b/dfusion_rust_core/src/database/mod.rs
@@ -3,9 +3,9 @@ mod graph_reader;
 
 use web3::types::{H256, U256};
 
+use super::models;
 pub use error::*;
 pub use graph_reader::GraphReader;
-use super::models;
 
 pub trait DbInterface: Send + Sync {
     fn get_balances_for_state_root(
@@ -16,18 +16,10 @@ pub trait DbInterface: Send + Sync {
         &self,
         state_index: &U256,
     ) -> Result<models::AccountState, DatabaseError>;
-    fn get_deposits_of_slot(
-        &self,
-        slot: &U256,
-    ) -> Result<Vec<models::PendingFlux>, DatabaseError>;
-    fn get_withdraws_of_slot(
-        &self,
-        slot: &U256,
-    ) -> Result<Vec<models::PendingFlux>, DatabaseError>;
-    fn get_orders_of_slot(
-        &self,
-        slot: &U256,
-    ) -> Result<Vec<models::Order>, DatabaseError>;
+    fn get_deposits_of_slot(&self, slot: &U256) -> Result<Vec<models::PendingFlux>, DatabaseError>;
+    fn get_withdraws_of_slot(&self, slot: &U256)
+        -> Result<Vec<models::PendingFlux>, DatabaseError>;
+    fn get_orders_of_slot(&self, slot: &U256) -> Result<Vec<models::Order>, DatabaseError>;
     fn get_standing_orders_of_slot(
         &self,
         slot: &U256,
@@ -47,18 +39,39 @@ pub mod tests {
         pub get_deposits_of_slot: Mock<U256, Result<Vec<models::PendingFlux>, DatabaseError>>,
         pub get_withdraws_of_slot: Mock<U256, Result<Vec<models::PendingFlux>, DatabaseError>>,
         pub get_orders_of_slot: Mock<U256, Result<Vec<models::Order>, DatabaseError>>,
-        pub get_standing_orders_of_slot: Mock<U256, Result<[models::StandingOrder; models::NUM_RESERVED_ACCOUNTS], DatabaseError>>,
+        pub get_standing_orders_of_slot: Mock<
+            U256,
+            Result<[models::StandingOrder; models::NUM_RESERVED_ACCOUNTS], DatabaseError>,
+        >,
     }
 
     impl DbInterfaceMock {
         pub fn new() -> DbInterfaceMock {
             DbInterfaceMock {
-                get_balances_for_state_root: Mock::new(Err(DatabaseError::new(ErrorKind::Unknown, "Unexpected call to get_balances_for_state_root"))),
-                get_balances_for_state_index: Mock::new(Err(DatabaseError::new(ErrorKind::Unknown, "Unexpected call to get_balances_for_state_root"))),
-                get_deposits_of_slot: Mock::new(Err(DatabaseError::new(ErrorKind::Unknown, "Unexpected call to get_deposits_of_slot"))),
-                get_withdraws_of_slot: Mock::new(Err(DatabaseError::new(ErrorKind::Unknown, "Unexpected call to get_withdraws_of_slot"))),
-                get_orders_of_slot: Mock::new(Err(DatabaseError::new(ErrorKind::Unknown, "Unexpected call to get_withdraws_of_slot"))),
-                get_standing_orders_of_slot: Mock::new(Err(DatabaseError::new(ErrorKind::Unknown, "Unexpected call to get_standing_orders_of_slot"))),
+                get_balances_for_state_root: Mock::new(Err(DatabaseError::new(
+                    ErrorKind::Unknown,
+                    "Unexpected call to get_balances_for_state_root",
+                ))),
+                get_balances_for_state_index: Mock::new(Err(DatabaseError::new(
+                    ErrorKind::Unknown,
+                    "Unexpected call to get_balances_for_state_root",
+                ))),
+                get_deposits_of_slot: Mock::new(Err(DatabaseError::new(
+                    ErrorKind::Unknown,
+                    "Unexpected call to get_deposits_of_slot",
+                ))),
+                get_withdraws_of_slot: Mock::new(Err(DatabaseError::new(
+                    ErrorKind::Unknown,
+                    "Unexpected call to get_withdraws_of_slot",
+                ))),
+                get_orders_of_slot: Mock::new(Err(DatabaseError::new(
+                    ErrorKind::Unknown,
+                    "Unexpected call to get_withdraws_of_slot",
+                ))),
+                get_standing_orders_of_slot: Mock::new(Err(DatabaseError::new(
+                    ErrorKind::Unknown,
+                    "Unexpected call to get_standing_orders_of_slot",
+                ))),
             }
         }
     }
@@ -74,7 +87,7 @@ pub mod tests {
             &self,
             state_root: &H256,
         ) -> Result<models::AccountState, DatabaseError> {
-            self.get_balances_for_state_root.called(*state_root)  // https://github.com/intellij-rust/intellij-rust/issues/3164
+            self.get_balances_for_state_root.called(*state_root) // https://github.com/intellij-rust/intellij-rust/issues/3164
         }
         fn get_balances_for_state_index(
             &self,
@@ -94,10 +107,7 @@ pub mod tests {
         ) -> Result<Vec<models::PendingFlux>, DatabaseError> {
             self.get_withdraws_of_slot.called(*slot)
         }
-        fn get_orders_of_slot(
-            &self,
-            slot: &U256,
-        ) -> Result<Vec<models::Order>, DatabaseError> {
+        fn get_orders_of_slot(&self, slot: &U256) -> Result<Vec<models::Order>, DatabaseError> {
             self.get_orders_of_slot.called(*slot)
         }
         fn get_standing_orders_of_slot(

--- a/dfusion_rust_core/src/lib.rs
+++ b/dfusion_rust_core/src/lib.rs
@@ -1,8 +1,8 @@
 #[macro_use]
 extern crate log;
 
-pub mod models;
 pub mod database;
+pub mod models;
 
 use graph::prelude::SubgraphDeploymentId;
 
@@ -12,5 +12,6 @@ extern crate lazy_static;
 pub const SUBGRAPH_NAME: &str = "dfusion";
 
 lazy_static! {
-    static ref SUBGRAPH_ID: SubgraphDeploymentId = SubgraphDeploymentId::new(SUBGRAPH_NAME).unwrap();
+    static ref SUBGRAPH_ID: SubgraphDeploymentId =
+        SubgraphDeploymentId::new(SUBGRAPH_NAME).unwrap();
 }

--- a/dfusion_rust_core/src/models/account_state.rs
+++ b/dfusion_rust_core/src/models/account_state.rs
@@ -3,9 +3,9 @@ use graph::data::store::Entity;
 use serde_derive::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
-use web3::types::{H256, U256, Log};
+use web3::types::{Log, H256, U256};
 
-use crate::models::{TOKENS, RollingHashable, PendingFlux, Order, Solution};
+use crate::models::{Order, PendingFlux, RollingHashable, Solution, TOKENS};
 
 use super::util::*;
 
@@ -20,7 +20,12 @@ pub struct AccountState {
 
 impl AccountState {
     pub fn new(state_hash: H256, state_index: U256, balances: Vec<u128>, num_tokens: u8) -> Self {
-        AccountState { state_hash, state_index, balances, num_tokens }
+        AccountState {
+            state_hash,
+            state_index,
+            balances,
+            num_tokens,
+        }
     }
     fn balance_index(&self, token_id: u8, account_id: u16) -> usize {
         self.num_tokens as usize * account_id as usize + token_id as usize
@@ -30,17 +35,24 @@ impl AccountState {
     }
     pub fn increment_balance(&mut self, token_id: u8, account_id: u16, amount: u128) {
         let index = self.balance_index(token_id, account_id);
-        debug!("Incrementing account {} balance of token {} by {}", account_id, token_id, amount);
+        debug!(
+            "Incrementing account {} balance of token {} by {}",
+            account_id, token_id, amount
+        );
         self.balances[index] += amount;
     }
     pub fn decrement_balance(&mut self, token_id: u8, account_id: u16, amount: u128) {
         let index = self.balance_index(token_id, account_id);
-        debug!("Decrementing account {} balance of token {} by {}", account_id, token_id, amount);
+        debug!(
+            "Decrementing account {} balance of token {} by {}",
+            account_id, token_id, amount
+        );
         self.balances[index] -= amount;
     }
     pub fn accounts(&self) -> u16 {
         assert_eq!(
-            self.balances.len() % self.num_tokens as usize, 0,
+            self.balances.len() % self.num_tokens as usize,
+            0,
             "Balance vector cannot be split into equal accounts"
         );
         (self.balances.len() / self.num_tokens as usize) as u16
@@ -104,12 +116,14 @@ impl RollingHashable for AccountState {
 impl From<mongodb::ordered::OrderedDocument> for AccountState {
     fn from(document: mongodb::ordered::OrderedDocument) -> Self {
         AccountState {
-            state_hash: document.get_str("stateHash")
+            state_hash: document
+                .get_str("stateHash")
                 .unwrap()
                 .parse::<H256>()
                 .unwrap(),
             state_index: U256::from(document.get_i32("stateIndex").unwrap()),
-            balances: document.get_array("balances")
+            balances: document
+                .get_array("balances")
                 .unwrap()
                 .iter()
                 .map(|e| e.as_str().unwrap().parse().unwrap())
@@ -159,46 +173,56 @@ impl Into<Entity> for AccountState {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use web3::types::{H256, Bytes};
     use crate::models::order::BatchInformation;
+    use web3::types::{Bytes, H256};
 
     #[test]
     fn test_state_rolling_hash() {
         // Empty state
         let mut balances = vec![0; 3000];
-        let state_hash = "77b01abfbad57cb7a1344b12709603ea3b9ad803ef5ea09814ca212748f54733".parse::<H256>().unwrap();
+        let state_hash = "77b01abfbad57cb7a1344b12709603ea3b9ad803ef5ea09814ca212748f54733"
+            .parse::<H256>()
+            .unwrap();
         let state = AccountState {
             state_hash: state_hash.clone(),
             state_index: U256::one(),
             balances: balances.clone(),
             num_tokens: TOKENS,
         };
-        assert_eq!(
-            state.rolling_hash(0),
-            state_hash
-        );
+        assert_eq!(state.rolling_hash(0), state_hash);
 
         // AccountState with single deposit
         balances[62] = 18;
-        let state_hash = "a0cde336d10dbaf3df98ba662bacf25d95062db7b3e0083bd4bad4a6c7a1cd41".parse::<H256>().unwrap();
+        let state_hash = "a0cde336d10dbaf3df98ba662bacf25d95062db7b3e0083bd4bad4a6c7a1cd41"
+            .parse::<H256>()
+            .unwrap();
         let state = AccountState {
             state_hash: state_hash.clone(),
             state_index: U256::one(),
             balances,
             num_tokens: TOKENS,
         };
-        assert_eq!(
-            state.rolling_hash(0),
-            state_hash
-        );
+        assert_eq!(state.rolling_hash(0), state_hash);
     }
 
     #[test]
     fn test_from_log() {
         let bytes: Vec<Vec<u8>> = vec![
-            /* state_hash */ vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            /* num_tokens */ vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 30],
-            /* num_accounts */ vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 100],
+            /* state_hash */
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0,
+            ],
+            /* num_tokens */
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 30,
+            ],
+            /* num_accounts */
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 100,
+            ],
         ];
 
         let log = Arc::new(Log {
@@ -266,7 +290,7 @@ pub mod tests {
             buy_token: 0,
             sell_token: 1,
             buy_amount: 1,
-            sell_amount: 1
+            sell_amount: 1,
         };
 
         let order_2 = Order {
@@ -278,7 +302,7 @@ pub mod tests {
             buy_token: 1,
             sell_token: 0,
             buy_amount: 1,
-            sell_amount: 1
+            sell_amount: 1,
         };
 
         let results = Solution {
@@ -295,15 +319,7 @@ pub mod tests {
             state.state_hash,
             "Incorrect state hash!"
         );
-        assert_eq!(
-            U256::from(2),
-            state.state_index,
-            "Incorrect state index!"
-        );
-        assert_eq!(
-            state.balances,
-            vec![1, 0, 0, 1],
-            "Incorrect balances!"
-        );
+        assert_eq!(U256::from(2), state.state_index, "Incorrect state index!");
+        assert_eq!(state.balances, vec![1, 0, 0, 1], "Incorrect balances!");
     }
 }

--- a/dfusion_rust_core/src/models/flux.rs
+++ b/dfusion_rust_core/src/models/flux.rs
@@ -2,29 +2,29 @@ use byteorder::{BigEndian, WriteBytesExt};
 use graph::data::store::Entity;
 use serde_derive::{Deserialize, Serialize};
 use std::sync::Arc;
-use web3::types::{H256, U256, Log};
+use web3::types::{Log, H256, U256};
 
-use crate::models::{Serializable, RootHashable, merkleize};
 use super::util::*;
+use crate::models::{merkleize, RootHashable, Serializable};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug, Ord, PartialOrd, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct PendingFlux {
-  pub slot_index: u16,
-  pub slot: U256,
-  pub account_id: u16,
-  pub token_id: u8,
-  pub amount: u128,
+    pub slot_index: u16,
+    pub slot: U256,
+    pub account_id: u16,
+    pub token_id: u8,
+    pub amount: u128,
 }
 
 impl Serializable for PendingFlux {
-  fn bytes(&self) -> Vec<u8> {
-    let mut wtr = vec![0; 13];
-    wtr.write_u16::<BigEndian>(self.account_id).unwrap();
-    wtr.write_u8(self.token_id).unwrap();
-    wtr.write_u128::<BigEndian>(self.amount).unwrap();
-    wtr
-  }
+    fn bytes(&self) -> Vec<u8> {
+        let mut wtr = vec![0; 13];
+        wtr.write_u16::<BigEndian>(self.account_id).unwrap();
+        wtr.write_u8(self.token_id).unwrap();
+        wtr.write_u128::<BigEndian>(self.amount).unwrap();
+        wtr
+    }
 }
 
 impl From<mongodb::ordered::OrderedDocument> for PendingFlux {
@@ -102,47 +102,65 @@ pub mod tests {
 
 #[cfg(test)]
 pub mod unit_test {
-  use super::*;
-  use graph::bigdecimal::BigDecimal;
-  use web3::types::{H256, Bytes};
-  use std::str::FromStr;
+    use super::*;
+    use graph::bigdecimal::BigDecimal;
+    use std::str::FromStr;
+    use web3::types::{Bytes, H256};
 
-  #[test]
-  fn test_pending_flux_root_hash() {
-    let deposit = PendingFlux {
-      slot_index: 0,
-      slot: U256::zero(),
-      account_id: 3,
-      token_id: 3,
-      amount: 18,
-    };
-    // one valid withdraw
-    assert_eq!(
-        vec![deposit.clone()].root_hash(&vec![true]),
-        H256::from_str(
-            "4a77ba0bc619056248f2f2793075eb6f49cf35dacb5cccfe1e71392046a06b79"
-        ).unwrap()
-    );
-    // no valid withdraws
-    assert_eq!(
-        vec![deposit].root_hash(&vec![false]),
-        H256::from_str(
-            "87eb0ddba57e35f6d286673802a4af5975e22506c7cf4c64bb6be5ee11527f2c"
-        ).unwrap()
-    );
-  }
+    #[test]
+    fn test_pending_flux_root_hash() {
+        let deposit = PendingFlux {
+            slot_index: 0,
+            slot: U256::zero(),
+            account_id: 3,
+            token_id: 3,
+            amount: 18,
+        };
+        // one valid withdraw
+        assert_eq!(
+            vec![deposit.clone()].root_hash(&vec![true]),
+            H256::from_str("4a77ba0bc619056248f2f2793075eb6f49cf35dacb5cccfe1e71392046a06b79")
+                .unwrap()
+        );
+        // no valid withdraws
+        assert_eq!(
+            vec![deposit].root_hash(&vec![false]),
+            H256::from_str("87eb0ddba57e35f6d286673802a4af5975e22506c7cf4c64bb6be5ee11527f2c")
+                .unwrap()
+        );
+    }
 
-  #[test]
-  fn test_from_log() {
-      let bytes: Vec<Vec<u8>> = vec![
-        /* account_id_bytes */ vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-        /* token_id_bytes */ vec![ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-        /* amount_bytes */ vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0],
-        /* slot_bytes */ vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        /* slot_index_bytes */ vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-      ];
+    #[test]
+    fn test_from_log() {
+        let bytes: Vec<Vec<u8>> = vec![
+            /* account_id_bytes */
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ],
+            /* token_id_bytes */
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ],
+            /* amount_bytes */
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13, 224,
+                182, 179, 167, 100, 0, 0,
+            ],
+            /* slot_bytes */
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0,
+            ],
+            /* slot_index_bytes */
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0,
+            ],
+        ];
 
-      let log = Arc::new(Log {
+        let log = Arc::new(Log {
             address: 1.into(),
             topics: vec![],
             data: Bytes(bytes.iter().flat_map(|i| i.iter()).cloned().collect()),
@@ -165,18 +183,18 @@ pub mod unit_test {
         };
 
         assert_eq!(expected_flux, PendingFlux::from(log));
-  }
+    }
 
-  #[test]
-  fn test_to_and_from_entity() {
-      let flux = PendingFlux {
+    #[test]
+    fn test_to_and_from_entity() {
+        let flux = PendingFlux {
             account_id: 1,
             token_id: 1,
             amount: 1 * (10 as u128).pow(18),
             slot: U256::zero(),
             slot_index: 0,
         };
-        
+
         let mut entity = Entity::new();
         entity.set("accountId", 1);
         entity.set("tokenId", 1);
@@ -186,5 +204,5 @@ pub mod unit_test {
 
         assert_eq!(entity, flux.clone().into());
         assert_eq!(flux, PendingFlux::from(entity));
-  }
+    }
 }

--- a/dfusion_rust_core/src/models/mod.rs
+++ b/dfusion_rust_core/src/models/mod.rs
@@ -7,10 +7,10 @@ pub mod util;
 
 pub use crate::models::account_state::AccountState;
 pub use crate::models::flux::PendingFlux;
+pub use crate::models::order::BatchInformation;
 pub use crate::models::order::Order;
 pub use crate::models::solution::Solution;
 pub use crate::models::standing_order::StandingOrder;
-pub use crate::models::order::BatchInformation;
 
 use sha2::{Digest, Sha256};
 use web3::types::H256;
@@ -46,12 +46,15 @@ fn merkleize(leafs: Vec<Vec<u8>>) -> H256 {
     if leafs.len() == 1 {
         return H256::from(leafs[0].as_slice());
     }
-    let next_layer = leafs.chunks(2).map(|pair| {
-        let mut hasher = Sha256::new();
-        hasher.input(&pair[0]);
-        hasher.input(&pair[1]);
-        hasher.result().to_vec()
-    }).collect();
+    let next_layer = leafs
+        .chunks(2)
+        .map(|pair| {
+            let mut hasher = Sha256::new();
+            hasher.input(&pair[0]);
+            hasher.input(&pair[1]);
+            hasher.result().to_vec()
+        })
+        .collect();
     merkleize(next_layer)
 }
 

--- a/dfusion_rust_core/src/models/order.rs
+++ b/dfusion_rust_core/src/models/order.rs
@@ -1,12 +1,12 @@
 use byteorder::{BigEndian, WriteBytesExt};
 use graph::data::store::Entity;
-use serde_derive::{Deserialize};
+use serde_derive::Deserialize;
 use std::sync::Arc;
-use web3::types::{H256, U256, Log};
+use web3::types::{Log, H256, U256};
 
 use super::util::*;
 
-use crate::models::{Serializable, RollingHashable, iter_hash};
+use crate::models::{iter_hash, RollingHashable, Serializable};
 
 #[derive(Debug, Clone, Deserialize, Eq, Ord, PartialEq, PartialOrd)]
 #[serde(rename_all = "camelCase")]
@@ -26,28 +26,24 @@ pub struct Order {
     pub sell_amount: u128,
 }
 
-
 impl Order {
-    pub fn from_encoded_order (
-        account_id: u16,
-        bytes: &[u8; 26]
-    ) -> Self {
-        let buy_token = u8::from_le_bytes([bytes[25]]);    // 1 byte
-        let sell_token = u8::from_le_bytes([bytes[24]]);   // 1 byte
+    pub fn from_encoded_order(account_id: u16, bytes: &[u8; 26]) -> Self {
+        let buy_token = u8::from_le_bytes([bytes[25]]); // 1 byte
+        let sell_token = u8::from_le_bytes([bytes[24]]); // 1 byte
         let sell_amount = read_amount(
-            &get_amount_from_slice(&bytes[12..24])         // 12 bytes
+            &get_amount_from_slice(&bytes[12..24]), // 12 bytes
         );
         let buy_amount = read_amount(
-            &get_amount_from_slice(&bytes[0..12])          // 12 bytes
+            &get_amount_from_slice(&bytes[0..12]), // 12 bytes
         );
-        
+
         Order {
             batch_information: None,
             account_id,
             buy_token,
             sell_token,
             buy_amount,
-            sell_amount
+            sell_amount,
         }
     }
 }
@@ -74,7 +70,7 @@ impl From<Arc<Log>> for Order {
     fn from(log: Arc<Log>) -> Self {
         let mut bytes: Vec<u8> = log.data.0.clone();
         Order {
-            batch_information: Some(BatchInformation{
+            batch_information: Some(BatchInformation {
                 slot: U256::pop_from_log_data(&mut bytes),
                 slot_index: u16::pop_from_log_data(&mut bytes),
             }),
@@ -89,12 +85,15 @@ impl From<Arc<Log>> for Order {
 
 impl From<Entity> for Order {
     fn from(entity: Entity) -> Self {
-        let batch_information = entity.get("auctionId")
+        let batch_information = entity
+            .get("auctionId")
             .and(entity.get("slotIndex"))
-            .and_then(|_| Some(BatchInformation{
-                slot: U256::from_entity(&entity, "auctionId"),
-                slot_index: u16::from_entity(&entity, "slotIndex"),
-            }));
+            .and_then(|_| {
+                Some(BatchInformation {
+                    slot: U256::from_entity(&entity, "auctionId"),
+                    slot_index: u16::from_entity(&entity, "slotIndex"),
+                })
+            });
 
         Order {
             batch_information,
@@ -110,7 +109,7 @@ impl From<Entity> for Order {
 impl From<mongodb::ordered::OrderedDocument> for Order {
     fn from(document: mongodb::ordered::OrderedDocument) -> Self {
         Order {
-            batch_information: Some(BatchInformation{
+            batch_information: Some(BatchInformation {
                 slot: U256::from(document.get_i32("auctionId").unwrap()),
                 slot_index: document.get_i32("slotIndex").unwrap() as u16,
             }),
@@ -141,7 +140,8 @@ impl Into<Entity> for Order {
 
 impl<T: Serializable> RollingHashable for Vec<T> {
     fn rolling_hash(&self, nonce: u32) -> H256 {
-        self.iter().fold(H256::from(u64::from(nonce)), |acc, w| iter_hash(w, &acc))
+        self.iter()
+            .fold(H256::from(u64::from(nonce)), |acc, w| iter_hash(w, &acc))
     }
 }
 
@@ -149,7 +149,7 @@ pub mod tests {
     use super::*;
     pub fn create_order_for_test() -> Order {
         Order {
-            batch_information: Some(BatchInformation{
+            batch_information: Some(BatchInformation {
                 slot: U256::zero(),
                 slot_index: 0,
             }),
@@ -166,41 +166,68 @@ pub mod tests {
 pub mod unit_test {
     use super::*;
     use graph::bigdecimal::BigDecimal;
-    use web3::types::{Bytes, H256};
     use std::str::FromStr;
+    use web3::types::{Bytes, H256};
 
     #[test]
     fn test_order_rolling_hash() {
-    let order = Order {
-        batch_information: Some(BatchInformation{
-        slot: U256::zero(),
-        slot_index: 0,
-        }),
-        account_id: 1,
-        buy_token: 3,
-        sell_token: 2,
-        buy_amount: 5,
-        sell_amount: 4,
-    };
+        let order = Order {
+            batch_information: Some(BatchInformation {
+                slot: U256::zero(),
+                slot_index: 0,
+            }),
+            account_id: 1,
+            buy_token: 3,
+            sell_token: 2,
+            buy_amount: 5,
+            sell_amount: 4,
+        };
 
-    assert_eq!(
-    vec![order].rolling_hash(0),
-    H256::from_str(
-        "8c253b4588a6d87b02b5f7d1424020b7b5f8c0397e464e087d2830a126d3b699"
-        ).unwrap()
-    );
+        assert_eq!(
+            vec![order].rolling_hash(0),
+            H256::from_str("8c253b4588a6d87b02b5f7d1424020b7b5f8c0397e464e087d2830a126d3b699")
+                .unwrap()
+        );
     }
 
     #[test]
     fn test_from_log() {
         let bytes: Vec<Vec<u8>> = vec![
-        /* slot_bytes */ vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        /* slot_index_bytes */ vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        /* account_id_bytes */ vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-        /* buy_token_bytes */ vec![ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3],
-        /* sell_token_bytes */ vec![ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2],
-        /* buy_amount_bytes */ vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0],
-        /* sell_amount_bytes */ vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0],
+            /* slot_bytes */
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0,
+            ],
+            /* slot_index_bytes */
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0,
+            ],
+            /* account_id_bytes */
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ],
+            /* buy_token_bytes */
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 3,
+            ],
+            /* sell_token_bytes */
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 2,
+            ],
+            /* buy_amount_bytes */
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13, 224,
+                182, 179, 167, 100, 0, 0,
+            ],
+            /* sell_amount_bytes */
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13, 224,
+                182, 179, 167, 100, 0, 0,
+            ],
         ];
 
         let log = Arc::new(Log {
@@ -218,7 +245,7 @@ pub mod unit_test {
         });
 
         let expected_order = Order {
-            batch_information: Some(BatchInformation{
+            batch_information: Some(BatchInformation {
                 slot: U256::zero(),
                 slot_index: 0,
             }),
@@ -234,7 +261,7 @@ pub mod unit_test {
 
     #[test]
     fn test_into_and_from_entity() {
-        let order = create_order_for_test();        
+        let order = create_order_for_test();
         let entity = create_entity_for_test();
 
         assert_eq!(entity, order.clone().into());
@@ -262,21 +289,33 @@ pub mod unit_test {
 
         let mut actual_entity = entity.clone();
         actual_entity.remove("slotIndex");
-        assert_eq!(expected_order, Order::from(actual_entity), "No batch info if there's no slot index");
+        assert_eq!(
+            expected_order,
+            Order::from(actual_entity),
+            "No batch info if there's no slot index"
+        );
 
         let mut actual_entity = entity.clone();
         actual_entity.remove("auctionId");
-        assert_eq!(expected_order, Order::from(actual_entity), "No batch info if there's no auctionId");
+        assert_eq!(
+            expected_order,
+            Order::from(actual_entity),
+            "No batch info if there's no auctionId"
+        );
 
         let mut actual_entity = entity.clone();
         actual_entity.remove("slotIndex");
         actual_entity.remove("auctionId");
-        assert_eq!(expected_order, Order::from(actual_entity), "No batch info if there's no slot index and auctionId");
+        assert_eq!(
+            expected_order,
+            Order::from(actual_entity),
+            "No batch info if there's no slot index and auctionId"
+        );
     }
 
     fn create_order_for_test() -> Order {
         Order {
-            batch_information: Some(BatchInformation{
+            batch_information: Some(BatchInformation {
                 slot: U256::zero(),
                 slot_index: 0,
             }),
@@ -298,6 +337,6 @@ pub mod unit_test {
         entity.set("buyAmount", BigDecimal::from(1 * (10 as u64).pow(18)));
         entity.set("sellAmount", BigDecimal::from(2 * (10 as u64).pow(18)));
 
-        entity 
+        entity
     }
 }

--- a/dfusion_rust_core/src/models/solution.rs
+++ b/dfusion_rust_core/src/models/solution.rs
@@ -24,7 +24,8 @@ impl Solution {
 
 impl Serializable for Solution {
     fn bytes(&self) -> Vec<u8> {
-        let alternating_buy_sell_amounts: Vec<u128> = self.executed_buy_amounts
+        let alternating_buy_sell_amounts: Vec<u128> = self
+            .executed_buy_amounts
             .iter()
             .zip(self.executed_sell_amounts.iter())
             .flat_map(|tup| once(tup.0).chain(once(tup.1)))
@@ -43,25 +44,20 @@ impl Deserializable for Solution {
         let volumes = bytes.split_off(TOKENS as usize * 12);
         let prices = bytes
             .chunks_exact(12)
-            .map(|chunk| {
-                util::read_amount(
-                    &util::get_amount_from_slice(chunk)
-                )
-            })
+            .map(|chunk| util::read_amount(&util::get_amount_from_slice(chunk)))
             .collect();
         info!("Recovered prices as: {:?}", prices);
 
         let mut executed_buy_amounts: Vec<u128> = vec![];
         let mut executed_sell_amounts: Vec<u128> = vec![];
-        volumes.chunks_exact(2 * 12)
-            .for_each(|chunk| {
-                executed_buy_amounts.push(util::read_amount(
-                    &util::get_amount_from_slice(&chunk[0..12])
-                ));
-                executed_sell_amounts.push(util::read_amount(
-                    &util::get_amount_from_slice(&chunk[12..24])
-                ));
-            });
+        volumes.chunks_exact(2 * 12).for_each(|chunk| {
+            executed_buy_amounts.push(util::read_amount(&util::get_amount_from_slice(
+                &chunk[0..12],
+            )));
+            executed_sell_amounts.push(util::read_amount(&util::get_amount_from_slice(
+                &chunk[12..24],
+            )));
+        });
         Solution {
             surplus: None,
             prices,
@@ -92,11 +88,59 @@ pub mod unit_test {
 
     #[test]
     fn test_deserialize_e2e_example() {
-        let bytes = vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let bytes = vec![
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, 0,
+            0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 13, 224, 182,
+            179, 167, 100, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, 0, 0, 0, 0, 13,
+            224, 182, 179, 167, 100, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+        ];
         let parsed_solution = Solution::from_bytes(bytes);
         let expected = Solution {
             surplus: None,
-            prices: vec![1, 10u128.pow(18), 10u128.pow(18), 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            prices: vec![
+                1,
+                10u128.pow(18),
+                10u128.pow(18),
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+            ],
             executed_buy_amounts: vec![10u128.pow(18), 10u128.pow(18)],
             executed_sell_amounts: vec![10u128.pow(18), 10u128.pow(18)],
         };

--- a/dfusion_rust_core/src/models/standing_order.rs
+++ b/dfusion_rust_core/src/models/standing_order.rs
@@ -2,12 +2,12 @@ use crate::models;
 use crate::models::{ConcatenatingHashable, RollingHashable};
 
 use array_macro::array;
+use graph::data::store::Entity;
 use serde_derive::Deserialize;
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
-use web3::types::{Log};
+use web3::types::Log;
 use web3::types::{H256, U256};
-use graph::data::store::{Entity};
 
 use super::util::*;
 
@@ -77,14 +77,14 @@ impl From<mongodb::ordered::OrderedDocument> for StandingOrder {
                 .iter()
                 .map(|raw_order| raw_order.as_document().unwrap())
                 .map(|order_doc| super::Order {
-                        batch_information: None,
-                        account_id,
-                        buy_token: order_doc.get_i32("buyToken").unwrap() as u8,
-                        sell_token: order_doc.get_i32("sellToken").unwrap() as u8,
-                        buy_amount: order_doc.get_str("buyAmount").unwrap().parse().unwrap(),
-                        sell_amount: order_doc.get_str("sellAmount").unwrap().parse().unwrap(),
-                    }
-                ).collect()
+                    batch_information: None,
+                    account_id,
+                    buy_token: order_doc.get_i32("buyToken").unwrap() as u8,
+                    sell_token: order_doc.get_i32("sellToken").unwrap() as u8,
+                    buy_amount: order_doc.get_str("buyAmount").unwrap().parse().unwrap(),
+                    sell_amount: order_doc.get_str("sellAmount").unwrap().parse().unwrap(),
+                })
+                .collect(),
         }
     }
 }
@@ -92,8 +92,12 @@ impl From<mongodb::ordered::OrderedDocument> for StandingOrder {
 impl From<&Arc<Log>> for StandingOrder {
     fn from(log: &Arc<Log>) -> Self {
         let mut bytes: Vec<u8> = log.data.0.clone();
-        info!("Parsing StandingOrder from bytes. {} bytes. {:?}", bytes.len(), bytes);
-        
+        info!(
+            "Parsing StandingOrder from bytes. {} bytes. {:?}",
+            bytes.len(),
+            bytes
+        );
+
         // Get basic data from event
         let batch_index = U256::pop_from_log_data(&mut bytes);
         let valid_from_auction_id = U256::pop_from_log_data(&mut bytes);
@@ -102,18 +106,29 @@ impl From<&Arc<Log>> for StandingOrder {
         let bytes_init = u8::pop_from_log_data(&mut bytes) as usize;
         let byte_size = u8::pop_from_log_data(&mut bytes) as usize;
 
-        info!("Extracting packed order. Bytes: {}-{}", bytes_init, bytes_init + byte_size);
+        info!(
+            "Extracting packed order. Bytes: {}-{}",
+            bytes_init,
+            bytes_init + byte_size
+        );
         let packed_orders_bytes = &bytes[0..byte_size];
-        info!("Parsing orders from packedOrders. {} bytes. {:?}", packed_orders_bytes.len(), packed_orders_bytes);
-        assert!(packed_orders_bytes.len() % 26 == 0, "Each order should be packed in 26 bytes");
-                
+        info!(
+            "Parsing orders from packedOrders. {} bytes. {:?}",
+            packed_orders_bytes.len(),
+            packed_orders_bytes
+        );
+        assert!(
+            packed_orders_bytes.len() % 26 == 0,
+            "Each order should be packed in 26 bytes"
+        );
+
         // Extract packed order info
         let orders: Vec<models::Order> = packed_orders_bytes
             .chunks(26)
             .map(|chunk| {
                 let mut chunk_array = [0; 26];
                 chunk_array.copy_from_slice(chunk);
-                
+
                 models::Order::from_encoded_order(account_id, &chunk_array)
             })
             .collect();
@@ -122,17 +137,17 @@ impl From<&Arc<Log>> for StandingOrder {
             account_id,
             batch_index,
             valid_from_auction_id,
-            orders
+            orders,
         }
     }
 }
-
 
 impl From<(Entity, Vec<Entity>)> for StandingOrder {
     fn from(entities: (Entity, Vec<Entity>)) -> Self {
         let batch_entity = entities.0;
         let mut order_entities_iter = entities.1.into_iter();
-        let order_ids = batch_entity.get("orders")
+        let order_ids = batch_entity
+            .get("orders")
             .expect("it should contain order ids")
             .clone()
             .as_list()
@@ -148,14 +163,16 @@ impl From<(Entity, Vec<Entity>)> for StandingOrder {
         let batch_index = U256::from_entity(&batch_entity, "batchIndex");
         let valid_from_auction_id = U256::from_entity(&batch_entity, "validFromAuctionId");
 
-        let orders = order_ids.iter()
+        let orders = order_ids
+            .iter()
             .map(|order_id| {
                 // Get matching order for the id
                 let order_entity: Entity = order_entities_iter
                     .find(|current_order| {
-                        let current_order_id = current_order.get("id")
-                            .expect("The entity orders should have an id that match the standing order");
-                            
+                        let current_order_id = current_order.get("id").expect(
+                            "The entity orders should have an id that match the standing order",
+                        );
+
                         current_order_id == order_id
                     })
                     .expect("The standing order has and id not found in the entity Vec");
@@ -170,14 +187,14 @@ impl From<(Entity, Vec<Entity>)> for StandingOrder {
             account_id,
             batch_index,
             valid_from_auction_id,
-            orders
+            orders,
         }
     }
 }
 
 impl Into<Entity> for StandingOrder {
     fn into(self) -> Entity {
-        let mut entity = Entity::new();                
+        let mut entity = Entity::new();
         entity.set("accountId", self.account_id.to_value());
         entity.set("batchIndex", self.batch_index.to_value());
         entity.set("validFromAuctionId", self.valid_from_auction_id.to_value());
@@ -187,14 +204,13 @@ impl Into<Entity> for StandingOrder {
     }
 }
 
-
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use std::str::FromStr;
     use graph::bigdecimal::BigDecimal;
-    use web3::types::{Bytes, H256};
     use graph::data::store::Value;
+    use std::str::FromStr;
+    use web3::types::{Bytes, H256};
 
     #[test]
     fn concatenating_hash() {
@@ -241,7 +257,7 @@ pub mod tests {
         let mut expected_standing_order = create_standing_order_for_test();
 
         // Remove the orders, the From<Entity> doesn't have enough info about the orders
-        expected_standing_order.orders = vec![]; 
+        expected_standing_order.orders = vec![];
         let actual_standing_order: StandingOrder = StandingOrder::from((entity, vec![]));
 
         assert_eq!(actual_standing_order, expected_standing_order);
@@ -252,9 +268,7 @@ pub mod tests {
         let entity = create_entity_for_test();
         let expected_standing_order = create_standing_order_for_test();
 
-        let order_entities = vec![
-            create_entity_order_for_test()
-        ];
+        let order_entities = vec![create_entity_order_for_test()];
         let actual_standing_order: StandingOrder = StandingOrder::from((entity, order_entities));
 
         assert_eq!(actual_standing_order, expected_standing_order);
@@ -271,31 +285,40 @@ pub mod tests {
                 sell_token: 1,
                 buy_token: 2,
                 sell_amount: 2 * (10 as u128).pow(18),
-                buy_amount: (10 as u128).pow(18)
-            }]
+                buy_amount: (10 as u128).pow(18),
+            }],
         }
     }
 
     pub fn create_entity_for_test() -> Entity {
         let mut entity = Entity::new();
-        entity.set("id", Value::String(
-            String::from("f5eb19f104583ad72d26d51078e15c5d2203c354d8c30438d66860bc61975038_0")
-        ));
+        entity.set(
+            "id",
+            Value::String(String::from(
+                "f5eb19f104583ad72d26d51078e15c5d2203c354d8c30438d66860bc61975038_0",
+            )),
+        );
         entity.set("accountId", 1);
         entity.set("batchIndex", BigDecimal::from(2));
         entity.set("validFromAuctionId", BigDecimal::from(3));
-        entity.set("orders", vec![
-            Value::String(String::from("f5eb19f104583ad72d26d51078e15c5d2203c354d8c30438d66860bc61975038_0_0"))
-        ]);
+        entity.set(
+            "orders",
+            vec![Value::String(String::from(
+                "f5eb19f104583ad72d26d51078e15c5d2203c354d8c30438d66860bc61975038_0_0",
+            ))],
+        );
 
         entity
     }
 
     pub fn create_entity_order_for_test() -> Entity {
         let mut entity = Entity::new();
-        entity.set("id", Value::String(
-            String::from("f5eb19f104583ad72d26d51078e15c5d2203c354d8c30438d66860bc61975038_0_0")
-        ));
+        entity.set(
+            "id",
+            Value::String(String::from(
+                "f5eb19f104583ad72d26d51078e15c5d2203c354d8c30438d66860bc61975038_0_0",
+            )),
+        );
         entity.set("accountId", 1);
         entity.set("buyToken", 2);
         entity.set("sellToken", 1);
@@ -319,27 +342,39 @@ pub mod tests {
     pub fn create_log_for_test() -> Arc<Log> {
         let bytes: Vec<Vec<u8>> = vec![
             // batch_index: 1
-            vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,0, 0, 0, 2],
-
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 2,
+            ],
             // valid_from_auction_id: 3
-            vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3],
-
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 3,
+            ],
             // account_id: 1
-            vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ],
             // bytes start position
-            vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128],
-
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 128,
+            ],
             // bytes size
-            vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 26],
-
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 26,
+            ],
             // packed_orders: Buy token 2, for token 1. Buy 1e18 for 2e18.
             //    000000000de0b6b3a7640000 000000001bc16d674ec80000 0201
             //    00 00 00 00 0d  e0   b6   b3   a7   64   00 00 00 00 00 00 1b  c1   6d   67   4e  c8   00 00 02 01
-            vec![ 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, 0, 0, 0, 0, 27, 193, 109, 103, 78, 200, 0, 0, 1, 2],
-
+            vec![
+                0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, 0, 0, 0, 0, 27, 193, 109, 103, 78,
+                200, 0, 0, 1, 2,
+            ],
             // Unused space for bytes field
-            vec![ 0, 0, 0, 0, 0, 0]
+            vec![0, 0, 0, 0, 0, 0],
         ];
 
         Arc::new(Log {

--- a/dfusion_rust_core/src/models/util.rs
+++ b/dfusion_rust_core/src/models/util.rs
@@ -1,10 +1,10 @@
 use byteorder::{BigEndian, ByteOrder};
-use std::convert::TryInto;
 use graph::bigdecimal::BigDecimal;
 use graph::data::store::{Entity, Value};
 use std::convert::TryFrom;
+use std::convert::TryInto;
 use std::str::FromStr;
-use web3::types::{U256, H256};
+use web3::types::{H256, U256};
 
 pub trait PopFromLogData {
     fn pop_from_log_data(bytes: &mut Vec<u8>) -> Self;
@@ -30,17 +30,13 @@ impl PopFromLogData for u128 {
 
 impl PopFromLogData for U256 {
     fn pop_from_log_data(bytes: &mut Vec<u8>) -> Self {
-        U256::from_big_endian(
-            bytes.drain(0..32).collect::<Vec<u8>>().as_slice()
-        )
+        U256::from_big_endian(bytes.drain(0..32).collect::<Vec<u8>>().as_slice())
     }
 }
 
 impl PopFromLogData for H256 {
     fn pop_from_log_data(bytes: &mut Vec<u8>) -> Self {
-        H256::from(
-            bytes.drain(0..32).collect::<Vec<u8>>().as_slice()
-        )
+        H256::from(bytes.drain(0..32).collect::<Vec<u8>>().as_slice())
     }
 }
 
@@ -99,53 +95,63 @@ pub trait EntityParsing {
 
 impl EntityParsing for u8 {
     fn from_entity(entity: &Entity, field: &str) -> Self {
-        u8::try_from(entity
-            .get(field)
-            .and_then(|value| value.clone().as_int())
-            .unwrap_or_else(|| panic!("Couldn't get field {} as uint", field))
-        ).unwrap_or_else(|_| panic!("Couldn't cast {} from i32 to u8", field))
+        u8::try_from(
+            entity
+                .get(field)
+                .and_then(|value| value.clone().as_int())
+                .unwrap_or_else(|| panic!("Couldn't get field {} as uint", field)),
+        )
+        .unwrap_or_else(|_| panic!("Couldn't cast {} from i32 to u8", field))
     }
 }
 
 impl EntityParsing for u16 {
     fn from_entity(entity: &Entity, field: &str) -> Self {
-        u16::try_from(entity
-            .get(field)
-            .and_then(|value| value.clone().as_int())
-            .unwrap_or_else(|| panic!("Couldn't get field {} as uint", field))
-        ).unwrap_or_else(|_| panic!("Couldn't cast {} from i32 to u16", field))
+        u16::try_from(
+            entity
+                .get(field)
+                .and_then(|value| value.clone().as_int())
+                .unwrap_or_else(|| panic!("Couldn't get field {} as uint", field)),
+        )
+        .unwrap_or_else(|_| panic!("Couldn't cast {} from i32 to u16", field))
     }
 }
 
 impl EntityParsing for u128 {
     fn from_entity(entity: &Entity, field: &str) -> Self {
-        u128::from_str(&entity
-            .get(field)
-            .and_then(|value| value.clone().as_big_decimal())
-            .map(|decimal| decimal.to_string())
-            .unwrap_or_else(|| panic!("Couldn't get field {} as big decimal", field))
-        ).unwrap_or_else(|_| panic!("Couldn't cast {} from string to u128", field))
+        u128::from_str(
+            &entity
+                .get(field)
+                .and_then(|value| value.clone().as_big_decimal())
+                .map(|decimal| decimal.to_string())
+                .unwrap_or_else(|| panic!("Couldn't get field {} as big decimal", field)),
+        )
+        .unwrap_or_else(|_| panic!("Couldn't cast {} from string to u128", field))
     }
 }
 
 impl EntityParsing for U256 {
     fn from_entity(entity: &Entity, field: &str) -> Self {
-        U256::from_str(&entity
-            .get(field)
-            .and_then(|value| value.clone().as_big_decimal())
-            .map(|decimal| decimal.to_string())
-            .unwrap_or_else(|| panic!("Couldn't get field {} as big decimal", field))
-        ).unwrap_or_else(|_| panic!("Couldn't cast {} from string to U256", field))
+        U256::from_str(
+            &entity
+                .get(field)
+                .and_then(|value| value.clone().as_big_decimal())
+                .map(|decimal| decimal.to_string())
+                .unwrap_or_else(|| panic!("Couldn't get field {} as big decimal", field)),
+        )
+        .unwrap_or_else(|_| panic!("Couldn't cast {} from string to U256", field))
     }
 }
 
 impl EntityParsing for H256 {
     fn from_entity(entity: &Entity, field: &str) -> Self {
-        H256::from_str(&entity
-            .get(field)
-            .and_then(|value| value.clone().as_string())
-            .unwrap_or_else(|| panic!("Couldn't get field {} as string", field))
-        ).unwrap_or_else(|_| panic!("Couldn't cast {} from string to H256", field))
+        H256::from_str(
+            &entity
+                .get(field)
+                .and_then(|value| value.clone().as_string())
+                .unwrap_or_else(|| panic!("Couldn't get field {} as string", field)),
+        )
+        .unwrap_or_else(|_| panic!("Couldn't cast {} from string to H256", field))
     }
 }
 
@@ -154,16 +160,23 @@ impl EntityParsing for Vec<u128> {
         entity
             .get(field)
             .and_then(|value| value.clone().as_list())
-            .map(|list| list
-                .into_iter()
-                .map(|value| u128::from_str(
-                        &value.clone()
-                            .as_big_decimal()
-                            .map(|decimal| decimal.to_string())
-                            .unwrap_or_else(|| panic!("Couldn't convert value {} to big decimal", &value))
-                    ).unwrap_or_else(|_| panic!("Couldn't parse value {} to u128", &value)))
-                .collect::<Vec<u128>>()
-            ).unwrap_or_else(|| panic!("Couldn't get field {} as list", field))
+            .map(|list| {
+                list.into_iter()
+                    .map(|value| {
+                        u128::from_str(
+                            &value
+                                .clone()
+                                .as_big_decimal()
+                                .map(|decimal| decimal.to_string())
+                                .unwrap_or_else(|| {
+                                    panic!("Couldn't convert value {} to big decimal", &value)
+                                }),
+                        )
+                        .unwrap_or_else(|_| panic!("Couldn't parse value {} to u128", &value))
+                    })
+                    .collect::<Vec<u128>>()
+            })
+            .unwrap_or_else(|| panic!("Couldn't get field {} as list", field))
     }
 }
 
@@ -174,8 +187,9 @@ pub fn get_amount_from_slice(bytes: &[u8]) -> [u8; 12] {
     bytes_12
 }
 
-pub fn read_amount(bytes: &[u8; 12]) -> u128 {    
-    let bytes = [0u8, 0u8, 0u8, 0u8].iter()
+pub fn read_amount(bytes: &[u8; 12]) -> u128 {
+    let bytes = [0u8, 0u8, 0u8, 0u8]
+        .iter()
         .chain(bytes.iter())
         .cloned()
         .collect::<Vec<u8>>();

--- a/driver/src/bin/main.rs
+++ b/driver/src/bin/main.rs
@@ -2,14 +2,14 @@ extern crate simple_logger;
 
 use driver::contract::SnappContractImpl;
 use driver::mongo_db::MongoDB;
-use driver::price_finding::NaiveSolver;
 use driver::price_finding::LinearOptimisationPriceFinder;
+use driver::price_finding::NaiveSolver;
 use driver::price_finding::PriceFinding;
 use driver::run_driver_components;
 
+use std::env;
 use std::thread;
 use std::time::Duration;
-use std::env;
 
 fn main() {
     simple_logger::init_with_level(log::Level::Info).unwrap();
@@ -18,9 +18,8 @@ fn main() {
     let db_instance = MongoDB::new(db_host, db_port).unwrap();
     let contract = SnappContractImpl::new().unwrap();
 
-    let solver_env_var = env::var("LINEAR_OPTIMIZATION_SOLVER")
-        .unwrap_or_else(|_| "0".to_string());
-    let mut price_finder : Box<dyn PriceFinding> = if solver_env_var == "1" {
+    let solver_env_var = env::var("LINEAR_OPTIMIZATION_SOLVER").unwrap_or_else(|_| "0".to_string());
+    let mut price_finder: Box<dyn PriceFinding> = if solver_env_var == "1" {
         Box::new(LinearOptimisationPriceFinder::new())
     } else {
         Box::new(NaiveSolver {})

--- a/driver/src/contract.rs
+++ b/driver/src/contract.rs
@@ -3,7 +3,7 @@ extern crate mock_it;
 
 use web3::contract::{Contract, Options};
 use web3::futures::Future;
-use web3::types::{Address, H256, U256, U128, BlockId};
+use web3::types::{Address, BlockId, H256, U128, U256};
 
 use crate::error::DriverError;
 
@@ -23,7 +23,6 @@ pub trait SnappContract {
     fn get_current_auction_slot(&self) -> Result<U256>;
     fn calculate_order_hash(&self, slot: U256, standing_order_index: Vec<U128>) -> Result<H256>;
 
-
     // Deposit Slots
     fn creation_timestamp_for_deposit_slot(&self, slot: U256) -> Result<U256>;
     fn deposit_hash_for_slot(&self, slot: U256) -> Result<H256>;
@@ -40,9 +39,30 @@ pub trait SnappContract {
     fn has_auction_slot_been_applied(&self, slot: U256) -> Result<bool>;
 
     // Write methods
-    fn apply_deposits(&self, slot: U256, prev_state: H256, new_state: H256, deposit_hash: H256) -> Result<()>;
-    fn apply_withdraws(&self, slot: U256, merkle_root: H256, prev_state: H256, new_state: H256, withdraw_hash: H256) -> Result<()>;
-    fn apply_auction(&self, slot: U256, prev_state: H256, new_state: H256, order_hash: H256, standing_order_index: Vec<U128>, prices_and_volumes: Vec<u8>) -> Result<()>;
+    fn apply_deposits(
+        &self,
+        slot: U256,
+        prev_state: H256,
+        new_state: H256,
+        deposit_hash: H256,
+    ) -> Result<()>;
+    fn apply_withdraws(
+        &self,
+        slot: U256,
+        merkle_root: H256,
+        prev_state: H256,
+        new_state: H256,
+        withdraw_hash: H256,
+    ) -> Result<()>;
+    fn apply_auction(
+        &self,
+        slot: U256,
+        prev_state: H256,
+        new_state: H256,
+        order_hash: H256,
+        standing_order_index: Vec<U128>,
+        prices_and_volumes: Vec<u8>,
+    ) -> Result<()>;
 }
 
 #[allow(dead_code)] // event_loop needs to be retained to keep web3 connection open
@@ -54,33 +74,42 @@ pub struct SnappContractImpl {
 
 impl SnappContractImpl {
     pub fn new() -> Result<Self> {
-        let (event_loop, transport) = web3::transports::Http::new(&(env::var("ETHEREUM_NODE_URL")?))?;
+        let (event_loop, transport) =
+            web3::transports::Http::new(&(env::var("ETHEREUM_NODE_URL")?))?;
         let web3 = web3::Web3::new(transport);
 
         let contents = fs::read_to_string("dex-contracts/build/contracts/SnappAuction.json")?;
         let snapp_base: serde_json::Value = serde_json::from_str(&contents)?;
-        let snapp_base_abi: String = snapp_base.get("abi").ok_or("No ABI for contract")?.to_string();
+        let snapp_base_abi: String = snapp_base
+            .get("abi")
+            .ok_or("No ABI for contract")?
+            .to_string();
 
         let snapp_address = hex::decode(&(env::var("SNAPP_CONTRACT_ADDRESS")?)[2..])?;
         let address: Address = Address::from(&snapp_address[..]);
         let contract = Contract::from_json(web3.eth(), address, snapp_base_abi.as_bytes())?;
-        Ok(SnappContractImpl { contract, web3, event_loop })
+        Ok(SnappContractImpl {
+            contract,
+            web3,
+            event_loop,
+        })
     }
 
     fn account_with_sufficient_balance(&self) -> Option<Address> {
         let accounts: Vec<Address> = self.web3.eth().accounts().wait().ok()?;
-        accounts.into_iter().find(|&acc| {
-            match self.web3.eth().balance(acc, None).wait() {
+        accounts
+            .into_iter()
+            .find(|&acc| match self.web3.eth().balance(acc, None).wait() {
                 Ok(balance) => !balance.is_zero(),
                 Err(_) => false,
-            }
-        })
+            })
     }
 }
 
 impl SnappContract for SnappContractImpl {
     fn get_current_block_timestamp(&self) -> Result<U256> {
-        self.web3.eth()
+        self.web3
+            .eth()
             .block_number()
             .wait()
             .and_then(|block_number| {
@@ -89,177 +118,253 @@ impl SnappContract for SnappContractImpl {
                     .block(BlockId::from(block_number.as_u64()))
                     .wait()
             })
-            .and_then(|block_option| {
-                match block_option {
-                    Some(block) => Ok(block.timestamp),
-                    None => Err(web3::Error::from("Current block not found"))
-                }
+            .and_then(|block_option| match block_option {
+                Some(block) => Ok(block.timestamp),
+                None => Err(web3::Error::from("Current block not found")),
             })
             .map_err(DriverError::from)
     }
 
     fn get_current_state_root(&self) -> Result<H256> {
-        self.contract.query(
-            "getCurrentStateRoot", (), None, Options::default(), None
-        ).wait().map_err(DriverError::from)
+        self.contract
+            .query("getCurrentStateRoot", (), None, Options::default(), None)
+            .wait()
+            .map_err(DriverError::from)
     }
 
     fn get_current_deposit_slot(&self) -> Result<U256> {
-        self.contract.query(
-            "getCurrentDepositIndex", (), None, Options::default(), None
-        ).wait().map_err(DriverError::from)
+        self.contract
+            .query("getCurrentDepositIndex", (), None, Options::default(), None)
+            .wait()
+            .map_err(DriverError::from)
     }
 
     fn get_current_withdraw_slot(&self) -> Result<U256> {
-        self.contract.query(
-            "getCurrentWithdrawIndex", (), None, Options::default(), None
-        ).wait().map_err(DriverError::from)
+        self.contract
+            .query(
+                "getCurrentWithdrawIndex",
+                (),
+                None,
+                Options::default(),
+                None,
+            )
+            .wait()
+            .map_err(DriverError::from)
     }
 
     fn get_current_auction_slot(&self) -> Result<U256> {
-        self.contract.query(
-            "auctionIndex", (), None, Options::default(), None
-        ).wait().map_err(DriverError::from)
+        self.contract
+            .query("auctionIndex", (), None, Options::default(), None)
+            .wait()
+            .map_err(DriverError::from)
     }
 
     fn creation_timestamp_for_deposit_slot(&self, slot: U256) -> Result<U256> {
-        self.contract.query(
-            "getDepositCreationTimestamp", slot, None, Options::default(), None,
-        ).wait().map_err(DriverError::from)
+        self.contract
+            .query(
+                "getDepositCreationTimestamp",
+                slot,
+                None,
+                Options::default(),
+                None,
+            )
+            .wait()
+            .map_err(DriverError::from)
     }
 
     fn deposit_hash_for_slot(&self, slot: U256) -> Result<H256> {
-        self.contract.query(
-            "getDepositHash", slot, None, Options::default(), None,
-        ).wait().map_err(DriverError::from)
+        self.contract
+            .query("getDepositHash", slot, None, Options::default(), None)
+            .wait()
+            .map_err(DriverError::from)
     }
 
     fn has_deposit_slot_been_applied(&self, slot: U256) -> Result<bool> {
-        self.contract.query(
-            "hasDepositBeenApplied", slot, None, Options::default(), None,
-        ).wait().map_err(DriverError::from)
+        self.contract
+            .query(
+                "hasDepositBeenApplied",
+                slot,
+                None,
+                Options::default(),
+                None,
+            )
+            .wait()
+            .map_err(DriverError::from)
     }
 
     fn creation_timestamp_for_withdraw_slot(&self, slot: U256) -> Result<U256> {
-        self.contract.query(
-            "getWithdrawCreationTimestamp", slot, None, Options::default(), None,
-        ).wait().map_err(DriverError::from)
+        self.contract
+            .query(
+                "getWithdrawCreationTimestamp",
+                slot,
+                None,
+                Options::default(),
+                None,
+            )
+            .wait()
+            .map_err(DriverError::from)
     }
 
     fn withdraw_hash_for_slot(&self, slot: U256) -> Result<H256> {
-        self.contract.query(
-            "getWithdrawHash", slot, None, Options::default(), None,
-        ).wait().map_err(DriverError::from)
+        self.contract
+            .query("getWithdrawHash", slot, None, Options::default(), None)
+            .wait()
+            .map_err(DriverError::from)
     }
 
     fn has_withdraw_slot_been_applied(&self, slot: U256) -> Result<bool> {
-        self.contract.query(
-            "hasWithdrawBeenApplied", slot, None, Options::default(), None,
-        ).wait().map_err(DriverError::from)
+        self.contract
+            .query(
+                "hasWithdrawBeenApplied",
+                slot,
+                None,
+                Options::default(),
+                None,
+            )
+            .wait()
+            .map_err(DriverError::from)
     }
 
     fn creation_timestamp_for_auction_slot(&self, slot: U256) -> Result<U256> {
-        self.contract.query(
-            "getAuctionCreationTimestamp", slot, None, Options::default(), None,
-        ).wait().map_err(DriverError::from)
+        self.contract
+            .query(
+                "getAuctionCreationTimestamp",
+                slot,
+                None,
+                Options::default(),
+                None,
+            )
+            .wait()
+            .map_err(DriverError::from)
     }
 
     fn order_hash_for_slot(&self, slot: U256) -> Result<H256> {
-        self.contract.query(
-            "getOrderHash", slot, None, Options::default(), None,
-        ).wait().map_err(DriverError::from)
+        self.contract
+            .query("getOrderHash", slot, None, Options::default(), None)
+            .wait()
+            .map_err(DriverError::from)
     }
 
     fn has_auction_slot_been_applied(&self, slot: U256) -> Result<bool> {
-        self.contract.query(
-            "hasAuctionBeenApplied", slot, None, Options::default(), None,
-        ).wait().map_err(DriverError::from)
+        self.contract
+            .query(
+                "hasAuctionBeenApplied",
+                slot,
+                None,
+                Options::default(),
+                None,
+            )
+            .wait()
+            .map_err(DriverError::from)
     }
-    
+
     fn apply_deposits(
-        &self, 
+        &self,
         slot: U256,
         prev_state: H256,
         new_state: H256,
-        deposit_hash: H256) -> Result<()> {
-            let account = self.account_with_sufficient_balance().ok_or("Not enough balance to send Txs")?;
-            self.contract.call(
+        deposit_hash: H256,
+    ) -> Result<()> {
+        let account = self
+            .account_with_sufficient_balance()
+            .ok_or("Not enough balance to send Txs")?;
+        self.contract
+            .call(
                 "applyDeposits",
                 (slot, prev_state, new_state, deposit_hash),
                 account,
                 Options::default(),
-            ).wait()
+            )
+            .wait()
             .map_err(DriverError::from)
-            .map(|_|())
+            .map(|_| ())
     }
 
     fn apply_withdraws(
-        &self, 
+        &self,
         slot: U256,
         merkle_root: H256,
         prev_state: H256,
         new_state: H256,
-        withdraw_hash: H256) -> Result<()> {
-            // HERE WE NEED TO BE SURE THAT THE SENDING ACCOUNT IS THE OWNER
-            let account = self.account_with_sufficient_balance().ok_or("Not enough balance to send Txs")?;
-            self.contract.call(
+        withdraw_hash: H256,
+    ) -> Result<()> {
+        // HERE WE NEED TO BE SURE THAT THE SENDING ACCOUNT IS THE OWNER
+        let account = self
+            .account_with_sufficient_balance()
+            .ok_or("Not enough balance to send Txs")?;
+        self.contract
+            .call(
                 "applyWithdrawals",
                 (slot, merkle_root, prev_state, new_state, withdraw_hash),
-                account,    
-                Options::with(|mut opt| { // usual gas estimate is not working
+                account,
+                Options::with(|mut opt| {
+                    // usual gas estimate is not working
                     opt.gas_price = Some(25.into());
                     opt.gas = Some(1_000_000.into());
                 }),
-            ).wait()
+            )
+            .wait()
             .map_err(DriverError::from)
-            .map(|_|())
+            .map(|_| ())
     }
 
     fn apply_auction(
-        &self, 
+        &self,
         slot: U256,
         prev_state: H256,
         new_state: H256,
         order_hash: H256,
         standing_order_index: Vec<U128>,
-        prices_and_volumes: Vec<u8>) -> Result<()> {
-            info!("prices_and_volumes: {:?}", &prices_and_volumes);
-            let account = self.account_with_sufficient_balance().ok_or("Not enough balance to send Txs")?;
+        prices_and_volumes: Vec<u8>,
+    ) -> Result<()> {
+        info!("prices_and_volumes: {:?}", &prices_and_volumes);
+        let account = self
+            .account_with_sufficient_balance()
+            .ok_or("Not enough balance to send Txs")?;
 
-            let mut options = Options::default();
-            options.gas = Some(U256::from(5_000_000));
-            self.contract.call(
+        let mut options = Options::default();
+        options.gas = Some(U256::from(5_000_000));
+        self.contract
+            .call(
                 "applyAuction",
-                (slot, prev_state, new_state, order_hash, standing_order_index, prices_and_volumes),
+                (
+                    slot,
+                    prev_state,
+                    new_state,
+                    order_hash,
+                    standing_order_index,
+                    prices_and_volumes,
+                ),
                 account,
                 options,
-            ).wait()
+            )
+            .wait()
             .map_err(DriverError::from)
-            .map(|_|())
+            .map(|_| ())
     }
-    
-    fn calculate_order_hash(
-        &self, slot: U256,
-        standing_order_index: Vec<U128>) -> Result<H256> {
-        self.contract.query(
-            "calculateOrderHash",
-            (slot, standing_order_index),
-            None,
-            Options::default(),
-            None
-        ).wait()
-        .map_err(DriverError::from)
+
+    fn calculate_order_hash(&self, slot: U256, standing_order_index: Vec<U128>) -> Result<H256> {
+        self.contract
+            .query(
+                "calculateOrderHash",
+                (slot, standing_order_index),
+                None,
+                Options::default(),
+                None,
+            )
+            .wait()
+            .map_err(DriverError::from)
     }
 }
 
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use mock_it::Mock;
+    use crate::error::ErrorKind;
     use mock_it::Matcher;
     use mock_it::Matcher::*;
-    use crate::error::ErrorKind;
-    
+    use mock_it::Mock;
+
     #[derive(Clone)]
     pub struct SnappContractMock {
         pub get_current_block_timestamp: Mock<(), Result<U256>>,
@@ -277,32 +382,105 @@ pub mod tests {
         pub order_hash_for_slot: Mock<U256, Result<H256>>,
         pub has_auction_slot_been_applied: Mock<U256, Result<bool>>,
         pub apply_deposits: Mock<(U256, Matcher<H256>, Matcher<H256>, Matcher<H256>), Result<()>>,
-        pub apply_withdraws: Mock<(U256, Matcher<H256>, Matcher<H256>, Matcher<H256>, Matcher<H256>), Result<()>>,
-        pub apply_auction: Mock<(U256, Matcher<H256>, Matcher<H256>, Matcher<H256>, Matcher<Vec<U128>>, Matcher<Vec<u8>>), Result<()>>,
+        pub apply_withdraws: Mock<
+            (
+                U256,
+                Matcher<H256>,
+                Matcher<H256>,
+                Matcher<H256>,
+                Matcher<H256>,
+            ),
+            Result<()>,
+        >,
+        pub apply_auction: Mock<
+            (
+                U256,
+                Matcher<H256>,
+                Matcher<H256>,
+                Matcher<H256>,
+                Matcher<Vec<U128>>,
+                Matcher<Vec<u8>>,
+            ),
+            Result<()>,
+        >,
         pub calculate_order_hash: Mock<(U256, Matcher<Vec<U128>>), Result<H256>>,
     }
 
     impl SnappContractMock {
         pub fn new() -> SnappContractMock {
             SnappContractMock {
-                get_current_block_timestamp: Mock::new(Err(DriverError::new("Unexpected call to get_current_block_timestamp", ErrorKind::Unknown))),
-                get_current_state_root: Mock::new(Err(DriverError::new("Unexpected call to get_current_state_root", ErrorKind::Unknown))),
-                get_current_deposit_slot: Mock::new(Err(DriverError::new("Unexpected call to get_current_deposit_slot", ErrorKind::Unknown))),
-                get_current_withdraw_slot: Mock::new(Err(DriverError::new("Unexpected call to get_current_withdraw_slot", ErrorKind::Unknown))),
-                get_current_auction_slot: Mock::new(Err(DriverError::new("Unexpected call to get_current_auction_slot", ErrorKind::Unknown))),
-                creation_timestamp_for_deposit_slot: Mock::new(Err(DriverError::new("Unexpected call to creation_timestamp_for_deposit_slot", ErrorKind::Unknown))),
-                deposit_hash_for_slot: Mock::new(Err(DriverError::new("Unexpected call to deposit_hash_for_slot", ErrorKind::Unknown))),
-                has_deposit_slot_been_applied: Mock::new(Err(DriverError::new("Unexpected call to has_deposit_slot_been_applied", ErrorKind::Unknown))),
-                creation_timestamp_for_withdraw_slot: Mock::new(Err(DriverError::new("Unexpected call to creation_timestamp_for_withdraw_slot", ErrorKind::Unknown))),
-                withdraw_hash_for_slot: Mock::new(Err(DriverError::new("Unexpected call to withdraw_hash_for_slot", ErrorKind::Unknown))),
-                has_withdraw_slot_been_applied: Mock::new(Err(DriverError::new("Unexpected call to has_withdraw_slot_been_applied", ErrorKind::Unknown))),
-                creation_timestamp_for_auction_slot: Mock::new(Err(DriverError::new("Unexpected call to creation_timestamp_for_auction_slot", ErrorKind::Unknown))),
-                order_hash_for_slot: Mock::new(Err(DriverError::new("Unexpected call to order_hash_for_slot", ErrorKind::Unknown))),
-                has_auction_slot_been_applied: Mock::new(Err(DriverError::new("Unexpected call to has_auction_slot_been_applied", ErrorKind::Unknown))),
-                apply_deposits: Mock::new(Err(DriverError::new("Unexpected call to apply_deposits", ErrorKind::Unknown))),
-                apply_withdraws: Mock::new(Err(DriverError::new("Unexpected call to apply_withdraws", ErrorKind::Unknown))),
-                apply_auction: Mock::new(Err(DriverError::new("Unexpected call to apply_auctions", ErrorKind::Unknown))),
-                calculate_order_hash: Mock::new(Err(DriverError::new("Unexpected call to calculate_order_hash", ErrorKind::Unknown))),
+                get_current_block_timestamp: Mock::new(Err(DriverError::new(
+                    "Unexpected call to get_current_block_timestamp",
+                    ErrorKind::Unknown,
+                ))),
+                get_current_state_root: Mock::new(Err(DriverError::new(
+                    "Unexpected call to get_current_state_root",
+                    ErrorKind::Unknown,
+                ))),
+                get_current_deposit_slot: Mock::new(Err(DriverError::new(
+                    "Unexpected call to get_current_deposit_slot",
+                    ErrorKind::Unknown,
+                ))),
+                get_current_withdraw_slot: Mock::new(Err(DriverError::new(
+                    "Unexpected call to get_current_withdraw_slot",
+                    ErrorKind::Unknown,
+                ))),
+                get_current_auction_slot: Mock::new(Err(DriverError::new(
+                    "Unexpected call to get_current_auction_slot",
+                    ErrorKind::Unknown,
+                ))),
+                creation_timestamp_for_deposit_slot: Mock::new(Err(DriverError::new(
+                    "Unexpected call to creation_timestamp_for_deposit_slot",
+                    ErrorKind::Unknown,
+                ))),
+                deposit_hash_for_slot: Mock::new(Err(DriverError::new(
+                    "Unexpected call to deposit_hash_for_slot",
+                    ErrorKind::Unknown,
+                ))),
+                has_deposit_slot_been_applied: Mock::new(Err(DriverError::new(
+                    "Unexpected call to has_deposit_slot_been_applied",
+                    ErrorKind::Unknown,
+                ))),
+                creation_timestamp_for_withdraw_slot: Mock::new(Err(DriverError::new(
+                    "Unexpected call to creation_timestamp_for_withdraw_slot",
+                    ErrorKind::Unknown,
+                ))),
+                withdraw_hash_for_slot: Mock::new(Err(DriverError::new(
+                    "Unexpected call to withdraw_hash_for_slot",
+                    ErrorKind::Unknown,
+                ))),
+                has_withdraw_slot_been_applied: Mock::new(Err(DriverError::new(
+                    "Unexpected call to has_withdraw_slot_been_applied",
+                    ErrorKind::Unknown,
+                ))),
+                creation_timestamp_for_auction_slot: Mock::new(Err(DriverError::new(
+                    "Unexpected call to creation_timestamp_for_auction_slot",
+                    ErrorKind::Unknown,
+                ))),
+                order_hash_for_slot: Mock::new(Err(DriverError::new(
+                    "Unexpected call to order_hash_for_slot",
+                    ErrorKind::Unknown,
+                ))),
+                has_auction_slot_been_applied: Mock::new(Err(DriverError::new(
+                    "Unexpected call to has_auction_slot_been_applied",
+                    ErrorKind::Unknown,
+                ))),
+                apply_deposits: Mock::new(Err(DriverError::new(
+                    "Unexpected call to apply_deposits",
+                    ErrorKind::Unknown,
+                ))),
+                apply_withdraws: Mock::new(Err(DriverError::new(
+                    "Unexpected call to apply_withdraws",
+                    ErrorKind::Unknown,
+                ))),
+                apply_auction: Mock::new(Err(DriverError::new(
+                    "Unexpected call to apply_auctions",
+                    ErrorKind::Unknown,
+                ))),
+                calculate_order_hash: Mock::new(Err(DriverError::new(
+                    "Unexpected call to calculate_order_hash",
+                    ErrorKind::Unknown,
+                ))),
             }
         }
     }
@@ -323,7 +501,7 @@ pub mod tests {
         fn get_current_auction_slot(&self) -> Result<U256> {
             self.get_current_auction_slot.called(())
         }
-        fn creation_timestamp_for_deposit_slot(&self, slot: U256) -> Result<U256>{
+        fn creation_timestamp_for_deposit_slot(&self, slot: U256) -> Result<U256> {
             self.creation_timestamp_for_deposit_slot.called(slot)
         }
         fn deposit_hash_for_slot(&self, slot: U256) -> Result<H256> {
@@ -350,17 +528,57 @@ pub mod tests {
         fn has_auction_slot_been_applied(&self, slot: U256) -> Result<bool> {
             self.has_auction_slot_been_applied.called(slot)
         }
-        fn apply_deposits(&self, slot: U256, prev_state: H256, new_state: H256, deposit_hash: H256) -> Result<()> {
-            self.apply_deposits.called((slot, Val(prev_state), Val(new_state), Val(deposit_hash)))
+        fn apply_deposits(
+            &self,
+            slot: U256,
+            prev_state: H256,
+            new_state: H256,
+            deposit_hash: H256,
+        ) -> Result<()> {
+            self.apply_deposits
+                .called((slot, Val(prev_state), Val(new_state), Val(deposit_hash)))
         }
-        fn apply_withdraws(&self, slot: U256, merkle_root: H256, prev_state: H256, new_state: H256, withdraw_hash: H256) -> Result<()> {
-            self.apply_withdraws.called((slot, Val(merkle_root), Val(prev_state), Val(new_state), Val(withdraw_hash)))
+        fn apply_withdraws(
+            &self,
+            slot: U256,
+            merkle_root: H256,
+            prev_state: H256,
+            new_state: H256,
+            withdraw_hash: H256,
+        ) -> Result<()> {
+            self.apply_withdraws.called((
+                slot,
+                Val(merkle_root),
+                Val(prev_state),
+                Val(new_state),
+                Val(withdraw_hash),
+            ))
         }
-        fn apply_auction(&self, slot: U256, prev_state: H256, new_state: H256, order_hash: H256, standing_order_index: Vec<U128>, prices_and_volumes: Vec<u8>) -> Result<()> {
-            self.apply_auction.called((slot, Val(prev_state), Val(new_state), Val(order_hash), Val(standing_order_index), Val(prices_and_volumes)))
+        fn apply_auction(
+            &self,
+            slot: U256,
+            prev_state: H256,
+            new_state: H256,
+            order_hash: H256,
+            standing_order_index: Vec<U128>,
+            prices_and_volumes: Vec<u8>,
+        ) -> Result<()> {
+            self.apply_auction.called((
+                slot,
+                Val(prev_state),
+                Val(new_state),
+                Val(order_hash),
+                Val(standing_order_index),
+                Val(prices_and_volumes),
+            ))
         }
-        fn calculate_order_hash(&self, slot: U256, standing_order_index: Vec<U128>) -> Result<H256> {
-            self.calculate_order_hash.called((slot, Val(standing_order_index)))
+        fn calculate_order_hash(
+            &self,
+            slot: U256,
+            standing_order_index: Vec<U128>,
+        ) -> Result<H256> {
+            self.calculate_order_hash
+                .called((slot, Val(standing_order_index)))
         }
     }
 }

--- a/driver/src/deposit_driver.rs
+++ b/driver/src/deposit_driver.rs
@@ -1,26 +1,24 @@
-use crate::error::DriverError;
 use crate::contract::SnappContract;
-use crate::util::{find_first_unapplied_slot, can_process, hash_consistency_check};
+use crate::error::DriverError;
+use crate::util::{can_process, find_first_unapplied_slot, hash_consistency_check};
 
 use dfusion_core::database::DbInterface;
-use dfusion_core::models::{RollingHashable};
+use dfusion_core::models::RollingHashable;
 
-pub fn run_deposit_listener<D, C>(db: &D, contract: &C) -> Result<(bool), DriverError> 
-    where   D: DbInterface,
-            C: SnappContract
+pub fn run_deposit_listener<D, C>(db: &D, contract: &C) -> Result<(bool), DriverError>
+where
+    D: DbInterface,
+    C: SnappContract,
 {
     let deposit_slot = contract.get_current_deposit_slot()?;
 
     info!("Current top deposit_slot is {:?}", deposit_slot);
-    let slot = find_first_unapplied_slot(
-        deposit_slot, 
-        &|i| contract.has_deposit_slot_been_applied(i)
-    )?;
+    let slot =
+        find_first_unapplied_slot(deposit_slot, &|i| contract.has_deposit_slot_been_applied(i))?;
     if slot <= deposit_slot {
         info!("Highest unprocessed deposit_slot is {:?}", slot);
-        if can_process(slot, contract,
-            &|i| contract.creation_timestamp_for_deposit_slot(i)
-        )? {
+        let creation_time_block = |i| contract.creation_timestamp_for_deposit_slot(i);
+        if can_process(slot, contract, &creation_time_block)? {
             info!("Processing deposit_slot {:?}", slot);
             let state_root = contract.get_current_state_root()?;
             let contract_deposit_hash = contract.deposit_hash_for_slot(slot)?;
@@ -31,9 +29,14 @@ pub fn run_deposit_listener<D, C>(db: &D, contract: &C) -> Result<(bool), Driver
             hash_consistency_check(deposit_hash, contract_deposit_hash, "deposit")?;
 
             balances.apply_deposits(&deposits);
-            
+
             info!("New AccountState hash is {}", balances.state_hash);
-            contract.apply_deposits(slot, state_root, balances.state_hash, contract_deposit_hash)?;
+            contract.apply_deposits(
+                slot,
+                state_root,
+                balances.state_hash,
+                contract_deposit_hash,
+            )?;
             return Ok(true);
         } else {
             info!("Need to wait before processing deposit_slot {:?}", slot);
@@ -47,19 +50,19 @@ pub fn run_deposit_listener<D, C>(db: &D, contract: &C) -> Result<(bool), Driver
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dfusion_core::database::tests::DbInterfaceMock;
-    use dfusion_core::models::flux::tests::create_flux_for_test;
-    use dfusion_core::models;
     use crate::contract::tests::SnappContractMock;
+    use crate::error::ErrorKind;
+    use dfusion_core::database::tests::DbInterfaceMock;
+    use dfusion_core::models;
+    use dfusion_core::models::flux::tests::create_flux_for_test;
     use mock_it::Matcher::*;
     use web3::types::{H256, U256};
-    use crate::error::{ErrorKind};
 
     #[test]
     fn applies_current_state_if_unapplied_and_enough_blocks_passed() {
         let slot = U256::from(1);
         let state_hash = H256::zero();
-        let deposits = vec![create_flux_for_test(1,1), create_flux_for_test(1,2)];
+        let deposits = vec![create_flux_for_test(1, 1), create_flux_for_test(1, 2)];
         let state = models::AccountState::new(
             state_hash,
             U256::one(),
@@ -68,18 +71,46 @@ mod tests {
         );
 
         let contract = SnappContractMock::new();
-        contract.get_current_deposit_slot.given(()).will_return(Ok(slot));
-        contract.has_deposit_slot_been_applied.given(slot).will_return(Ok(false));
-        contract.has_deposit_slot_been_applied.given(slot - 1).will_return(Ok(true));
-        contract.creation_timestamp_for_deposit_slot.given(slot).will_return(Ok(U256::from(10)));
-        contract.get_current_block_timestamp.given(()).will_return(Ok(U256::from(200)));
-        contract.deposit_hash_for_slot.given(slot).will_return(Ok(deposits.rolling_hash(0)));
-        contract.get_current_state_root.given(()).will_return(Ok(state_hash));
-        contract.apply_deposits.given((slot, Any, Any, Any)).will_return(Ok(()));
+        contract
+            .get_current_deposit_slot
+            .given(())
+            .will_return(Ok(slot));
+        contract
+            .has_deposit_slot_been_applied
+            .given(slot)
+            .will_return(Ok(false));
+        contract
+            .has_deposit_slot_been_applied
+            .given(slot - 1)
+            .will_return(Ok(true));
+        contract
+            .creation_timestamp_for_deposit_slot
+            .given(slot)
+            .will_return(Ok(U256::from(10)));
+        contract
+            .get_current_block_timestamp
+            .given(())
+            .will_return(Ok(U256::from(200)));
+        contract
+            .deposit_hash_for_slot
+            .given(slot)
+            .will_return(Ok(deposits.rolling_hash(0)));
+        contract
+            .get_current_state_root
+            .given(())
+            .will_return(Ok(state_hash));
+        contract
+            .apply_deposits
+            .given((slot, Any, Any, Any))
+            .will_return(Ok(()));
 
         let db = DbInterfaceMock::new();
-        db.get_deposits_of_slot.given(U256::one()).will_return(Ok(deposits));
-        db.get_balances_for_state_root.given(state_hash).will_return(Ok(state));
+        db.get_deposits_of_slot
+            .given(U256::one())
+            .will_return(Ok(deposits));
+        db.get_balances_for_state_root
+            .given(state_hash)
+            .will_return(Ok(state));
 
         assert_eq!(run_deposit_listener(&db, &contract), Ok(true));
     }
@@ -97,16 +128,36 @@ mod tests {
         );
 
         let contract = SnappContractMock::new();
-        contract.get_current_state_root.given(()).will_return(Ok(state_hash));        
-        contract.get_current_deposit_slot.given(()).will_return(Ok(slot));
-        contract.has_deposit_slot_been_applied.given(slot).will_return(Ok(true));
+        contract
+            .get_current_state_root
+            .given(())
+            .will_return(Ok(state_hash));
+        contract
+            .get_current_deposit_slot
+            .given(())
+            .will_return(Ok(slot));
+        contract
+            .has_deposit_slot_been_applied
+            .given(slot)
+            .will_return(Ok(true));
 
-        contract.get_current_block_timestamp.given(()).will_return(Ok(U256::from(11)));
-        contract.creation_timestamp_for_deposit_slot.given(slot + 1).will_return(Ok(U256::from(10)));
-        contract.deposit_hash_for_slot.given(slot + 1).will_return(Ok(H256::zero()));
+        contract
+            .get_current_block_timestamp
+            .given(())
+            .will_return(Ok(U256::from(11)));
+        contract
+            .creation_timestamp_for_deposit_slot
+            .given(slot + 1)
+            .will_return(Ok(U256::from(10)));
+        contract
+            .deposit_hash_for_slot
+            .given(slot + 1)
+            .will_return(Ok(H256::zero()));
 
         let db = DbInterfaceMock::new();
-        db.get_balances_for_state_root.given(state_hash).will_return(Ok(state));
+        db.get_balances_for_state_root
+            .given(state_hash)
+            .will_return(Ok(state));
 
         assert_eq!(run_deposit_listener(&db, &contract), Ok(false));
     }
@@ -115,7 +166,7 @@ mod tests {
     fn does_not_apply_if_highest_slot_too_close_to_current_block() {
         let slot = U256::from(1);
         let state_hash = H256::zero();
-        let deposits = vec![create_flux_for_test(1,1), create_flux_for_test(1,2)];
+        let deposits = vec![create_flux_for_test(1, 1), create_flux_for_test(1, 2)];
 
         let state = models::AccountState::new(
             state_hash,
@@ -125,17 +176,40 @@ mod tests {
         );
 
         let contract = SnappContractMock::new();
-        contract.get_current_state_root.given(()).will_return(Ok(state_hash));        
-        contract.get_current_deposit_slot.given(()).will_return(Ok(slot));
-        contract.has_deposit_slot_been_applied.given(slot).will_return(Ok(false));
-        contract.has_deposit_slot_been_applied.given(slot-1).will_return(Ok(true));
+        contract
+            .get_current_state_root
+            .given(())
+            .will_return(Ok(state_hash));
+        contract
+            .get_current_deposit_slot
+            .given(())
+            .will_return(Ok(slot));
+        contract
+            .has_deposit_slot_been_applied
+            .given(slot)
+            .will_return(Ok(false));
+        contract
+            .has_deposit_slot_been_applied
+            .given(slot - 1)
+            .will_return(Ok(true));
 
-        contract.creation_timestamp_for_deposit_slot.given(slot).will_return(Ok(U256::from(10)));
-        contract.get_current_block_timestamp.given(()).will_return(Ok(U256::from(11)));
-        contract.deposit_hash_for_slot.given(slot).will_return(Ok(deposits.rolling_hash(0)));
+        contract
+            .creation_timestamp_for_deposit_slot
+            .given(slot)
+            .will_return(Ok(U256::from(10)));
+        contract
+            .get_current_block_timestamp
+            .given(())
+            .will_return(Ok(U256::from(11)));
+        contract
+            .deposit_hash_for_slot
+            .given(slot)
+            .will_return(Ok(deposits.rolling_hash(0)));
 
         let db = DbInterfaceMock::new();
-        db.get_balances_for_state_root.given(state_hash).will_return(Ok(state));
+        db.get_balances_for_state_root
+            .given(state_hash)
+            .will_return(Ok(state));
 
         assert_eq!(run_deposit_listener(&db, &contract), Ok(false));
     }
@@ -144,21 +218,45 @@ mod tests {
     fn applies_all_unapplied_states_before_current() {
         let slot = U256::from(1);
         let state_hash = H256::zero();
-        let first_deposits = vec![create_flux_for_test(0,1), create_flux_for_test(0,2)];
-        let second_deposits = vec![create_flux_for_test(1,1), create_flux_for_test(1,2)];
+        let first_deposits = vec![create_flux_for_test(0, 1), create_flux_for_test(0, 2)];
+        let second_deposits = vec![create_flux_for_test(1, 1), create_flux_for_test(1, 2)];
 
         let contract = SnappContractMock::new();
-        contract.get_current_deposit_slot.given(()).will_return(Ok(slot));
+        contract
+            .get_current_deposit_slot
+            .given(())
+            .will_return(Ok(slot));
 
-        contract.has_deposit_slot_been_applied.given(slot).will_return(Ok(false));
-        contract.has_deposit_slot_been_applied.given(slot - 1).will_return(Ok(false));
+        contract
+            .has_deposit_slot_been_applied
+            .given(slot)
+            .will_return(Ok(false));
+        contract
+            .has_deposit_slot_been_applied
+            .given(slot - 1)
+            .will_return(Ok(false));
 
-        contract.creation_timestamp_for_deposit_slot.given(slot-1).will_return(Ok(U256::from(10)));
-        contract.get_current_block_timestamp.given(()).will_return(Ok(U256::from(200)));
-        contract.deposit_hash_for_slot.given(slot-1).will_return(Ok(second_deposits.rolling_hash(0)));
+        contract
+            .creation_timestamp_for_deposit_slot
+            .given(slot - 1)
+            .will_return(Ok(U256::from(10)));
+        contract
+            .get_current_block_timestamp
+            .given(())
+            .will_return(Ok(U256::from(200)));
+        contract
+            .deposit_hash_for_slot
+            .given(slot - 1)
+            .will_return(Ok(second_deposits.rolling_hash(0)));
 
-        contract.get_current_state_root.given(()).will_return(Ok(state_hash));
-        contract.apply_deposits.given((slot - 1, Any, Any, Any)).will_return(Ok(()));
+        contract
+            .get_current_state_root
+            .given(())
+            .will_return(Ok(state_hash));
+        contract
+            .apply_deposits
+            .given((slot - 1, Any, Any, Any))
+            .will_return(Ok(()));
 
         let state = models::AccountState::new(
             state_hash,
@@ -168,9 +266,13 @@ mod tests {
         );
 
         let db = DbInterfaceMock::new();
-        db.get_deposits_of_slot.given(U256::zero()).will_return(Ok(first_deposits));
-        db.get_balances_for_state_root.given(state_hash).will_return(Ok(state));
-        
+        db.get_deposits_of_slot
+            .given(U256::zero())
+            .will_return(Ok(first_deposits));
+        db.get_balances_for_state_root
+            .given(state_hash)
+            .will_return(Ok(state));
+
         assert_eq!(run_deposit_listener(&db, &contract), Ok(true));
     }
 
@@ -179,7 +281,7 @@ mod tests {
         let slot = U256::from(1);
         let state_hash = H256::zero();
 
-        let deposits = vec![create_flux_for_test(1,1), create_flux_for_test(1,2)];
+        let deposits = vec![create_flux_for_test(1, 1), create_flux_for_test(1, 2)];
 
         let state = models::AccountState::new(
             state_hash,
@@ -189,19 +291,44 @@ mod tests {
         );
 
         let contract = SnappContractMock::new();
-        contract.get_current_deposit_slot.given(()).will_return(Ok(slot));
-        contract.has_deposit_slot_been_applied.given(slot).will_return(Ok(false));
-        contract.has_deposit_slot_been_applied.given(slot - 1).will_return(Ok(true));
+        contract
+            .get_current_deposit_slot
+            .given(())
+            .will_return(Ok(slot));
+        contract
+            .has_deposit_slot_been_applied
+            .given(slot)
+            .will_return(Ok(false));
+        contract
+            .has_deposit_slot_been_applied
+            .given(slot - 1)
+            .will_return(Ok(true));
 
-        contract.creation_timestamp_for_deposit_slot.given(slot).will_return(Ok(U256::from(10)));
-        contract.get_current_block_timestamp.given(()).will_return(Ok(U256::from(200)));
-        
-        contract.deposit_hash_for_slot.given(slot).will_return(Ok(H256::zero()));
-        contract.get_current_state_root.given(()).will_return(Ok(state_hash));
+        contract
+            .creation_timestamp_for_deposit_slot
+            .given(slot)
+            .will_return(Ok(U256::from(10)));
+        contract
+            .get_current_block_timestamp
+            .given(())
+            .will_return(Ok(U256::from(200)));
+
+        contract
+            .deposit_hash_for_slot
+            .given(slot)
+            .will_return(Ok(H256::zero()));
+        contract
+            .get_current_state_root
+            .given(())
+            .will_return(Ok(state_hash));
 
         let db = DbInterfaceMock::new();
-        db.get_deposits_of_slot.given(U256::one()).will_return(Ok(deposits));
-        db.get_balances_for_state_root.given(state_hash).will_return(Ok(state));
+        db.get_deposits_of_slot
+            .given(U256::one())
+            .will_return(Ok(deposits));
+        db.get_balances_for_state_root
+            .given(state_hash)
+            .will_return(Ok(state));
 
         let error = run_deposit_listener(&db, &contract).expect_err("Expected Error");
         assert_eq!(error.kind, ErrorKind::StateError);

--- a/driver/src/error.rs
+++ b/driver/src/error.rs
@@ -1,6 +1,6 @@
+use ethabi;
 use std::error::Error;
 use std::fmt;
-use ethabi;
 
 use dfusion_core::database::DatabaseError;
 
@@ -83,7 +83,10 @@ impl From<DatabaseError> for DriverError {
 
 impl DriverError {
     pub fn new(msg: &str, kind: ErrorKind) -> DriverError {
-        DriverError{details: msg.to_string(), kind}
+        DriverError {
+            details: msg.to_string(),
+            kind,
+        }
     }
 }
 impl fmt::Display for DriverError {

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -2,27 +2,27 @@ extern crate hex;
 extern crate mongodb;
 #[macro_use]
 extern crate log;
+extern crate dfusion_core;
 extern crate rustc_hex;
 extern crate serde_json;
 extern crate web3;
-extern crate dfusion_core;
 
 use crate::contract::SnappContractImpl;
-use crate::mongo_db::MongoDB;
 use crate::deposit_driver::run_deposit_listener;
+use crate::mongo_db::MongoDB;
 use crate::order_driver::run_order_listener;
 use crate::price_finding::PriceFinding;
 use crate::withdraw_driver::run_withdraw_listener;
 
 pub mod contract;
-pub mod mongo_db;
 pub mod error;
+pub mod mongo_db;
 pub mod price_finding;
 
 mod deposit_driver;
 mod order_driver;
-mod withdraw_driver;
 mod util;
+mod withdraw_driver;
 
 pub fn run_driver_components(
     db: &MongoDB,
@@ -40,4 +40,3 @@ pub fn run_driver_components(
     }
     //...
 }
-

--- a/driver/src/order_driver.rs
+++ b/driver/src/order_driver.rs
@@ -1,36 +1,36 @@
 use crate::contract::SnappContract;
 use crate::error::DriverError;
 use crate::price_finding::PriceFinding;
-use crate::util::{find_first_unapplied_slot, can_process, hash_consistency_check};
+use crate::util::{can_process, find_first_unapplied_slot, hash_consistency_check};
 
 use dfusion_core::database::DbInterface;
 use dfusion_core::models::{
-    RollingHashable, Serializable, ConcatenatingHashable, AccountState, Order, StandingOrder,
-    Solution,
+    AccountState, ConcatenatingHashable, Order, RollingHashable, Serializable, Solution,
+    StandingOrder,
 };
 
 use web3::types::U128;
 
 pub fn run_order_listener<D, C>(
-    db: &D, 
+    db: &D,
     contract: &C,
-    price_finder: &mut PriceFinding
+    price_finder: &mut PriceFinding,
 ) -> Result<bool, DriverError>
-    where   D: DbInterface,
-            C: SnappContract,
+where
+    D: DbInterface,
+    C: SnappContract,
 {
     let auction_slot = contract.get_current_auction_slot()?;
 
     info!("Current top auction slot is {:?}", auction_slot);
-    let slot = find_first_unapplied_slot(
-        auction_slot,
-        &|i| contract.has_auction_slot_been_applied(i)
-    )?;
+    let slot =
+        find_first_unapplied_slot(auction_slot, &|i| contract.has_auction_slot_been_applied(i))?;
     if slot <= auction_slot {
         info!("Highest unprocessed auction slot is {:?}", slot);
-        if can_process(slot, contract,
-            &|i| contract.creation_timestamp_for_auction_slot(i)
-        )? {
+        let creation_time_block = |i| {
+            contract.creation_timestamp_for_auction_slot(i)
+        };
+        if can_process(slot, contract, &creation_time_block)? {
             info!("Processing auction slot {:?}", slot);
             let state_root = contract.get_current_state_root()?;
             let non_reserved_orders_hash_from_contract = contract.order_hash_for_slot(slot)?;
@@ -38,27 +38,43 @@ pub fn run_order_listener<D, C>(
 
             let mut orders = db.get_orders_of_slot(&slot)?;
             let non_reserved_orders_hash = orders.rolling_hash(0);
-            hash_consistency_check(non_reserved_orders_hash, non_reserved_orders_hash_from_contract, "non-reserved-orders")?;
+            hash_consistency_check(
+                non_reserved_orders_hash,
+                non_reserved_orders_hash_from_contract,
+                "non-reserved-orders",
+            )?;
 
             let standing_orders = db.get_standing_orders_of_slot(&slot)?;
-            
-            orders.extend(standing_orders
-                .iter()
-                .filter(|standing_order| standing_order.num_orders() > 0)
-                .flat_map(|standing_order| standing_order.get_orders().clone())
+
+            orders.extend(
+                standing_orders
+                    .iter()
+                    .filter(|standing_order| standing_order.num_orders() > 0)
+                    .flat_map(|standing_order| standing_order.get_orders().clone()),
             );
             info!("All Orders: {:?}", orders);
 
             let standing_order_indexes = batch_index_from_standing_orders(&standing_orders);
-            let total_order_hash_from_contract = contract.calculate_order_hash(slot, standing_order_indexes.clone())?;
-            let total_order_hash_calculated = standing_orders.concatenating_hash(non_reserved_orders_hash);
-            hash_consistency_check(total_order_hash_calculated, total_order_hash_from_contract, "overall-order")?;
+            let total_order_hash_from_contract =
+                contract.calculate_order_hash(slot, standing_order_indexes.clone())?;
+            let total_order_hash_calculated =
+                standing_orders.concatenating_hash(non_reserved_orders_hash);
+            hash_consistency_check(
+                total_order_hash_calculated,
+                total_order_hash_from_contract,
+                "overall-order",
+            )?;
 
             let solution = if !orders.is_empty() {
-                price_finder.find_prices(&orders, &state).unwrap_or_else(|e| {
-                    error!("Error computing result: {}\n Falling back to trivial solution", e);
-                    Solution::trivial(orders.len())
-                })
+                price_finder
+                    .find_prices(&orders, &state)
+                    .unwrap_or_else(|e| {
+                        error!(
+                            "Error computing result: {}\n Falling back to trivial solution",
+                            e
+                        );
+                        Solution::trivial(orders.len())
+                    })
             } else {
                 warn!("No orders in batch. Falling back to trivial solution");
                 Solution::trivial(orders.len())
@@ -67,10 +83,20 @@ pub fn run_order_listener<D, C>(
             // Compute updated balances
             update_balances(&mut state, &orders, &solution);
             let new_state_root = state.rolling_hash(state.state_index.low_u32() + 1);
-            
-            info!("New AccountState hash is {}, Solution: {:?}", new_state_root, solution);
 
-            contract.apply_auction(slot, state_root, new_state_root, total_order_hash_from_contract, standing_order_indexes, solution.bytes())?;
+            info!(
+                "New AccountState hash is {}, Solution: {:?}",
+                new_state_root, solution
+            );
+
+            contract.apply_auction(
+                slot,
+                state_root,
+                new_state_root,
+                total_order_hash_from_contract,
+                standing_order_indexes,
+                solution.bytes(),
+            )?;
             return Ok(true);
         } else {
             info!("Need to wait before processing auction slot {:?}", slot);
@@ -90,21 +116,24 @@ fn update_balances(state: &mut AccountState, orders: &[Order], solution: &Soluti
 }
 
 fn batch_index_from_standing_orders(standing_orders: &[StandingOrder]) -> Vec<U128> {
-        standing_orders.iter().map(|o| U128::from(o.batch_index)).collect() 
+    standing_orders
+        .iter()
+        .map(|o| U128::from(o.batch_index))
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::contract::tests::SnappContractMock;
-    use dfusion_core::database::tests::DbInterfaceMock;
-    use dfusion_core::models::{NUM_RESERVED_ACCOUNTS, TOKENS};
-    use dfusion_core::models::order::tests::create_order_for_test;
+    use crate::error::ErrorKind;
+    use crate::price_finding::error::PriceFindingError;
     use crate::price_finding::price_finder_interface::tests::PriceFindingMock;
+    use dfusion_core::database::tests::DbInterfaceMock;
+    use dfusion_core::models::order::tests::create_order_for_test;
+    use dfusion_core::models::{NUM_RESERVED_ACCOUNTS, TOKENS};
     use mock_it::Matcher::*;
     use web3::types::{H256, U128, U256};
-    use crate::error::{ErrorKind};
-    use crate::price_finding::error::{PriceFindingError};
 
     #[test]
     fn applies_current_state_if_unapplied_and_enough_blocks_passed() {
@@ -118,21 +147,56 @@ mod tests {
             TOKENS,
         );
         let contract = SnappContractMock::new();
-        contract.get_current_auction_slot.given(()).will_return(Ok(slot));
-        contract.has_auction_slot_been_applied.given(slot).will_return(Ok(false));
-        contract.has_auction_slot_been_applied.given(slot - 1).will_return(Ok(true));
-        contract.creation_timestamp_for_auction_slot.given(slot).will_return(Ok(U256::from(10)));
-        contract.get_current_block_timestamp.given(()).will_return(Ok(U256::from(200)));
-        contract.order_hash_for_slot.given(slot).will_return(Ok(orders.rolling_hash(0)));
-        contract.get_current_state_root.given(()).will_return(Ok(state_hash));
-        contract.calculate_order_hash.given((slot, Any)).will_return(Ok(H256::from("0x438d54b20a21fa0b2f8f176c86446d9db7067f6e68a1e58c22873544eb20d72c")));
+        contract
+            .get_current_auction_slot
+            .given(())
+            .will_return(Ok(slot));
+        contract
+            .has_auction_slot_been_applied
+            .given(slot)
+            .will_return(Ok(false));
+        contract
+            .has_auction_slot_been_applied
+            .given(slot - 1)
+            .will_return(Ok(true));
+        contract
+            .creation_timestamp_for_auction_slot
+            .given(slot)
+            .will_return(Ok(U256::from(10)));
+        contract
+            .get_current_block_timestamp
+            .given(())
+            .will_return(Ok(U256::from(200)));
+        contract
+            .order_hash_for_slot
+            .given(slot)
+            .will_return(Ok(orders.rolling_hash(0)));
+        contract
+            .get_current_state_root
+            .given(())
+            .will_return(Ok(state_hash));
+        contract
+            .calculate_order_hash
+            .given((slot, Any))
+            .will_return(Ok(H256::from(
+                "0x438d54b20a21fa0b2f8f176c86446d9db7067f6e68a1e58c22873544eb20d72c",
+            )));
 
-        contract.apply_auction.given((slot, Any, Any, Any, Any, Any)).will_return(Ok(()));
+        contract
+            .apply_auction
+            .given((slot, Any, Any, Any, Any, Any))
+            .will_return(Ok(()));
         let standing_orders = StandingOrder::empty_array();
         let db = DbInterfaceMock::new();
-        db.get_orders_of_slot.given(U256::one()).will_return(Ok(orders.clone()));
-        db.get_standing_orders_of_slot.given(U256::one()).will_return(Ok(standing_orders));
-        db.get_balances_for_state_root.given(state_hash).will_return(Ok(state.clone()));
+        db.get_orders_of_slot
+            .given(U256::one())
+            .will_return(Ok(orders.clone()));
+        db.get_standing_orders_of_slot
+            .given(U256::one())
+            .will_return(Ok(standing_orders));
+        db.get_balances_for_state_root
+            .given(state_hash)
+            .will_return(Ok(state.clone()));
 
         let mut pf = PriceFindingMock::new();
         let expected_solution = Solution {
@@ -141,7 +205,9 @@ mod tests {
             executed_sell_amounts: vec![0, 2],
             executed_buy_amounts: vec![0, 2],
         };
-        pf.find_prices.given((orders, state)).will_return(Ok(expected_solution));
+        pf.find_prices
+            .given((orders, state))
+            .will_return(Ok(expected_solution));
 
         assert_eq!(run_order_listener(&db, &contract, &mut pf), Ok(true));
     }
@@ -150,8 +216,14 @@ mod tests {
     fn does_not_apply_if_highest_slot_already_applied() {
         let slot = U256::from(1);
         let contract = SnappContractMock::new();
-        contract.get_current_auction_slot.given(()).will_return(Ok(slot));
-        contract.has_auction_slot_been_applied.given(slot).will_return(Ok(true));
+        contract
+            .get_current_auction_slot
+            .given(())
+            .will_return(Ok(slot));
+        contract
+            .has_auction_slot_been_applied
+            .given(slot)
+            .will_return(Ok(true));
 
         let db = DbInterfaceMock::new();
         let mut pf = PriceFindingMock::new();
@@ -163,12 +235,27 @@ mod tests {
     fn does_not_apply_if_highest_slot_too_close_to_current_block() {
         let slot = U256::from(1);
         let contract = SnappContractMock::new();
-        contract.get_current_auction_slot.given(()).will_return(Ok(slot));
-        contract.has_auction_slot_been_applied.given(slot).will_return(Ok(false));
-        contract.has_auction_slot_been_applied.given(slot-1).will_return(Ok(true));
+        contract
+            .get_current_auction_slot
+            .given(())
+            .will_return(Ok(slot));
+        contract
+            .has_auction_slot_been_applied
+            .given(slot)
+            .will_return(Ok(false));
+        contract
+            .has_auction_slot_been_applied
+            .given(slot - 1)
+            .will_return(Ok(true));
 
-        contract.creation_timestamp_for_auction_slot.given(slot).will_return(Ok(U256::from(10)));
-        contract.get_current_block_timestamp.given(()).will_return(Ok(U256::from(11)));
+        contract
+            .creation_timestamp_for_auction_slot
+            .given(slot)
+            .will_return(Ok(U256::from(10)));
+        contract
+            .get_current_block_timestamp
+            .given(())
+            .will_return(Ok(U256::from(11)));
 
         let db = DbInterfaceMock::new();
         let mut pf = PriceFindingMock::new();
@@ -184,19 +271,48 @@ mod tests {
         let second_orders = vec![create_order_for_test(), create_order_for_test()];
 
         let contract = SnappContractMock::new();
-        contract.get_current_auction_slot.given(()).will_return(Ok(slot));
+        contract
+            .get_current_auction_slot
+            .given(())
+            .will_return(Ok(slot));
 
-        contract.has_auction_slot_been_applied.given(slot).will_return(Ok(false));
-        contract.has_auction_slot_been_applied.given(slot - 1).will_return(Ok(false));
+        contract
+            .has_auction_slot_been_applied
+            .given(slot)
+            .will_return(Ok(false));
+        contract
+            .has_auction_slot_been_applied
+            .given(slot - 1)
+            .will_return(Ok(false));
 
-        contract.creation_timestamp_for_auction_slot.given(slot-1).will_return(Ok(U256::from(10)));
+        contract
+            .creation_timestamp_for_auction_slot
+            .given(slot - 1)
+            .will_return(Ok(U256::from(10)));
 
-        contract.get_current_block_timestamp.given(()).will_return(Ok(U256::from(200)));
-        contract.order_hash_for_slot.given(slot-1).will_return(Ok(second_orders.rolling_hash(0)));
-        contract.calculate_order_hash.given((slot-1, Any)).will_return(Ok(H256::from("0x438d54b20a21fa0b2f8f176c86446d9db7067f6e68a1e58c22873544eb20d72c")));
+        contract
+            .get_current_block_timestamp
+            .given(())
+            .will_return(Ok(U256::from(200)));
+        contract
+            .order_hash_for_slot
+            .given(slot - 1)
+            .will_return(Ok(second_orders.rolling_hash(0)));
+        contract
+            .calculate_order_hash
+            .given((slot - 1, Any))
+            .will_return(Ok(H256::from(
+                "0x438d54b20a21fa0b2f8f176c86446d9db7067f6e68a1e58c22873544eb20d72c",
+            )));
 
-        contract.get_current_state_root.given(()).will_return(Ok(state_hash));
-        contract.apply_auction.given((slot - 1, Any, Any, Any, Any, Any)).will_return(Ok(()));
+        contract
+            .get_current_state_root
+            .given(())
+            .will_return(Ok(state_hash));
+        contract
+            .apply_auction
+            .given((slot - 1, Any, Any, Any, Any, Any))
+            .will_return(Ok(()));
 
         let state = AccountState::new(
             state_hash,
@@ -206,9 +322,15 @@ mod tests {
         );
         let standing_orders = StandingOrder::empty_array();
         let db = DbInterfaceMock::new();
-        db.get_orders_of_slot.given(U256::zero()).will_return(Ok(first_orders.clone()));
-        db.get_standing_orders_of_slot.given(U256::zero()).will_return(Ok(standing_orders));
-        db.get_balances_for_state_root.given(state_hash).will_return(Ok(state.clone()));
+        db.get_orders_of_slot
+            .given(U256::zero())
+            .will_return(Ok(first_orders.clone()));
+        db.get_standing_orders_of_slot
+            .given(U256::zero())
+            .will_return(Ok(standing_orders));
+        db.get_balances_for_state_root
+            .given(state_hash)
+            .will_return(Ok(state.clone()));
 
         let mut pf = PriceFindingMock::new();
         let expected_solution = Solution {
@@ -217,7 +339,9 @@ mod tests {
             executed_sell_amounts: vec![0, 2],
             executed_buy_amounts: vec![0, 2],
         };
-        pf.find_prices.given((first_orders, state)).will_return(Ok(expected_solution));
+        pf.find_prices
+            .given((first_orders, state))
+            .will_return(Ok(expected_solution));
 
         assert_eq!(run_order_listener(&db, &contract, &mut pf), Ok(true));
         assert_eq!(run_order_listener(&db, &contract, &mut pf), Ok(true));
@@ -238,19 +362,44 @@ mod tests {
         );
 
         let contract = SnappContractMock::new();
-        contract.get_current_auction_slot.given(()).will_return(Ok(slot));
-        contract.has_auction_slot_been_applied.given(slot).will_return(Ok(false));
-        contract.has_auction_slot_been_applied.given(slot - 1).will_return(Ok(true));
+        contract
+            .get_current_auction_slot
+            .given(())
+            .will_return(Ok(slot));
+        contract
+            .has_auction_slot_been_applied
+            .given(slot)
+            .will_return(Ok(false));
+        contract
+            .has_auction_slot_been_applied
+            .given(slot - 1)
+            .will_return(Ok(true));
 
-        contract.creation_timestamp_for_auction_slot.given(slot).will_return(Ok(U256::from(10)));
-        contract.get_current_block_timestamp.given(()).will_return(Ok(U256::from(200)));
-        
-        contract.order_hash_for_slot.given(slot).will_return(Ok(H256::zero()));
-        contract.get_current_state_root.given(()).will_return(Ok(state_hash));
+        contract
+            .creation_timestamp_for_auction_slot
+            .given(slot)
+            .will_return(Ok(U256::from(10)));
+        contract
+            .get_current_block_timestamp
+            .given(())
+            .will_return(Ok(U256::from(200)));
+
+        contract
+            .order_hash_for_slot
+            .given(slot)
+            .will_return(Ok(H256::zero()));
+        contract
+            .get_current_state_root
+            .given(())
+            .will_return(Ok(state_hash));
 
         let db = DbInterfaceMock::new();
-        db.get_orders_of_slot.given(U256::one()).will_return(Ok(orders.clone()));
-        db.get_balances_for_state_root.given(state_hash).will_return(Ok(state.clone()));
+        db.get_orders_of_slot
+            .given(U256::one())
+            .will_return(Ok(orders.clone()));
+        db.get_balances_for_state_root
+            .given(state_hash)
+            .will_return(Ok(state.clone()));
 
         let mut pf = PriceFindingMock::new();
 
@@ -263,7 +412,10 @@ mod tests {
         let slot = U256::from(1);
         let state_hash = H256::zero();
         let standing_order = StandingOrder::new(
-            1, U256::zero(), U256::from(3), vec![create_order_for_test(), create_order_for_test()]
+            1,
+            U256::zero(),
+            U256::from(3),
+            vec![create_order_for_test(), create_order_for_test()],
         );
 
         let state = AccountState::new(
@@ -274,22 +426,57 @@ mod tests {
         );
 
         let contract = SnappContractMock::new();
-        contract.get_current_auction_slot.given(()).will_return(Ok(slot));
-        contract.has_auction_slot_been_applied.given(slot).will_return(Ok(false));
-        contract.has_auction_slot_been_applied.given(slot - 1).will_return(Ok(true));
-        contract.creation_timestamp_for_auction_slot.given(slot).will_return(Ok(U256::from(10)));
-        contract.get_current_block_timestamp.given(()).will_return(Ok(U256::from(200)));
-        contract.order_hash_for_slot.given(slot).will_return(Ok(H256::zero()));
-        contract.calculate_order_hash.given((slot, Any)).will_return(Ok(H256::from("0x6bdda4f03645914c836a16ba8565f26dffb7bec640b31e1f23e0b3b22f0a64ae")));
-        contract.get_current_state_root.given(()).will_return(Ok(state_hash));
-        contract.apply_auction.given((slot, Any, Any, Any, Any, Any)).will_return(Ok(()));
+        contract
+            .get_current_auction_slot
+            .given(())
+            .will_return(Ok(slot));
+        contract
+            .has_auction_slot_been_applied
+            .given(slot)
+            .will_return(Ok(false));
+        contract
+            .has_auction_slot_been_applied
+            .given(slot - 1)
+            .will_return(Ok(true));
+        contract
+            .creation_timestamp_for_auction_slot
+            .given(slot)
+            .will_return(Ok(U256::from(10)));
+        contract
+            .get_current_block_timestamp
+            .given(())
+            .will_return(Ok(U256::from(200)));
+        contract
+            .order_hash_for_slot
+            .given(slot)
+            .will_return(Ok(H256::zero()));
+        contract
+            .calculate_order_hash
+            .given((slot, Any))
+            .will_return(Ok(H256::from(
+                "0x6bdda4f03645914c836a16ba8565f26dffb7bec640b31e1f23e0b3b22f0a64ae",
+            )));
+        contract
+            .get_current_state_root
+            .given(())
+            .will_return(Ok(state_hash));
+        contract
+            .apply_auction
+            .given((slot, Any, Any, Any, Any, Any))
+            .will_return(Ok(()));
 
         let mut standing_orders = StandingOrder::empty_array();
         standing_orders[1] = standing_order.clone();
         let db = DbInterfaceMock::new();
-        db.get_orders_of_slot.given(U256::one()).will_return(Ok(vec![]));
-        db.get_standing_orders_of_slot.given(U256::one()).will_return(Ok(standing_orders.clone()));
-        db.get_balances_for_state_root.given(state_hash).will_return(Ok(state.clone()));
+        db.get_orders_of_slot
+            .given(U256::one())
+            .will_return(Ok(vec![]));
+        db.get_standing_orders_of_slot
+            .given(U256::one())
+            .will_return(Ok(standing_orders.clone()));
+        db.get_balances_for_state_root
+            .given(state_hash)
+            .will_return(Ok(state.clone()));
 
         let mut pf = PriceFindingMock::new();
         pf.find_prices
@@ -300,49 +487,48 @@ mod tests {
     }
 
     #[test]
-    fn test_get_standing_orders_indexes(){
+    fn test_get_standing_orders_indexes() {
         let standing_order = StandingOrder::new(
-            1, U256::from(3), U256::from(2), vec![create_order_for_test(), create_order_for_test()]
+            1,
+            U256::from(3),
+            U256::from(2),
+            vec![create_order_for_test(), create_order_for_test()],
         );
-        let empty_order = StandingOrder::new(
-            0, U256::zero(), U256::from(2), vec![]
-        );
+        let empty_order = StandingOrder::new(0, U256::zero(), U256::from(2), vec![]);
         let mut standing_orders = vec![empty_order; NUM_RESERVED_ACCOUNTS as usize];
         standing_orders[1] = standing_order.clone();
         let mut standing_order_indexes = vec![U128::zero(); NUM_RESERVED_ACCOUNTS as usize];
         standing_order_indexes[1] = U128::from(3);
-        assert_eq!(batch_index_from_standing_orders(&standing_orders), standing_order_indexes);
+        assert_eq!(
+            batch_index_from_standing_orders(&standing_orders),
+            standing_order_indexes
+        );
     }
 
     #[test]
-    fn test_update_balances(){
-        let mut state = AccountState::new(
-            H256::zero(),
-            U256::one(),
-            vec![100; 70],
-            TOKENS,
-        );
+    fn test_update_balances() {
+        let mut state = AccountState::new(H256::zero(), U256::one(), vec![100; 70], TOKENS);
         let solution = Solution {
             surplus: U256::from_dec_str("0").ok(),
             prices: vec![1, 2],
             executed_sell_amounts: vec![1, 1],
             executed_buy_amounts: vec![1, 1],
         };
-        let order_1 = Order{
-          batch_information: None,
-          account_id: 1,
-          sell_token: 0,
-          buy_token: 1,
-          sell_amount: 4,
-          buy_amount: 5,
+        let order_1 = Order {
+            batch_information: None,
+            account_id: 1,
+            sell_token: 0,
+            buy_token: 1,
+            sell_amount: 4,
+            buy_amount: 5,
         };
-        let order_2 = Order{
-          batch_information: None,
-          account_id: 0,
-          sell_token: 1,
-          buy_token: 0,
-          sell_amount: 5,
-          buy_amount: 4,
+        let order_2 = Order {
+            batch_information: None,
+            account_id: 0,
+            sell_token: 1,
+            buy_token: 0,
+            sell_amount: 5,
+            buy_amount: 4,
         };
         let orders = vec![order_1, order_2];
 

--- a/driver/src/price_finding/error.rs
+++ b/driver/src/price_finding/error.rs
@@ -38,12 +38,15 @@ impl From<&str> for PriceFindingError {
 }
 impl PriceFindingError {
     pub fn new(msg: &str, kind: ErrorKind) -> PriceFindingError {
-        PriceFindingError{details: msg.to_string(), kind}
+        PriceFindingError {
+            details: msg.to_string(),
+            kind,
+        }
     }
 }
 impl fmt::Display for PriceFindingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f,"{}",self.details)
+        write!(f, "{}", self.details)
     }
 }
 impl Error for PriceFindingError {

--- a/driver/src/price_finding/mod.rs
+++ b/driver/src/price_finding/mod.rs
@@ -1,9 +1,8 @@
-
 pub mod error;
 pub mod linear_optimization_price_finder;
 pub mod naive_solver;
 pub mod price_finder_interface;
 
-pub use crate::price_finding::price_finder_interface::PriceFinding;
 pub use crate::price_finding::linear_optimization_price_finder::LinearOptimisationPriceFinder;
 pub use crate::price_finding::naive_solver::NaiveSolver;
+pub use crate::price_finding::price_finder_interface::PriceFinding;

--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -4,39 +4,45 @@ use super::error::PriceFindingError;
 
 pub trait PriceFinding {
     fn find_prices(
-        &mut self, 
+        &mut self,
         orders: &[models::Order],
-        state: &models::AccountState
+        state: &models::AccountState,
     ) -> Result<models::Solution, PriceFindingError>;
 }
 
 #[cfg(test)]
 pub mod tests {
     extern crate mock_it;
-    
+
+    use super::super::error::ErrorKind;
     use super::*;
     use dfusion_core::models::Serializable;
     use mock_it::Mock;
     use web3::types::U256;
-    use super::super::error::ErrorKind;
 
     pub struct PriceFindingMock {
-        pub find_prices: Mock<(Vec<models::Order>, models::AccountState), Result<models::Solution, PriceFindingError>>,
+        pub find_prices: Mock<
+            (Vec<models::Order>, models::AccountState),
+            Result<models::Solution, PriceFindingError>,
+        >,
     }
 
     impl PriceFindingMock {
         pub fn new() -> PriceFindingMock {
             PriceFindingMock {
-                find_prices: Mock::new(Err(PriceFindingError::new("Unexpected call to find_prices", ErrorKind::Unknown))),
+                find_prices: Mock::new(Err(PriceFindingError::new(
+                    "Unexpected call to find_prices",
+                    ErrorKind::Unknown,
+                ))),
             }
         }
     }
 
     impl PriceFinding for PriceFindingMock {
         fn find_prices(
-            &mut self, 
+            &mut self,
             orders: &[models::Order],
-            state: &models::AccountState
+            state: &models::AccountState,
         ) -> Result<models::Solution, PriceFindingError> {
             self.find_prices.called((orders.to_vec(), state.to_owned()))
         }
@@ -46,17 +52,20 @@ pub mod tests {
     fn test_serialize_solution() {
         let solution = models::Solution {
             surplus: Some(U256::zero()),
-            prices: vec![1,2],
+            prices: vec![1, 2],
             executed_sell_amounts: vec![3, 4],
             executed_buy_amounts: vec![5, 6],
         };
-        assert_eq!(solution.bytes(), vec![
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, // p1
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, // p2
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, // b1
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, // s1
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, // b2
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, // s2
-        ]);
+        assert_eq!(
+            solution.bytes(),
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, // p1
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, // p2
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, // b1
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, // s1
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, // b2
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, // s2
+            ]
+        );
     }
 }

--- a/listener/src/event_handler/deposit_handler.rs
+++ b/listener/src/event_handler/deposit_handler.rs
@@ -6,12 +6,12 @@ use dfusion_core::models::PendingFlux;
 
 use graph::components::ethereum::EthereumBlock;
 use graph::components::store::EntityOperation;
-use graph::data::store::{Entity};
+use graph::data::store::Entity;
 
 use web3::types::{Log, Transaction};
 
-use super::EventHandler;
 use super::util;
+use super::EventHandler;
 
 #[derive(Debug, Clone)]
 pub struct DepositHandler {}
@@ -22,23 +22,21 @@ impl EventHandler for DepositHandler {
         logger: Logger,
         _block: Arc<EthereumBlock>,
         _transaction: Arc<Transaction>,
-        log: Arc<Log>
+        log: Arc<Log>,
     ) -> Result<Vec<EntityOperation>, Error> {
         let entity_id = util::entity_id_from_log(&log);
         let flux = PendingFlux::from(log);
-        
+
         info!(logger, "Processing Deposit {:?}", &flux);
-        
+
         let mut entity: Entity = flux.into();
         // We do not care about the ID inside the flux data model,
         // so we have to set them later.
         entity.set("id", &entity_id);
-        
-        Ok(vec![
-            EntityOperation::Set {
-                key: util::entity_key("Deposit", &entity),
-                data: entity
-            }
-        ])
+
+        Ok(vec![EntityOperation::Set {
+            key: util::entity_key("Deposit", &entity),
+            data: entity,
+        }])
     }
 }

--- a/listener/src/event_handler/flux_transition_handler.rs
+++ b/listener/src/event_handler/flux_transition_handler.rs
@@ -1,7 +1,7 @@
 use super::*;
 
-use dfusion_core::models::util::{PopFromLogData, ToValue};
 use dfusion_core::database::DbInterface;
+use dfusion_core::models::util::{PopFromLogData, ToValue};
 
 use graph::data::store::Entity;
 use std::fmt;
@@ -14,9 +14,7 @@ pub struct FluxTransitionHandler {
 
 impl FluxTransitionHandler {
     pub fn new(store: Arc<DbInterface>) -> Self {
-        FluxTransitionHandler{
-            store
-        }
+        FluxTransitionHandler { store }
     }
 }
 
@@ -47,7 +45,7 @@ impl EventHandler for FluxTransitionHandler {
         logger: Logger,
         _block: Arc<EthereumBlock>,
         _transaction: Arc<Transaction>,
-        log: Arc<Log>
+        log: Arc<Log>,
     ) -> Result<Vec<EntityOperation>, Error> {
         let mut data = log.data.0.clone();
         let transition_type: FluxTransitionType = u8::pop_from_log_data(&mut data).into();
@@ -57,19 +55,22 @@ impl EventHandler for FluxTransitionHandler {
 
         info!(logger, "Received Flux AccountState Transition Event");
 
-        let mut account_state = self.store
+        let mut account_state = self
+            .store
             .get_balances_for_state_index(&state_index)
             .map_err(|e| failure::err_msg(format!("{}", e)))?;
 
         match transition_type {
             FluxTransitionType::Deposit => {
-                let deposits = self.store
+                let deposits = self
+                    .store
                     .get_deposits_of_slot(&slot)
                     .map_err(|e| failure::err_msg(format!("{}", e)))?;
                 account_state.apply_deposits(&deposits);
-            },
+            }
             FluxTransitionType::Withdraw => {
-                let withdraws = self.store
+                let withdraws = self
+                    .store
                     .get_withdraws_of_slot(&slot)
                     .map_err(|e| failure::err_msg(format!("{}", e)))?;
                 account_state.apply_withdraws(&withdraws);
@@ -78,12 +79,10 @@ impl EventHandler for FluxTransitionHandler {
         let mut entity: Entity = account_state.into();
         // We set the state root as claimed by the event
         entity.set("id", new_state_hash.to_value());
-        Ok(vec![
-            EntityOperation::Set {
-                key: util::entity_key("AccountState", &entity),
-                data: entity
-            }
-        ])
+        Ok(vec![EntityOperation::Set {
+            key: util::entity_key("AccountState", &entity),
+            data: entity,
+        }])
     }
 }
 
@@ -92,7 +91,7 @@ pub mod test {
     use super::*;
     use dfusion_core::database::tests::DbInterfaceMock;
     use dfusion_core::database::*;
-    use dfusion_core::models::{PendingFlux, AccountState};
+    use dfusion_core::models::{AccountState, PendingFlux};
     use web3::types::{Bytes, H256};
 
     #[test]
@@ -101,7 +100,8 @@ pub mod test {
 
         // Add previous account state and pending deposits into Store
         let existing_state = AccountState::new(H256::zero(), U256::zero(), vec![0, 0, 0, 0], 1);
-        store.get_balances_for_state_index
+        store
+            .get_balances_for_state_index
             .given(U256::zero())
             .will_return(Ok(existing_state));
 
@@ -120,7 +120,8 @@ pub mod test {
             token_id: 0,
             amount: 10,
         };
-        store.get_deposits_of_slot
+        store
+            .get_deposits_of_slot
             .given(U256::zero())
             .will_return(Ok(vec![first_deposit, second_deposit]));
 
@@ -128,17 +129,20 @@ pub mod test {
         let handler = FluxTransitionHandler::new(store);
         let log = create_state_transition_event(FluxTransitionType::Deposit, 1, H256::from(1), 0);
         let result = handler.process_event(
-            util::test::logger(), 
+            util::test::logger(),
             Arc::new(util::test::fake_block()),
-            Arc::new(util::test::fake_tx()), 
-            log
+            Arc::new(util::test::fake_tx()),
+            log,
         );
-        let expected_new_state = AccountState::new(H256::from(1), U256::one(), vec![10, 10, 0, 0], 1);
+        let expected_new_state =
+            AccountState::new(H256::from(1), U256::one(), vec![10, 10, 0, 0], 1);
 
         assert!(result.is_ok());
         match result.unwrap().pop().unwrap() {
-            EntityOperation::Set { key: _, data } => assert_eq!(AccountState::from(data), expected_new_state),
-            _ => assert!(false)
+            EntityOperation::Set { key: _, data } => {
+                assert_eq!(AccountState::from(data), expected_new_state)
+            }
+            _ => assert!(false),
         }
     }
 
@@ -147,17 +151,21 @@ pub mod test {
         let store = Arc::new(DbInterfaceMock::new());
 
         // No data in store
-        store.get_balances_for_state_index
+        store
+            .get_balances_for_state_index
             .given(U256::zero())
-            .will_return(Err(DatabaseError::new(ErrorKind::StateError, "No State found")));
+            .will_return(Err(DatabaseError::new(
+                ErrorKind::StateError,
+                "No State found",
+            )));
 
         let handler = FluxTransitionHandler::new(store);
         let log = create_state_transition_event(FluxTransitionType::Deposit, 1, H256::from(1), 0);
         let result = handler.process_event(
-            util::test::logger(), 
+            util::test::logger(),
             Arc::new(util::test::fake_block()),
-            Arc::new(util::test::fake_tx()), 
-            log
+            Arc::new(util::test::fake_tx()),
+            log,
         );
         assert!(result.is_err());
     }
@@ -167,13 +175,9 @@ pub mod test {
         let store = Arc::new(DbInterfaceMock::new());
 
         // Add previous account state and pending withdraws into Store
-        let existing_state = AccountState::new(
-            H256::zero(),
-            U256::zero(),
-            vec![10, 20, 0, 0],
-            1
-        );
-        store.get_balances_for_state_index
+        let existing_state = AccountState::new(H256::zero(), U256::zero(), vec![10, 20, 0, 0], 1);
+        store
+            .get_balances_for_state_index
             .given(U256::zero())
             .will_return(Ok(existing_state));
 
@@ -198,54 +202,146 @@ pub mod test {
             token_id: 1,
             amount: 10,
         };
-        
-        store.get_withdraws_of_slot
+
+        store
+            .get_withdraws_of_slot
             .given(U256::zero())
-            .will_return(Ok(vec![
-                first_withdraw,
-                second_withdraw,
-                invalid_withdraw,
-            ]));
+            .will_return(Ok(vec![first_withdraw, second_withdraw, invalid_withdraw]));
 
         // Process event
         let handler = FluxTransitionHandler::new(store);
-        let log = create_state_transition_event(
-            FluxTransitionType::Withdraw,
-            1,
-            H256::from(1),
-            0
-        );
+        let log = create_state_transition_event(FluxTransitionType::Withdraw, 1, H256::from(1), 0);
         let result = handler.process_event(
             util::test::logger(),
             Arc::new(util::test::fake_block()),
             Arc::new(util::test::fake_tx()),
-            log
+            log,
         );
-        let expected_new_state = AccountState::new(
-            H256::from(1),
-            U256::one(),
-            vec![0, 10, 0, 0],
-            1
-        );
+        let expected_new_state =
+            AccountState::new(H256::from(1), U256::one(), vec![0, 10, 0, 0], 1);
 
         assert!(result.is_ok());
         match result.unwrap().pop().unwrap() {
-            EntityOperation::Set { key: _, data } => assert_eq!(AccountState::from(data), expected_new_state),
-            _ => assert!(false)
+            EntityOperation::Set { key: _, data } => {
+                assert_eq!(AccountState::from(data), expected_new_state)
+            }
+            _ => assert!(false),
         }
     }
 
     fn create_state_transition_event(
-        transition_type: FluxTransitionType, 
-        new_state_index: u8, 
+        transition_type: FluxTransitionType,
+        new_state_index: u8,
         new_state_root: H256,
-        applied_slot: u8
+        applied_slot: u8,
     ) -> Arc<Log> {
         let bytes: Vec<Vec<u8>> = vec![
-            /* transition_type */ vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, transition_type as u8],
-            /* new_state_index */ vec![ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, new_state_index],
+            /* transition_type */
+            vec![
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                transition_type as u8,
+            ],
+            /* new_state_index */
+            vec![
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                new_state_index,
+            ],
             /* new_state_hash */ new_state_root[..].to_vec(),
-            /* applied_slot */ vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, applied_slot],
+            /* applied_slot */
+            vec![
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                applied_slot,
+            ],
         ];
 
         Arc::new(Log {

--- a/listener/src/event_handler/initialization_handler.rs
+++ b/listener/src/event_handler/initialization_handler.rs
@@ -13,17 +13,15 @@ impl EventHandler for InitializationHandler {
         logger: Logger,
         _block: Arc<EthereumBlock>,
         _transaction: Arc<Transaction>,
-        log: Arc<Log>
+        log: Arc<Log>,
     ) -> Result<Vec<EntityOperation>, Error> {
         info!(logger, "Processing SnappBase Initialization Event");
         let state = AccountState::from(log);
         let entity: Entity = state.into();
-        
-        Ok(vec![
-            EntityOperation::Set {
-                key: util::entity_key("AccountState", &entity),
-                data: entity
-            }
-        ])
+
+        Ok(vec![EntityOperation::Set {
+            key: util::entity_key("AccountState", &entity),
+            data: entity,
+        }])
     }
 }

--- a/listener/src/event_handler/mod.rs
+++ b/listener/src/event_handler/mod.rs
@@ -37,6 +37,6 @@ pub trait EventHandler: Send + Sync + Debug {
         logger: Logger,
         block: Arc<EthereumBlock>,
         transaction: Arc<Transaction>,
-        log: Arc<Log>
+        log: Arc<Log>,
     ) -> Result<Vec<EntityOperation>, Error>;
 }

--- a/listener/src/event_handler/order_handler.rs
+++ b/listener/src/event_handler/order_handler.rs
@@ -6,12 +6,12 @@ use dfusion_core::models::Order;
 
 use graph::components::ethereum::EthereumBlock;
 use graph::components::store::EntityOperation;
-use graph::data::store::{Entity};
+use graph::data::store::Entity;
 
 use web3::types::{Log, Transaction};
 
-use super::EventHandler;
 use super::util;
+use super::EventHandler;
 
 #[derive(Debug, Clone)]
 pub struct SellOrderHandler {}
@@ -22,7 +22,7 @@ impl EventHandler for SellOrderHandler {
         logger: Logger,
         _block: Arc<EthereumBlock>,
         _transaction: Arc<Transaction>,
-        log: Arc<Log>
+        log: Arc<Log>,
     ) -> Result<Vec<EntityOperation>, Error> {
         let entity_id = util::entity_id_from_log(&log);
         let order = Order::from(log);
@@ -31,11 +31,9 @@ impl EventHandler for SellOrderHandler {
         let mut entity: Entity = order.into();
         entity.set("id", &entity_id);
 
-        Ok(vec![
-            EntityOperation::Set {
-                key: util::entity_key("SellOrder", &entity),
-                data: entity
-            }
-        ])
+        Ok(vec![EntityOperation::Set {
+            key: util::entity_key("SellOrder", &entity),
+            data: entity,
+        }])
     }
 }

--- a/listener/src/event_handler/standing_order_handler.rs
+++ b/listener/src/event_handler/standing_order_handler.rs
@@ -1,10 +1,10 @@
-use failure::Error;
 use super::EventHandler;
+use failure::Error;
 use slog::Logger;
 use std::sync::Arc;
 
 use graph::components::ethereum::EthereumBlock;
-use graph::components::store::{EntityOperation};
+use graph::components::store::EntityOperation;
 use graph::data::store::{Entity, Value};
 
 use dfusion_core::models::StandingOrder;
@@ -22,25 +22,24 @@ impl EventHandler for StandingOrderHandler {
         logger: Logger,
         _block: Arc<EthereumBlock>,
         _transaction: Arc<Transaction>,
-        log: Arc<Log>
+        log: Arc<Log>,
     ) -> Result<Vec<EntityOperation>, Error> {
         // Get entities from log
         let (standing_order_entity, order_entities) = get_entities_from_log(&logger, &log);
 
         // Define operations to persist orders
-        let mut entity_operations: Vec<EntityOperation> = order_entities.into_iter()
-            .map(|order| {
-                EntityOperation::Set {
-                    key: util::entity_key("SellOrder", &order),
-                    data: order
-                }
+        let mut entity_operations: Vec<EntityOperation> = order_entities
+            .into_iter()
+            .map(|order| EntityOperation::Set {
+                key: util::entity_key("SellOrder", &order),
+                data: order,
             })
             .collect();
 
         // Add operation to persist the standing order
         entity_operations.push(EntityOperation::Set {
             key: util::entity_key("StandingSellOrderBatch", &standing_order_entity),
-            data: standing_order_entity
+            data: standing_order_entity,
         });
 
         Ok(entity_operations)
@@ -52,18 +51,20 @@ fn get_entities_from_log(logger: &Logger, log: &Arc<Log>) -> (Entity, Vec<Entity
     let orders = standing_order.get_orders().clone();
     let entity_id = format!(
         "{}_{}_{}",
-        standing_order.account_id,
-        standing_order.batch_index,
-        standing_order.valid_from_auction_id
+        standing_order.account_id, standing_order.batch_index, standing_order.valid_from_auction_id
     );
-    info!(logger, "Processing StandingOrder batch. Id: {}. Data: {:?}", &entity_id, &standing_order);
+    info!(
+        logger,
+        "Processing StandingOrder batch. Id: {}. Data: {:?}", &entity_id, &standing_order
+    );
 
     // Get standing order entity and set id
     let mut standing_order_entity: Entity = standing_order.into();
     standing_order_entity.set("id", &entity_id);
 
     // Get order entities and their ids
-    let order_entities: Vec<Entity> = orders.into_iter()
+    let order_entities: Vec<Entity> = orders
+        .into_iter()
         .enumerate()
         .map(|(order_number, order)| {
             // Transform order into Entity and add id
@@ -84,41 +85,44 @@ fn get_entities_from_log(logger: &Logger, log: &Arc<Log>) -> (Entity, Vec<Entity
     (standing_order_entity, order_entities)
 }
 
-
-
 #[cfg(test)]
 pub mod test {
     use super::*;
-    use web3::types::{Bytes};
     use graph::components::store::EntityKey;
+    use web3::types::Bytes;
 
     #[test]
     fn test_handle_standing_order() {
-        let handler = StandingOrderHandler{};
+        let handler = StandingOrderHandler {};
         let log = create_log_for_test();
 
         let result = handler.process_event(
-            util::test::logger(), 
+            util::test::logger(),
             Arc::new(util::test::fake_block()),
             Arc::new(util::test::fake_tx()),
-            log
+            log,
         );
 
         let operations: Vec<EntityOperation> = result.expect("The handler should succeed");
         assert_eq!(operations.len(), 2, "Expected exactly two operations");
         let expected_entity_types = ["SellOrder", "StandingSellOrderBatch"];
-        
+
         // Check that the two operations are persisting a SellOrder and a StandingSellOrderBatch
-        for (operation, expected_entity_type) in operations.iter().zip(expected_entity_types.iter()) {
+        for (operation, expected_entity_type) in operations.iter().zip(expected_entity_types.iter())
+        {
             match operation {
-                EntityOperation::Set { key: EntityKey {
-                    subgraph_id: _subgraph_id,
-                    entity_type,
-                    entity_id: _entity_id
-                }, data: _data} => {
+                EntityOperation::Set {
+                    key:
+                        EntityKey {
+                            subgraph_id: _subgraph_id,
+                            entity_type,
+                            entity_id: _entity_id,
+                        },
+                    data: _data,
+                } => {
                     assert_eq!(entity_type, expected_entity_type);
-                },
-                _ => panic!("Expected a Set Entity operation")
+                }
+                _ => panic!("Expected a Set Entity operation"),
             }
         }
     }
@@ -126,27 +130,39 @@ pub mod test {
     pub fn create_log_for_test() -> Arc<Log> {
         let bytes: Vec<Vec<u8>> = vec![
             // batch_index: 1
-            vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,0, 0, 0, 2],
-
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 2,
+            ],
             // valid_from_auction_id: 3
-            vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3],
-
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 3,
+            ],
             // account_id: 1
-            vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ],
             // bytes start position
-            vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128],
-
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 128,
+            ],
             // bytes size
-            vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 26],
-
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 26,
+            ],
             // packed_orders: Buy token 2, for token 1. Buy 1e18 for 2e18.
             //    000000000de0b6b3a7640000 000000001bc16d674ec80000 0201
             //    00 00 00 00 0d  e0   b6   b3   a7   64   00 00 00 00 00 00 1b  c1   6d   67   4e  c8   00 00 02 01
-            vec![ 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, 0, 0, 0, 0, 27, 193, 109, 103, 78, 200, 0, 0, 2, 1],
-
+            vec![
+                0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, 0, 0, 0, 0, 27, 193, 109, 103, 78,
+                200, 0, 0, 2, 1,
+            ],
             // Unused space for bytes field
-            vec![ 0, 0, 0, 0, 0, 0]
+            vec![0, 0, 0, 0, 0, 0],
         ];
 
         Arc::new(Log {

--- a/listener/src/event_handler/util.rs
+++ b/listener/src/event_handler/util.rs
@@ -1,22 +1,20 @@
-use std::sync::Arc;
 use graph::components::store::EntityKey;
 use graph::data::store::Entity;
+use std::sync::Arc;
 use web3::types::Log;
 
 use crate::SUBGRAPH_ID;
 
 pub fn entity_id_from_log(log: &Arc<Log>) -> String {
-    format!("{:x}_{}", 
-        &log.block_hash.unwrap(), 
-        &log.log_index.unwrap()
-    )
+    format!("{:x}_{}", &log.block_hash.unwrap(), &log.log_index.unwrap())
 }
 
 pub fn entity_key(entity_type: &str, entity: &Entity) -> EntityKey {
     EntityKey {
         subgraph_id: SUBGRAPH_ID.clone(),
         entity_type: entity_type.to_string(),
-        entity_id: entity.get("id")
+        entity_id: entity
+            .get("id")
             .and_then(|v| v.clone().as_string())
             .unwrap(),
     }
@@ -26,7 +24,7 @@ pub fn entity_key(entity_type: &str, entity: &Entity) -> EntityKey {
 pub mod test {
     use graph::components::ethereum::EthereumBlock;
     use slog::Logger;
-    use web3::types::{Block, Bytes, H2048, H256, H160, Transaction, U256};
+    use web3::types::{Block, Bytes, Transaction, H160, H2048, H256, U256};
 
     pub fn logger() -> Logger {
         Logger::root(slog::Discard, o!())
@@ -48,7 +46,7 @@ pub mod test {
         }
     }
 
-    pub fn fake_block() -> EthereumBlock{
+    pub fn fake_block() -> EthereumBlock {
         EthereumBlock {
             block: Block {
                 hash: None,

--- a/listener/src/event_handler/withdraw_handler.rs
+++ b/listener/src/event_handler/withdraw_handler.rs
@@ -6,12 +6,12 @@ use dfusion_core::models::PendingFlux;
 
 use graph::components::ethereum::EthereumBlock;
 use graph::components::store::EntityOperation;
-use graph::data::store::{Entity};
+use graph::data::store::Entity;
 
 use web3::types::{Log, Transaction};
 
-use super::EventHandler;
 use super::util;
+use super::EventHandler;
 
 #[derive(Debug, Clone)]
 pub struct WithdrawHandler {}
@@ -22,7 +22,7 @@ impl EventHandler for WithdrawHandler {
         logger: Logger,
         _block: Arc<EthereumBlock>,
         _transaction: Arc<Transaction>,
-        log: Arc<Log>
+        log: Arc<Log>,
     ) -> Result<Vec<EntityOperation>, Error> {
         let entity_id = util::entity_id_from_log(&log);
         let flux = PendingFlux::from(log);
@@ -32,11 +32,9 @@ impl EventHandler for WithdrawHandler {
         let mut entity: Entity = flux.into();
         entity.set("id", &entity_id);
 
-        Ok(vec![
-            EntityOperation::Set {
-                key: util::entity_key("Withdraw", &entity),
-                data: entity
-            }
-        ])
+        Ok(vec![EntityOperation::Set {
+            key: util::entity_key("Withdraw", &entity),
+            data: entity,
+        }])
     }
 }

--- a/listener/src/link_resolver.rs
+++ b/listener/src/link_resolver.rs
@@ -2,7 +2,6 @@ use graph::components::link_resolver::JsonValueStream;
 use graph::data::subgraph::Link;
 use graph::prelude::LinkResolver as LinkResolverTrait;
 
-use futures::prelude::*;
 use futures::future::*;
 use slog::Logger;
 use std::fs::File;
@@ -10,7 +9,8 @@ use std::io::prelude::*;
 use std::path::Path;
 
 fn read_file(file: &str) -> Result<Vec<u8>, failure::Error> {
-    let path = format!("listener/subgraph_definition/{}", 
+    let path = format!(
+        "listener/subgraph_definition/{}",
         Path::new(file)
             .iter()
             .last()
@@ -35,7 +35,7 @@ impl LinkResolverTrait for LocalLinkResolver {
         info!(logger, "Resolving link {}", &link.link);
         match read_file(&link.link) {
             Ok(res) => Box::new(ok(res)),
-            Err(e) => Box::new(err(e))
+            Err(e) => Box::new(err(e)),
         }
     }
 

--- a/listener/src/runtime_host.rs
+++ b/listener/src/runtime_host.rs
@@ -6,8 +6,10 @@ use std::sync::Arc;
 
 use dfusion_core::database::DbInterface;
 
-use graph::components::ethereum::{EthereumCall, EthereumBlockTriggerType, EthereumBlock};
-use graph::components::subgraph::{RuntimeHost as RuntimeHostTrait, RuntimeHostBuilder, BlockState};
+use graph::components::ethereum::{EthereumBlock, EthereumBlockTriggerType, EthereumCall};
+use graph::components::subgraph::{
+    BlockState, RuntimeHost as RuntimeHostTrait, RuntimeHostBuilder,
+};
 
 use graph::data::subgraph::{DataSource, SubgraphDeploymentId};
 
@@ -16,36 +18,24 @@ use tiny_keccak::keccak256;
 use web3::types::{Log, Transaction, H256};
 
 use crate::event_handler::{
-    EventHandler,
-    DepositHandler,
-    InitializationHandler,
-    FluxTransitionHandler,
-    WithdrawHandler,
-    StandingOrderHandler,
-    SellOrderHandler,
-    AuctionSettlementHandler
+    AuctionSettlementHandler, DepositHandler, EventHandler, FluxTransitionHandler,
+    InitializationHandler, SellOrderHandler, StandingOrderHandler, WithdrawHandler,
 };
 
 type HandlerMap = HashMap<H256, Box<dyn EventHandler>>;
 
-fn register_event(handlers: &mut HandlerMap, name: &str, handler: Box<dyn EventHandler>)
-{
-    handlers.insert(
-        H256::from(keccak256(name.as_bytes())),
-        handler,
-    );
+fn register_event(handlers: &mut HandlerMap, name: &str, handler: Box<dyn EventHandler>) {
+    handlers.insert(H256::from(keccak256(name.as_bytes())), handler);
 }
 
 #[derive(Clone)]
 pub struct RustRuntimeHostBuilder {
-    store: Arc<DbInterface>
+    store: Arc<DbInterface>,
 }
 
 impl RustRuntimeHostBuilder {
     pub fn new(store: Arc<DbInterface>) -> Self {
-        RustRuntimeHostBuilder {
-            store
-        }
+        RustRuntimeHostBuilder { store }
     }
 }
 
@@ -63,7 +53,7 @@ impl RuntimeHostBuilder for RustRuntimeHostBuilder {
 
 #[derive(Debug)]
 pub struct RustRuntimeHost {
-    handlers: HashMap<H256, Box<dyn EventHandler>>
+    handlers: HashMap<H256, Box<dyn EventHandler>>,
 }
 
 impl RustRuntimeHost {
@@ -104,9 +94,7 @@ impl RustRuntimeHost {
             "AuctionSettlement(uint256,uint256,bytes32,bytes)",
             Box::new(AuctionSettlementHandler::new(store.clone())),
         );
-        RustRuntimeHost {
-            handlers
-        }
+        RustRuntimeHost { handlers }
     }
 }
 
@@ -132,7 +120,7 @@ impl RuntimeHostTrait for RustRuntimeHost {
         transaction: Arc<Transaction>,
         log: Arc<Log>,
         state: BlockState,
-    ) -> Box<Future<Item=BlockState, Error=Error> + Send> {
+    ) -> Box<Future<Item = BlockState, Error = Error> + Send> {
         info!(logger, "Received event");
         let mut state = state;
         if let Some(handler) = self.handlers.get(&log.topics[0]) {
@@ -154,7 +142,7 @@ impl RuntimeHostTrait for RustRuntimeHost {
         _transaction: Arc<Transaction>,
         _call: Arc<EthereumCall>,
         _state: BlockState,
-    ) -> Box<Future<Item=BlockState, Error=Error> + Send> {
+    ) -> Box<Future<Item = BlockState, Error = Error> + Send> {
         unimplemented!();
     }
 
@@ -165,7 +153,7 @@ impl RuntimeHostTrait for RustRuntimeHost {
         _block: Arc<EthereumBlock>,
         _trigger_type: EthereumBlockTriggerType,
         _state: BlockState,
-    ) -> Box<Future<Item=BlockState, Error=Error> + Send> {
+    ) -> Box<Future<Item = BlockState, Error = Error> + Send> {
         unimplemented!();
     }
 }


### PR DESCRIPTION
I have been seeing a lot of unrelated changes in some of the recent PRs which come from some people using rustfmt in their IDEs.

This PR makes the entire workspace comply with rustformat.

To add rustformat to VSCode, add the line 

```js
"editor.formatOnSave": true,
```

to your Settings.json.

Wondering what the best way would be to enforce proper formatting on PR level. Could we have travis automatically commit formatting changes in case someone forgets to format?