### PR TITLE
[Easy] renaming surplus to objective value

### DIFF
--- a/dfusion_rust_core/src/models/account_state.rs
+++ b/dfusion_rust_core/src/models/account_state.rs
@@ -321,7 +321,7 @@ pub mod tests {
         };
 
         let results = Solution {
-            surplus: None,
+            objective_value: None,
             prices: vec![1, 1],
             executed_buy_amounts: vec![1, 1],
             executed_sell_amounts: vec![1, 1],

--- a/dfusion_rust_core/src/models/solution.rs
+++ b/dfusion_rust_core/src/models/solution.rs
@@ -8,7 +8,7 @@ use std::iter::once;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Solution {
-    pub surplus: Option<U256>,
+    pub objective_value: Option<U256>,
     pub prices: Vec<u128>,
     pub executed_buy_amounts: Vec<u128>,
     pub executed_sell_amounts: Vec<u128>,
@@ -17,7 +17,7 @@ pub struct Solution {
 impl Solution {
     pub fn trivial(num_orders: usize) -> Self {
         Solution {
-            surplus: Some(U256::zero()),
+            objective_value: Some(U256::zero()),
             prices: vec![0; TOKENS as usize],
             executed_buy_amounts: vec![0; num_orders],
             executed_sell_amounts: vec![0; num_orders],
@@ -62,7 +62,7 @@ impl Deserializable for Solution {
             )));
         });
         Solution {
-            surplus: None,
+            objective_value: None,
             prices,
             executed_buy_amounts,
             executed_sell_amounts,
@@ -77,7 +77,7 @@ pub mod unit_test {
     #[test]
     fn test_serialize_deserialize() {
         let solution = Solution {
-            surplus: None,
+            objective_value: None,
             prices: vec![42; TOKENS as usize],
             executed_buy_amounts: vec![4, 5, 6],
             executed_sell_amounts: vec![1, 2, 3],
@@ -111,7 +111,7 @@ pub mod unit_test {
         ];
         let parsed_solution = Solution::from_bytes(bytes);
         let expected = Solution {
-            surplus: None,
+            objective_value: None,
             prices: vec![
                 1,
                 10u128.pow(18),

--- a/driver/src/driver/order_driver.rs
+++ b/driver/src/driver/order_driver.rs
@@ -161,7 +161,7 @@ impl<'a> OrderProcessor<'a> {
             new_state_root,
             total_order_hash_from_contract,
             standing_order_indexes,
-            solution.surplus.unwrap_or_else(U256::zero),
+            solution.objective_value.unwrap_or_else(U256::zero),
         )?;
 
         self.auction_bids.insert(
@@ -270,7 +270,7 @@ mod tests {
 
         let mut pf = PriceFindingMock::default();
         let expected_solution = Solution {
-            surplus: Some(U256::zero()),
+            objective_value: Some(U256::zero()),
             prices: vec![1, 2],
             executed_sell_amounts: vec![0, 2],
             executed_buy_amounts: vec![0, 2],
@@ -507,7 +507,7 @@ mod tests {
 
         let mut pf = PriceFindingMock::default();
         let expected_solution = Solution {
-            surplus: Some(U256::zero()),
+            objective_value: Some(U256::zero()),
             prices: vec![1, 2],
             executed_sell_amounts: vec![0, 2],
             executed_buy_amounts: vec![0, 2],
@@ -692,7 +692,7 @@ mod tests {
     fn test_update_balances() {
         let mut state = AccountState::new(H256::zero(), U256::one(), vec![100; 60], TOKENS);
         let solution = Solution {
-            surplus: U256::from_dec_str("0").ok(),
+            objective_value: U256::from_dec_str("0").ok(),
             prices: vec![1, 2],
             executed_sell_amounts: vec![1, 1],
             executed_buy_amounts: vec![1, 1],

--- a/driver/src/driver/stablex_driver.rs
+++ b/driver/src/driver/stablex_driver.rs
@@ -90,7 +90,7 @@ mod tests {
             .will_return(Ok(()));
 
         let solution = Solution {
-            surplus: Some(U256::zero()),
+            objective_value: Some(U256::zero()),
             prices: vec![1, 2],
             executed_sell_amounts: vec![0, 2],
             executed_buy_amounts: vec![0, 2],
@@ -128,7 +128,7 @@ mod tests {
             .will_return(Ok(()));
 
         let solution = Solution {
-            surplus: Some(U256::zero()),
+            objective_value: Some(U256::zero()),
             prices: vec![1, 2],
             executed_sell_amounts: vec![0, 2],
             executed_buy_amounts: vec![0, 2],

--- a/driver/src/price_finding/linear_optimization_price_finder.rs
+++ b/driver/src/price_finding/linear_optimization_price_finder.rs
@@ -110,7 +110,7 @@ fn deserialize_result(
     let orders = json["orders"]
         .as_array()
         .ok_or_else(|| "No 'orders' list in json")?;
-    let surplus = Some(
+    let objective_value = Some(
         orders
             .iter()
             .map(|o| {
@@ -122,15 +122,17 @@ fn deserialize_result(
                             ErrorKind::JsonError,
                         )
                     })
-                    .and_then(|surplus| {
-                        U256::from_dec_str(surplus).map_err(|e| {
+                    .and_then(|objective_value| {
+                        U256::from_dec_str(objective_value).map_err(|e| {
                             PriceFindingError::new(&format!("{:?}", e), ErrorKind::ParseIntError)
                         })
                     })
             })
             .collect::<Result<Vec<U256>, PriceFindingError>>()?
             .iter()
-            .fold(U256::zero(), |acc, surplus| surplus.saturating_add(acc)),
+            .fold(U256::zero(), |acc, objective_value| {
+                objective_value.saturating_add(acc)
+            }),
     );
     let executed_sell_amounts = orders
         .iter()
@@ -161,7 +163,7 @@ fn deserialize_result(
         })
         .collect::<Result<Vec<u128>, PriceFindingError>>()?;
     Ok(models::Solution {
-        surplus,
+        objective_value,
         prices,
         executed_sell_amounts,
         executed_buy_amounts,
@@ -289,7 +291,7 @@ pub mod tests {
         });
 
         let expected_solution = models::Solution {
-            surplus: U256::from_dec_str("15854632034944469292777429010439194350").ok(),
+            objective_value: U256::from_dec_str("15854632034944469292777429010439194350").ok(),
             prices: vec![14_024_052_566_155_238_000, 1_526_784_674_855_762_300],
             executed_sell_amounts: vec![0, 318_390_084_925_498_118_944],
             executed_buy_amounts: vec![0, 95_042_777_139_162_480_000],
@@ -331,7 +333,7 @@ pub mod tests {
         assert_eq!(err.description(), "No 'orders' list in json");
     }
     #[test]
-    fn serialize_result_fails_if_order_does_not_have_surplus() {
+    fn serialize_result_fails_if_order_does_not_have_objective_value() {
         let json = json!({
             "prices": {
                 "token0": "100",

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -24,7 +24,7 @@ trait Matchable {
     ) -> Option<OrderPairType>;
     fn opposite_tokens(&self, other: &Order) -> bool;
     fn have_price_overlap(&self, other: &Order) -> bool;
-    fn surplus(&self, buy_price: u128, exec_buy_amount: u128, exec_sell_amount: u128) -> U256;
+    fn objective_value(&self, buy_price: u128, exec_buy_amount: u128, exec_sell_amount: u128) -> U256;
 }
 
 impl Matchable for Order {
@@ -73,7 +73,7 @@ impl Matchable for Order {
                 <= u128_to_u256(other.sell_amount) * u128_to_u256(self.sell_amount)
     }
 
-    fn surplus(&self, buy_price: u128, exec_buy_amount: u128, exec_sell_amount: u128) -> U256 {
+    fn objective_value(&self, buy_price: u128, exec_buy_amount: u128, exec_sell_amount: u128) -> U256 {
         let relative_buy = (u128_to_u256(self.buy_amount) * u128_to_u256(exec_sell_amount))
             .ceiled_div(u128_to_u256(self.sell_amount));
         (u128_to_u256(exec_buy_amount) - relative_buy) * u128_to_u256(buy_price)
@@ -100,7 +100,7 @@ impl PriceFinding for NaiveSolver {
         let mut prices: Vec<u128> = vec![0; TOKENS as usize];
         let mut exec_buy_amount: Vec<u128> = vec![0; orders.len()];
         let mut exec_sell_amount: Vec<u128> = vec![0; orders.len()];
-        let mut total_surplus = U256::zero();
+        let mut total_objective_value = U256::zero();
 
         let mut found_flag = false;
 
@@ -142,17 +142,17 @@ impl PriceFinding for NaiveSolver {
                     None => continue,
                 }
                 found_flag = true;
-                let x_surplus = x.surplus(
+                let x_objective_value = x.objective_value(
                     prices[x.buy_token as usize],
                     exec_buy_amount[i],
                     exec_sell_amount[i],
                 );
-                let y_surplus = y.surplus(
+                let y_objective_value = y.objective_value(
                     prices[y.buy_token as usize],
                     exec_buy_amount[j],
                     exec_sell_amount[j],
                 );
-                total_surplus = x_surplus.checked_add(y_surplus).unwrap();
+                total_objective_value = x_objective_value.checked_add(y_objective_value).unwrap();
                 break;
             }
             if found_flag {
@@ -179,7 +179,7 @@ impl PriceFinding for NaiveSolver {
         }
 
         let solution = Solution {
-            surplus: Some(total_surplus),
+            objective_value: Some(total_objective_value),
             prices,
             executed_sell_amounts: exec_sell_amount,
             executed_buy_amounts: exec_buy_amount,
@@ -224,7 +224,7 @@ pub mod tests {
         let solver = NaiveSolver::new(None);
         let res = solver.find_prices(&orders, &state).unwrap();
 
-        assert_eq!(Some(u128_to_u256(16 * 10u128.pow(36))), res.surplus);
+        assert_eq!(Some(u128_to_u256(16 * 10u128.pow(36))), res.objective_value);
         assert_eq!(
             vec![4 * 10u128.pow(18), 52 * 10u128.pow(18)],
             res.executed_buy_amounts
@@ -262,7 +262,7 @@ pub mod tests {
         let solver = NaiveSolver::new(None);
         let res = solver.find_prices(&orders, &state).unwrap();
 
-        assert_eq!(Some(u128_to_u256(16 * 10u128.pow(36))), res.surplus);
+        assert_eq!(Some(u128_to_u256(16 * 10u128.pow(36))), res.objective_value);
         assert_eq!(
             vec![52 * 10u128.pow(18), 4 * 10u128.pow(18)],
             res.executed_buy_amounts
@@ -300,7 +300,7 @@ pub mod tests {
         let solver = NaiveSolver::new(None);
         let res = solver.find_prices(&orders, &state).unwrap();
 
-        assert_eq!(Some(u128_to_u256(92 * 10u128.pow(36))), res.surplus);
+        assert_eq!(Some(u128_to_u256(92 * 10u128.pow(36))), res.objective_value);
         assert_eq!(
             vec![16 * 10u128.pow(18), 10 * 10u128.pow(18)],
             res.executed_buy_amounts
@@ -386,7 +386,7 @@ pub mod tests {
         let solver = NaiveSolver::new(None);
         let res = solver.find_prices(&orders, &state).unwrap();
 
-        assert_eq!(Some(U256::from(16)), res.surplus);
+        assert_eq!(Some(U256::from(16)), res.objective_value);
         assert_eq!(vec![0, 0, 0, 52, 4, 0], res.executed_buy_amounts);
         assert_eq!(vec![0, 0, 0, 4, 52, 0], res.executed_sell_amounts);
         assert_eq!(4, res.prices[1]);

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -24,7 +24,12 @@ trait Matchable {
     ) -> Option<OrderPairType>;
     fn opposite_tokens(&self, other: &Order) -> bool;
     fn have_price_overlap(&self, other: &Order) -> bool;
-    fn objective_value(&self, buy_price: u128, exec_buy_amount: u128, exec_sell_amount: u128) -> U256;
+    fn objective_value(
+        &self,
+        buy_price: u128,
+        exec_buy_amount: u128,
+        exec_sell_amount: u128,
+    ) -> U256;
 }
 
 impl Matchable for Order {
@@ -73,7 +78,12 @@ impl Matchable for Order {
                 <= u128_to_u256(other.sell_amount) * u128_to_u256(self.sell_amount)
     }
 
-    fn objective_value(&self, buy_price: u128, exec_buy_amount: u128, exec_sell_amount: u128) -> U256 {
+    fn objective_value(
+        &self,
+        buy_price: u128,
+        exec_buy_amount: u128,
+        exec_sell_amount: u128,
+    ) -> U256 {
         let relative_buy = (u128_to_u256(self.buy_amount) * u128_to_u256(exec_sell_amount))
             .ceiled_div(u128_to_u256(self.sell_amount));
         (u128_to_u256(exec_buy_amount) - relative_buy) * u128_to_u256(buy_price)

--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -65,7 +65,7 @@ pub mod tests {
     #[test]
     fn test_serialize_solution() {
         let solution = models::Solution {
-            surplus: Some(U256::zero()),
+            objective_value: Some(U256::zero()),
             prices: vec![1, 2],
             executed_sell_amounts: vec![3, 4],
             executed_buy_amounts: vec![5, 6],


### PR DESCRIPTION
As Felix mentioned in the other PR #269, our solution model is used in different contexts. Hence, it is appropriate to replace the name surplus with a more general name.

----
testplan:
unit tests