### PR TITLE
Implement fee mechanism for naive solver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3289,7 +3289,7 @@ name = "yaml-rust"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]

--- a/driver/src/bin/main.rs
+++ b/driver/src/bin/main.rs
@@ -5,8 +5,8 @@ use dfusion_core::database::GraphReader;
 
 use driver::contract::SnappContractImpl;
 use driver::order_driver::OrderProcessor;
-use driver::price_finding::NaiveSolver;
 use driver::price_finding::LinearOptimisationPriceFinder;
+use driver::price_finding::NaiveSolver;
 use driver::price_finding::PriceFinding;
 use driver::run_driver_components;
 
@@ -21,18 +21,16 @@ fn main() {
     // driver logger
     simple_logger::init_with_level(log::Level::Info).unwrap();
     let graph_logger = logger(false);
-    
     let postgres_url = env::var("POSTGRES_URL").expect("Specify POSTGRES_URL variable");
     let store_reader = GraphNodeReader::new(postgres_url, &graph_logger);
     let db_instance = GraphReader::new(Box::new(store_reader));
     let contract = SnappContractImpl::new().unwrap();
-    
 
     let solver_env_var = env::var("LINEAR_OPTIMIZATION_SOLVER").unwrap_or_else(|_| "0".to_string());
     let mut price_finder: Box<dyn PriceFinding> = if solver_env_var == "1" {
         Box::new(LinearOptimisationPriceFinder::new())
     } else {
-        Box::new(NaiveSolver {})
+        Box::new(NaiveSolver::new(None))
     };
 
     let mut order_processor = OrderProcessor::new(&db_instance, &contract, &mut *price_finder);

--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -2,6 +2,13 @@ use dfusion_core::models;
 
 use super::error::PriceFindingError;
 
+#[derive(Clone)]
+pub struct Fee {
+    pub token: u8,
+    /// Value between [0, 1] mapping from 0% -> 100%
+    pub percentage: f64,
+}
+
 pub trait PriceFinding {
     fn find_prices(
         &mut self,


### PR DESCRIPTION
This PR adds an optional fee parameter to the NaiveSolver. The logic is changed as follows:
1) We make "space" for the fee to be taken. This is we change the limit price to be more permissive. To achieve this we either require more stuff to be bought or less stuff to be sold (both would make the deal "better" for the user).
2) We do the matching logic as before
3) We post-process the volumes taking away the fees (increasing sellVolume if feeToken is sold, reducing buyVolume if fee token is bought)

### Example

```
Order {
    account_id: 0,
    sell_token: 0,
    buy_token: 1,
    sell_amount: 20000,
    buy_amount: 9990,
},
Order {
    account_id: 0,
    sell_token: 1,
    buy_token: 0,
    sell_amount: 9990,
    buy_amount: 19960,
},
```

Adjusted orders after step 1)
```
Order {
    account_id: 0,
    sell_token: 0,
    buy_token: 1,
    sell_amount: 19980,
    buy_amount: 9990,
},
Order {
    account_id: 0,
    sell_token: 1,
    buy_token: 0,
    sell_amount: 9990,
    buy_amount: 19980 ,
},
```

Normal matching step 2) gives the following volumes:

```
Sell: [19980, 9990]
Buy [9990, 19980]
```

Adjusted volumes after step 3):

```
Sell: [20000, 9990]
Buy [9990, 19960]
```

Leading to a surplus of 40 units of token 0 (fee that goes to the solution finder)

### Test Plan

Added example as a unit test (comes from the [dex-smart contract repo](https://github.com/gnosis/dex-contracts/blob/master/test/stablecoin_converter.js#L38))

Also making sure current build (E2E tests) aren't broken