### PR TITLE
Adding a merge when green config

### DIFF
--- a/.github/merge-when-green.yml
+++ b/.github/merge-when-green.yml
@@ -1,0 +1,1 @@
+mergeMethod: squash


### PR DESCRIPTION
Given our long-running builds, I install ["merge when green"](https://github.com/phstc/probot-merge-when-green) which allows us to label a PR which will then get automatically merged as soon as travis is green (given prior approval).

This config makes it so that the commits will be squashed instead of the default (merged).

### Test Plan

use label on this PR and see that commit gets squashed.