### PR TITLE
Simplify docker compose setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-node_modules
+**/node_modules
 target
 npm-debug.log
 Dockerfile*

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,9 +53,9 @@ matrix:
       install:
         - cd dex-contracts && npm ci && npx truffle compile && npm run networks-inject && cd ..
         - echo -e $GITLAB_PRIVATE_KEY > .ssh/id_rsa && chmod 0500 .ssh/id_rsa
-        - docker-compose build --build-arg use_solver=1 stablex-rinkeby
+        - docker-compose build --build-arg use_solver=1 stablex
       script:
-        - docker-compose up -d stablex-rinkeby
+        - docker-compose -f docker-compose.yml -f docker-compose.rinkeby.yaml up -d stablex
         - ./test/e2e-tests-stablex-rinkeby.sh
       after_failure:
         - docker-compose logs

--- a/README.md
+++ b/README.md
@@ -154,5 +154,5 @@ docker-compose build
 In order to start StableX for the Rinkeby network, make sure that the env variables in common-rinkeby.env are up to date and then start the specific docker:
 
 ```
-docker-compose up stablex-rinkeby
+docker-compose -f docker-compose.yml -f docker-compose.rinkeby.yaml up stablex
 ```

--- a/docker-compose.rinkeby.yaml
+++ b/docker-compose.rinkeby.yaml
@@ -1,0 +1,4 @@
+version: '3.6'
+services:
+  stablex:
+    env_file: common-rinkeby.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,11 @@
 version: '3.6'
-x-rust-service-basic:
-  &rust-service-basic
+x-rust-service:
+  &rust-service
   build:
     context: .
     dockerfile: docker/rust/Dockerfile
   restart: always
-
-x-rust-service-development:
-  &rust-service-development
-  << : *rust-service-basic
-  depends_on:
-    - ganache-cli
-  env_file:
-    - common.env
-  environment:
-    - RUST_BACKTRACE=1
-
-x-rust-service-rinkeby:
-  &rust-service-rinkeby
-  << : *rust-service-basic
-  env_file:
-    - common-rinkeby.env
+  env_file: common.env
   environment:
     - RUST_BACKTRACE=1
 
@@ -53,8 +38,10 @@ services:
       POSTGRES_DB: dfusion
 
   driver:
-    << : *rust-service-development
+    << : *rust-service
     command: cargo run --bin dfusion
+    depends_on:
+      - ganache-cli
     volumes:
       # Don't sync target, otherwise we rebuild on every deploy
       - ./dex-contracts:/app/dex-contracts
@@ -62,7 +49,7 @@ services:
       - ./driver/src:/app/driver/src
 
   graph-listener:
-    << : *rust-service-development
+    << : *rust-service
     command: /app/docker/rust/run_listener.sh
     depends_on:
       - ganache-cli
@@ -79,21 +66,11 @@ services:
       - ./listener/subgraph_definition:/app/listener/subgraph_definition
 
   stablex:
-    << : *rust-service-development
+    << : *rust-service
     image: stablex
+    depends_on:
+      - ganache-cli
     command: cargo run --bin stablex
-    restart: always
-    volumes:
-      # Don't sync target, otherwise we rebuild on every deploy
-      - ./dex-contracts:/app/dex-contracts
-      - ./dfusion_rust_core/src:/app/dfusion_rust_core/src
-      - ./driver/src:/app/driver/src
-
-  stablex-rinkeby:
-    << : *rust-service-rinkeby
-    image: stablex-rinkeby
-    command: cargo run --bin stablex
-    restart: always
     volumes:
       # Don't sync target, otherwise we rebuild on every deploy
       - ./dex-contracts:/app/dex-contracts

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -8,7 +8,7 @@ sudo apt-get update && sudo apt-get install -y python-pip && sudo pip install aw
 $(aws ecr get-login --no-include-email --region $AWS_REGION)
 
 echo "Tagging latest image with solver...";
-docker tag stablex-rinkeby $REGISTRY_URI:$TRAVIS_BRANCH
+docker tag stablex $REGISTRY_URI:$TRAVIS_BRANCH
 
 echo "Pushing image";
 docker push $REGISTRY_URI:$TRAVIS_BRANCH


### PR DESCRIPTION
This PR cleans up the `docker-compose.yml` file. At the moment, we have a bunch of very similar targets that have a complicated dependency structure:

```
                      ,---- rust-service-development <-- stablex/driver/graph_listener
rust-service-basic  <-|
                      `---- rust-service-rinkeby <--- stablex-rinkeby
```

However, the build for rinkeby is the same as for ganache. All we really need is to use a different .env file. Continuing this pattern for other services and eventually mainnet will become very messy.
I believe using [multiple compose files](https://docs.docker.com/compose/extends/) is the better option as it allows to override specific values (e.g. the env file used).

Instead of running `docker-compose up stablex-rinkeby` we now specify the "base" config file and the override file

```
docker-compose -f docker-compose.yml -f docker-compose.rinkeby.yaml up -d stablex
```

which will result in the following config:

```
  build:
    context: .
    dockerfile: docker/rust/Dockerfile
  restart: always
  *env_file: common-rinkeby.env*
  image: stablex
    depends_on:
      - ganache-cli
  command: cargo run --bin stablex
  volumes:
    - ./dex-contracts:/app/dex-contracts
    - ./dfusion_rust_core/src:/app/dfusion_rust_core/src
    - ./driver/src:/app/driver/src
```

It's a bit unfortunate that we cannot remove the ganache-cli dependency in the override (it looks like the options are additive), but I don't think this is such a big issue. If we really wanted, we could create a `docker-compose.ganache.yaml` which adds this dependency (and leave it out of the base config). However this would require the longer `docker-compose` command whenever we test locally. What do people think?

For mainnet this would become:

```
docker-compose -f docker-compose.yml -f docker-compose.mainnet.yaml up -d stablex
```

For convenience on a local machine, I'd suggest to create an ALIAS for the longer command.

Another reason for this pattern, is that in a future PR I will create a multi-staged build where instead of exporting all the source files we only export the readily build rust binary. This can now easily be added by overriding the `build` rule in a `docker-compose.binary.yaml`.

### Testplan

Travis