### PR TITLE
New env for auto deploying docker image

### DIFF
--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -20,10 +20,10 @@ echo "The image has been pushed";
 rm -rf .ssh/*
 
 if [ -n "$AUTODEPLOY_URL" ] && [ -n "$AUTODEPLOY_TOKEN" ]; then
-  # Notifying webhook
-  curl -s --output /dev/null --write-out "%{http_code}" \
+    # Notifying webhook
+    curl -s --output /dev/null --write-out "%{http_code}" \
     -H "Content-Type: application/json" \
     -X POST \
-    -d '{"token": "'$AUTODEPLOY_TOKEN'", "push_data": {"tag": "'$TRAVIS_BRANCH'" }}' \
+    -d '{"token": "'$AUTODEPLOY_TOKEN'", "push_data": {"tag": "'$AUTODEPLOY_TAG'" }}' \
     $AUTODEPLOY_URL
 fi


### PR DESCRIPTION
This new env is required as we want to set a different tag for the docker image than the one specified in the $TRAVIS_BRANCH

--
testplan: praying