### PR TITLE
[Docker] fix truffle docker file

### DIFF
--- a/docker/truffle/Dockerfile
+++ b/docker/truffle/Dockerfile
@@ -2,11 +2,8 @@ FROM node:10.15-alpine
 
 # Create app directory
 WORKDIR /app/dex-contracts
-# Don't copy git artifacts as they contain backpointers to the parent repo
-COPY dex-contracts/[^.git]* ./
+COPY dex-contracts ./
 COPY docker/truffle/run.sh /app/run.sh
 
 # Dependencies will Install app dependencies
 RUN apk add --update --no-cache --virtual build-dependencies git python make g++ ca-certificates
-RUN npm install
-RUN npm run network-inject

--- a/docker/truffle/Dockerfile
+++ b/docker/truffle/Dockerfile
@@ -8,5 +8,5 @@ COPY docker/truffle/run.sh /app/run.sh
 
 # Dependencies will Install app dependencies
 RUN apk add --update --no-cache --virtual build-dependencies git python make g++ ca-certificates
-RUN npm install --production
+RUN npm install
 RUN npm run network-inject

--- a/docker/truffle/Dockerfile
+++ b/docker/truffle/Dockerfile
@@ -2,8 +2,4 @@ FROM node:10.15-alpine
 
 # Create app directory
 WORKDIR /app/dex-contracts
-COPY dex-contracts ./
 COPY docker/truffle/run.sh /app/run.sh
-
-# Dependencies will Install app dependencies
-RUN apk add --update --no-cache --virtual build-dependencies git python make g++ ca-certificates

--- a/docker/truffle/run.sh
+++ b/docker/truffle/run.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
-node_modules/.bin/truffle migrate --reset --network developmentdocker
+export GANACHE_HOST='ganache-cli'
+npx truffle migrate --reset
 touch build/migration.flag


### PR DESCRIPTION
#280 excluded the git file in the truffle docker. However the command suggested doesn't actually copy the file structure as expected (it only copies all folders recursively but no top level files).

The reason things were still working are that we are always mounting the original dex-contracts repo as a volume in the docker container. Thus, removing the git file and most importantly doing any installation or injection are pointless.

This PR removes the unnecessary steps and makes sure we can actually run the migrations from within docker.

Note that it will still be required to run npm install locally before starting the container.

### Test Plan

```
cd dex-contract && rm -rf build && cd ..
docker-compose build truffle
docker-compose up truffle
```

See no errors