### PR TITLE
Always log rinkeby e2e test logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,7 @@ matrix:
       script:
         - docker-compose -f docker-compose.yml -f docker-compose.rinkeby.yml -f docker-compose.binary.yml up -d stablex
         - ./test/e2e-tests-stablex-rinkeby.sh
-      after_failure:
+      after_script:
         - docker-compose logs
       deploy:
         - provider: script


### PR DESCRIPTION
This change snuck in #363 but shouldn't have. This addresses that.

### Test Plan

CI -> verify logs are dumped at end of rinkeby e2e test.