### PR TITLE
[NaiveSolver] bugfixes and more exhaustive unit tests

### DIFF
--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -72,11 +72,8 @@ impl Matchable for Order {
     }
 
     fn surplus(&self, buy_price: u128, exec_buy_amount: u128, exec_sell_amount: u128) -> U256 {
-        // Note that: ceil(p / float(q)) == (p + q - 1) // q
-        let relative_buy = (u128_to_u256(self.buy_amount) * u128_to_u256(exec_sell_amount)
-            + u128_to_u256(self.sell_amount)
-            - 1)
-            / u128_to_u256(self.sell_amount);
+        let relative_buy = 
+            (u128_to_u256(self.buy_amount) * u128_to_u256(exec_sell_amount)).ceiled_div(u128_to_u256(self.sell_amount));
         (u128_to_u256(exec_buy_amount) - relative_buy) * u128_to_u256(buy_price)
     }
 }

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -212,7 +212,7 @@ fn order_with_buffer_for_fee(order: &Order, fee: &Option<Fee>) -> Order {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::util::{u256_to_u128};
+    use crate::util::u256_to_u128;
     use dfusion_core::models::account_state::test_util::*;
     use std::collections::HashMap;
     use web3::types::{H160, H256};

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -68,14 +68,14 @@ impl Matchable for Order {
 
     fn have_price_overlap(&self, other: &Order) -> bool {
         self.sell_amount > 0
-        && other.sell_amount > 0
-        && u128_to_u256(self.buy_amount) * u128_to_u256(other.buy_amount)
-            <= u128_to_u256(other.sell_amount) * u128_to_u256(self.sell_amount)
+            && other.sell_amount > 0
+            && u128_to_u256(self.buy_amount) * u128_to_u256(other.buy_amount)
+                <= u128_to_u256(other.sell_amount) * u128_to_u256(self.sell_amount)
     }
 
     fn surplus(&self, buy_price: u128, exec_buy_amount: u128, exec_sell_amount: u128) -> U256 {
-        let relative_buy = 
-            (u128_to_u256(self.buy_amount) * u128_to_u256(exec_sell_amount)).ceiled_div(u128_to_u256(self.sell_amount));
+        let relative_buy = (u128_to_u256(self.buy_amount) * u128_to_u256(exec_sell_amount))
+            .ceiled_div(u128_to_u256(self.sell_amount));
         (u128_to_u256(exec_buy_amount) - relative_buy) * u128_to_u256(buy_price)
     }
 }

--- a/driver/src/util.rs
+++ b/driver/src/util.rs
@@ -13,6 +13,17 @@ pub fn u128_to_u256(x: u128) -> U256 {
     U256::from_big_endian(&x.to_be_bytes())
 }
 
+pub trait CeiledDiv {
+    fn ceiled_div(&self, divisor: Self) -> Self;
+}
+
+impl CeiledDiv for u128 {
+    fn ceiled_div(&self, divisor: u128) -> u128 {
+        //ceil(p / float(q)) == (p + q - 1) / q
+        (self + divisor - 1) / divisor
+    }
+}
+
 pub fn find_first_unapplied_slot(
     upper_bound: U256,
     has_slot_been_applied: &dyn Fn(U256) -> Result<bool, DriverError>,

--- a/driver/src/util.rs
+++ b/driver/src/util.rs
@@ -24,6 +24,13 @@ impl CeiledDiv for u128 {
     }
 }
 
+impl CeiledDiv for U256 {
+    fn ceiled_div(&self, divisor: U256) -> U256 {
+        //ceil(p / float(q)) == (p + q - 1) / q
+        (self + divisor - 1) / divisor
+    }
+}
+
 pub fn find_first_unapplied_slot(
     upper_bound: U256,
     has_slot_been_applied: &dyn Fn(U256) -> Result<bool, DriverError>,

--- a/driver/src/util.rs
+++ b/driver/src/util.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::str::FromStr;
 
 use web3::types::{H256, U256};
 
@@ -11,6 +12,10 @@ const BATCH_TIME_SECONDS: u32 = 3 * 60;
 
 pub fn u128_to_u256(x: u128) -> U256 {
     U256::from_big_endian(&x.to_be_bytes())
+}
+
+pub fn u256_to_u128(x: U256) -> u128 {
+    u128::from_str(&x.to_string()).unwrap()
 }
 
 pub trait CeiledDiv {

--- a/driver/src/util.rs
+++ b/driver/src/util.rs
@@ -119,4 +119,30 @@ pub mod tests {
             u128_to_u256(a)
         );
     }
+
+    #[test]
+    fn test_ceiled_div_u128() {
+        assert_eq!(0u128.ceiled_div(10), 0);
+        assert_eq!(1u128.ceiled_div(10), 1);
+        assert_eq!(10u128.ceiled_div(10), 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_ceiled_div_by_0_u128() {
+        1u128.ceiled_div(0);
+    }
+
+    #[test]
+    fn test_ceiled_div_u256() {
+        assert_eq!(U256::from(0).ceiled_div(U256::from(10)), U256::from(0));
+        assert_eq!(U256::from(1).ceiled_div(U256::from(10)), U256::from(1));
+        assert_eq!(U256::from(10).ceiled_div(U256::from(10)), U256::from(1));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_ceiled_div_by_0_u256() {
+        U256::one().ceiled_div(U256::zero());
+    }
 }

--- a/driver/src/util.rs
+++ b/driver/src/util.rs
@@ -116,6 +116,7 @@ pub mod tests {
         let a: u128 = 1;
         assert_eq!(U256::from(1), u128_to_u256(a));
     }
+
     #[test]
     fn test_u128_to_u256_on_max() {
         let a = u128::max_value();
@@ -134,7 +135,7 @@ pub mod tests {
             u256_to_u128(U256::from_dec_str("340282366920938463463374607431768211455").unwrap())
         );
     }
-    
+
     #[test]
     #[should_panic]
     fn test_u256_to_u128_panics_on_overflow() {

--- a/driver/src/util.rs
+++ b/driver/src/util.rs
@@ -134,6 +134,12 @@ pub mod tests {
     }
 
     #[test]
+    #[should_panic]
+    fn test_ceiled_div_overflow_u128() {
+        u128::max_value().ceiled_div(1);
+    }
+
+    #[test]
     fn test_ceiled_div_u256() {
         assert_eq!(U256::from(0).ceiled_div(U256::from(10)), U256::from(0));
         assert_eq!(U256::from(1).ceiled_div(U256::from(10)), U256::from(1));
@@ -144,5 +150,11 @@ pub mod tests {
     #[should_panic]
     fn test_ceiled_div_by_0_u256() {
         U256::one().ceiled_div(U256::zero());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_ceiled_div_overflow_u256() {
+        U256::max_value().ceiled_div(U256::from(1));
     }
 }

--- a/driver/src/util.rs
+++ b/driver/src/util.rs
@@ -126,6 +126,22 @@ pub mod tests {
     }
 
     #[test]
+    fn test_256_to_u128_works() {
+        assert_eq!(0u128, u256_to_u128(U256::from(0)));
+        assert_eq!(1u128, u256_to_u128(U256::from(1)));
+        assert_eq!(
+            u128::max_value(),
+            u256_to_u128(U256::from_dec_str("340282366920938463463374607431768211455").unwrap())
+        );
+    }
+    
+    #[test]
+    #[should_panic]
+    fn test_u256_to_u128_panics_on_overflow() {
+        u256_to_u128(U256::from_dec_str("340282366920938463463374607431768211456").unwrap());
+    }
+
+    #[test]
     fn test_ceiled_div_u128() {
         assert_eq!(0u128.ceiled_div(10), 0);
         assert_eq!(1u128.ceiled_div(10), 1);


### PR DESCRIPTION
There were some issues with the NaiveSolver, which prevented the stableX e2e tests from working. Most importantly:

1) Price computation for `OrderPairType::BothFullyFilled` was inverted.
2) The rounding in `order_with_buffer_for_fee ` was done on the fee multiplier (.999 -> 1.0) instead of on the product of amount and fee leading to no reduction in the sell amount (and thus violating max. sell amounts when fee was added).

I interpreted this as a sign of poor unit tests and thus spent some time building more robust one:

First, I added a function that performs the validity checks of the smart contract (so that our tests can check that a solution will be accepted).

I then added unit tests for the three cases (left fully matched, right fully matched, both fully matched) that also work with the fee.

This should give us reasonable confidence that the smart contract accepts solutions from the NaiveSolver