### PR TITLE
[Easy] Deploying images on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,11 @@ matrix:
       after_script:
         - docker-compose logs
       deploy:
-        provider: script
-        script: ./docker/deploy.sh
-        on:
-          branch: master
+        - provider: script
+          script: ./docker/deploy.sh $TRAVIS_BRANCH
+          on:
+            branch: master
+        - provider: script
+          script: ./docker/deploy.sh $TRAVIS_TAG
+          on:
+            tags: true

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -2,21 +2,23 @@
 
 set -euo pipefail
 
+image_name=$1
+
 sudo apt-get update && sudo apt-get install -y python-pip && sudo pip install awscli
 
 # Get login token and execute login
 $(aws ecr get-login --no-include-email --region $AWS_REGION)
 
 echo "Tagging latest image with solver...";
-docker build --tag $REGISTRY_URI:$TRAVIS_BRANCH -f docker/rust/release/Dockerfile .
+docker build --tag $REGISTRY_URI:$image_name -f docker/rust/release/Dockerfile .
 
 echo "Pushing image";
-docker push $REGISTRY_URI:$TRAVIS_BRANCH
+docker push $REGISTRY_URI:$image_name
 
 echo "The image has been pushed";
 rm -rf .ssh/*
 
-if [ -n "$AUTODEPLOY_URL" ] && [ -n "$AUTODEPLOY_TOKEN" ]; then
+if [ "$image_name" == "master" ] && [ -n "$AUTODEPLOY_URL" ] && [ -n "$AUTODEPLOY_TOKEN" ]; then
     # Notifying webhook
     curl -s --output /dev/null --write-out "%{http_code}" \
     -H "Content-Type: application/json" \


### PR DESCRIPTION
Currently, we only deploy on master builds. We should do the same on tags. This will allow us to easily create deployments for different versions, even though the master branch train keeps on chugging.

<a href="https://gitme.me/image?url=https%3A%2F%2Fmedia2.giphy.com%2Fmedia%2FBWQuTmejBHMaSP9LEp%2Fgiphy.gif&token=train_chugging" data-gitmeme-token="train_chugging"><img src="https://media2.giphy.com/media/BWQuTmejBHMaSP9LEp/giphy.gif" title="Created by gitme.me with /train_chugging"/></a>