### PR TITLE
[Easy] Use `u128` Conversion

### DIFF
--- a/driver/src/contracts/stablex_auction_element.rs
+++ b/driver/src/contracts/stablex_auction_element.rs
@@ -4,7 +4,7 @@ use dfusion_core::models::{BatchInformation, Order};
 use std::collections::HashMap;
 use web3::types::{H160, U256};
 
-use crate::util::{u128_to_u256, u256_to_u128, CeiledDiv};
+use crate::util::CeiledDiv;
 
 #[derive(Debug, PartialEq)]
 pub struct StableXAuctionElement {
@@ -75,8 +75,8 @@ fn compute_buy_sell_amounts(numerator: u128, denominator: u128, remaining: u128)
     // 0 on buyAmount (numerator) is a Market Sell Order.
     let buy_amount = if denominator > 0 {
         // up-casting to handle overflow
-        let top = u128_to_u256(remaining) * u128_to_u256(numerator);
-        u256_to_u128((top).ceiled_div(u128_to_u256(denominator)))
+        let top = U256::from(remaining) * U256::from(numerator);
+        (top).ceiled_div(U256::from(denominator)).as_u128()
     } else {
         0
     };

--- a/driver/src/snapp.rs
+++ b/driver/src/snapp.rs
@@ -2,7 +2,6 @@
 //! Snapp objective value calculation as the driver is expected to provide this
 //! value on solution submission.
 
-use crate::util::u128_to_u256;
 use dfusion_core::models::{Order, Solution};
 use thiserror::Error;
 use web3::types::U256;
@@ -93,11 +92,11 @@ impl SnappOrder for Order {
         exec_buy_amt: u128,
         exec_sell_amt: u128,
     ) -> Result<U256, SnappObjectiveError> {
-        let buy_price = u128_to_u256(buy_price);
-        let exec_buy_amt = u128_to_u256(exec_buy_amt);
-        let exec_sell_amt = u128_to_u256(exec_sell_amt);
-        let buy_amt = u128_to_u256(self.buy_amount);
-        let sell_amt = u128_to_u256(self.sell_amount);
+        let buy_price = U256::from(buy_price);
+        let exec_buy_amt = U256::from(exec_buy_amt);
+        let exec_sell_amt = U256::from(exec_sell_amt);
+        let buy_amt = U256::from(self.buy_amount);
+        let sell_amt = U256::from(self.sell_amount);
 
         // the utility is caculated in two parts, this is done to avoid overflows
         let utility_with_error = exec_buy_amt


### PR DESCRIPTION
`U256` now provides conversion to and from `u128`. Use it instead of our own.

### Test Plan

CI