### PR TITLE
Add order utility and disregarded utility calculation

### DIFF
--- a/dfusion_rust_core/src/lib.rs
+++ b/dfusion_rust_core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod database;
 pub mod models;
+pub mod util;
 
 use graph::prelude::SubgraphDeploymentId;
 

--- a/dfusion_rust_core/src/models/order.rs
+++ b/dfusion_rust_core/src/models/order.rs
@@ -67,12 +67,6 @@ impl Order {
         let buy_amount = u128_to_u256(self.buy_amount);
         let sell_amount = u128_to_u256(self.sell_amount);
 
-        // essential_utility = (exec_buy_amount - (exec_sell_amount * buy_amount)
-        //   / sell_amount) * buy_price
-        // essential_utility = (((exec_sell_amount * buy_amount) % sell_amount)
-        //   * buy_price) / sell_amount
-        // utility = essential_utility - essential_utility
-
         let essential_utility = exec_buy_amount
             .checked_sub((exec_sell_amount * buy_amount).checked_div(sell_amount)?)?
             * buy_price;
@@ -101,10 +95,6 @@ impl Order {
         let exec_sell_amount = u128_to_u256(exec_sell_amount);
         let buy_amount = u128_to_u256(self.buy_amount);
         let sell_amount = u128_to_u256(self.sell_amount);
-
-        // limit_term = sell_price * sell_amount - buy_amount * buy_price
-        // leftover_sell_amount = sell_amount - exec_sell_amount
-        // disregarded_utility = (limit_term * leftover_sell_amount) / sell_amount
 
         let limit_term = (sell_price * sell_amount).checked_sub(buy_amount * buy_price)?;
         let leftover_sell_amount = sell_amount.checked_sub(exec_sell_amount)?;
@@ -383,7 +373,7 @@ pub mod tests {
             order.utility(buy_price, exec_buy_amount, exec_sell_amount),
             // u = ((xb * os - xs * ob) * bp) / os
             //   = ((10 * 100 - 90 * 10) * 9) / 100
-            //   = 100
+            //   = 9
             Some(9.into())
         );
     }

--- a/dfusion_rust_core/src/util.rs
+++ b/dfusion_rust_core/src/util.rs
@@ -1,0 +1,55 @@
+use std::convert::TryInto;
+use web3::types::U256;
+
+/// Convert a u128 to a U256.
+pub fn u128_to_u256(x: u128) -> U256 {
+    U256::from_big_endian(&x.to_be_bytes())
+}
+
+/// Convert a U256 to a u128.
+///
+/// # Panics
+///
+/// Panics if the U256 overflows a u128.
+pub fn u256_to_u128(x: U256) -> u128 {
+    let mut bytes = [0u8; 32];
+    x.to_big_endian(&mut bytes[..]);
+
+    let hi = u128::from_be_bytes(bytes[..16].try_into().expect("correct slice length"));
+    let lo = u128::from_be_bytes(bytes[16..].try_into().expect("correct slice length"));
+
+    assert_eq!(hi, 0, "U256 to u128 overflow");
+    lo
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn test_u128_to_u256() {
+        assert_eq!(
+            u128_to_u256(u128::max_value()),
+            U256::from_dec_str("340282366920938463463374607431768211455").unwrap(),
+            "failed on 128::max_value()"
+        );
+        assert_eq!(u128_to_u256(1u128), U256::from(1), "failed on 1u128");
+        assert_eq!(u128_to_u256(0u128), U256::from(0), "failed on 0u128");
+    }
+
+    #[test]
+    fn test_256_to_u128_works() {
+        assert_eq!(0u128, u256_to_u128(U256::from(0)));
+        assert_eq!(1u128, u256_to_u128(U256::from(1)));
+        assert_eq!(
+            u128::max_value(),
+            u256_to_u128(U256::from_dec_str("340282366920938463463374607431768211455").unwrap())
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_u256_to_u128_panics_on_overflow() {
+        u256_to_u128(U256::from_dec_str("340282366920938463463374607431768211456").unwrap());
+    }
+}

--- a/driver/src/util.rs
+++ b/driver/src/util.rs
@@ -1,7 +1,6 @@
 use log::info;
 
 use std::env;
-use std::str::FromStr;
 
 use web3::types::{H256, U256};
 
@@ -12,13 +11,7 @@ use crate::price_finding::{Fee, LinearOptimisationPriceFinder, NaiveSolver, Pric
 
 const BATCH_TIME_SECONDS: u32 = 3 * 60;
 
-pub fn u128_to_u256(x: u128) -> U256 {
-    U256::from_big_endian(&x.to_be_bytes())
-}
-
-pub fn u256_to_u128(x: U256) -> u128 {
-    u128::from_str(&x.to_string()).unwrap()
-}
+pub use dfusion_core::util::*;
 
 pub trait CeiledDiv {
     fn ceiled_div(&self, divisor: Self) -> Self;
@@ -112,33 +105,6 @@ pub fn create_price_finder(fee: Option<Fee>) -> Box<dyn PriceFinding> {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-
-    #[test]
-    fn test_u128_to_u256() {
-        assert_eq!(
-            u128_to_u256(u128::max_value()),
-            U256::from_dec_str("340282366920938463463374607431768211455").unwrap(),
-            "failed on 128::max_value()"
-        );
-        assert_eq!(u128_to_u256(1u128), U256::from(1), "failed on 1u128");
-        assert_eq!(u128_to_u256(0u128), U256::from(0), "failed on 0u128");
-    }
-
-    #[test]
-    fn test_256_to_u128_works() {
-        assert_eq!(0u128, u256_to_u128(U256::from(0)));
-        assert_eq!(1u128, u256_to_u128(U256::from(1)));
-        assert_eq!(
-            u128::max_value(),
-            u256_to_u128(U256::from_dec_str("340282366920938463463374607431768211455").unwrap())
-        );
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_u256_to_u128_panics_on_overflow() {
-        u256_to_u128(U256::from_dec_str("340282366920938463463374607431768211456").unwrap());
-    }
 
     #[test]
     fn test_ceiled_div_u128() {


### PR DESCRIPTION
In order to ultimately calculate a solution's objective value we need to calculate the utility and disregarded utility per order. This PR implements those calculations.

This PR is the first part of the PR #281 as it was too big and got difficult to review.

### Testplan

Unit tests were added with and will be run on CI to verify calculations