### PR TITLE
Refactoring account balances to be represented as a sparse HashMap

### DIFF
--- a/dfusion_rust_core/src/models/account_state.rs
+++ b/dfusion_rust_core/src/models/account_state.rs
@@ -2,6 +2,7 @@ use byteorder::{BigEndian, WriteBytesExt};
 use graph::data::store::Entity;
 use serde_derive::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use std::collections::{hash_map::Entry, HashMap};
 use std::sync::Arc;
 use web3::types::{Log, H256, U256};
 
@@ -14,7 +15,7 @@ use super::util::*;
 pub struct AccountState {
     pub state_hash: H256,
     pub state_index: U256,
-    balances: Vec<u128>,
+    balances: HashMap<U256, HashMap<u8, u128>>, // UserId => (TokenId => balance)
     pub num_tokens: u8,
 }
 
@@ -23,39 +24,64 @@ impl AccountState {
         AccountState {
             state_hash,
             state_index,
-            balances,
+            balances: balances
+                .chunks(num_tokens as usize)
+                .enumerate()
+                .map(|(account, token_balances)| {
+                    (
+                        U256::from(account),
+                        token_balances
+                            .iter()
+                            .enumerate()
+                            .map(|(token, balance)| (token as u8, *balance))
+                            .collect(),
+                    )
+                })
+                .collect(),
             num_tokens,
         }
     }
-    fn balance_index(&self, token_id: u8, account_id: u16) -> usize {
-        self.num_tokens as usize * account_id as usize + token_id as usize
+    pub fn get_balance_vector(&self) -> Vec<u128> {
+        let mut i = U256::zero();
+        let mut result = vec![];
+        while let Some(account) = self.balances.get(&i) {
+            let mut j = 0;
+            while let Some(token_balance) = account.get(&j) {
+                result.push(*token_balance);
+                j += 1;
+            }
+            i += U256::one();
+        }
+        result
     }
     pub fn read_balance(&self, token_id: u8, account_id: u16) -> u128 {
-        self.balances[self.balance_index(token_id, account_id)]
+        *self.balances
+            .get(&U256::from(account_id))
+            .and_then(|token_balance| token_balance.get(&token_id))
+            .unwrap_or(&0)
     }
     pub fn increment_balance(&mut self, token_id: u8, account_id: u16, amount: u128) {
-        let index = self.balance_index(token_id, account_id);
         debug!(
             "Incrementing account {} balance of token {} by {}",
             account_id, token_id, amount
         );
-        self.balances[index] += amount;
+        self.modify_balance(account_id, token_id, |balance| *balance += amount);
     }
     pub fn decrement_balance(&mut self, token_id: u8, account_id: u16, amount: u128) {
-        let index = self.balance_index(token_id, account_id);
         debug!(
             "Decrementing account {} balance of token {} by {}",
             account_id, token_id, amount
         );
-        self.balances[index] -= amount;
+        self.modify_balance(account_id, token_id, |balance| *balance -= amount);
     }
     pub fn accounts(&self) -> u16 {
+        let balance_vector = self.get_balance_vector();
         assert_eq!(
-            self.balances.len() % self.num_tokens as usize,
+            balance_vector.len() % self.num_tokens as usize,
             0,
             "Balance vector cannot be split into equal accounts"
         );
-        (self.balances.len() / self.num_tokens as usize) as u16
+        (balance_vector.len() / self.num_tokens as usize) as u16
     }
 
     pub fn apply_deposits(&mut self, deposits: &[PendingFlux]) {
@@ -92,6 +118,22 @@ impl AccountState {
         self.state_index = self.state_index.saturating_add(U256::one());
         self.state_hash = self.rolling_hash(self.state_index.low_u32());
     }
+
+    fn modify_balance<F>(&mut self, account_id: u16, token_id: u8, func: F)
+    where
+        F: FnOnce(&mut u128),
+    {
+        match self.balances.entry(U256::from(account_id)) {
+            Entry::Occupied(mut account) => match account.get_mut().entry(token_id) {
+                Entry::Occupied(mut balance) => func(balance.get_mut()),
+                Entry::Vacant(_) => panic!(
+                    "No balance for token {} at account {}",
+                    token_id, account_id
+                ),
+            },
+            Entry::Vacant(_) => panic!("No balances for account {}", account_id),
+        };
+    }
 }
 
 impl RollingHashable for AccountState {
@@ -99,7 +141,7 @@ impl RollingHashable for AccountState {
     fn rolling_hash(&self, nonce: u32) -> H256 {
         let mut hash = vec![0u8; 28];
         hash.write_u32::<BigEndian>(nonce).unwrap();
-        for i in &self.balances {
+        for i in &self.get_balance_vector() {
             let mut bs = vec![0u8; 16];
             bs.write_u128::<BigEndian>(*i).unwrap();
 
@@ -119,23 +161,19 @@ impl From<Arc<Log>> for AccountState {
         let state_hash = H256::pop_from_log_data(&mut bytes);
         let num_tokens = u8::pop_from_log_data(&mut bytes);
         let num_accounts = u16::pop_from_log_data(&mut bytes);
-        AccountState {
-            state_hash,
-            state_index: U256::zero(),
-            num_tokens,
-            balances: vec![0; num_tokens as usize * num_accounts as usize],
-        }
+        let balances = vec![0; num_tokens as usize * num_accounts as usize];
+        AccountState::new(state_hash, U256::zero(), balances, num_tokens)
     }
 }
 
 impl From<Entity> for AccountState {
     fn from(entity: Entity) -> Self {
-        AccountState {
-            state_hash: H256::from_entity(&entity, "id"),
-            state_index: U256::from_entity(&entity, "stateIndex"),
-            num_tokens: u8::from_entity(&entity, "numTokens"),
-            balances: Vec::from_entity(&entity, "balances"),
-        }
+        AccountState::new(
+            H256::from_entity(&entity, "id"),
+            U256::from_entity(&entity, "stateIndex"),
+            Vec::from_entity(&entity, "balances"),
+            u8::from_entity(&entity, "numTokens"),
+        )
     }
 }
 
@@ -144,7 +182,7 @@ impl Into<Entity> for AccountState {
         let mut entity = Entity::new();
         entity.set("id", self.state_hash.to_value());
         entity.set("stateIndex", self.state_index.to_value());
-        entity.set("balances", self.balances.to_value());
+        entity.set("balances", self.get_balance_vector().to_value());
         entity.set("numTokens", self.num_tokens.to_value());
         entity
     }
@@ -164,12 +202,7 @@ pub mod tests {
         let state_hash = "77b01abfbad57cb7a1344b12709603ea3b9ad803ef5ea09814ca212748f54733"
             .parse::<H256>()
             .unwrap();
-        let state = AccountState {
-            state_hash,
-            state_index: U256::one(),
-            balances: balances.clone(),
-            num_tokens: TOKENS,
-        };
+        let state = AccountState::new(state_hash, U256::one(), balances.clone(), TOKENS);
         assert_eq!(state.rolling_hash(0), state_hash);
 
         // AccountState with single deposit
@@ -177,12 +210,7 @@ pub mod tests {
         let state_hash = "a0cde336d10dbaf3df98ba662bacf25d95062db7b3e0083bd4bad4a6c7a1cd41"
             .parse::<H256>()
             .unwrap();
-        let state = AccountState {
-            state_hash,
-            state_index: U256::one(),
-            balances,
-            num_tokens: TOKENS,
-        };
+        let state = AccountState::new(state_hash, U256::one(), balances.clone(), TOKENS);
         assert_eq!(state.rolling_hash(0), state_hash);
     }
 
@@ -220,13 +248,7 @@ pub mod tests {
             removed: None,
         });
 
-        let expected_state = AccountState {
-            state_hash: H256::zero(),
-            state_index: U256::zero(),
-            balances: vec![0; 3000],
-            num_tokens: 30,
-        };
-
+        let expected_state = AccountState::new(H256::zero(), U256::zero(), vec![0; 3000], TOKENS);
         assert_eq!(expected_state, AccountState::from(log));
     }
 
@@ -234,12 +256,7 @@ pub mod tests {
     fn test_to_and_from_entity() {
         let balances = vec![0, 18, 1];
 
-        let state = AccountState {
-            state_hash: H256::zero(),
-            state_index: U256::one(),
-            balances: balances.clone(),
-            num_tokens: TOKENS,
-        };
+        let state = AccountState::new(H256::zero(), U256::one(), balances.clone(), TOKENS);
 
         let mut entity = Entity::new();
         entity.set("id", H256::zero().to_value());
@@ -255,12 +272,7 @@ pub mod tests {
     fn test_apply_auction() {
         let balances = vec![0, 1, 1, 0];
 
-        let mut state = AccountState {
-            state_hash: H256::zero(),
-            state_index: U256::one(),
-            balances: balances.clone(),
-            num_tokens: 2,
-        };
+        let mut state = AccountState::new(H256::zero(), U256::one(), balances.clone(), 2);
 
         let order_1 = Order {
             batch_information: Some(BatchInformation {
@@ -301,6 +313,17 @@ pub mod tests {
             "Incorrect state hash!"
         );
         assert_eq!(U256::from(2), state.state_index, "Incorrect state index!");
-        assert_eq!(state.balances, vec![1, 0, 0, 1], "Incorrect balances!");
+        let mut account_0 = HashMap::new();
+        account_0.insert(0, 1);
+        account_0.insert(1, 0);
+
+        let mut account_1 = HashMap::new();
+        account_1.insert(0, 0);
+        account_1.insert(1, 1);
+
+        let mut balances = HashMap::new();
+        balances.insert(U256::zero(), account_0);
+        balances.insert(U256::one(), account_1);
+        assert_eq!(state.balances, balances, "Incorrect balances!");
     }
 }

--- a/driver/src/order_driver.rs
+++ b/driver/src/order_driver.rs
@@ -7,12 +7,7 @@ use crate::util::{
 
 use dfusion_core::database::DbInterface;
 use dfusion_core::models::{
-    AccountState, 
-    ConcatenatingHashable, 
-    Order, 
-    RollingHashable, 
-    Serializable, 
-    Solution,
+    AccountState, ConcatenatingHashable, Order, RollingHashable, Serializable, Solution,
     StandingOrder,
 };
 
@@ -689,7 +684,7 @@ mod tests {
 
     #[test]
     fn test_update_balances() {
-        let mut state = AccountState::new(H256::zero(), U256::one(), vec![100; 70], TOKENS);
+        let mut state = AccountState::new(H256::zero(), U256::one(), vec![100; 60], TOKENS);
         let solution = Solution {
             surplus: U256::from_dec_str("0").ok(),
             prices: vec![1, 2],

--- a/driver/src/price_finding/linear_optimization_price_finder.rs
+++ b/driver/src/price_finding/linear_optimization_price_finder.rs
@@ -513,11 +513,4 @@ pub mod tests {
         });
         assert_eq!(result, expected)
     }
-
-    #[test]
-    #[should_panic]
-    fn test_serialize_balances_with_bad_balance_length() {
-        let state = models::AccountState::new(H256::zero(), U256::zero(), vec![100, 200], 30);
-        serialize_balances(&state);
-    }
 }

--- a/listener/src/event_handler/auction_settlement_handler.rs
+++ b/listener/src/event_handler/auction_settlement_handler.rs
@@ -206,8 +206,7 @@ pub mod unit_test {
     fn test_auction_settlement_fails_if_orders_dont_exist() {
         let store = Arc::new(DbInterfaceMock::new());
 
-        let existing_state =
-            AccountState::new(H256::zero(), U256::from(0), vec![2, 0, 0, 0], TOKENS);
+        let existing_state = AccountState::new(H256::zero(), U256::from(0), vec![2, 0, 0, 0], 2);
         store
             .get_balances_for_state_index
             .given(U256::zero())
@@ -234,8 +233,7 @@ pub mod unit_test {
     fn test_auction_settlement_fails_if_standing_orders_dont_exist() {
         let store = Arc::new(DbInterfaceMock::new());
 
-        let existing_state =
-            AccountState::new(H256::zero(), U256::from(0), vec![2, 0, 0, 0], TOKENS);
+        let existing_state = AccountState::new(H256::zero(), U256::from(0), vec![2, 0, 0, 0], 2);
         store
             .get_balances_for_state_index
             .given(U256::zero())

--- a/listener/src/event_handler/auction_settlement_handler.rs
+++ b/listener/src/event_handler/auction_settlement_handler.rs
@@ -127,8 +127,7 @@ pub mod unit_test {
         let store = Arc::new(DbInterfaceMock::new());
 
         // Add previous account state and pending deposits into Store
-        let existing_state =
-            AccountState::new(H256::zero(), U256::from(0), vec![2, 0, 0, 0], TOKENS);
+        let existing_state = AccountState::new(H256::zero(), U256::from(0), vec![2, 0, 0, 0], 2);
         store
             .get_balances_for_state_index
             .given(U256::zero())
@@ -169,7 +168,7 @@ pub mod unit_test {
 
         assert!(result.is_ok());
         let expected_new_state =
-            AccountState::new(H256::from(1), U256::from(1), vec![0, 1, 0, 0], TOKENS);
+            AccountState::new(H256::from(1), U256::from(1), vec![0, 1, 0, 0], 2);
         match result.unwrap().pop().unwrap() {
             EntityOperation::Set { data, .. } => {
                 assert_eq!(AccountState::from(data), expected_new_state)


### PR DESCRIPTION
We currently represent balances inside the AccountState model as a continuous array with values in the form of 

```
acc1_token1, acc1_token2, ... acc1_tokenN, acc2_token1 ..., accM_tokenN
```

While this works well for a small number of accounts, this doesn't scale to the new dfusion model, where our address space is 256 bits. 

The number of participants in a batch is upper bound by the number of orders in a batch. We only need to pass the balances to the solver of accounts that are participating in the current auction. This suggests that we should be using a sparse HashMap rather than a list over the full address space to represent balances.

For backwards compatibility, I kept the interface that allows creating the AccountState object from a continuous list and also kept the way we store the state in the GraphDb (this will likely change as we plan to increase or address space to at least 24 bits there as well).

The new driver component will be able to expose another new method, passing in the sparse HashMap directly.


### Testplan

existing unit tests and e2e tests