### PR TITLE
[Refactor] Make Accounts wide enough to hold addresses

### DIFF
--- a/dfusion_rust_core/src/models/flux.rs
+++ b/dfusion_rust_core/src/models/flux.rs
@@ -1,8 +1,9 @@
 use byteorder::{BigEndian, WriteBytesExt};
 use graph::data::store::Entity;
 use serde_derive::{Deserialize, Serialize};
+use std::convert::TryInto;
 use std::sync::Arc;
-use web3::types::{Log, H256, U256};
+use web3::types::{Log, H160, H256, U256};
 
 use super::util::*;
 use crate::models::{merkleize, RootHashable, Serializable};
@@ -12,7 +13,7 @@ use crate::models::{merkleize, RootHashable, Serializable};
 pub struct PendingFlux {
     pub slot_index: u16,
     pub slot: U256,
-    pub account_id: u16,
+    pub account_id: H160,
     pub token_id: u8,
     pub amount: u128,
 }
@@ -20,7 +21,8 @@ pub struct PendingFlux {
 impl Serializable for PendingFlux {
     fn bytes(&self) -> Vec<u8> {
         let mut wtr = vec![0; 13];
-        wtr.write_u16::<BigEndian>(self.account_id).unwrap();
+        wtr.write_u16::<BigEndian>(self.account_id.low_u64().try_into().unwrap())
+            .unwrap();
         wtr.write_u8(self.token_id).unwrap();
         wtr.write_u128::<BigEndian>(self.amount).unwrap();
         wtr
@@ -31,7 +33,7 @@ impl From<Arc<Log>> for PendingFlux {
     fn from(log: Arc<Log>) -> Self {
         let mut bytes: Vec<u8> = log.data.0.clone();
         PendingFlux {
-            account_id: u16::pop_from_log_data(&mut bytes),
+            account_id: H160::pop_from_log_data(&mut bytes),
             token_id: u8::pop_from_log_data(&mut bytes),
             amount: u128::pop_from_log_data(&mut bytes),
             slot: U256::pop_from_log_data(&mut bytes),
@@ -43,7 +45,7 @@ impl From<Arc<Log>> for PendingFlux {
 impl From<Entity> for PendingFlux {
     fn from(entity: Entity) -> Self {
         PendingFlux {
-            account_id: u16::from_entity(&entity, "accountId"),
+            account_id: H160::from_entity(&entity, "accountId"),
             token_id: u8::from_entity(&entity, "tokenId"),
             amount: u128::from_entity(&entity, "amount"),
             slot: U256::from_entity(&entity, "slot"),
@@ -82,7 +84,7 @@ pub mod tests {
         PendingFlux {
             slot_index,
             slot: U256::from(slot),
-            account_id: 1,
+            account_id: H160::from(1),
             token_id: 1,
             amount: 10,
         }
@@ -101,7 +103,7 @@ pub mod unit_test {
         let deposit = PendingFlux {
             slot_index: 0,
             slot: U256::zero(),
-            account_id: 3,
+            account_id: H160::from(3),
             token_id: 3,
             amount: 18,
         };
@@ -164,7 +166,7 @@ pub mod unit_test {
         });
 
         let expected_flux = PendingFlux {
-            account_id: 1,
+            account_id: H160::from(1),
             token_id: 1,
             amount: (10 as u128).pow(18),
             slot: U256::zero(),
@@ -177,7 +179,7 @@ pub mod unit_test {
     #[test]
     fn test_to_and_from_entity() {
         let flux = PendingFlux {
-            account_id: 1,
+            account_id: H160::from(1),
             token_id: 1,
             amount: (10 as u128).pow(18),
             slot: U256::zero(),
@@ -186,7 +188,7 @@ pub mod unit_test {
 
         let mut entity = Entity::new();
         entity.set("id", "0 - 0");
-        entity.set("accountId", 1);
+        entity.set("accountId", "0000000000000000000000000000000000000001");
         entity.set("tokenId", 1);
         entity.set("amount", BigDecimal::from((10 as u64).pow(18)));
         entity.set("slot", BigDecimal::from(0));

--- a/dfusion_rust_core/src/models/flux.rs
+++ b/dfusion_rust_core/src/models/flux.rs
@@ -1,7 +1,6 @@
 use byteorder::{BigEndian, WriteBytesExt};
 use graph::data::store::Entity;
 use serde_derive::{Deserialize, Serialize};
-use std::convert::TryInto;
 use std::sync::Arc;
 use web3::types::{Log, H160, H256, U256};
 
@@ -21,8 +20,10 @@ pub struct PendingFlux {
 impl Serializable for PendingFlux {
     fn bytes(&self) -> Vec<u8> {
         let mut wtr = vec![0; 13];
-        wtr.write_u16::<BigEndian>(self.account_id.low_u64().try_into().unwrap())
-            .unwrap();
+        // For now we only write the low 2 bytes, since for the purpose of hashing,
+        // the account space is still 16 bits
+        wtr.write_u8(self.account_id[18]).unwrap();
+        wtr.write_u8(self.account_id[19]).unwrap();
         wtr.write_u8(self.token_id).unwrap();
         wtr.write_u128::<BigEndian>(self.amount).unwrap();
         wtr

--- a/dfusion_rust_core/src/models/order.rs
+++ b/dfusion_rust_core/src/models/order.rs
@@ -1,7 +1,6 @@
-use byteorder::{BigEndian, WriteBytesExt};
+use byteorder::WriteBytesExt;
 use graph::data::store::Entity;
 use serde_derive::Deserialize;
-use std::convert::TryInto;
 use std::sync::Arc;
 use web3::types::{Log, H160, H256, U256};
 
@@ -56,8 +55,10 @@ impl Serializable for Order {
         wtr.extend(self.sell_amount.bytes());
         wtr.write_u8(self.sell_token).unwrap();
         wtr.write_u8(self.buy_token).unwrap();
-        wtr.write_u16::<BigEndian>(self.account_id.low_u64().try_into().unwrap())
-            .unwrap();
+        // For now we only write the low 2 bytes, since for the purpose of hashing,
+        // the account space is still 16 bits
+        wtr.write_u8(self.account_id[18]).unwrap();
+        wtr.write_u8(self.account_id[19]).unwrap();
         wtr
     }
 }

--- a/dfusion_rust_core/src/models/util.rs
+++ b/dfusion_rust_core/src/models/util.rs
@@ -4,7 +4,7 @@ use graph::data::store::{Entity, Value};
 use std::convert::TryFrom;
 use std::convert::TryInto;
 use std::str::FromStr;
-use web3::types::{H256, U256};
+use web3::types::{H160, H256, U256};
 
 pub trait PopFromLogData {
     fn pop_from_log_data(bytes: &mut Vec<u8>) -> Self;
@@ -31,6 +31,12 @@ impl PopFromLogData for u128 {
 impl PopFromLogData for U256 {
     fn pop_from_log_data(bytes: &mut Vec<u8>) -> Self {
         U256::from_big_endian(bytes.drain(0..32).collect::<Vec<u8>>().as_slice())
+    }
+}
+
+impl PopFromLogData for H160 {
+    fn pop_from_log_data(bytes: &mut Vec<u8>) -> Self {
+        H256::from(bytes.drain(0..32).collect::<Vec<u8>>().as_slice()).into()
     }
 }
 
@@ -71,6 +77,12 @@ impl ToValue for u128 {
 impl ToValue for U256 {
     fn to_value(&self) -> Value {
         BigDecimal::from_str(&self.to_string()).unwrap().into()
+    }
+}
+
+impl ToValue for H160 {
+    fn to_value(&self) -> Value {
+        format!("{:x}", self).into()
     }
 }
 
@@ -140,6 +152,18 @@ impl EntityParsing for U256 {
                 .unwrap_or_else(|| panic!("Couldn't get field {} as big decimal", field)),
         )
         .unwrap_or_else(|_| panic!("Couldn't cast {} from string to U256", field))
+    }
+}
+
+impl EntityParsing for H160 {
+    fn from_entity(entity: &Entity, field: &str) -> Self {
+        H160::from_str(
+            &entity
+                .get(field)
+                .and_then(|value| value.clone().as_string())
+                .unwrap_or_else(|| panic!("Couldn't get field {} as string", field)),
+        )
+        .unwrap_or_else(|_| panic!("Couldn't cast {} from string to H160", field))
     }
 }
 

--- a/driver/src/order_driver.rs
+++ b/driver/src/order_driver.rs
@@ -199,7 +199,7 @@ mod tests {
     use dfusion_core::models::order::tests::create_order_for_test;
     use dfusion_core::models::{NUM_RESERVED_ACCOUNTS, TOKENS};
     use mock_it::Matcher::*;
-    use web3::types::{H256, U128, U256};
+    use web3::types::{H160, H256, U128, U256};
 
     #[test]
     fn bids_for_and_applies_auction_if_unapplied_and_enough_blocks_passed() {
@@ -588,7 +588,7 @@ mod tests {
         let slot = U256::from(1);
         let state_hash = H256::zero();
         let standing_order = StandingOrder::new(
-            1,
+            H160::from(1),
             U256::zero(),
             U256::from(3),
             vec![create_order_for_test(), create_order_for_test()],
@@ -666,12 +666,12 @@ mod tests {
     #[test]
     fn test_get_standing_orders_indexes() {
         let standing_order = StandingOrder::new(
-            1,
+            H160::from(1),
             U256::from(3),
             U256::from(2),
             vec![create_order_for_test(), create_order_for_test()],
         );
-        let empty_order = StandingOrder::new(0, U256::zero(), U256::from(2), vec![]);
+        let empty_order = StandingOrder::new(H160::zero(), U256::zero(), U256::from(2), vec![]);
         let mut standing_orders = vec![empty_order; NUM_RESERVED_ACCOUNTS as usize];
         standing_orders[1] = standing_order.clone();
         let mut standing_order_indexes = vec![U128::zero(); NUM_RESERVED_ACCOUNTS as usize];
@@ -693,7 +693,7 @@ mod tests {
         };
         let order_1 = Order {
             batch_information: None,
-            account_id: 1,
+            account_id: H160::from(1),
             sell_token: 0,
             buy_token: 1,
             sell_amount: 4,
@@ -701,7 +701,7 @@ mod tests {
         };
         let order_2 = Order {
             batch_information: None,
-            account_id: 0,
+            account_id: H160::from(0),
             sell_token: 1,
             buy_token: 0,
             sell_amount: 5,
@@ -710,9 +710,9 @@ mod tests {
         let orders = vec![order_1, order_2];
 
         update_balances(&mut state, &orders, &solution);
-        assert_eq!(state.read_balance(0, 0), 101);
-        assert_eq!(state.read_balance(1, 0), 99);
-        assert_eq!(state.read_balance(0, 1), 99);
-        assert_eq!(state.read_balance(1, 1), 101);
+        assert_eq!(state.read_balance(0, H160::from(0)), 101);
+        assert_eq!(state.read_balance(1, H160::from(0)), 99);
+        assert_eq!(state.read_balance(0, H160::from(1)), 99);
+        assert_eq!(state.read_balance(1, H160::from(1)), 101);
     }
 }

--- a/driver/src/price_finding/linear_optimization_price_finder.rs
+++ b/driver/src/price_finding/linear_optimization_price_finder.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;
 use std::process::Command;
-use web3::types::U256;
+use web3::types::{H160, U256};
 
 const RESULT_FOLDER: &str = "./results/tmp/";
 type Prices = HashMap<String, String>;
@@ -46,8 +46,8 @@ fn token_id(token: u8) -> String {
     format!("token{}", token)
 }
 
-fn account_id(account: u16) -> String {
-    format!("account{}", account)
+fn account_id(account: H160) -> String {
+    format!("{:x}", account)
 }
 
 fn serialize_balances(state: &models::AccountState, orders: &[models::Order]) -> serde_json::Value {
@@ -291,7 +291,7 @@ pub mod tests {
     fn test_serialize_order() {
         let order = models::Order {
             batch_information: None,
-            account_id: 0,
+            account_id: H160::from(0),
             sell_token: 1,
             buy_token: 2,
             sell_amount: 100,
@@ -303,7 +303,7 @@ pub mod tests {
             "buyToken": "token2",
             "sellAmount": "100",
             "buyAmount": "200",
-            "accountID": "account0",
+            "accountID": "0000000000000000000000000000000000000000",
             "ID": "1"
         });
         assert_eq!(result, expected);
@@ -509,7 +509,7 @@ pub mod tests {
         let orders = [
             models::Order {
                 batch_information: None,
-                account_id: 0,
+                account_id: H160::from(0),
                 sell_token: 1,
                 buy_token: 2,
                 sell_amount: 100,
@@ -517,7 +517,7 @@ pub mod tests {
             },
             models::Order {
                 batch_information: None,
-                account_id: 1,
+                account_id: H160::from(1),
                 sell_token: 2,
                 buy_token: 1,
                 sell_amount: 200,
@@ -526,11 +526,11 @@ pub mod tests {
         ];
         let result = serialize_balances(&state, &orders);
         let expected = json!({
-            "account0": {
+            "0000000000000000000000000000000000000000": {
                 "token1": "200",
                 "token2": "300",
             },
-            "account1": {
+            "0000000000000000000000000000000000000001": {
                 "token1": "500",
                 "token2": "600",
             }

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -215,7 +215,7 @@ fn order_with_buffer_for_fee(order: &Order, fee: &Option<Fee>) -> Order {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use web3::types::H256;
+    use web3::types::{H160, H256};
 
     #[test]
     fn test_type_ia() {
@@ -228,7 +228,7 @@ pub mod tests {
         let orders = vec![
             Order {
                 batch_information: None,
-                account_id: 1,
+                account_id: H160::from(1),
                 sell_token: 1,
                 buy_token: 2,
                 sell_amount: 52,
@@ -236,7 +236,7 @@ pub mod tests {
             },
             Order {
                 batch_information: None,
-                account_id: 0,
+                account_id: H160::from(0),
                 sell_token: 2,
                 buy_token: 1,
                 sell_amount: 15,
@@ -259,7 +259,7 @@ pub mod tests {
         let orders = vec![
             Order {
                 batch_information: None,
-                account_id: 0,
+                account_id: H160::from(1),
                 sell_token: 2,
                 buy_token: 1,
                 sell_amount: 15,
@@ -267,7 +267,7 @@ pub mod tests {
             },
             Order {
                 batch_information: None,
-                account_id: 1,
+                account_id: H160::from(1),
                 sell_token: 1,
                 buy_token: 2,
                 sell_amount: 52,
@@ -290,7 +290,7 @@ pub mod tests {
         let orders = vec![
             Order {
                 batch_information: None,
-                account_id: 0,
+                account_id: H160::from(1),
                 sell_token: 2,
                 buy_token: 1,
                 sell_amount: 10,
@@ -298,7 +298,7 @@ pub mod tests {
             },
             Order {
                 batch_information: None,
-                account_id: 1,
+                account_id: H160::from(1),
                 sell_token: 1,
                 buy_token: 2,
                 sell_amount: 16,
@@ -321,7 +321,7 @@ pub mod tests {
         let orders = vec![
             Order {
                 batch_information: None,
-                account_id: 0,
+                account_id: H160::from(0),
                 sell_token: 3,
                 buy_token: 2,
                 sell_amount: 12,
@@ -329,7 +329,7 @@ pub mod tests {
             },
             Order {
                 batch_information: None,
-                account_id: 1,
+                account_id: H160::from(1),
                 sell_token: 2,
                 buy_token: 3,
                 sell_amount: 20,
@@ -337,7 +337,7 @@ pub mod tests {
             },
             Order {
                 batch_information: None,
-                account_id: 2,
+                account_id: H160::from(2),
                 sell_token: 3,
                 buy_token: 1,
                 sell_amount: 10,
@@ -345,7 +345,7 @@ pub mod tests {
             },
             Order {
                 batch_information: None,
-                account_id: 3,
+                account_id: H160::from(3),
                 sell_token: 2,
                 buy_token: 1,
                 sell_amount: 15,
@@ -353,7 +353,7 @@ pub mod tests {
             },
             Order {
                 batch_information: None,
-                account_id: 4,
+                account_id: H160::from(4),
                 sell_token: 1,
                 buy_token: 2,
                 sell_amount: 52,
@@ -361,7 +361,7 @@ pub mod tests {
             },
             Order {
                 batch_information: None,
-                account_id: 5,
+                account_id: H160::from(5),
                 sell_token: 1,
                 buy_token: 3,
                 sell_amount: 280,
@@ -384,7 +384,7 @@ pub mod tests {
         let orders = vec![
             Order {
                 batch_information: None,
-                account_id: 1,
+                account_id: H160::from(1),
                 sell_token: 1,
                 buy_token: 2,
                 sell_amount: 52,
@@ -392,7 +392,7 @@ pub mod tests {
             },
             Order {
                 batch_information: None,
-                account_id: 0,
+                account_id: H160::from(0),
                 sell_token: 2,
                 buy_token: 1,
                 sell_amount: 15,
@@ -415,7 +415,7 @@ pub mod tests {
         let orders = vec![
             Order {
                 batch_information: None,
-                account_id: 1,
+                account_id: H160::from(1),
                 sell_token: 1,
                 buy_token: 2,
                 sell_amount: 52,
@@ -423,7 +423,7 @@ pub mod tests {
             },
             Order {
                 batch_information: None,
-                account_id: 0,
+                account_id: H160::from(0),
                 sell_token: 2,
                 buy_token: 1,
                 sell_amount: 10,
@@ -446,7 +446,7 @@ pub mod tests {
         let orders = vec![
             Order {
                 batch_information: None,
-                account_id: 0,
+                account_id: H160::from(0),
                 sell_token: 0,
                 buy_token: 1,
                 sell_amount: 20000,
@@ -454,7 +454,7 @@ pub mod tests {
             },
             Order {
                 batch_information: None,
-                account_id: 0,
+                account_id: H160::from(0),
                 sell_token: 1,
                 buy_token: 0,
                 sell_amount: 9990,
@@ -482,7 +482,7 @@ pub mod tests {
         let orders = vec![
             Order {
                 batch_information: None,
-                account_id: 0,
+                account_id: H160::from(0),
                 sell_token: 0,
                 buy_token: 1,
                 sell_amount: 20000,
@@ -490,7 +490,7 @@ pub mod tests {
             },
             Order {
                 batch_information: None,
-                account_id: 0,
+                account_id: H160::from(0),
                 sell_token: 1,
                 buy_token: 0,
                 sell_amount: 9990,

--- a/driver/src/withdraw_driver.rs
+++ b/driver/src/withdraw_driver.rs
@@ -67,7 +67,7 @@ mod tests {
     use dfusion_core::models::flux::tests::create_flux_for_test;
     use dfusion_core::models::{AccountState, PendingFlux, TOKENS};
     use mock_it::Matcher::*;
-    use web3::types::{H256, U256};
+    use web3::types::{H160, H256, U256};
 
     #[test]
     fn applies_current_state_if_unapplied_and_enough_blocks_passed() {
@@ -304,7 +304,7 @@ mod tests {
             PendingFlux {
                 slot_index: 2,
                 slot: U256::one(),
-                account_id: 0,
+                account_id: H160::from(0),
                 token_id: 1,
                 amount: 10,
             },
@@ -315,7 +315,7 @@ mod tests {
             vec![100; (TOKENS * 2) as usize],
             TOKENS,
         );
-        state.decrement_balance(1, 0, 100);
+        state.decrement_balance(1, H160::from(0), 100);
 
         let merkle_root = withdraws.root_hash(&[true, false]);
 

--- a/listener/src/event_handler/auction_settlement_handler.rs
+++ b/listener/src/event_handler/auction_settlement_handler.rs
@@ -120,7 +120,7 @@ pub mod unit_test {
     use dfusion_core::database::tests::DbInterfaceMock;
     use dfusion_core::database::{DatabaseError, ErrorKind};
     use dfusion_core::models::{AccountState, BatchInformation, Order, StandingOrder, TOKENS};
-    use web3::types::{Bytes, H256, U256};
+    use web3::types::{Bytes, H160, H256, U256};
 
     #[test]
     fn test_from_log() {
@@ -138,7 +138,7 @@ pub mod unit_test {
                 slot: U256::zero(),
                 slot_index: 0,
             }),
-            account_id: 0,
+            account_id: H160::from(0),
             buy_token: 1,
             sell_token: 0,
             buy_amount: 1,

--- a/listener/src/event_handler/flux_transition_handler.rs
+++ b/listener/src/event_handler/flux_transition_handler.rs
@@ -107,7 +107,7 @@ pub mod test {
     use dfusion_core::database::tests::DbInterfaceMock;
     use dfusion_core::database::*;
     use dfusion_core::models::{AccountState, PendingFlux};
-    use web3::types::{Bytes, H256};
+    use web3::types::{Bytes, H160, H256};
 
     #[test]
     fn test_applies_deposits_existing_state() {
@@ -123,7 +123,7 @@ pub mod test {
         let first_deposit = PendingFlux {
             slot_index: 0,
             slot: U256::zero(),
-            account_id: 0,
+            account_id: H160::from(0),
             token_id: 0,
             amount: 10,
         };
@@ -131,7 +131,7 @@ pub mod test {
         let second_deposit = PendingFlux {
             slot_index: 1,
             slot: U256::zero(),
-            account_id: 1,
+            account_id: H160::from(1),
             token_id: 0,
             amount: 10,
         };
@@ -199,21 +199,21 @@ pub mod test {
         let first_withdraw = PendingFlux {
             slot_index: 0,
             slot: U256::zero(),
-            account_id: 0,
+            account_id: H160::from(0),
             token_id: 0,
             amount: 10,
         };
         let second_withdraw = PendingFlux {
             slot_index: 1,
             slot: U256::zero(),
-            account_id: 1,
+            account_id: H160::from(1),
             token_id: 0,
             amount: 10,
         };
         let invalid_withdraw = PendingFlux {
             slot_index: 1,
             slot: U256::zero(),
-            account_id: 1,
+            account_id: H160::from(1),
             token_id: 1,
             amount: 10,
         };

--- a/listener/subgraph_definition/schema.graphql
+++ b/listener/subgraph_definition/schema.graphql
@@ -1,6 +1,6 @@
 type Deposit @entity {
     id: ID!
-    accountId: Int!
+    accountId: String!
     tokenId: Int!
     amount: BigInt!
     slot: BigInt!
@@ -16,7 +16,7 @@ type AccountState @entity {
 
 type Withdraw @entity {
     id: ID!
-    accountId: Int!
+    accountId: String!
     tokenId: Int!
     amount: BigInt!
     slot: BigInt!
@@ -26,7 +26,7 @@ type Withdraw @entity {
 
 type StandingSellOrderBatch @entity {
     id: ID!
-    accountId: Int!
+    accountId: String!
     batchIndex: BigInt!
     validFromAuctionId: BigInt!
     orders: [SellOrder!]
@@ -34,7 +34,7 @@ type StandingSellOrderBatch @entity {
 
 type SellOrder @entity {
     id: ID!
-    accountId: Int!
+    accountId: String!
     buyToken: Int!
     sellToken: Int!
     buyAmount: BigInt!

--- a/test/e2e-tests-auction.sh
+++ b/test/e2e-tests-auction.sh
@@ -30,7 +30,7 @@ step "Place 6 orders in current Auction" \
 step_with_retry "[theGraph] SellOrder was added to graph db - accountId 5's sellOrder === 280" \
 "source ../test/utils.sh && query_graphql \
     \"query { \
-        sellOrders(where: { accountId: 5}) { \
+        sellOrders(where: { accountId: \\\"0000000000000000000000000000000000000005\\\" }) { \
             sellAmount \
         } \
     }\" | grep 28000000000000000000"

--- a/test/e2e-tests-deposit-withdraw.sh
+++ b/test/e2e-tests-deposit-withdraw.sh
@@ -16,7 +16,7 @@ step "Deposit 18 of token 2 for user 2" \
 step_with_retry "Deposit was added to graph DB" \
 "source ../test/utils.sh && query_graphql \
     \"query { \
-        deposits(where: { accountId: 2}) { \
+        deposits(where: { accountId: \\\"0000000000000000000000000000000000000002\\\"}) { \
             amount \
         } \
     }\" | grep 18000000000000000000"
@@ -47,7 +47,7 @@ step "Request withdraw of 18 of token 2 by account 2" \
 step_with_retry "Withdraw was added to graph db" \
 "source ../test/utils.sh && query_graphql \
     \"query { \
-        withdraws(where: { accountId: 2 }) { \
+        withdraws(where: { accountId: \\\"0000000000000000000000000000000000000002\\\" }) { \
             amount \
         } \
     }\" | grep 18000000000000000000"

--- a/test/e2e-tests-standing-order.sh
+++ b/test/e2e-tests-standing-order.sh
@@ -21,7 +21,7 @@ step_with_retry "Check graph standing order batch has been recorded" \
 "source ../test/utils.sh && query_graphql \
     \"query { \
         standingSellOrderBatches(where: { \
-          accountId: 0, \
+          accountId: \\\"0000000000000000000000000000000000000000\\\" , \
           batchIndex: 0, \
           validFromAuctionId: 0 \
         }) { \
@@ -80,7 +80,7 @@ step_with_retry "Check graph standing order batch has been updated" \
 "source ../test/utils.sh && query_graphql \
     \"query { \
         standingSellOrderBatches(where: { \
-          accountId: 0, \
+          accountId: \\\"0000000000000000000000000000000000000000\\\" , \
           batchIndex: 1, \
           validFromAuctionId: 2 \
         }) { \
@@ -100,7 +100,7 @@ step_with_retry "Check graph standing order batch has been deleted" \
 "source ../test/utils.sh && query_graphql \
     \"query { \
         standingSellOrderBatches(where: { \
-          accountId: 0, \
+          accountId: \\\"0000000000000000000000000000000000000000\\\" , \
           batchIndex: 1, \
           validFromAuctionId: 2 \
         }) { \


### PR DESCRIPTION
This PR changes the data type of account_id from u16 to H160 (address type in solidity).

This is needed since in the StableX contract we don't compress the address space to 16 bits anymore.

### Test Plan

Travis