### PR TITLE
[Easy] Remove Solution Objective Value Field

### DIFF
--- a/dfusion_rust_core/src/models/account_state.rs
+++ b/dfusion_rust_core/src/models/account_state.rs
@@ -321,7 +321,6 @@ pub mod tests {
         };
 
         let results = Solution {
-            objective_value: None,
             prices: vec![1, 1],
             executed_buy_amounts: vec![1, 1],
             executed_sell_amounts: vec![1, 1],

--- a/dfusion_rust_core/src/models/order.rs
+++ b/dfusion_rust_core/src/models/order.rs
@@ -91,11 +91,9 @@ impl From<Entity> for Order {
         let batch_information = entity
             .get("auctionId")
             .and(entity.get("slotIndex"))
-            .and_then(|_| {
-                Some(BatchInformation {
-                    slot: U256::from_entity(&entity, "auctionId"),
-                    slot_index: u16::from_entity(&entity, "slotIndex"),
-                })
+            .map(|_| BatchInformation {
+                slot: U256::from_entity(&entity, "auctionId"),
+                slot_index: u16::from_entity(&entity, "slotIndex"),
             });
 
         Order {

--- a/dfusion_rust_core/src/models/solution.rs
+++ b/dfusion_rust_core/src/models/solution.rs
@@ -2,13 +2,10 @@ use super::*;
 
 use log::info;
 
-use web3::types::U256;
-
 use std::iter::once;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Solution {
-    pub objective_value: Option<U256>,
     pub prices: Vec<u128>,
     pub executed_buy_amounts: Vec<u128>,
     pub executed_sell_amounts: Vec<u128>,
@@ -17,7 +14,6 @@ pub struct Solution {
 impl Solution {
     pub fn trivial(num_orders: usize) -> Self {
         Solution {
-            objective_value: Some(U256::zero()),
             prices: vec![0; TOKENS as usize],
             executed_buy_amounts: vec![0; num_orders],
             executed_sell_amounts: vec![0; num_orders],
@@ -68,7 +64,6 @@ impl Deserializable for Solution {
             )));
         });
         Solution {
-            objective_value: None,
             prices,
             executed_buy_amounts,
             executed_sell_amounts,
@@ -86,7 +81,6 @@ pub mod unit_test {
         assert!(!trivial.is_non_trivial());
 
         let non_trivial = Solution {
-            objective_value: None,
             prices: vec![42; TOKENS as usize],
             executed_buy_amounts: vec![4, 5, 6],
             executed_sell_amounts: vec![1, 2, 3],
@@ -97,7 +91,6 @@ pub mod unit_test {
     #[test]
     fn test_serialize_deserialize() {
         let solution = Solution {
-            objective_value: None,
             prices: vec![42; TOKENS as usize],
             executed_buy_amounts: vec![4, 5, 6],
             executed_sell_amounts: vec![1, 2, 3],
@@ -131,7 +124,6 @@ pub mod unit_test {
         ];
         let parsed_solution = Solution::from_bytes(bytes);
         let expected = Solution {
-            objective_value: None,
             prices: vec![
                 1,
                 10u128.pow(18),

--- a/driver/src/driver/order_driver.rs
+++ b/driver/src/driver/order_driver.rs
@@ -282,7 +282,6 @@ mod tests {
 
         let mut pf = PriceFindingMock::default();
         let expected_solution = Solution {
-            objective_value: Some(U256::zero()),
             prices: vec![1, 2],
             executed_sell_amounts: vec![0, 2],
             executed_buy_amounts: vec![0, 2],
@@ -519,7 +518,6 @@ mod tests {
 
         let mut pf = PriceFindingMock::default();
         let expected_solution = Solution {
-            objective_value: Some(U256::zero()),
             prices: vec![1, 2],
             executed_sell_amounts: vec![0, 2],
             executed_buy_amounts: vec![0, 2],
@@ -704,7 +702,6 @@ mod tests {
     fn test_update_balances() {
         let mut state = AccountState::new(H256::zero(), U256::one(), vec![100; 60], TOKENS);
         let solution = Solution {
-            objective_value: U256::from_dec_str("0").ok(),
             prices: vec![1, 2],
             executed_sell_amounts: vec![1, 1],
             executed_buy_amounts: vec![1, 1],

--- a/driver/src/driver/stablex_driver.rs
+++ b/driver/src/driver/stablex_driver.rs
@@ -109,7 +109,6 @@ mod tests {
             .will_return(Ok(()));
 
         let solution = Solution {
-            objective_value: Some(U256::zero()),
             prices: vec![1, 2],
             executed_sell_amounts: vec![0, 2],
             executed_buy_amounts: vec![0, 2],
@@ -152,7 +151,6 @@ mod tests {
             .will_return(Ok(()));
 
         let solution = Solution {
-            objective_value: Some(U256::zero()),
             prices: vec![1, 2],
             executed_sell_amounts: vec![0, 2],
             executed_buy_amounts: vec![0, 2],

--- a/driver/src/price_finding/linear_optimization_price_finder.rs
+++ b/driver/src/price_finding/linear_optimization_price_finder.rs
@@ -138,8 +138,8 @@ fn deserialize_result(
                 .and_then(|amount| amount.parse::<u128>().map_err(PriceFindingError::from))
         })
         .collect::<Result<Vec<u128>, PriceFindingError>>()?;
+
     Ok(models::Solution {
-        objective_value: None,
         prices,
         executed_sell_amounts,
         executed_buy_amounts,
@@ -265,7 +265,6 @@ pub mod tests {
         });
 
         let expected_solution = models::Solution {
-            objective_value: None,
             prices: vec![14_024_052_566_155_238_000, 1_526_784_674_855_762_300],
             executed_sell_amounts: vec![0, 318_390_084_925_498_118_944],
             executed_buy_amounts: vec![0, 95_042_777_139_162_480_000],

--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -32,7 +32,6 @@ pub mod tests {
     use super::*;
     use dfusion_core::models::Serializable;
     use mock_it::Mock;
-    use web3::types::U256;
 
     pub struct PriceFindingMock {
         pub find_prices: Mock<
@@ -65,7 +64,6 @@ pub mod tests {
     #[test]
     fn test_serialize_solution() {
         let solution = models::Solution {
-            objective_value: Some(U256::zero()),
             prices: vec![1, 2],
             executed_sell_amounts: vec![3, 4],
             executed_buy_amounts: vec![5, 6],

--- a/driver/src/price_finding/snapp_naive_solver.rs
+++ b/driver/src/price_finding/snapp_naive_solver.rs
@@ -186,7 +186,7 @@ pub mod tests {
     use crate::util::u256_to_u128;
     use dfusion_core::models::account_state::test_util::*;
     use std::collections::HashMap;
-    use web3::types::{U256, H160, H256};
+    use web3::types::{H160, H256, U256};
 
     #[test]
     fn test_type_left_fully_matched_no_fee() {

--- a/driver/src/price_finding/snapp_naive_solver.rs
+++ b/driver/src/price_finding/snapp_naive_solver.rs
@@ -1,5 +1,3 @@
-use web3::types::U256;
-
 use dfusion_core::models::{AccountState, Order, Solution, TOKENS};
 
 use crate::price_finding::error::PriceFindingError;
@@ -188,7 +186,7 @@ pub mod tests {
     use crate::util::u256_to_u128;
     use dfusion_core::models::account_state::test_util::*;
     use std::collections::HashMap;
-    use web3::types::{H160, H256};
+    use web3::types::{U256, H160, H256};
 
     #[test]
     fn test_type_left_fully_matched_no_fee() {

--- a/driver/src/snapp.rs
+++ b/driver/src/snapp.rs
@@ -167,7 +167,6 @@ mod tests {
         ];
 
         let solution = Solution {
-            objective_value: None,
             prices: vec![10u128.pow(18), 2_500_000_000_000_000_000],
             executed_buy_amounts: vec![2_497_500_000_000_000_000, 10u128.pow(18)],
             executed_sell_amounts: vec![10u128.pow(18), 2_502_502_502_502_502_502],
@@ -222,7 +221,6 @@ mod tests {
         }];
 
         let solution = Solution {
-            objective_value: None,
             prices: vec![10u128.pow(18)],
             executed_buy_amounts: vec![10u128.pow(18)],
             executed_sell_amounts: vec![10u128.pow(18)],
@@ -254,7 +252,6 @@ mod tests {
         ];
 
         let solution = Solution {
-            objective_value: None,
             prices: vec![10u128.pow(18), 10u128.pow(18)],
             executed_buy_amounts: vec![10u128.pow(18)],
             executed_sell_amounts: vec![10u128.pow(18)],
@@ -277,7 +274,6 @@ mod tests {
         }];
 
         let solution = Solution {
-            objective_value: None,
             prices: vec![10u128.pow(18), 10u128.pow(18)],
             executed_buy_amounts: vec![10u128.pow(18)],
             executed_sell_amounts: vec![10u128.pow(18)],
@@ -309,7 +305,6 @@ mod tests {
         ];
 
         let solution = Solution {
-            objective_value: None,
             prices: vec![u128::max_value(), 10u128.pow(18)],
             executed_buy_amounts: vec![u128::max_value(), u128::max_value()],
             executed_sell_amounts: vec![0, 0],


### PR DESCRIPTION
Remove the solution objective value field as it is no longer used. We now calculate the Snapp objective value for submitting solutions to Snapp and we use the contract to evaluate the objective value in StableX.

This affects PR #302 and might cause merge conflicts. Depends on #304.

### Test Plan

unit and e2e tests