### PR TITLE
[Docker] fix truffle docker image

### DIFF
--- a/docker/truffle/Dockerfile
+++ b/docker/truffle/Dockerfile
@@ -2,10 +2,9 @@ FROM node:10.15-alpine
 
 # Create app directory
 WORKDIR /app/dex-contracts
-COPY dex-contracts ./
+# Don't copy git artifacts as they contain backpointers to the parent repo
+COPY dex-contracts/[^.git]* ./
 COPY docker/truffle/run.sh /app/run.sh
-# Since we only copy the submodule, get rid of the parent repository information
-RUN rm -rf .git
 
 # Dependencies will Install app dependencies
 RUN apk add --update --no-cache --virtual build-dependencies git python make g++ ca-certificates

--- a/docker/truffle/Dockerfile
+++ b/docker/truffle/Dockerfile
@@ -4,6 +4,8 @@ FROM node:10.15-alpine
 WORKDIR /app/dex-contracts
 COPY dex-contracts ./
 COPY docker/truffle/run.sh /app/run.sh
+# Since we only copy the submodule, get rid of the parent repository information
+RUN rm -rf .git
 
 # Dependencies will Install app dependencies
 RUN apk add --update --no-cache --virtual build-dependencies git python make g++ ca-certificates


### PR DESCRIPTION
It turns out that `npm install` inside the docker image was not working due to the following error:

```
npm ERR! fatal: not a git repository: /app/dex-contracts/../.git/modules/dex-contracts
```

This was because we copy the git submodule dex-contracts into the docker container without its parent directory (cf. Dockerfile line 5). The `.git` file inside dex-contracts contains a pointer to its parent module which in the container does not exist (`/app/dex-contracts/../.git/modules/dex-contracts`).

This caused the error above.

I suggest to fix this by removing the git reference inside the container after copying the folder.

## Test Plan

Inside dex-services, go into dex-contracts submodule and `rm -rf node_modules`. Back up in dex-services run `docker-compose build truffle` and see no errors.