### PR TITLE
[Easy] misc clippy fixes

### DIFF
--- a/dfusion_rust_core/src/database/graph_reader.rs
+++ b/dfusion_rust_core/src/database/graph_reader.rs
@@ -9,11 +9,11 @@ use crate::models::StandingOrder;
 use graph_node_reader::StoreReader;
 
 pub struct GraphReader {
-    reader: Box<StoreReader>,
+    reader: Box<dyn StoreReader>,
 }
 
 impl GraphReader {
-    pub fn new(reader: Box<StoreReader>) -> Self {
+    pub fn new(reader: Box<dyn StoreReader>) -> Self {
         GraphReader { reader }
     }
 

--- a/dfusion_rust_core/src/models/account_state.rs
+++ b/dfusion_rust_core/src/models/account_state.rs
@@ -165,7 +165,7 @@ pub mod tests {
             .parse::<H256>()
             .unwrap();
         let state = AccountState {
-            state_hash: state_hash.clone(),
+            state_hash,
             state_index: U256::one(),
             balances: balances.clone(),
             num_tokens: TOKENS,
@@ -178,7 +178,7 @@ pub mod tests {
             .parse::<H256>()
             .unwrap();
         let state = AccountState {
-            state_hash: state_hash.clone(),
+            state_hash,
             state_index: U256::one(),
             balances,
             num_tokens: TOKENS,

--- a/dfusion_rust_core/src/models/flux.rs
+++ b/dfusion_rust_core/src/models/flux.rs
@@ -107,13 +107,13 @@ pub mod unit_test {
         };
         // one valid withdraw
         assert_eq!(
-            vec![deposit.clone()].root_hash(&vec![true]),
+            vec![deposit.clone()].root_hash(&[true]),
             H256::from_str("4a77ba0bc619056248f2f2793075eb6f49cf35dacb5cccfe1e71392046a06b79")
                 .unwrap()
         );
         // no valid withdraws
         assert_eq!(
-            vec![deposit].root_hash(&vec![false]),
+            vec![deposit].root_hash(&[false]),
             H256::from_str("87eb0ddba57e35f6d286673802a4af5975e22506c7cf4c64bb6be5ee11527f2c")
                 .unwrap()
         );
@@ -166,7 +166,7 @@ pub mod unit_test {
         let expected_flux = PendingFlux {
             account_id: 1,
             token_id: 1,
-            amount: 1 * (10 as u128).pow(18),
+            amount: (10 as u128).pow(18),
             slot: U256::zero(),
             slot_index: 0,
         };
@@ -179,7 +179,7 @@ pub mod unit_test {
         let flux = PendingFlux {
             account_id: 1,
             token_id: 1,
-            amount: 1 * (10 as u128).pow(18),
+            amount: (10 as u128).pow(18),
             slot: U256::zero(),
             slot_index: 0,
         };
@@ -188,7 +188,7 @@ pub mod unit_test {
         entity.set("id", "0 - 0");
         entity.set("accountId", 1);
         entity.set("tokenId", 1);
-        entity.set("amount", BigDecimal::from(1 * (10 as u64).pow(18)));
+        entity.set("amount", BigDecimal::from((10 as u64).pow(18)));
         entity.set("slot", BigDecimal::from(0));
         entity.set("slotIndex", 0);
 

--- a/dfusion_rust_core/src/models/order.rs
+++ b/dfusion_rust_core/src/models/order.rs
@@ -236,8 +236,8 @@ pub mod unit_test {
             account_id: 1,
             buy_token: 3,
             sell_token: 2,
-            buy_amount: 1 * (10 as u128).pow(18),
-            sell_amount: 1 * (10 as u128).pow(18),
+            buy_amount: (10 as u128).pow(18),
+            sell_amount: (10 as u128).pow(18),
         };
 
         assert_eq!(expected_order, Order::from(log));
@@ -306,7 +306,7 @@ pub mod unit_test {
             account_id: 1,
             buy_token: 1,
             sell_token: 2,
-            buy_amount: 1 * (10 as u128).pow(18),
+            buy_amount: (10 as u128).pow(18),
             sell_amount: 2 * (10 as u128).pow(18),
         }
     }
@@ -318,7 +318,7 @@ pub mod unit_test {
         entity.set("accountId", 1);
         entity.set("buyToken", 1);
         entity.set("sellToken", 2);
-        entity.set("buyAmount", BigDecimal::from(1 * (10 as u64).pow(18)));
+        entity.set("buyAmount", BigDecimal::from((10 as u64).pow(18)));
         entity.set("sellAmount", BigDecimal::from(2 * (10 as u64).pow(18)));
 
         entity

--- a/dfusion_rust_core/src/models/standing_order.rs
+++ b/dfusion_rust_core/src/models/standing_order.rs
@@ -295,7 +295,7 @@ pub mod tests {
         entity.set("accountId", 1);
         entity.set("buyToken", 2);
         entity.set("sellToken", 1);
-        entity.set("buyAmount", BigDecimal::from(1 * (10 as u64).pow(18)));
+        entity.set("buyAmount", BigDecimal::from((10 as u64).pow(18)));
         entity.set("sellAmount", BigDecimal::from(2 * (10 as u64).pow(18)));
 
         entity

--- a/driver/src/contract.rs
+++ b/driver/src/contract.rs
@@ -322,7 +322,10 @@ impl SnappContract for SnappContractImpl {
         new_state: H256,
         prices_and_volumes: Vec<u8>,
     ) -> Result<()> {
-        debug!("Applying Auction with result bytes: {:?}", &prices_and_volumes);
+        debug!(
+            "Applying Auction with result bytes: {:?}",
+            &prices_and_volumes
+        );
         let account = self
             .account_with_sufficient_balance()
             .ok_or("Not enough balance to send Txs")?;
@@ -398,6 +401,24 @@ pub mod tests {
     use mock_it::Matcher::*;
     use mock_it::Mock;
 
+    type ApplyDeopositArguments = (U256, Matcher<H256>, Matcher<H256>, Matcher<H256>);
+    type ApplyWithdrawArguments = (
+        U256,
+        Matcher<H256>,
+        Matcher<H256>,
+        Matcher<H256>,
+        Matcher<H256>,
+    );
+    type ApplyAuctionArguments = (U256, Matcher<H256>, Matcher<H256>, Matcher<Vec<u8>>);
+    type ApplySolutionArguments = (
+        U256,
+        Matcher<H256>,
+        Matcher<H256>,
+        Matcher<H256>,
+        Matcher<Vec<U128>>,
+        U256,
+    );
+
     #[derive(Clone)]
     pub struct SnappContractMock {
         pub get_current_block_timestamp: Mock<(), Result<U256>>,
@@ -414,34 +435,15 @@ pub mod tests {
         pub creation_timestamp_for_auction_slot: Mock<U256, Result<U256>>,
         pub order_hash_for_slot: Mock<U256, Result<H256>>,
         pub has_auction_slot_been_applied: Mock<U256, Result<bool>>,
-        pub apply_deposits: Mock<(U256, Matcher<H256>, Matcher<H256>, Matcher<H256>), Result<()>>,
-        pub apply_withdraws: Mock<
-            (
-                U256,
-                Matcher<H256>,
-                Matcher<H256>,
-                Matcher<H256>,
-                Matcher<H256>,
-            ),
-            Result<()>,
-        >,
-        pub apply_auction: Mock<(U256, Matcher<H256>, Matcher<H256>, Matcher<Vec<u8>>), Result<()>>,
-        pub auction_solution_bid: Mock<
-            (
-                U256,
-                Matcher<H256>,
-                Matcher<H256>,
-                Matcher<H256>,
-                Matcher<Vec<U128>>,
-                U256,
-            ),
-            Result<()>,
-        >,
+        pub apply_deposits: Mock<ApplyDeopositArguments, Result<()>>,
+        pub apply_withdraws: Mock<ApplyWithdrawArguments, Result<()>>,
+        pub apply_auction: Mock<ApplyAuctionArguments, Result<()>>,
+        pub auction_solution_bid: Mock<ApplySolutionArguments, Result<()>>,
         pub calculate_order_hash: Mock<(U256, Matcher<Vec<U128>>), Result<H256>>,
     }
 
     impl SnappContractMock {
-        pub fn new() -> SnappContractMock {
+        pub fn default() -> SnappContractMock {
             SnappContractMock {
                 get_current_block_timestamp: Mock::new(Err(DriverError::new(
                     "Unexpected call to get_current_block_timestamp",

--- a/driver/src/contract.rs
+++ b/driver/src/contract.rs
@@ -442,8 +442,8 @@ pub mod tests {
         pub calculate_order_hash: Mock<(U256, Matcher<Vec<U128>>), Result<H256>>,
     }
 
-    impl SnappContractMock {
-        pub fn default() -> SnappContractMock {
+    impl Default for SnappContractMock {
+        fn default() -> SnappContractMock {
             SnappContractMock {
                 get_current_block_timestamp: Mock::new(Err(DriverError::new(
                     "Unexpected call to get_current_block_timestamp",

--- a/driver/src/deposit_driver.rs
+++ b/driver/src/deposit_driver.rs
@@ -74,7 +74,7 @@ mod tests {
             models::TOKENS,
         );
 
-        let contract = SnappContractMock::new();
+        let contract = SnappContractMock::default();
         contract
             .get_current_deposit_slot
             .given(())
@@ -131,7 +131,7 @@ mod tests {
             models::TOKENS,
         );
 
-        let contract = SnappContractMock::new();
+        let contract = SnappContractMock::default();
         contract
             .get_current_state_root
             .given(())
@@ -179,7 +179,7 @@ mod tests {
             models::TOKENS,
         );
 
-        let contract = SnappContractMock::new();
+        let contract = SnappContractMock::default();
         contract
             .get_current_state_root
             .given(())
@@ -225,7 +225,7 @@ mod tests {
         let first_deposits = vec![create_flux_for_test(0, 1), create_flux_for_test(0, 2)];
         let second_deposits = vec![create_flux_for_test(1, 1), create_flux_for_test(1, 2)];
 
-        let contract = SnappContractMock::new();
+        let contract = SnappContractMock::default();
         contract
             .get_current_deposit_slot
             .given(())
@@ -294,7 +294,7 @@ mod tests {
             models::TOKENS,
         );
 
-        let contract = SnappContractMock::new();
+        let contract = SnappContractMock::default();
         contract
             .get_current_deposit_slot
             .given(())

--- a/driver/src/order_driver.rs
+++ b/driver/src/order_driver.rs
@@ -7,7 +7,12 @@ use crate::util::{
 
 use dfusion_core::database::DbInterface;
 use dfusion_core::models::{
-    AccountState, ConcatenatingHashable, Order, RollingHashable, Serializable, Solution,
+    AccountState, 
+    ConcatenatingHashable, 
+    Order, 
+    RollingHashable, 
+    Serializable, 
+    Solution,
     StandingOrder,
 };
 

--- a/driver/src/price_finding/linear_optimization_price_finder.rs
+++ b/driver/src/price_finding/linear_optimization_price_finder.rs
@@ -266,9 +266,7 @@ pub mod tests {
             read_output: return_result,
         };
 
-        solver
-            .find_prices(&vec![], &state)
-            .expect("Should not fail");
+        solver.find_prices(&[], &state).expect("Should not fail");
 
         let expected_prices: Prices = [
             ("token0".to_owned(), "14024052566155238000".to_owned()),
@@ -333,9 +331,9 @@ pub mod tests {
 
         let expected_solution = models::Solution {
             surplus: U256::from_dec_str("15854632034944469292777429010439194350").ok(),
-            prices: vec![14024052566155238000, 1526784674855762300],
-            executed_sell_amounts: vec![0, 318390084925498118944],
-            executed_buy_amounts: vec![0, 95042777139162480000],
+            prices: vec![14_024_052_566_155_238_000, 1_526_784_674_855_762_300],
+            executed_sell_amounts: vec![0, 318_390_084_925_498_118_944],
+            executed_buy_amounts: vec![0, 95_042_777_139_162_480_000],
         };
 
         let (prices, solution) = deserialize_result(&json, 2).expect("Should not fail to parse");

--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -27,8 +27,8 @@ pub mod tests {
         >,
     }
 
-    impl PriceFindingMock {
-        pub fn default() -> PriceFindingMock {
+    impl Default for PriceFindingMock {
+        fn default() -> PriceFindingMock {
             PriceFindingMock {
                 find_prices: Mock::new(Err(PriceFindingError::new(
                     "Unexpected call to find_prices",

--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -28,7 +28,7 @@ pub mod tests {
     }
 
     impl PriceFindingMock {
-        pub fn new() -> PriceFindingMock {
+        pub fn default() -> PriceFindingMock {
             PriceFindingMock {
                 find_prices: Mock::new(Err(PriceFindingError::new(
                     "Unexpected call to find_prices",

--- a/driver/src/util.rs
+++ b/driver/src/util.rs
@@ -8,7 +8,7 @@ const BATCH_TIME_SECONDS: u32 = 3 * 60;
 
 pub fn find_first_unapplied_slot(
     upper_bound: U256,
-    has_slot_been_applied: &Fn(U256) -> Result<bool, DriverError>,
+    has_slot_been_applied: &dyn Fn(U256) -> Result<bool, DriverError>,
 ) -> Result<U256, DriverError> {
     if upper_bound == U256::max_value() {
         return Ok(U256::zero());
@@ -49,7 +49,7 @@ pub enum ProcessingState {
 pub fn batch_processing_state<C>(
     slot: U256,
     contract: &C,
-    creation_block_time: &Fn(U256) -> Result<U256, DriverError>,
+    creation_block_time: &dyn Fn(U256) -> Result<U256, DriverError>,
 ) -> Result<ProcessingState, DriverError>
 where
     C: SnappContract,

--- a/driver/src/withdraw_driver.rs
+++ b/driver/src/withdraw_driver.rs
@@ -15,10 +15,9 @@ where
     let withdraw_slot = contract.get_current_withdraw_slot()?;
 
     info!("Current top withdraw_slot is {:?}", withdraw_slot);
-    let slot = find_first_unapplied_slot(
-        withdraw_slot,
-        &|i| contract.has_withdraw_slot_been_applied(i),
-    )?;
+    let slot = find_first_unapplied_slot(withdraw_slot, &|i| {
+        contract.has_withdraw_slot_been_applied(i)
+    })?;
     if slot <= withdraw_slot {
         info!("Highest unprocessed withdraw_slot is {:?}", slot);
         let processing_state = batch_processing_state(slot, contract, &|i| {
@@ -82,7 +81,7 @@ mod tests {
             TOKENS,
         );
 
-        let contract = SnappContractMock::new();
+        let contract = SnappContractMock::default();
         contract
             .get_current_withdraw_slot
             .given(())
@@ -130,7 +129,7 @@ mod tests {
     #[test]
     fn does_not_apply_if_highest_slot_already_applied() {
         let slot = U256::from(1);
-        let contract = SnappContractMock::new();
+        let contract = SnappContractMock::default();
         contract
             .get_current_withdraw_slot
             .given(())
@@ -147,7 +146,7 @@ mod tests {
     #[test]
     fn does_not_apply_if_highest_slot_too_close_to_current_block() {
         let slot = U256::from(1);
-        let contract = SnappContractMock::new();
+        let contract = SnappContractMock::default();
         contract
             .get_current_withdraw_slot
             .given(())
@@ -181,7 +180,7 @@ mod tests {
         let first_withdraws = vec![create_flux_for_test(0, 1), create_flux_for_test(0, 2)];
         let second_withdraws = vec![create_flux_for_test(1, 1), create_flux_for_test(1, 2)];
 
-        let contract = SnappContractMock::new();
+        let contract = SnappContractMock::default();
         contract
             .get_current_withdraw_slot
             .given(())
@@ -252,7 +251,7 @@ mod tests {
             TOKENS,
         );
 
-        let contract = SnappContractMock::new();
+        let contract = SnappContractMock::default();
         contract
             .get_current_withdraw_slot
             .given(())
@@ -318,9 +317,9 @@ mod tests {
         );
         state.decrement_balance(1, 0, 100);
 
-        let merkle_root = withdraws.root_hash(&vec![true, false]);
+        let merkle_root = withdraws.root_hash(&[true, false]);
 
-        let contract = SnappContractMock::new();
+        let contract = SnappContractMock::default();
         contract
             .get_current_withdraw_slot
             .given(())

--- a/listener/src/event_handler/auction_settlement_handler.rs
+++ b/listener/src/event_handler/auction_settlement_handler.rs
@@ -23,11 +23,11 @@ use super::EventHandler;
 
 #[derive(Clone)]
 pub struct AuctionSettlementHandler {
-    store: Arc<DbInterface>,
+    store: Arc<dyn DbInterface>,
 }
 
 impl AuctionSettlementHandler {
-    pub fn new(store: Arc<DbInterface>) -> Self {
+    pub fn new(store: Arc<dyn DbInterface>) -> Self {
         AuctionSettlementHandler { store }
     }
 }
@@ -171,10 +171,10 @@ pub mod unit_test {
         let expected_new_state =
             AccountState::new(H256::from(1), U256::from(1), vec![0, 1, 0, 0], TOKENS);
         match result.unwrap().pop().unwrap() {
-            EntityOperation::Set { key: _, data } => {
+            EntityOperation::Set { data, .. } => {
                 assert_eq!(AccountState::from(data), expected_new_state)
             }
-            _ => assert!(false),
+            _ => unreachable!(),
         }
     }
 

--- a/listener/src/event_handler/flux_transition_handler.rs
+++ b/listener/src/event_handler/flux_transition_handler.rs
@@ -9,11 +9,11 @@ use web3::types::{H256, U256};
 
 #[derive(Clone)]
 pub struct FluxTransitionHandler {
-    store: Arc<DbInterface>,
+    store: Arc<dyn DbInterface>,
 }
 
 impl FluxTransitionHandler {
-    pub fn new(store: Arc<DbInterface>) -> Self {
+    pub fn new(store: Arc<dyn DbInterface>) -> Self {
         FluxTransitionHandler { store }
     }
 }

--- a/listener/src/link_resolver.rs
+++ b/listener/src/link_resolver.rs
@@ -31,7 +31,7 @@ impl LinkResolverTrait for LocalLinkResolver {
         &self,
         logger: &Logger,
         link: &Link,
-    ) -> Box<Future<Item = Vec<u8>, Error = failure::Error> + Send> {
+    ) -> Box<dyn Future<Item = Vec<u8>, Error = failure::Error> + Send> {
         info!(logger, "Resolving link {}", &link.link);
         match read_file(&link.link) {
             Ok(res) => Box::new(ok(res)),
@@ -42,7 +42,7 @@ impl LinkResolverTrait for LocalLinkResolver {
     fn json_stream(
         &self,
         _link: &Link,
-    ) -> Box<Future<Item = JsonValueStream, Error = failure::Error> + Send + 'static> {
+    ) -> Box<dyn Future<Item = JsonValueStream, Error = failure::Error> + Send + 'static> {
         unimplemented!();
     }
 }

--- a/listener/src/runtime_host.rs
+++ b/listener/src/runtime_host.rs
@@ -30,11 +30,11 @@ fn register_event(handlers: &mut HandlerMap, name: &str, handler: Box<dyn EventH
 
 #[derive(Clone)]
 pub struct RustRuntimeHostBuilder {
-    store: Arc<DbInterface>,
+    store: Arc<dyn DbInterface>,
 }
 
 impl RustRuntimeHostBuilder {
-    pub fn new(store: Arc<DbInterface>) -> Self {
+    pub fn new(store: Arc<dyn DbInterface>) -> Self {
         RustRuntimeHostBuilder { store }
     }
 }
@@ -57,7 +57,7 @@ pub struct RustRuntimeHost {
 }
 
 impl RustRuntimeHost {
-    fn new(store: Arc<DbInterface>) -> Self {
+    fn new(store: Arc<dyn DbInterface>) -> Self {
         let mut handlers = HashMap::new();
         register_event(
             &mut handlers,
@@ -120,7 +120,7 @@ impl RuntimeHostTrait for RustRuntimeHost {
         transaction: Arc<Transaction>,
         log: Arc<Log>,
         state: BlockState,
-    ) -> Box<Future<Item = BlockState, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send> {
         info!(logger, "Received event");
         let mut state = state;
         if let Some(handler) = self.handlers.get(&log.topics[0]) {
@@ -142,7 +142,7 @@ impl RuntimeHostTrait for RustRuntimeHost {
         _transaction: Arc<Transaction>,
         _call: Arc<EthereumCall>,
         _state: BlockState,
-    ) -> Box<Future<Item = BlockState, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send> {
         unimplemented!();
     }
 
@@ -153,7 +153,7 @@ impl RuntimeHostTrait for RustRuntimeHost {
         _block: Arc<EthereumBlock>,
         _trigger_type: EthereumBlockTriggerType,
         _state: BlockState,
-    ) -> Box<Future<Item = BlockState, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send> {
         unimplemented!();
     }
 }


### PR DESCRIPTION
This PR fixes a bunch of clippy suggestions which are not land blocking (since they are minor). More specifically:

- trait objects without an explicit `dyn` are deprecated
- &vec![...] == &[...]
- complex types in mocks should be extracted (typedef)
- new methods without arguments should be implemented via Default trait
- don't use clone on copy types