### PR TITLE
[Easy] taking the `utilitlyPerOrder` out, as Tom's interface no longer support it

### DIFF
--- a/driver/src/price_finding/linear_optimization_price_finder.rs
+++ b/driver/src/price_finding/linear_optimization_price_finder.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;
 use std::process::Command;
-use web3::types::{H160, U256};
+use web3::types::H160;
 
 const RESULT_FOLDER: &str = "./results/tmp/";
 type Prices = HashMap<String, String>;
@@ -110,30 +110,7 @@ fn deserialize_result(
     let orders = json["orders"]
         .as_array()
         .ok_or_else(|| "No 'orders' list in json")?;
-    let objective_value = Some(
-        orders
-            .iter()
-            .map(|o| {
-                o["execUtility"]
-                    .as_str()
-                    .ok_or_else(|| {
-                        PriceFindingError::new(
-                            "No 'execUtility' field on order",
-                            ErrorKind::JsonError,
-                        )
-                    })
-                    .and_then(|objective_value| {
-                        U256::from_dec_str(objective_value).map_err(|e| {
-                            PriceFindingError::new(&format!("{:?}", e), ErrorKind::ParseIntError)
-                        })
-                    })
-            })
-            .collect::<Result<Vec<U256>, PriceFindingError>>()?
-            .iter()
-            .fold(U256::zero(), |acc, objective_value| {
-                objective_value.saturating_add(acc)
-            }),
-    );
+    let objective_value = None;
     let executed_sell_amounts = orders
         .iter()
         .map(|o| {
@@ -291,7 +268,7 @@ pub mod tests {
         });
 
         let expected_solution = models::Solution {
-            objective_value: U256::from_dec_str("15854632034944469292777429010439194350").ok(),
+            objective_value: None,
             prices: vec![14_024_052_566_155_238_000, 1_526_784_674_855_762_300],
             executed_sell_amounts: vec![0, 318_390_084_925_498_118_944],
             executed_buy_amounts: vec![0, 95_042_777_139_162_480_000],
@@ -331,40 +308,6 @@ pub mod tests {
         });
         let err = deserialize_result(&json, 1).expect_err("Should fail to parse");
         assert_eq!(err.description(), "No 'orders' list in json");
-    }
-    #[test]
-    fn serialize_result_fails_if_order_does_not_have_objective_value() {
-        let json = json!({
-            "prices": {
-                "token0": "100",
-            },
-            "orders": [
-                {
-                    "execSellAmount": "0",
-                    "execBuyAmount": "0",
-                }
-            ]
-        });
-        let err = deserialize_result(&json, 1).expect_err("Should fail to parse");
-        assert_eq!(err.description(), "No 'execUtility' field on order");
-    }
-
-    #[test]
-    fn serialize_result_fails_if_order_suprlus_not_parseable() {
-        let json = json!({
-            "prices": {
-                "token0": "100",
-            },
-            "orders": [
-                {
-                    "execSellAmount": "0",
-                    "execBuyAmount": "0",
-                    "execUtility": "0a0b"
-                }
-            ]
-        });
-        let err = deserialize_result(&json, 1).expect_err("Should fail to parse");
-        assert_eq!(err.kind, ErrorKind::ParseIntError);
     }
 
     #[test]

--- a/driver/src/price_finding/linear_optimization_price_finder.rs
+++ b/driver/src/price_finding/linear_optimization_price_finder.rs
@@ -110,7 +110,6 @@ fn deserialize_result(
     let orders = json["orders"]
         .as_array()
         .ok_or_else(|| "No 'orders' list in json")?;
-    let objective_value = None;
     let executed_sell_amounts = orders
         .iter()
         .map(|o| {
@@ -140,7 +139,7 @@ fn deserialize_result(
         })
         .collect::<Result<Vec<u128>, PriceFindingError>>()?;
     Ok(models::Solution {
-        objective_value,
+        objective_value: None,
         prices,
         executed_sell_amounts,
         executed_buy_amounts,
@@ -222,7 +221,7 @@ pub mod tests {
     use super::*;
     use dfusion_core::models::account_state::test_util::*;
     use std::error::Error;
-    use web3::types::H256;
+    use web3::types::{H256, U256};
 
     #[test]
     fn test_serialize_order() {


### PR DESCRIPTION
[Easy] taking the `utilitlyPerOrder` out, as Tom's interface no longer support it

Without this fix, the integration of Tom's solver is no longer working. 

---
testplan:
```
docker-compose build --build-arg use_solver=1 stablex
docker-compose up stablex
cd dex-contracts
npx truffle migrate
```
and run the e2e test. It is expected to fail, though you want to check in the driver console that prices were submitted succesfully