### PR TITLE
[Easy] Remove duplicate print statement

### DIFF
--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -184,7 +184,6 @@ impl PriceFinding for NaiveSolver {
             executed_sell_amounts: exec_sell_amount,
             executed_buy_amounts: exec_buy_amount,
         };
-        info!("Solution: {:?}", &solution);
         Ok(solution)
     }
 }


### PR DESCRIPTION
Trivial PR that justs removes the duplicate solution printing when using the naive solver. The stablex_driver already prints the found solution (for both naive as well as linear solver)

### Tes Plan

Run e2e demo in solver, see no duplicate printing of solution data.