### PR TITLE
[Easy] Stricter Linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ matrix:
         - rustup component add clippy rustfmt
       script:
         - cargo test --all
-        - cargo clippy --all -- -D warnings
-        - cargo fmt -- --check
+        - cargo clippy --all --all-targets -- -D warnings
+        - cargo fmt --all -- --check
     - language: generic
       name: "dƒusion e2e Tests"
       cache: 

--- a/dfusion_rust_core/src/models/order.rs
+++ b/dfusion_rust_core/src/models/order.rs
@@ -91,11 +91,9 @@ impl From<Entity> for Order {
         let batch_information = entity
             .get("auctionId")
             .and(entity.get("slotIndex"))
-            .and_then(|_| {
-                Some(BatchInformation {
-                    slot: U256::from_entity(&entity, "auctionId"),
-                    slot_index: u16::from_entity(&entity, "slotIndex"),
-                })
+            .map(|_| BatchInformation {
+                slot: U256::from_entity(&entity, "auctionId"),
+                slot_index: u16::from_entity(&entity, "slotIndex"),
             });
 
         Order {


### PR DESCRIPTION
This adds stricter linting by running `cargo fmt` on all workspace crates as well as running `cargo clippy` on all targets (including the `test` target, which we currently ignore) to check more code.

### Test plan

CI still passes