### PR TITLE
Fixing linear optimzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ cargo test --lib
 
 For this to work, you will need to have read access to the [solver's gitlab repo](https://gitlab.gnosisdev.com/dfusion/batchauctions). You will also need to have SSH Key authentication for your gitlab account enabled (see [tutorial](https://docs.gitlab.com/ee/ssh/))
 
-In your top-level git folder, create a `.ssh/` folder and move or copy the private and public ssh key that are registered with your gitlab account in there.
+In your top-level git folder, create a `.ssh/` folder and move or copy the private and public ssh key (`id_rsa` & `id_rsa.pub`) registered with your gitlab account in there.
 Then, run
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -105,6 +105,19 @@ cd driver
 cargo test --lib
 ```
 
+## Running with linear optimization solver
+
+For this to work, you will need to have read access to the [solver's gitlab repo](https://gitlab.gnosisdev.com/dfusion/batchauctions). You will also need to have SSH Key authentication for your gitlab account enabled (see [tutorial](https://docs.gitlab.com/ee/ssh/))
+
+In your top-level git folder, create a `.ssh/` folder and move or copy the private and public ssh key that are registered with your gitlab account in there.
+Then, run
+
+```sh
+docker-compose build --build-arg use_solver=1 driver
+```
+
+Afterwards, when you run your environment with `docker-compose up` the linear optimizer should be automatically used. Note that the e2e might no longer work, as their resolution depends on the naive and not the optimal solving strategy.
+
 ## Troubleshooting
 
 #### docker-compose build

--- a/docker/rust/clone_solver.sh
+++ b/docker/rust/clone_solver.sh
@@ -4,13 +4,14 @@ set -e
 # Authorize SSH Host
 mkdir -p /root/.ssh
 chmod 0700 /root/.ssh && \
-ssh-keyscan gitlab.com > /root/.ssh/known_hosts
+ssh-keyscan gitlab.gnosisdev.com > /root/.ssh/known_hosts
 
 # Copy SSH key
 cp .ssh/id_rsa /root/.ssh/id_rsa
 cp .ssh/id_rsa.pub /root/.ssh/id_rsa.pub
 
 # Clone and install dependencies
-git clone git@gitlab.com:twalth3r/batchauctions.git
+git clone git@gitlab.gnosisdev.com:dfusion/batchauctions.git
 cd batchauctions
+git checkout v0.1
 pip install -r requirements.txt

--- a/driver/src/price_finding/linear_optimization_price_finder.rs
+++ b/driver/src/price_finding/linear_optimization_price_finder.rs
@@ -213,7 +213,7 @@ fn write_input(input_file: &str, input: &serde_json::Value) -> std::io::Result<(
 
 fn run_solver(input_file: &str) -> Result<(), PriceFindingError> {
     let output = Command::new("python")
-        .arg("../batchauctions/scripts/optimize_e2e.py")
+        .arg("./batchauctions/scripts/optimize_e2e.py")
         .arg(input_file)
         .args(&["--solverTimelimit", "120"])
         .args(&["--outputDir", RESULT_FOLDER])


### PR DESCRIPTION
Using the linear solver was broken (like everything that doesn't run as part of CI usually is), because the path from which the driver is run changed one up (when moving from rust projects to rust workspace).

I used this opportunity to adjust the repo to the new gitlab repo, add some explanation in the README and pin the repo against a version that we know works with the old prototype.

When running the stablecoin excange, we'll likely make the tag/rev an environment variable so it can be different for StableX and dƒusion.

### Test Plan

Follow the steps in the readme to make sure the linear optimiser is giving good auction results (I ran the auciton e2e test to try it out).