### PR TITLE
[Stablex] Better driver logging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,6 @@ services:
       - ./dex-contracts:/app/dex-contracts
       - ./dfusion_rust_core/src:/app/dfusion_rust_core/src
       - ./driver/src:/app/driver/src
-      - ../batchauctions:/app/batchauctions/
 
   graph-listener:
     << : *rust-service
@@ -76,4 +75,3 @@ services:
       - ./dex-contracts:/app/dex-contracts
       - ./dfusion_rust_core/src:/app/dfusion_rust_core/src
       - ./driver/src:/app/driver/src
-      - ../batchauctions:/app/batchauctions/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       - ./dex-contracts:/app/dex-contracts
       - ./dfusion_rust_core/src:/app/dfusion_rust_core/src
       - ./driver/src:/app/driver/src
+      - ../batchauctions:/app/batchauctions/
 
   graph-listener:
     << : *rust-service
@@ -75,3 +76,4 @@ services:
       - ./dex-contracts:/app/dex-contracts
       - ./dfusion_rust_core/src:/app/dfusion_rust_core/src
       - ./driver/src:/app/driver/src
+      - ../batchauctions:/app/batchauctions/

--- a/docker/rust/clone_solver.sh
+++ b/docker/rust/clone_solver.sh
@@ -13,5 +13,5 @@ cp .ssh/id_rsa.pub /root/.ssh/id_rsa.pub
 # Clone and install dependencies
 git clone git@gitlab.gnosisdev.com:dfusion/batchauctions.git
 cd batchauctions
-git checkout 136213199bfd47e94a8b9f97132c9d099baded1f
+git checkout v0.2
 pip install -r requirements.txt

--- a/docker/rust/clone_solver.sh
+++ b/docker/rust/clone_solver.sh
@@ -13,5 +13,5 @@ cp .ssh/id_rsa.pub /root/.ssh/id_rsa.pub
 # Clone and install dependencies
 git clone git@gitlab.gnosisdev.com:dfusion/batchauctions.git
 cd batchauctions
-git checkout v0.1
+git checkout 136213199bfd47e94a8b9f97132c9d099baded1f
 pip install -r requirements.txt

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -101,7 +101,7 @@ impl StableXContract for StableXContractImpl {
                 Options::with(|mut opt| {
                     // usual gas estimate is not working
                     opt.gas_price = Some(25.into());
-                    opt.gas = Some(1_000_000.into());
+                    opt.gas = Some(5_000_000.into());
                 }),
             )
             .wait()

--- a/driver/src/driver/stablex_driver.rs
+++ b/driver/src/driver/stablex_driver.rs
@@ -44,7 +44,7 @@ impl<'a> StableXDriver<'a> {
             info!("Successfully applied solution to batch {}", batch);
             true
         } else {
-            info!("Not submitting 0 volume solution for batch {}", batch);
+            info!("Not submitting trivial solution for batch {}", batch);
             false
         };
         self.past_auctions.insert(batch);

--- a/driver/src/driver/stablex_driver.rs
+++ b/driver/src/driver/stablex_driver.rs
@@ -2,6 +2,8 @@ use crate::contracts::stablex_contract::StableXContract;
 use crate::error::DriverError;
 use crate::price_finding::PriceFinding;
 
+use dfusion_core::models::Solution;
+
 use std::collections::HashSet;
 
 use web3::types::U256;
@@ -25,17 +27,28 @@ impl<'a> StableXDriver<'a> {
         // Try to process previous batch auction
         let batch = self.contract.get_current_auction_index()? - 1;
         if self.past_auctions.contains(&batch) {
-            info!("Already processed batch {}", batch);
             return Ok(false);
         }
         let (account_state, orders) = self.contract.get_auction_data(batch)?;
-        let solution = self.price_finder.find_prices(&orders, &account_state)?;
+        let solution = if orders.is_empty() {
+            info!("No orders in batch {}", batch);
+            Solution::trivial(0)
+        } else {
+            let solution = self.price_finder.find_prices(&orders, &account_state)?;
+            info!("Computed solution: {:?}", &solution);
+            solution
+        };
 
-        info!("Submitting solution: {:?}", &solution);
-        self.contract.submit_solution(batch, orders, solution)?;
+        let submitted = if solution.executed_sell_amounts.iter().sum::<u128>() > 0 {
+            self.contract.submit_solution(batch, orders, solution)?;
+            info!("Successfully applied solution to batch {}", batch);
+            true
+        } else {
+            info!("Not submitting 0 volume solution for batch {}", batch);
+            false
+        };
         self.past_auctions.insert(batch);
-        info!("Successfully applied solution to batch {}", batch);
-        Ok(true)
+        Ok(submitted)
     }
 }
 
@@ -47,7 +60,6 @@ mod tests {
 
     use dfusion_core::models::account_state::test_util::*;
     use dfusion_core::models::order::test_util::create_order_for_test;
-    use dfusion_core::models::Solution;
 
     use mock_it::Matcher::{Any, Val};
 
@@ -169,5 +181,65 @@ mod tests {
         let mut driver = StableXDriver::new(&contract, &mut pf);
 
         assert!(driver.run().is_err())
+    }
+
+    #[test]
+    fn test_do_not_invoke_solver_when_no_orders() {
+        let contract = StableXContractMock::default();
+        let mut pf = PriceFindingMock::default();
+
+        let orders = vec![];
+        let state = create_account_state_with_balance_for(&orders);
+
+        let batch = U256::from(42);
+        contract
+            .get_current_auction_index
+            .given(())
+            .will_return(Ok(batch));
+
+        contract
+            .get_auction_data
+            .given(batch - 1)
+            .will_return(Ok((state.clone(), orders.clone())));
+
+        let mut driver = StableXDriver::new(&contract, &mut pf);
+
+        assert!(driver.run().is_ok());
+        assert!(!mock_it::verify(
+            pf.find_prices.was_called_with((orders, state))
+        ));
+    }
+
+    #[test]
+    fn test_does_not_submit_empty_solution() {
+        let contract = StableXContractMock::default();
+        let mut pf = PriceFindingMock::default();
+
+        let orders = vec![create_order_for_test(), create_order_for_test()];
+        let state = create_account_state_with_balance_for(&orders);
+
+        let batch = U256::from(42);
+        contract
+            .get_current_auction_index
+            .given(())
+            .will_return(Ok(batch));
+
+        contract
+            .get_auction_data
+            .given(batch - 1)
+            .will_return(Ok((state.clone(), orders.clone())));
+
+        let solution = Solution::trivial(orders.len());
+        pf.find_prices
+            .given((orders, state))
+            .will_return(Ok(solution));
+
+        let mut driver = StableXDriver::new(&contract, &mut pf);
+        assert!(driver.run().is_ok());
+        assert!(!mock_it::verify(
+            contract
+                .submit_solution
+                .was_called_with((batch - 1, Any, Any))
+        ));
     }
 }

--- a/driver/src/price_finding/linear_optimization_price_finder.rs
+++ b/driver/src/price_finding/linear_optimization_price_finder.rs
@@ -478,12 +478,17 @@ pub mod tests {
     fn test_serialize_input_with_fee() {
         let fee = Fee {
             token: 0,
-            percentage: 0.001,
+            ratio: 0.001,
         };
         let solver = LinearOptimisationPriceFinder {
             write_input: |_, json: &serde_json::Value| {
-                assert_eq!(json["feeToken"], json!("token0"));
-                assert_eq!(json["feePercentage"], json!(0.001));
+                assert_eq!(
+                    json["fee"],
+                    json!({
+                        "token": "token0",
+                        "ratio": 0.001
+                    })
+                );
                 Ok(())
             },
             run_solver: |_| Ok(()),

--- a/driver/src/price_finding/linear_optimization_price_finder.rs
+++ b/driver/src/price_finding/linear_optimization_price_finder.rs
@@ -190,7 +190,7 @@ impl PriceFinding for LinearOptimisationPriceFinder {
         if let Some(fee) = &self.fee {
             input["fee"] = json!({
                 "token": token_id(fee.token),
-                "ratio": fee.percentage,
+                "ratio": fee.ratio,
             });
         }
         let input_file = format!("instance_{}.json", Utc::now().to_rfc3339());

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -92,7 +92,7 @@ impl NaiveSolver {
 
 impl PriceFinding for NaiveSolver {
     fn find_prices(
-        &mut self,
+        &self,
         orders: &[Order],
         state: &AccountState,
     ) -> Result<Solution, PriceFindingError> {
@@ -222,7 +222,7 @@ pub mod tests {
         let orders = order_pair_first_fully_matching_second();
         let state = create_account_state_with_balance_for(&orders);
 
-        let mut solver = NaiveSolver::new(None);
+        let solver = NaiveSolver::new(None);
         let res = solver.find_prices(&orders, &state).unwrap();
 
         assert_eq!(Some(u128_to_u256(16 * 10u128.pow(36))), res.surplus);
@@ -249,7 +249,7 @@ pub mod tests {
             ratio: 0.001,
         });
 
-        let mut solver = NaiveSolver::new(fee.clone());
+        let solver = NaiveSolver::new(fee.clone());
         let res = solver.find_prices(&orders, &state).unwrap();
         check_solution(&orders, res, &fee).unwrap();
     }
@@ -260,7 +260,7 @@ pub mod tests {
         orders.reverse();
         let state = create_account_state_with_balance_for(&orders);
 
-        let mut solver = NaiveSolver::new(None);
+        let solver = NaiveSolver::new(None);
         let res = solver.find_prices(&orders, &state).unwrap();
 
         assert_eq!(Some(u128_to_u256(16 * 10u128.pow(36))), res.surplus);
@@ -288,7 +288,7 @@ pub mod tests {
             ratio: 0.001,
         });
 
-        let mut solver = NaiveSolver::new(fee.clone());
+        let solver = NaiveSolver::new(fee.clone());
         let res = solver.find_prices(&orders, &state).unwrap();
         check_solution(&orders, res, &fee).unwrap();
     }
@@ -298,7 +298,7 @@ pub mod tests {
         let orders = order_pair_both_fully_matched();
         let state = create_account_state_with_balance_for(&orders);
 
-        let mut solver = NaiveSolver::new(None);
+        let solver = NaiveSolver::new(None);
         let res = solver.find_prices(&orders, &state).unwrap();
 
         assert_eq!(Some(u128_to_u256(92 * 10u128.pow(36))), res.surplus);
@@ -324,7 +324,7 @@ pub mod tests {
             token: 2,
             ratio: 0.001,
         });
-        let mut solver = NaiveSolver::new(fee.clone());
+        let solver = NaiveSolver::new(fee.clone());
         let res = solver.find_prices(&orders, &state).unwrap();
 
         check_solution(&orders, res, &fee).unwrap();
@@ -384,7 +384,7 @@ pub mod tests {
         ];
         let state = create_account_state_with_balance_for(&orders);
 
-        let mut solver = NaiveSolver::new(None);
+        let solver = NaiveSolver::new(None);
         let res = solver.find_prices(&orders, &state).unwrap();
 
         assert_eq!(Some(U256::from(16)), res.surplus);
@@ -423,7 +423,7 @@ pub mod tests {
             },
         ];
 
-        let mut solver = NaiveSolver::new(None);
+        let solver = NaiveSolver::new(None);
         let res = solver.find_prices(&orders, &state).unwrap();
         assert_eq!(res, Solution::trivial(orders.len()));
     }
@@ -450,7 +450,7 @@ pub mod tests {
         ];
         let state = create_account_state_with_balance_for(&orders);
 
-        let mut solver = NaiveSolver::new(None);
+        let solver = NaiveSolver::new(None);
         let res = solver.find_prices(&orders, &state).unwrap();
         assert_eq!(res, Solution::trivial(orders.len()));
     }
@@ -481,7 +481,7 @@ pub mod tests {
             token: 0,
             ratio: 0.001,
         });
-        let mut solver = NaiveSolver::new(fee.clone());
+        let solver = NaiveSolver::new(fee.clone());
         let res = solver.find_prices(&orders, &state).unwrap();
 
         assert_eq!(res.executed_sell_amounts, [20000, 9990]);
@@ -518,7 +518,7 @@ pub mod tests {
             token: 2,
             ratio: 0.001,
         });
-        let mut solver = NaiveSolver::new(fee.clone());
+        let solver = NaiveSolver::new(fee.clone());
         let res = solver.find_prices(&orders, &state).unwrap();
         assert_eq!(res, Solution::trivial(orders.len()));
     }
@@ -545,7 +545,7 @@ pub mod tests {
         ];
         let state = create_account_state_with_balance_for(&orders);
 
-        let mut solver = NaiveSolver::new(None);
+        let solver = NaiveSolver::new(None);
         let res = solver.find_prices(&orders, &state).unwrap();
         assert_eq!(res, Solution::trivial(orders.len()));
     }

--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -20,7 +20,7 @@ impl Default for Fee {
 
 pub trait PriceFinding {
     fn find_prices(
-        &mut self,
+        &self,
         orders: &[models::Order],
         state: &models::AccountState,
     ) -> Result<models::Solution, PriceFindingError>;
@@ -56,7 +56,7 @@ pub mod tests {
 
     impl PriceFinding for PriceFindingMock {
         fn find_prices(
-            &mut self,
+            &self,
             orders: &[models::Order],
             state: &models::AccountState,
         ) -> Result<models::Solution, PriceFindingError> {

--- a/driver/src/util.rs
+++ b/driver/src/util.rs
@@ -100,7 +100,7 @@ pub fn create_price_finder(fee: Option<Fee>) -> Box<dyn PriceFinding> {
     let solver_env_var = env::var("LINEAR_OPTIMIZATION_SOLVER").unwrap_or_else(|_| "0".to_string());
     if solver_env_var == "1" {
         info!("Using linear optimisation price finder");
-        Box::new(LinearOptimisationPriceFinder::new())
+        Box::new(LinearOptimisationPriceFinder::new(fee))
     } else {
         info!("Using naive price finder");
         Box::new(NaiveSolver::new(fee))

--- a/test/e2e-tests-stablex.sh
+++ b/test/e2e-tests-stablex.sh
@@ -11,8 +11,8 @@ step "Make sure we have enough balances for the trades" \
 npx truffle exec scripts/stablex/deposit.js --accountId=1 --tokenId=1 --amount=3000"
 
 step "Place 2 orders in current auction" \
-"npx truffle exec scripts/stablex/place_order.js --accountId=0 --buyToken=1 --sellToken=0 --minBuy=999 --maxSell=2000 --validFor=20 && \
-npx truffle exec scripts/stablex/place_order.js --accountId=1 --buyToken=0 --sellToken=1 --minBuy=1996 --maxSell=999 --validFor=20 "
+"npx truffle exec scripts/stablex/place_order.js --accountId=0 --buyToken=1 --sellToken=0 --minBuy=99 --maxSell=2000 --validFor=20 && \
+npx truffle exec scripts/stablex/place_order.js --accountId=1 --buyToken=0 --sellToken=1 --minBuy=199 --maxSell=999 --validFor=20 "
 
 step "Advance time to start auction" \
 "npx truffle exec scripts/wait_seconds.js 300"

--- a/test/e2e-tests-stablex.sh
+++ b/test/e2e-tests-stablex.sh
@@ -11,8 +11,8 @@ step "Make sure we have enough balances for the trades" \
 npx truffle exec scripts/stablex/deposit.js --accountId=1 --tokenId=1 --amount=3000"
 
 step "Place 2 orders in current auction" \
-"npx truffle exec scripts/stablex/place_order.js --accountId=0 --buyToken=1 --sellToken=0 --minBuy=99 --maxSell=2000 --validFor=20 && \
-npx truffle exec scripts/stablex/place_order.js --accountId=1 --buyToken=0 --sellToken=1 --minBuy=199 --maxSell=999 --validFor=20 "
+"npx truffle exec scripts/stablex/place_order.js --accountId=0 --buyToken=1 --sellToken=0 --minBuy=999 --maxSell=2000 --validFor=20 && \
+npx truffle exec scripts/stablex/place_order.js --accountId=1 --buyToken=0 --sellToken=1 --minBuy=1996 --maxSell=999 --validFor=20 "
 
 step "Advance time to start auction" \
 "npx truffle exec scripts/wait_seconds.js 300"


### PR DESCRIPTION
Right now our log output is pretty messy and verbose. This PR addresses it in the following way:

1. No longer log every 5 seconds that we have already applied the current batch
2. Don't invoke the solver on empty auctions (leading to some complaints in the solver)
3. Don't submit solutions that don't have any volume (and thus also no utility). That would just be waisting gas.

On top of that we update the smart contracts to not show the annoying error message about a Set not being readable before there are any entries.

### Test Plan

Running the demo with the linear solver, will now show

```
stablex_1         |     Finished dev [unoptimized + debuginfo] target(s) in 0.23s
stablex_1         |      Running `target/debug/stablex`
stablex_1         | 2019-09-26 16:22:50,937 INFO  [driver::util] Using linear optimisation price finder
stablex_1         | 2019-09-26 16:22:50,988 INFO  [driver::driver::stablex_driver] No orders in batch 5231715
stablex_1         | 2019-09-26 16:22:50,988 INFO  [driver::driver::stablex_driver] Not submitting 0 volume solution for batch 5231715
stablex_1         | 2019-09-26 16:23:54,621 INFO  [driver::driver::stablex_driver] Computed solution: Solution { surplus: Some(3596998402997999639577936039039039039039), prices: [1000000000000000000, 2000000000000000000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], executed_buy_amounts: [998999000999999899899, 1996000003997999800000], executed_sell_amounts: [1999997999999999799597, 998999000999999899899] }
stablex_1         | 2019-09-26 16:23:54,987 INFO  [driver::driver::stablex_driver] Successfully applied solution to batch 5231716
stablex_1         | 2019-09-26 16:24:02,981 INFO  [driver::driver::stablex_driver] Computed solution: Solution { surplus: Some(3596998403362023701801864760696680), prices: [1000000000000000000, 2000000000000000000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], executed_buy_amounts: [998999001101101, 1996000004200000], executed_sell_amounts: [1999998000202404, 998999001101101] }
```