### PR TITLE
[Easy] Fix gas price from WEI to GWEI

### DIFF
--- a/driver/src/contracts/snapp_contract.rs
+++ b/driver/src/contracts/snapp_contract.rs
@@ -299,7 +299,6 @@ impl SnappContract for SnappContractImpl {
                 (slot, merkle_root, prev_state, new_state, withdraw_hash),
                 Options::with(|mut opt| {
                     // usual gas estimate is not working
-                    opt.gas_price = Some(25.into());
                     opt.gas = Some(1_000_000.into());
                 }),
             )

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -91,7 +91,7 @@ impl StableXContract for StableXContractImpl {
                 ),
                 Options::with(|mut opt| {
                     // usual gas estimate is not working
-                    opt.gas_price = Some(25.into());
+                    opt.gas_price = Some(20_000_000_000u64.into());
                     opt.gas = Some(5_000_000.into());
                 }),
             )


### PR DESCRIPTION
Gas is usually provided in GIGA wei. In our current implementation we set the gas price to a very small wei amount.

When testing solution submission on Rinkeby this turned out to be problematic (tx didn't get mined).

I'm not sure how this worked in the past.

### Test Plan

Mined Rinkeby transaction with fix: https://rinkeby.etherscan.io/tx/0x20f6f26e0b2345e4be26080d6ee825f0c6143e07f0d10e184b9d43efb8a7f2af

Basically I created some orders between token 0 and 1 and made sure the service picks them up and applies a solution.