### PR TITLE
Using docker-compose kill to speed up restarts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
           - $HOME/.nvm/versions/node/v8.12.0/lib/node_modules
           - dex-contracts/node_modules/
       before_install:
-        - npm install -g truffle node-jq wait-port
+        - npm install -g node-jq wait-port
       install:
         - git submodule update --init
         - npm install -C dex-contracts

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,12 @@ matrix:
         directories:
           - $HOME/.nvm/versions/node/v8.12.0/lib/node_modules
           - dex-contracts/node_modules/
-      before_install:
-        - npm install -g node-jq wait-port
       install:
         - git submodule update --init
         - npm install -C dex-contracts
-        - cd dex-contracts && truffle compile && cd -
+        - cd dex-contracts && npx truffle compile && cd -
         - docker-compose up -d driver graph-listener | while read line ; do echo "$(date)| $line"; done; # prints timestamps for profiling
-        - cd dex-contracts && wait-port -t 30000 8545 && truffle migrate && cd -
+        - cd dex-contracts && npx wait-port -t 30000 8545 && npx truffle migrate && cd -
       script:
         - ./test/e2e-tests-deposit-withdraw.sh
         - ./test/restart-containers.sh

--- a/test/restart-containers.sh
+++ b/test/restart-containers.sh
@@ -2,6 +2,7 @@
 set -e
 
 docker-compose kill
+docker-compose rm -sf postgres
 docker-compose up -d driver graph-listener
 
 cd dex-contracts && npx wait-port -t 30000 8545 && npx truffle migrate && cd -

--- a/test/restart-containers.sh
+++ b/test/restart-containers.sh
@@ -1,13 +1,7 @@
 #!/bin/bash
 set -e
 
-docker-compose rm -sf postgres
-docker-compose up -d postgres
-
-docker-compose rm -sf ganache-cli
-docker-compose up -d ganache-cli
-
-docker-compose restart graph-listener
-docker-compose restart driver
+docker-compose kill
+docker-compose up -d driver graph-listener
 
 cd dex-contracts && npx wait-port -t 30000 8545 && npx truffle migrate && cd -


### PR DESCRIPTION
Restarting the containers between tests takes ~60s at the moment (cf. https://travis-ci.org/gnosis/dex-services/jobs/578335529#L530)

With this change I was able to reduce the time between restarts to <15s. This should lead to a speedup of ~1.5mn for our overall travis time.

### TestPlan

Observe restart-container.sh timing in travis.