### PR TITLE
[Easy] use npm ci instead of install

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ git clone git@github.com:gnosis/dex-services.git
 cd dex-services
 git submodule update --init
 cd dex-contracts 
-npm install && npx truffle compile
+npm ci && npx truffle compile
 cd ../
 docker-compose up
 ```

--- a/test/setup_contracts.sh
+++ b/test/setup_contracts.sh
@@ -3,6 +3,6 @@ set -e
 
 docker-compose up -d ganache-cli
 cd dex-contracts
-npm install
+npm ci
 npx wait-port -t 30000 8545
 npx truffle migrate


### PR DESCRIPTION
Let's use `npm ci` instead of `npm install` everywhere

### Test Plan

CI