### PR TITLE
[Cleanup] Remove Unused Dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,7 +572,6 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "mock-it 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "pairing 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple_logger 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1658,15 +1657,6 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pairing"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3469,7 +3459,6 @@ dependencies = [
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.48 (registry+https://github.com/rust-lang/crates.io-index)" = "b5ba300217253bcc5dc68bed23d782affa45000193866e025329aa8a7a9f05b8"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
-"checksum pairing 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ceda21136251c6d5a422d3d798d8ac22515a6e8d3521bb60c59a8349d36d0d57"
 "checksum parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)" = "511379a8194230c2395d2f5fa627a5a7e108a9f976656ce723ae68fca4097bfc"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa7767817701cce701d5585b9c4db3cdd02086398322c1d7e8bf5094a96a2ce7"

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -18,7 +18,6 @@ graph = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.13.2" }
 graph-node-reader = { git = "https://github.com/gnosis/graph-node-reader", tag = "v0.13.2" }
 hex = "0.3.2"
 log = "0.4.6"
-pairing = "0.14"
 rustc-hex = "*"
 serde_json = "1.0"
 simple_logger = "1.2.0"


### PR DESCRIPTION

This, unused, `pairing` dependency was causing an "import error"
```
error[E0432]: unresolved import `byteorder`
 --> driver/src/contracts/stablex_auction_element.rs:3:5
  |
3 | use byteorder::{BigEndian, ByteOrder};
  |     ^^^^^^^^^ help: a similar path exists: `pairing::byteorder`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0432`.
error: Could not compile `driver`.
```

Apparently, `pairing` also depends on `byteorder` so the compiler (even though it obviously knew) it was confused and crashed.

An attempt at removing the `byteorder` crate as a dependency and adjusting all imports to `use pairing::byteorder::ETC` resulted in a different failure.

**Solution** `pairing` was unused and removing it saved the day!


 