### PR TITLE
[Deploy] Allow multiple services to be restarted on master commit

### DIFF
--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -2,6 +2,15 @@
 
 set -euo pipefail
 
+function autodeploy {
+    # Notifying webhook
+    curl -s --output /dev/null --write-out "%{http_code}" \
+    -H "Content-Type: application/json" \
+    -X POST \
+    -d '{"token": "'$AUTODEPLOY_TOKEN'", "push_data": {"tag": "'$AUTODEPLOY_TAG'" }}' \
+    $1
+}
+
 image_name=$1
 
 sudo apt-get update && sudo apt-get install -y python-pip && sudo pip install awscli
@@ -18,11 +27,10 @@ docker push $REGISTRY_URI:$image_name
 echo "The image has been pushed";
 rm -rf .ssh/*
 
-if [ "$image_name" == "master" ] && [ -n "$AUTODEPLOY_URL" ] && [ -n "$AUTODEPLOY_TOKEN" ]; then
-    # Notifying webhook
-    curl -s --output /dev/null --write-out "%{http_code}" \
-    -H "Content-Type: application/json" \
-    -X POST \
-    -d '{"token": "'$AUTODEPLOY_TOKEN'", "push_data": {"tag": "'$AUTODEPLOY_TAG'" }}' \
-    $AUTODEPLOY_URL
+if [ "$image_name" == "master" ] && [ -n "$AUTODEPLOY_URLS" ] && [ -n "$AUTODEPLOY_TOKEN" ]; then
+    IFS=';'
+    read -ra AUTODEPLOY_URL_LIST <<< "$AUTODEPLOY_URLS"
+    for url in "${AUTODEPLOY_URL_LIST[@]}"; do
+      autodeploy "$url"
+    done
 fi

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -4,11 +4,13 @@ set -euo pipefail
 
 function autodeploy {
     # Notifying webhook
-    curl -s --output /dev/null --write-out "%{http_code}" \
-    -H "Content-Type: application/json" \
-    -X POST \
-    -d '{"token": "'$AUTODEPLOY_TOKEN'", "push_data": {"tag": "'$AUTODEPLOY_TAG'" }}' \
-    $1
+    curl -s \
+      --output /dev/null \
+      --write-out "%{http_code}" \
+      -H "Content-Type: application/json" \
+      -X POST \
+      -d '{"token": "'$AUTODEPLOY_TOKEN'", "push_data": {"tag": "'$AUTODEPLOY_TAG'" }}' \
+      $1
 }
 
 image_name=$1


### PR DESCRIPTION
Right now, we only restart the rinkeby AWS instance on master commits. This PR refactors the logic to allow for an array of autodeply URLs to be passed in (separated by semicolon).

This will allow us to restart both mainnet and rinkeby services on each master commit.

### Testplan
Printed the curl command locally. It remains to see bot services restart after this PR is merged in to master