### PR TITLE
[Easy] Use `tag` Instead of `rev` For `graph-node-reader` Dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,7 +490,7 @@ dependencies = [
  "array-macro 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.16.1 (git+https://github.com/graphprotocol/graph-node?tag=v0.16.1)",
- "graph-node-reader 0.16.1 (git+https://github.com/gnosis/graph-node-reader?rev=v0.16.1)",
+ "graph-node-reader 0.16.1 (git+https://github.com/gnosis/graph-node-reader?tag=v0.16.1)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mock-it 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -612,7 +612,7 @@ dependencies = [
  "ethabi 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-tx-sign 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.16.1 (git+https://github.com/graphprotocol/graph-node?tag=v0.16.1)",
- "graph-node-reader 0.16.1 (git+https://github.com/gnosis/graph-node-reader?rev=v0.16.1)",
+ "graph-node-reader 0.16.1 (git+https://github.com/gnosis/graph-node-reader?tag=v0.16.1)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -978,7 +978,7 @@ dependencies = [
 [[package]]
 name = "graph-node-reader"
 version = "0.16.1"
-source = "git+https://github.com/gnosis/graph-node-reader?rev=v0.16.1#a626066394a3b615786a45516b87734090b56eb8"
+source = "git+https://github.com/gnosis/graph-node-reader?tag=v0.16.1#a626066394a3b615786a45516b87734090b56eb8"
 dependencies = [
  "Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1410,7 +1410,7 @@ dependencies = [
  "graph-core 0.16.1 (git+https://github.com/graphprotocol/graph-node?tag=v0.16.1)",
  "graph-datasource-ethereum 0.16.1 (git+https://github.com/graphprotocol/graph-node?tag=v0.16.1)",
  "graph-mock 0.16.1 (git+https://github.com/graphprotocol/graph-node?tag=v0.16.1)",
- "graph-node-reader 0.16.1 (git+https://github.com/gnosis/graph-node-reader?rev=v0.16.1)",
+ "graph-node-reader 0.16.1 (git+https://github.com/gnosis/graph-node-reader?tag=v0.16.1)",
  "graph-server-http 0.16.1 (git+https://github.com/graphprotocol/graph-node?tag=v0.16.1)",
  "graph-server-websocket 0.16.1 (git+https://github.com/graphprotocol/graph-node?tag=v0.16.1)",
  "graph-store-postgres 0.16.1 (git+https://github.com/graphprotocol/graph-node?tag=v0.16.1)",
@@ -3497,7 +3497,7 @@ dependencies = [
 "checksum graph-datasource-ethereum 0.16.1 (git+https://github.com/graphprotocol/graph-node?tag=v0.16.1)" = "<none>"
 "checksum graph-graphql 0.16.1 (git+https://github.com/graphprotocol/graph-node?tag=v0.16.1)" = "<none>"
 "checksum graph-mock 0.16.1 (git+https://github.com/graphprotocol/graph-node?tag=v0.16.1)" = "<none>"
-"checksum graph-node-reader 0.16.1 (git+https://github.com/gnosis/graph-node-reader?rev=v0.16.1)" = "<none>"
+"checksum graph-node-reader 0.16.1 (git+https://github.com/gnosis/graph-node-reader?tag=v0.16.1)" = "<none>"
 "checksum graph-server-http 0.16.1 (git+https://github.com/graphprotocol/graph-node?tag=v0.16.1)" = "<none>"
 "checksum graph-server-websocket 0.16.1 (git+https://github.com/graphprotocol/graph-node?tag=v0.16.1)" = "<none>"
 "checksum graph-store-postgres 0.16.1 (git+https://github.com/graphprotocol/graph-node?tag=v0.16.1)" = "<none>"

--- a/dfusion_rust_core/Cargo.toml
+++ b/dfusion_rust_core/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 array-macro = "1.0.4"
 byteorder = "1.3.1"
 graph = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.16.1" }
-graph-node-reader = { git = "https://github.com/gnosis/graph-node-reader", rev = "v0.16.1" }
+graph-node-reader = { git = "https://github.com/gnosis/graph-node-reader", tag = "v0.16.1" }
 lazy_static = "1.4.0"
 log = "0.4.8"
 mock-it = "0.3.0"

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -17,7 +17,7 @@ ethabi = "8.0.1"
 ethereum-tx-sign = "3.0.0"
 dfusion_core = { path = "../dfusion_rust_core" }
 graph = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.16.1" }
-graph-node-reader = { git = "https://github.com/gnosis/graph-node-reader", rev = "v0.16.1" }
+graph-node-reader = { git = "https://github.com/gnosis/graph-node-reader", tag = "v0.16.1" }
 hex = "0.4.0"
 lazy_static = "1.4.0"
 log = "0.4.8"

--- a/listener/Cargo.toml
+++ b/listener/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 graph = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.16.1" }
 graph-core = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.16.1" }
 graph-datasource-ethereum = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.16.1" }
-graph-node-reader = { git = "https://github.com/gnosis/graph-node-reader", rev = "v0.16.1" }
+graph-node-reader = { git = "https://github.com/gnosis/graph-node-reader", tag = "v0.16.1" }
 graph-store-postgres = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.16.1" }
 graph-server-http = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.16.1" }
 graph-server-websocket = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.16.1" }


### PR DESCRIPTION
This oopsie was introduced in #336 

### Test Plan

None - both are the same revision