### PR TITLE
Re-add deleted e2e test assertions

### DIFF
--- a/test/e2e-tests-deposit-withdraw.sh
+++ b/test/e2e-tests-deposit-withdraw.sh
@@ -59,6 +59,15 @@ EXPECTED_HASH="7b738197bfe79b6d394499b0cac0186cdc2f65ae2239f2e9e3c698709c80cb67"
 step_with_retry "Check contract updated" \
 "npx truffle exec scripts/invokeViewFunction.js 'getCurrentStateRoot' | grep ${EXPECTED_HASH}"
 
+step_with_retry "Check account DB updated" \
+"source ../test/utils.sh && query_graphql \
+    \"query { \
+        accountStates(where: {id: \\\"${EXPECTED_HASH}\\\"}) {\
+            balances \
+        } \
+    }\" | jq .data.accountStates[0].balances[62] | grep -w 0"
+
+
 # Should now be able to claim withdraw and see a balance change
 step "Claim Withdraw" \
 "npx truffle exec scripts/claim_withdraw.js 0 2 2 | grep \"Success! Balance of token 2 before claim: 282000000000000000000, after claim: 300000000000000000000\""

--- a/test/e2e-tests-standing-order.sh
+++ b/test/e2e-tests-standing-order.sh
@@ -44,6 +44,14 @@ step_with_retry "Wait for bid to be placed" \
 step "Advance time to apply auction" \
 "npx truffle exec scripts/wait_seconds.js 181"
 
+step_with_retry "Assert Standing order account traded" \
+"source ../test/utils.sh && query_graphql \
+    \"query { \
+        accountStates(where: {stateIndex: \\\"2\\\"}) {\
+            balances \
+        } \
+    }\" | jq .data.accountStates[0].balances[1] | grep -w -2 1000000000000000000"
+
 step "Place matching sell order for standing order" \
 "npx truffle exec scripts/sell_order.js 1 2 1 1 1"
 
@@ -56,6 +64,14 @@ step_with_retry "Wait for bid to be placed" \
 
 step "Advance time to apply auction" \
 "npx truffle exec scripts/wait_seconds.js 181"
+
+step_with_retry "Make sure standing order is still traded" \
+"source ../test/utils.sh && query_graphql \
+    \"query { \
+        accountStates(where: {stateIndex: \\\"3\\\"}) {\
+            balances \
+        } \
+    }\" | jq .data.accountStates[0].balances[1] | grep -w -2 2000000000000000000"
 
 step "Update standing order" \
 "npx truffle exec scripts/standing_order.js 0 1 2 1 2"
@@ -103,9 +119,16 @@ step "Place matching sell order for standing order" \
 step "Advance time to bid for auction" \
 "npx truffle exec scripts/wait_seconds.js 181"
 
-EXPECTED_HASH="2b87dc830d051be72f4adcc3677daadab2f3f2253e9da51d803faeb0daa1532f"
 step_with_retry "Wait for bid to be placed" \
 "npx truffle exect scripts/invokeViewFunction.js auctions 2 | grep \"solver: '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1'\" "
 
 step "Advance time to apply auction" \
 "npx truffle exec scripts/wait_seconds.js 181"
+
+step_with_retry "Standing Order was no longer traded" \
+"source ../test/utils.sh && query_graphql \
+    \"query { \
+        accountStates(where: {stateIndex: \\\"4\\\"}) {\
+            balances \
+        } \
+    }\" | jq .data.accountStates[0].balances[1] | grep -w -2 2000000000000000000"


### PR DESCRIPTION
#227  (more specifically https://github.com/gnosis/dex-services/commit/248554708b8e5b85a4afcbc12646fa1f6ee5e7e3#diff-0085bcc75915940251129aadc6ef5004) remove a few assertions in the standing order e2e test for which we had no The Graph equivalent.

This PR re-adds those assertions.

