### PR TITLE
[Easy] Cache `.npm` Instead of `node_modules`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       name: "dƒusion e2e Tests"
       cache: 
         directories:
-          - dex-contracts/node_modules/
+          - $HOME/.npm
       install:
         - ./test/setup_contracts.sh
       script:
@@ -37,7 +37,7 @@ matrix:
       name: "StableX e2e Tests (Ganache)"
       cache: 
         directories:
-          - dex-contracts/node_modules/
+          - $HOME/.npm
       install:
         - ./test/setup_contracts.sh
       script:
@@ -49,7 +49,7 @@ matrix:
       name: "StableX e2e Tests (Rinkeby)"
       cache: 
         directories:
-          - dex-contracts/node_modules/
+          - $HOME/.npm
       install:
         - cd dex-contracts && npm ci && npx truffle compile && npm run networks-inject && cd ..
         - echo -e $GITLAB_PRIVATE_KEY > .ssh/id_rsa && chmod 0500 .ssh/id_rsa


### PR DESCRIPTION
The Travis configuration uses `npm ci`, which deletes `node_modules` before installing from NPM cache. Therefore, caching `node_modules` is not really useful, and we should instead get Travis to cache the NPM cache in `~/.npm`.

### Test Plan

None