### PR TITLE
PoC submit solution

### DIFF
--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -118,11 +118,7 @@ fn parse_auction_results(
     let mut owners: Vec<H160> = vec![];
     let mut order_ids: Vec<U128> = vec![];
     let mut volumes: Vec<U128> = vec![];
-    let zipped_amounts = solution
-        .executed_buy_amounts
-        .into_iter()
-        .zip(solution.executed_sell_amounts.into_iter());
-    for (order_index, (_buy_amount, sell_amount)) in zipped_amounts.enumerate() {
+    for (order_index, sell_amount) in solution.executed_sell_amounts.into_iter().enumerate() {
         if sell_amount > 0 {
             // order was touched!
             // Note that above condition is only holds for sell orders.
@@ -130,7 +126,7 @@ fn parse_auction_results(
             let order_batch_info = orders[order_index]
                 .batch_information
                 .as_ref()
-                .expect("Batch Information on StableX Order");
+                .expect("StableX Orders must have Batch Information");
             // TODO - using slot_index (u16) for order_id (U128) is temporary and not sustainable.
             order_ids.push(U128::from(order_batch_info.slot_index));
             // all orders are sell orders, so volumes are sell_amounts.

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -92,10 +92,12 @@ impl StableXContract for StableXContractImpl {
     }
 }
 
+type ContractRecognizedAuctionResults = (Vec<H160>, Vec<U128>, Vec<U128>, Vec<U128>, Vec<U128>);
+
 fn parse_auction_results(
     orders: Vec<Order>,
     solution: Solution,
-) -> (Vec<H160>, Vec<U128>, Vec<U128>, Vec<U128>, Vec<U128>) {
+) -> ContractRecognizedAuctionResults {
     // Representing the solution's price vector more compactly as:
     // sorted_touched_token_ids, non_zero_prices which are logically bound by index.
     // Example solution.prices = [3, 0, 1] will be transformed into [0, 2], [3, 1]

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -69,7 +69,7 @@ impl StableXContract for StableXContractImpl {
 
         // Representing the solution's price vector more compactly as:
         // sorted_touched_token_ids, non_zero_prices which are logically bound by index.
-        // Example solution.prices = [3, 0, 1] will be transformed into [2, 0], [1, 3]
+        // Example solution.prices = [3, 0, 1] will be transformed into [0, 2], [3, 1]
         let mut token_ids_for_price: Vec<U128> = vec![];
         let mut prices: Vec<U128> = vec![];
 

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -123,6 +123,7 @@ fn parse_auction_results(
             owners.push(orders[order_id].account_id);
             order_ids.push(U128::from(order_id));
             // Currently all orders are sell orders, so volumes are sell_amounts.
+            // TODO - push buy about if not sellOrder
             volumes.push(U128::from(sell_amount as usize));
         }
     }
@@ -190,12 +191,14 @@ pub mod tests {
         let solution = Solution {
             surplus: None,
             prices: vec![3, 0, 1],
-            executed_sell_amounts: vec![1, 3],
-            executed_buy_amounts: vec![3, 1],
+            executed_sell_amounts: vec![1, 3, 0, 0, 4],
+            executed_buy_amounts: vec![3, 1, 0, 2, 0],
         };
 
         let address_1 = H160::from(1);
-        let address_2 = H160::from(0);
+        let address_2 = H160::from(2);
+        let address_3 = H160::from(3);
+        let address_4 = H160::from(4);
 
         let order_1 = Order {
             batch_information: None,
@@ -213,15 +216,40 @@ pub mod tests {
             sell_amount: 3,
             buy_amount: 4,
         };
+        let order_3 = Order {
+            batch_information: None,
+            account_id: H160::from(0),
+            sell_token: 2,
+            buy_token: 0,
+            sell_amount: 2,
+            buy_amount: 1,
+        };
+        let order_4 = Order {
+            batch_information: None,
+            account_id: address_3,
+            sell_token: 2,
+            buy_token: 0,
+            sell_amount: 2,
+            buy_amount: 1,
+        };
+        let order_5 = Order {
+            batch_information: None,
+            account_id: address_4,
+            sell_token: 2,
+            buy_token: 0,
+            sell_amount: 2,
+            buy_amount: 1,
+        };
 
         let zero = U128::from(0);
         let one = U128::from(1);
         let two = U128::from(2);
         let three = U128::from(3);
+        let four = U128::from(4);
 
-        let expected_owners = vec![address_1, address_2];
-        let expected_order_ids = vec![zero, one];
-        let expected_volumes = vec![one, three];
+        let expected_owners = vec![address_1, address_2, address_3, address_4];
+        let expected_order_ids = vec![zero, one, three, four];
+        let expected_volumes = vec![one, three, zero, four];
         let expected_prices = vec![three, one];
         let expected_token_ids = vec![zero, two];
 
@@ -234,7 +262,7 @@ pub mod tests {
         );
 
         assert_eq!(
-            parse_auction_results(vec![order_1, order_2], solution),
+            parse_auction_results(vec![order_1, order_2, order_3, order_4, order_5], solution),
             expected_results
         );
     }

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -77,7 +77,7 @@ impl StableXContract for StableXContractImpl {
             }
         }
         // TODO - sort this thang by second element.
-//        price_token_binding.sort_by(|x, y| x.cmp());
+        price_token_binding.sort_by_key(|x| x.1);
         let (token_ids_for_price, prices): (Vec<U128>, Vec<U128>) = price_token_binding.iter().cloned().unzip();
 
         let mut owners: Vec<H160> = vec![];

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -245,11 +245,10 @@ pub mod tests {
         let one = U128::from(1);
         let two = U128::from(2);
         let three = U128::from(3);
-        let four = U128::from(4);
 
-        let expected_owners = vec![address_1, address_2, address_3, address_4];
-        let expected_order_ids = vec![zero, one, three, four];
-        let expected_volumes = vec![one, three, zero, four];
+        let expected_owners = vec![address_1, address_2];
+        let expected_order_ids = vec![zero, one];
+        let expected_volumes = vec![one, three];
         let expected_prices = vec![three, one];
         let expected_token_ids = vec![zero, two];
 

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -5,7 +5,7 @@ use dfusion_core::models::{AccountState, Order, Solution};
 
 use web3::contract::Options;
 use web3::futures::Future;
-use web3::types::{H160, U128, U256};
+use web3::types::{H160, U128};
 
 use crate::error::DriverError;
 
@@ -34,18 +34,18 @@ impl StableXContractImpl {
 }
 
 pub trait StableXContract {
-    fn get_current_auction_index(&self) -> Result<U256>;
-    fn get_auction_data(&self, _index: U256) -> Result<(AccountState, Vec<Order>)>;
+    fn get_current_auction_index(&self) -> Result<U128>;  // TODO - Make sure this works!
+    fn get_auction_data(&self, _index: u32) -> Result<(AccountState, Vec<Order>)>;
     fn submit_solution(
         &self,
-        batch_index: U256,
+        batch_index: u32,
         orders: Vec<Order>,
         solution: Solution,
     ) -> Result<()>;
 }
 
 impl StableXContract for StableXContractImpl {
-    fn get_current_auction_index(&self) -> Result<U256> {
+    fn get_current_auction_index(&self) -> Result<U128> {
         self.base
             .contract
             .query("getCurrentStateIndex", (), None, Options::default(), None)
@@ -53,13 +53,13 @@ impl StableXContract for StableXContractImpl {
             .map_err(DriverError::from)
     }
 
-    fn get_auction_data(&self, _index: U256) -> Result<(AccountState, Vec<Order>)> {
+    fn get_auction_data(&self, _index: u32) -> Result<(AccountState, Vec<Order>)> {
         unimplemented!();
     }
 
     fn submit_solution(
         &self,
-        batch_index: U256,
+        batch_index: u32,
         orders: Vec<Order>,
         solution: Solution,
     ) -> Result<()> {
@@ -76,7 +76,7 @@ impl StableXContract for StableXContractImpl {
             .call(
                 "submitSolution",
                 (
-                    batch_index,
+                    U128::from(batch_index),  // TODO - Ensure that this works!
                     owners,
                     order_ids,
                     volumes,
@@ -140,12 +140,12 @@ pub mod tests {
 
     use super::*;
 
-    type SubmitSolutionArguments = (U256, Matcher<Vec<Order>>, Matcher<Solution>);
+    type SubmitSolutionArguments = (u32, Matcher<Vec<Order>>, Matcher<Solution>);
 
     #[derive(Clone)]
     pub struct StableXContractMock {
-        pub get_current_auction_index: Mock<(), Result<U256>>,
-        pub get_auction_data: Mock<U256, Result<(AccountState, Vec<Order>)>>,
+        pub get_current_auction_index: Mock<(), Result<U128>>,
+        pub get_auction_data: Mock<u32, Result<(AccountState, Vec<Order>)>>,
         pub submit_solution: Mock<SubmitSolutionArguments, Result<()>>,
     }
 
@@ -169,15 +169,15 @@ pub mod tests {
     }
 
     impl StableXContract for StableXContractMock {
-        fn get_current_auction_index(&self) -> Result<U256> {
+        fn get_current_auction_index(&self) -> Result<U128> {
             self.get_current_auction_index.called(())
         }
-        fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
+        fn get_auction_data(&self, index: u32) -> Result<(AccountState, Vec<Order>)> {
             self.get_auction_data.called(index)
         }
         fn submit_solution(
             &self,
-            batch_index: U256,
+            batch_index: u32,
             orders: Vec<Order>,
             solution: Solution,
         ) -> Result<()> {

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -5,7 +5,7 @@ use dfusion_core::models::{AccountState, Order, Solution};
 
 use web3::contract::Options;
 use web3::futures::Future;
-use web3::types::U256;
+use web3::types::{H160, U128, U256};
 
 use crate::error::DriverError;
 
@@ -39,9 +39,9 @@ pub trait StableXContract {
     fn get_auction_data(&self, _index: U256) -> Result<(AccountState, Vec<Order>)>;
     fn submit_solution(
         &self,
-        _batch_index: U256,
-        _orders: Vec<Order>,
-        _solution: Solution,
+        batch_index: U256,
+        orders: Vec<Order>,
+        solution: Solution,
     ) -> Result<()>;
 }
 
@@ -59,11 +59,51 @@ impl StableXContract for StableXContractImpl {
 
     fn submit_solution(
         &self,
-        _batch_index: U256,
-        _orders: Vec<Order>,
-        _solution: Solution,
+        batch_index: U256,
+        orders: Vec<Order>,
+        solution: Solution,
     ) -> Result<()> {
-        unimplemented!();
+        let account = self.base
+            .account_with_sufficient_balance()
+            .ok_or("Not enough balance to send Txs")?;
+
+        // Representing the solution's price vector more compactly as:
+        // touched_token_ids, sorted_prices which are logically bound by index.
+        // Example solution.prices = [3, 0, 1] will be transformed into [2, 0], [1, 3]
+        let mut price_token_binding: Vec<(U128, U128)> = vec![];
+        for (token_id, price) in solution.prices.iter().enumerate() {
+            if *price > 0 {
+                price_token_binding.push((U128::from(token_id as usize), U128::from(*price as usize)))
+            }
+        }
+        // TODO - sort this thang by second element.
+//        price_token_binding.sort_by(|x, y| x.cmp());
+        let (token_ids_for_price, prices): (Vec<U128>, Vec<U128>) = price_token_binding.iter().cloned().unzip();
+
+        let mut owners: Vec<H160> = vec![];
+        let mut order_ids: Vec<U128> = vec![];
+        let mut volumes: Vec<U128> = vec![];
+        let zipped_amounts = solution.executed_buy_amounts.iter().zip(solution.executed_sell_amounts.iter());
+        for (order_id, (buy_amount, sell_amount)) in zipped_amounts.enumerate() {
+            if *buy_amount > 0 && *sell_amount > 0 {
+                // order was touched!
+                owners.push(orders[order_id].account_id);
+                order_ids.push(U128::from(order_id));
+                // Currently all orders are sell orders, so volumes are sell_amounts.
+                volumes.push(U128::from(*sell_amount as usize));
+            }
+        }
+
+        self.base.contract
+            .call(
+                "submitSolution",
+                (batch_index, owners, order_ids, volumes, prices, token_ids_for_price),
+                account,
+                Options::default(),
+            )
+            .wait()
+            .map_err(DriverError::from)
+            .map(|_| ())
     }
 }
 

--- a/driver/src/driver/deposit_driver.rs
+++ b/driver/src/driver/deposit_driver.rs
@@ -8,8 +8,8 @@ use dfusion_core::database::DbInterface;
 use dfusion_core::models::RollingHashable;
 
 pub fn run_deposit_listener(
-    db: &dyn DbInterface, 
-    contract: &dyn SnappContract
+    db: &dyn DbInterface,
+    contract: &dyn SnappContract,
 ) -> Result<(bool), DriverError> {
     let deposit_slot = contract.get_current_deposit_slot()?;
 

--- a/driver/src/driver/order_driver.rs
+++ b/driver/src/driver/order_driver.rs
@@ -37,9 +37,9 @@ pub enum ProcessResult {
 
 impl<'a> OrderProcessor<'a> {
     pub fn new(
-        db: &'a dyn DbInterface, 
-        contract: &'a dyn SnappContract, 
-        price_finder: &'a mut dyn PriceFinding
+        db: &'a dyn DbInterface,
+        contract: &'a dyn SnappContract,
+        price_finder: &'a mut dyn PriceFinding,
     ) -> Self {
         OrderProcessor {
             auction_bids: HashMap::new(),

--- a/driver/src/driver/withdraw_driver.rs
+++ b/driver/src/driver/withdraw_driver.rs
@@ -8,8 +8,8 @@ use dfusion_core::database::DbInterface;
 use dfusion_core::models::{RollingHashable, RootHashable};
 
 pub fn run_withdraw_listener(
-    db: &dyn DbInterface, 
-    contract: &dyn SnappContract
+    db: &dyn DbInterface,
+    contract: &dyn SnappContract,
 ) -> Result<(bool), DriverError> {
     let withdraw_slot = contract.get_current_withdraw_slot()?;
 

--- a/driver/src/error.rs
+++ b/driver/src/error.rs
@@ -94,7 +94,6 @@ impl From<PriceFindingError> for DriverError {
     }
 }
 
-
 impl DriverError {
     pub fn new(msg: &str, kind: ErrorKind) -> DriverError {
         DriverError {

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -21,9 +21,9 @@ pub mod price_finding;
 mod util;
 
 pub fn run_driver_components(
-    db: &dyn DbInterface, 
-    contract: &dyn SnappContract, 
-    order_processor: &mut OrderProcessor
+    db: &dyn DbInterface,
+    contract: &dyn SnappContract,
+    order_processor: &mut OrderProcessor,
 ) {
     if let Err(e) = run_deposit_listener(db, contract) {
         error!("Deposit_driver error: {}", e);

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -97,7 +97,7 @@ impl PriceFinding for NaiveSolver {
         state: &AccountState,
     ) -> Result<Solution, PriceFindingError> {
         // Initialize trivial solution
-        let mut prices: Vec<u128> = vec![1; TOKENS as usize];
+        let mut prices: Vec<u128> = vec![0; TOKENS as usize];
         let mut exec_buy_amount: Vec<u128> = vec![0; orders.len()];
         let mut exec_sell_amount: Vec<u128> = vec![0; orders.len()];
         let mut total_surplus = U256::zero();

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -96,7 +96,7 @@ impl PriceFinding for NaiveSolver {
         orders: &[Order],
         state: &AccountState,
     ) -> Result<Solution, PriceFindingError> {
-        // Initialize trivial solution
+        // Initialize trivial solution (default of zero indicates untouched token).
         let mut prices: Vec<u128> = vec![0; TOKENS as usize];
         let mut exec_buy_amount: Vec<u128> = vec![0; orders.len()];
         let mut exec_sell_amount: Vec<u128> = vec![0; orders.len()];


### PR DESCRIPTION
This change inmplements the `submit_solution` part of the StableX contract interface. For the purpose of simplified unit testing, two helper functions `encode_prices_for_contract` and `encode_execution_for_contract` are introduced to convert auction result data from the `<Order, Solution>` into a collection of vectors that the smart contract recognizes. 

A few new unit tests involving all possible corner cases to auction result parser are introduced. 

Test Plan: `cargo test`