### PR TITLE
Adding webhook to deployment

### DIFF
--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -19,9 +19,11 @@ docker push $REGISTRY_URI:$TRAVIS_BRANCH
 echo "The image has been pushed";
 rm -rf .ssh/*
 
-# Notifying webhook
-curl -s --output /dev/null --write-out "%{http_code}" \
-  -H "Content-Type: application/json" \
-  -X POST \
-  -d '{"token": "'$AUTODEPLOY_TOKEN'", "push_data": {"tag": "'$TRAVIS_BRANCH'" }}' \
-  $AUTODEPLOY_URL
+if [ -n "$AUTODEPLOY_URL" ] && [ -n "$AUTODEPLOY_TOKEN" ]; then
+  # Notifying webhook
+  curl -s --output /dev/null --write-out "%{http_code}" \
+    -H "Content-Type: application/json" \
+    -X POST \
+    -d '{"token": "'$AUTODEPLOY_TOKEN'", "push_data": {"tag": "'$TRAVIS_BRANCH'" }}' \
+    $AUTODEPLOY_URL
+fi

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -23,5 +23,5 @@ rm -rf .ssh/*
 curl -s --output /dev/null --write-out "%{http_code}" \
   -H "Content-Type: application/json" \
   -X POST \
-  -d '{"token": "$AUTODEPLOY_TOKEN", "push_data": {"tag": "'"$TRAVIS_BRANCH"'" }}' \
+  -d '{"token": "'$AUTODEPLOY_TOKEN'", "push_data": {"tag": "'$TRAVIS_BRANCH'" }}' \
   $AUTODEPLOY_URL

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -18,3 +18,10 @@ docker push $REGISTRY_URI:$TRAVIS_BRANCH
 
 echo "The image has been pushed";
 rm -rf .ssh/*
+
+# Notifying webhook
+curl -s --output /dev/null --write-out "%{http_code}" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d '{"token": "$AUTODEPLOY_TOKEN", "push_data": {"tag": "'"$TRAVIS_BRANCH"'" }}' \
+  $AUTODEPLOY_URL


### PR DESCRIPTION
This PR adds a call to an AUTODEPLOY url which will tell the AWS cluster that it has to restart our service (since there was a new deployment).

@davidalbela are you going to add the missing `AUTODEPLOY_URL` and `AUTODEPLOY_TOKEN ` secrets to our travis config?

### Test Plan

<a href="https://gitme.me/image?url=https%3A%2F%2Fmedia1.giphy.com%2Fmedia%2F26n7937SwZkal2Oju%2Fgiphy.gif&token=pray" data-gitmeme-token="pray"><img src="https://media1.giphy.com/media/26n7937SwZkal2Oju/giphy.gif" title="Created by gitme.me with /pray"/></a>