### PR TITLE
move u128_to_U256 to util file and test on 1 and max.

### DIFF
--- a/dfusion_rust_core/src/models/util.rs
+++ b/dfusion_rust_core/src/models/util.rs
@@ -144,7 +144,7 @@ impl EntityParsing for u128 {
 
 impl EntityParsing for U256 {
     fn from_entity(entity: &Entity, field: &str) -> Self {
-        U256::from_str(
+        U256::from_dec_str(
             &entity
                 .get(field)
                 .and_then(|value| value.clone().as_big_decimal())

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -3,6 +3,7 @@ use web3::types::U256;
 use dfusion_core::models::{AccountState, Order, Solution, TOKENS};
 
 use crate::price_finding::error::PriceFindingError;
+use crate::util::u128_to_u256;
 
 use super::price_finder_interface::{Fee, PriceFinding};
 
@@ -186,10 +187,6 @@ impl PriceFinding for NaiveSolver {
         info!("Solution: {:?}", &solution);
         Ok(solution)
     }
-}
-
-fn u128_to_u256(x: u128) -> U256 {
-    U256::from_big_endian(&x.to_be_bytes())
 }
 
 fn order_with_buffer_for_fee(order: &Order, fee: &Option<Fee>) -> Order {

--- a/driver/src/util.rs
+++ b/driver/src/util.rs
@@ -1,12 +1,17 @@
+use std::env;
+
+use web3::types::{H256, U256};
+
 use crate::contracts::snapp_contract::SnappContract;
 use crate::error::DriverError;
 use crate::error::ErrorKind;
 use crate::price_finding::{LinearOptimisationPriceFinder, NaiveSolver, PriceFinding};
 
-use std::env;
-use web3::types::{H256, U256};
-
 const BATCH_TIME_SECONDS: u32 = 3 * 60;
+
+pub fn u128_to_u256(x: u128) -> U256 {
+    U256::from_big_endian(&x.to_be_bytes())
+}
 
 pub fn find_first_unapplied_slot(
     upper_bound: U256,
@@ -76,5 +81,24 @@ pub fn create_price_finder() -> Box<dyn PriceFinding> {
     } else {
         info!("Using naive price finder");
         Box::new(NaiveSolver::new(None))
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn test_u128_to_u256_on_one() {
+        let a: u128 = 1;
+        assert_eq!(U256::from(1), u128_to_u256(a));
+    }
+    #[test]
+    fn test_u128_to_u256_on_max() {
+        let a = u128::max_value();
+        assert_eq!(
+            U256::from_dec_str("340282366920938463463374607431768211455").unwrap(),
+            u128_to_u256(a)
+        );
     }
 }


### PR DESCRIPTION
This useful function (previously only required by the `naive_solver`) will also come in handy in other places. throughout the driver (and possibly even the core) codebase.

I would have preferred to implement it more accurately as 

```js
impl From<u128> for U256 {
    fn from(value: u128) -> U256 {
        U256::from_big_endian(&x.to_be_bytes())
    }
}
```
but I believe this requires a contribution to the ethereum-types repo (where U256 is defined). 

Note also I found a place in the code where we were using `U256::from_str` which does not seem to exist (an untested bug). 
