### PR TITLE
Add Snapp Objective Value Calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,6 +601,7 @@ dependencies = [
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple_logger 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "web3 0.6.0 (git+https://github.com/tomusdrw/rust-web3?rev=56ad08e)",
 ]
 
@@ -1975,6 +1976,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "publicsuffix"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,6 +2021,14 @@ version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2733,6 +2750,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "synom"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2785,6 +2812,24 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3205,6 +3250,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -3677,11 +3727,13 @@ dependencies = [
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum pq-sys 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6ac25eee5a0582f45a67e837e350d784e7003bd29a5f460796772061ca49ffda"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+"checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum publicsuffix 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5afecba86dcf1e4fd610246f89899d1924fe12e1e89f555eb7c7f710f3c5ad1d"
 "checksum pwasm-utils 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "efb0dcbddbb600f47a7098d33762a00552c671992171637f5bb310b37fe1f0e4"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+"checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum r2d2 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bc42ce75d9f4447fb2a04bbe1ed5d18dd949104572850ec19b164e274919f81b"
 "checksum rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
@@ -3764,12 +3816,15 @@ dependencies = [
 "checksum stringprep 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)" = "bc945221ccf4a7e8c31222b9d1fc77aefdd6638eb901a6ce457a3dc29d4c31e8"
+"checksum syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
+"checksum thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "cc6b305ec0e323c7b6cfff6098a22516e0063d0bb7c3d88660a890217dca099a"
+"checksum thiserror-impl 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45ba8d810d9c48fc456b7ad54574e8bfb7c7918a57ad7a6e6a0985d7959e8597"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
@@ -3811,6 +3866,7 @@ dependencies = [
 "checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum utf-8 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -23,6 +23,7 @@ log = "0.4.6"
 rustc-hex = "*"
 serde_json = "1.0"
 simple_logger = "1.2.0"
+thiserror = "1.0"
 web3 = { git = "https://github.com/tomusdrw/rust-web3", rev = "56ad08e" }
 
 [dev-dependencies]

--- a/driver/src/driver/order_driver.rs
+++ b/driver/src/driver/order_driver.rs
@@ -1,7 +1,7 @@
 use crate::contracts::snapp_contract::SnappContract;
 use crate::error::{DriverError, ErrorKind};
 use crate::price_finding::PriceFinding;
-use crate::snapp::{SnappSolution};
+use crate::snapp::SnappSolution;
 use crate::util::{
     batch_processing_state, find_first_unapplied_slot, hash_consistency_check, ProcessingState,
 };

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -19,6 +19,7 @@ pub mod contracts;
 pub mod driver;
 pub mod error;
 pub mod price_finding;
+pub mod snapp;
 pub mod util;
 
 pub fn run_driver_components(

--- a/driver/src/snapp.rs
+++ b/driver/src/snapp.rs
@@ -7,6 +7,62 @@ use dfusion_core::models::{Order, Solution};
 use thiserror::Error;
 use web3::types::U256;
 
+/// Snapp specific extension trait for `Solution`. This extension trait provides
+/// an implementation to calculating the Snapp objective value which must be
+/// submitted with the solution.
+pub trait SnappSolution {
+    /// Returns the price for a token by ID or None if the token was not found.
+    fn get_token_price(&self, token_id: u16) -> Option<u128>;
+
+    /// Returns the objective value for submitting a solution to the Snapp smart
+    /// contract. The objective value is calculated as the total executed
+    /// utility of all orders.
+    ///
+    /// Note that this does not evaluate the validity of the solution and just
+    /// calculates the objective value.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(U256)` when the solution's objective value is correctly calculated
+    /// and `Err` otherwise. Errors can occur when:
+    /// - The order book does not match the solution (number of orders)
+    /// - The order's token ids are not found
+    /// - An invalid order
+    /// - An order where the limit price was not respected
+    /// - Total utility overflows a solidity `uint256`
+    fn snapp_objective_value(&self, orders: &[Order]) -> Result<U256, SnappObjectiveError>;
+}
+
+impl SnappSolution for Solution {
+    fn get_token_price(&self, token_id: u16) -> Option<u128> {
+        self.prices.get(token_id as usize).cloned()
+    }
+
+    fn snapp_objective_value(&self, orders: &[Order]) -> Result<U256, SnappObjectiveError> {
+        let mut total_executed_utility = U256::zero();
+        for (i, order) in orders.iter().enumerate() {
+            total_executed_utility = total_executed_utility
+                .checked_add(
+                    order.executed_utility(
+                        self.get_token_price(order.buy_token)
+                            .ok_or(SnappObjectiveError::TokenNotFound)?,
+                        *self
+                            .executed_buy_amounts
+                            .get(i)
+                            .ok_or(SnappObjectiveError::OrderBookMismatch)?,
+                        *self
+                            .executed_sell_amounts
+                            .get(i)
+                            .ok_or(SnappObjectiveError::OrderBookMismatch)?,
+                    )?,
+                )
+                .ok_or(SnappObjectiveError::TotalUtilityOverflow)?;
+        }
+
+        Ok(total_executed_utility)
+    }
+}
+
 /// Snapp specific extensions for `Order`. This extension trait provides the
 /// required functions for calculating the objective value used in the Snapp
 /// protocol which is needed for solution submission.
@@ -48,7 +104,7 @@ impl SnappOrder for Order {
             .checked_sub(
                 (exec_sell_amt * buy_amt)
                     .checked_div(sell_amt)
-                    .ok_or(SnappObjectiveError::BadOrder)?,
+                    .ok_or(SnappObjectiveError::InvalidOrder)?,
             )
             .ok_or(SnappObjectiveError::LimitPriceNotRespected)?
             * buy_price;
@@ -66,9 +122,16 @@ impl SnappOrder for Order {
 /// objective value.
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
 pub enum SnappObjectiveError {
+    /// A token referenced by an order was not found in the solution.
+    #[error("token not found")]
+    TokenNotFound,
+    /// The order book does not match the solution. This happens when the number
+    /// of orders does not equal the number of executed amounts.
+    #[error("the order book does not match the solution")]
+    OrderBookMismatch,
     /// The order contains invalid values such as a 0 sell amount.
     #[error("an order contains invalid values")]
-    BadOrder,
+    InvalidOrder,
     /// The limit price of an order was not respected. This causes an underflow
     /// during the utility calculation and as such the total objective value
     /// cannot be accurately determined.
@@ -83,6 +146,180 @@ pub enum SnappObjectiveError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn solution_objective_value() {
+        let orders = vec![
+            Order {
+                buy_token: 0,
+                sell_token: 1,
+                buy_amount: 2 * 10u128.pow(18),
+                sell_amount: 10u128.pow(18),
+                ..Order::default()
+            },
+            Order {
+                buy_token: 1,
+                sell_token: 0,
+                buy_amount: 10u128.pow(18),
+                sell_amount: 3 * 10u128.pow(18),
+                ..Order::default()
+            },
+        ];
+
+        let solution = Solution {
+            objective_value: None,
+            prices: vec![10u128.pow(18), 2_500_000_000_000_000_000],
+            executed_buy_amounts: vec![2_497_500_000_000_000_000, 10u128.pow(18)],
+            executed_sell_amounts: vec![10u128.pow(18), 2_502_502_502_502_502_502],
+        };
+
+        // U0 = ((xb * os - xs * ob) * pb) / os
+        //    = ((2.497eth * 1eth - 1eth * 2eth) * 1eth) / 1eth
+        //    = 497500000000000000000000000000000000
+        // U1 = ((xb * os - xs * ob) * pb) / os
+        //    = ((1eth * 3eth - 2.502eth * 1eth) * 2.5eth) / 3eth
+        //    = 414581247914581248333333333333333333
+        //    = 414581247914581248333333333333333334 -- with rounding error
+        //  O = U0 + U1
+        //    = 912081247914581248333333333333333334
+
+        assert_eq!(
+            solution.snapp_objective_value(&orders),
+            Ok(U256::from_dec_str("912081247914581248333333333333333334").unwrap())
+        );
+    }
+
+    #[test]
+    fn trivial_solution_objective_value() {
+        let orders: Vec<_> = (0..5)
+            .map(|i| Order {
+                buy_token: i,
+                sell_token: 5 - i,
+                buy_amount: 100,
+                sell_amount: 100,
+                ..Default::default()
+            })
+            .collect();
+
+        assert_eq!(
+            Solution::trivial(1).snapp_objective_value(&orders[..1]),
+            Ok(U256::zero())
+        );
+        assert_eq!(
+            Solution::trivial(5).snapp_objective_value(&orders),
+            Ok(U256::zero())
+        );
+    }
+
+    #[test]
+    fn solution_objective_value_token_not_found() {
+        let orders = vec![Order {
+            buy_token: 1,
+            sell_token: 0,
+            buy_amount: 10u128.pow(18),
+            sell_amount: 10u128.pow(18),
+            ..Order::default()
+        }];
+
+        let solution = Solution {
+            objective_value: None,
+            prices: vec![10u128.pow(18)],
+            executed_buy_amounts: vec![10u128.pow(18)],
+            executed_sell_amounts: vec![10u128.pow(18)],
+        };
+
+        assert_eq!(
+            solution.snapp_objective_value(&orders),
+            Err(SnappObjectiveError::TokenNotFound)
+        );
+    }
+
+    #[test]
+    fn solution_objective_value_order_book_mismatch() {
+        let orders = vec![
+            Order {
+                buy_token: 0,
+                sell_token: 1,
+                buy_amount: 10u128.pow(18),
+                sell_amount: 10u128.pow(18),
+                ..Order::default()
+            },
+            Order {
+                buy_token: 1,
+                sell_token: 0,
+                buy_amount: 10u128.pow(18),
+                sell_amount: 10u128.pow(18),
+                ..Order::default()
+            },
+        ];
+
+        let solution = Solution {
+            objective_value: None,
+            prices: vec![10u128.pow(18), 10u128.pow(18)],
+            executed_buy_amounts: vec![10u128.pow(18)],
+            executed_sell_amounts: vec![10u128.pow(18)],
+        };
+
+        assert_eq!(
+            solution.snapp_objective_value(&orders),
+            Err(SnappObjectiveError::OrderBookMismatch)
+        );
+    }
+
+    #[test]
+    fn solution_objective_value_order_utility_error() {
+        let orders = vec![Order {
+            buy_token: 0,
+            sell_token: 1,
+            buy_amount: 10u128.pow(18),
+            sell_amount: 0,
+            ..Order::default()
+        }];
+
+        let solution = Solution {
+            objective_value: None,
+            prices: vec![10u128.pow(18), 10u128.pow(18)],
+            executed_buy_amounts: vec![10u128.pow(18)],
+            executed_sell_amounts: vec![10u128.pow(18)],
+        };
+
+        assert_eq!(
+            solution.snapp_objective_value(&orders),
+            Err(SnappObjectiveError::InvalidOrder)
+        );
+    }
+
+    #[test]
+    fn solution_objective_value_overflow() {
+        let orders = vec![
+            Order {
+                buy_token: 0,
+                sell_token: 1,
+                buy_amount: 10u128.pow(18),
+                sell_amount: 10u128.pow(18),
+                ..Order::default()
+            },
+            Order {
+                buy_token: 0,
+                sell_token: 1,
+                buy_amount: 10u128.pow(18),
+                sell_amount: 10u128.pow(18),
+                ..Order::default()
+            },
+        ];
+
+        let solution = Solution {
+            objective_value: None,
+            prices: vec![u128::max_value(), 10u128.pow(18)],
+            executed_buy_amounts: vec![u128::max_value(), u128::max_value()],
+            executed_sell_amounts: vec![0, 0],
+        };
+
+        assert_eq!(
+            solution.snapp_objective_value(&orders),
+            Err(SnappObjectiveError::TotalUtilityOverflow)
+        );
+    }
 
     #[test]
     fn small_order_executed_utility() {
@@ -139,7 +376,7 @@ mod tests {
     }
 
     #[test]
-    fn order_executed_utility_err_bad_order() {
+    fn order_executed_utility_err_invalid_order() {
         let order = Order {
             buy_amount: 10u128.pow(18),
             sell_amount: 0,
@@ -150,7 +387,7 @@ mod tests {
 
         assert_eq!(
             order.executed_utility(buy_price, order.buy_amount, exec_sell_amt),
-            Err(SnappObjectiveError::BadOrder)
+            Err(SnappObjectiveError::InvalidOrder)
         );
     }
 

--- a/driver/src/snapp.rs
+++ b/driver/src/snapp.rs
@@ -1,0 +1,172 @@
+//! This module implements snapp specific extensions to models. Specifically
+//! Snapp objective value calculation as the driver is expected to provide this
+//! value on solution submission.
+
+use crate::util::u128_to_u256;
+use dfusion_core::models::{Order, Solution};
+use thiserror::Error;
+use web3::types::U256;
+
+/// Snapp specific extensions for `Order`. This extension trait provides the
+/// required functions for calculating the objective value used in the Snapp
+/// protocol which is needed for solution submission.
+pub trait SnappOrder {
+    /// Returns the executed utility of an order based on executed amounts
+    /// and closing prices.
+    ///
+    /// Note that utility is calculated with the following equasion:
+    /// `((exec_buy_amt * sell_amt - exec_sell_amt * buy_amt) * buy_price) /
+    /// sell_amt`
+    ///
+    /// # Returns
+    ///
+    /// `Ok(U256)` when the order executed utility is correctly calculated
+    /// and `Err` otherwise.
+    fn executed_utility(
+        &self,
+        buy_price: u128,
+        exec_buy_amt: u128,
+        exec_sell_amt: u128,
+    ) -> Result<U256, SnappObjectiveError>;
+}
+
+impl SnappOrder for Order {
+    fn executed_utility(
+        &self,
+        buy_price: u128,
+        exec_buy_amt: u128,
+        exec_sell_amt: u128,
+    ) -> Result<U256, SnappObjectiveError> {
+        let buy_price = u128_to_u256(buy_price);
+        let exec_buy_amt = u128_to_u256(exec_buy_amt);
+        let exec_sell_amt = u128_to_u256(exec_sell_amt);
+        let buy_amt = u128_to_u256(self.buy_amount);
+        let sell_amt = u128_to_u256(self.sell_amount);
+
+        // the utility is caculated in two parts, this is done to avoid overflows
+        let utility_with_error = exec_buy_amt
+            .checked_sub(
+                (exec_sell_amt * buy_amt)
+                    .checked_div(sell_amt)
+                    .ok_or(SnappObjectiveError::BadOrder)?,
+            )
+            .ok_or(SnappObjectiveError::LimitPriceNotRespected)?
+            * buy_price;
+        let utility_error = (((exec_sell_amt * buy_amt) % sell_amt) * buy_price) / sell_amt;
+
+        let utility = utility_with_error
+            .checked_sub(utility_error)
+            .ok_or(SnappObjectiveError::LimitPriceNotRespected)?;
+
+        Ok(utility)
+    }
+}
+
+/// Represents and error that can occur during the calculation of the Snapp
+/// objective value.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum SnappObjectiveError {
+    /// The order contains invalid values such as a 0 sell amount.
+    #[error("an order contains invalid values")]
+    BadOrder,
+    /// The limit price of an order was not respected. This causes an underflow
+    /// during the utility calculation and as such the total objective value
+    /// cannot be accurately determined.
+    #[error("the limit price of an order was not respected")]
+    LimitPriceNotRespected,
+    /// An overflow happened when calculating the total utility of a solution.
+    /// The total utility must fit in a solidity `uint256`.
+    #[error("total utility overflows a uint256")]
+    TotalUtilityOverflow,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn small_order_executed_utility() {
+        let order = Order {
+            buy_amount: 10,
+            sell_amount: 100,
+            ..Default::default()
+        };
+        let buy_price = 9;
+        let exec_buy_amt = 10;
+        let exec_sell_amt = 90;
+
+        assert_eq!(
+            order.executed_utility(buy_price, exec_buy_amt, exec_sell_amt),
+            // u = ((xb * os - xs * ob) * bp) / os
+            //   = ((10 * 100 - 90 * 10) * 9) / 100
+            //   = 9
+            Ok(9.into())
+        );
+    }
+
+    #[test]
+    fn large_order_executed_utility() {
+        let order = Order {
+            buy_amount: 10u128.pow(18),
+            sell_amount: 2 * 10u128.pow(18),
+            ..Default::default()
+        };
+        let buy_price = 2 * 10u128.pow(18);
+        let exec_buy_amt = 2 * 10u128.pow(18);
+        let exec_sell_amt = 10u128.pow(18);
+
+        assert_eq!(
+            order.executed_utility(buy_price, exec_buy_amt, exec_sell_amt),
+            // u = ((2e18 * 2e18 - 1e18 * 1e18) * 2e18) / 2e18
+            //   = 3e36
+            Ok(U256::from(3) * U256::from(10).pow(36.into()))
+        );
+    }
+
+    #[test]
+    fn exact_order_executed_utility() {
+        let order = Order {
+            buy_amount: 10u128.pow(18),
+            sell_amount: 2 * 10u128.pow(18),
+            ..Default::default()
+        };
+        let buy_price = 10u128.pow(18);
+
+        assert_eq!(
+            order.executed_utility(buy_price, order.buy_amount, order.sell_amount),
+            Ok(U256::zero())
+        );
+    }
+
+    #[test]
+    fn order_executed_utility_err_bad_order() {
+        let order = Order {
+            buy_amount: 10u128.pow(18),
+            sell_amount: 0,
+            ..Default::default()
+        };
+        let buy_price = 10u128.pow(18);
+        let exec_sell_amt = 10u128.pow(18);
+
+        assert_eq!(
+            order.executed_utility(buy_price, order.buy_amount, exec_sell_amt),
+            Err(SnappObjectiveError::BadOrder)
+        );
+    }
+
+    #[test]
+    fn order_executed_utility_err_non_respected_limit_price() {
+        let order = Order {
+            buy_amount: 10u128.pow(18),
+            sell_amount: 2 * 10u128.pow(18),
+            ..Default::default()
+        };
+        let buy_price = 10u128.pow(18);
+        let exec_sell_amt = order.sell_amount * 2;
+
+        assert_eq!(
+            order.executed_utility(buy_price, order.buy_amount, exec_sell_amt),
+            Err(SnappObjectiveError::LimitPriceNotRespected)
+        );
+    }
+}


### PR DESCRIPTION
Since the solver no longer calculates executed utility. Unfortunately this is required for computing the solution objective value which needs to be submitted with a solution for Snapp.

This PR is a first step to addressing this by calculating the Snapp objective value (the total executed utility of the orders) for submitting solutions.

This might help with #302 and with removing the `objective_value` field from the solution. This will also be nice for merging the two naive solvers together so it no longer needs to calculate this.

### Test Plan

Unit tests.