### PR TITLE
Logging Transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,6 +698,7 @@ dependencies = [
  "graph 0.16.1 (git+https://github.com/graphprotocol/graph-node?tag=v0.16.1)",
  "graph-node-reader 0.16.1 (git+https://github.com/gnosis/graph-node-reader?tag=v0.16.1)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mock-it 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -21,6 +21,7 @@ ethereum-tx-sign = "3.0.0"
 graph = { git = "https://github.com/graphprotocol/graph-node", tag = "v0.16.1" }
 graph-node-reader = { git = "https://github.com/gnosis/graph-node-reader", tag = "v0.16.1" }
 hex = "0.4.0"
+jsonrpc-core = "13.2.0"
 lazy_static = "1.4.0"
 log = "0.4.8"
 rustc-hex = "*"

--- a/driver/src/contracts/mod.rs
+++ b/driver/src/contracts/mod.rs
@@ -3,16 +3,19 @@ pub mod stablex_auction_element;
 pub mod stablex_contract;
 
 use crate::error::DriverError;
+use crate::transport::LoggingTransport;
 use ethcontract::contract::MethodDefaults;
 use ethcontract::{ethsign, Account, SecretKey, H256};
+use log::Level;
 use std::env;
 use web3::api::Web3;
 use web3::transports::{EventLoopHandle, Http};
 
-fn web3_provider() -> Result<(Web3<Http>, EventLoopHandle), DriverError> {
+fn web3_provider() -> Result<(Web3<LoggingTransport<Http>>, EventLoopHandle), DriverError> {
     let url = env::var("ETHEREUM_NODE_URL")?;
     let (event_loop, http) = Http::new(&url)?;
-    let web3 = Web3::new(http);
+    let logging = LoggingTransport::new(http, Level::Debug);
+    let web3 = Web3::new(logging);
 
     Ok((web3, event_loop))
 }

--- a/driver/src/contracts/mod.rs
+++ b/driver/src/contracts/mod.rs
@@ -14,7 +14,7 @@ use web3::transports::{EventLoopHandle, Http};
 fn web3_provider() -> Result<(Web3<LoggingTransport<Http>>, EventLoopHandle), DriverError> {
     let url = env::var("ETHEREUM_NODE_URL")?;
     let (event_loop, http) = Http::new(&url)?;
-    let logging = LoggingTransport::new(http, Level::Debug);
+    let logging = LoggingTransport::new(http, Level::Info);
     let web3 = Web3::new(logging);
 
     Ok((web3, event_loop))

--- a/driver/src/contracts/snapp_contract.rs
+++ b/driver/src/contracts/snapp_contract.rs
@@ -7,6 +7,7 @@ use web3::types::{BlockId, H160, H256, U128, U256};
 
 use crate::contracts;
 use crate::error::DriverError;
+use crate::transport::LoggingTransport;
 use crate::util::FutureWaitExt;
 
 type Result<T> = std::result::Result<T, DriverError>;
@@ -14,7 +15,7 @@ type Result<T> = std::result::Result<T, DriverError>;
 include!(concat!(env!("OUT_DIR"), "/snapp_auction.rs"));
 
 pub struct SnappContractImpl {
-    web3: Web3<Http>,
+    web3: Web3<LoggingTransport<Http>>,
     _event_loop: EventLoopHandle,
     instance: SnappAuction,
 }

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -21,6 +21,7 @@ pub mod driver;
 pub mod error;
 pub mod price_finding;
 pub mod snapp;
+pub mod transport;
 pub mod util;
 
 pub fn run_driver_components(

--- a/driver/src/transport.rs
+++ b/driver/src/transport.rs
@@ -1,0 +1,74 @@
+use jsonrpc_core::types::request::Call;
+use log::{log, Level};
+use serde_json::Value;
+use web3::error::Error;
+use web3::futures::{Async, Future, Poll};
+use web3::{RequestId, Transport};
+
+/// A `Transport` wrapper that logs RPC messages
+#[derive(Clone, Debug)]
+pub struct LoggingTransport<T> {
+    inner: T,
+    level: Level,
+}
+
+impl<T> LoggingTransport<T>
+where
+    T: Transport,
+{
+    /// Create a new `LoggingTranport` from an underlying transport and log
+    /// level.
+    pub fn new(inner: T, level: Level) -> Self {
+        LoggingTransport { inner, level }
+    }
+}
+
+impl<T> Transport for LoggingTransport<T>
+where
+    T: Transport,
+{
+    type Out = LoggingFuture<T::Out>;
+
+    fn prepare(&self, method: &str, params: Vec<Value>) -> (RequestId, Call) {
+        self.inner.prepare(method, params)
+    }
+
+    fn send(&self, id: RequestId, request: Call) -> Self::Out {
+        log!(self.level, "sending request ID {}: {:?}", id, request);
+        LoggingFuture {
+            inner: self.inner.send(id, request),
+            id,
+            level: self.level,
+        }
+    }
+}
+
+/// A future that wraps JSON RPC results.
+pub struct LoggingFuture<F> {
+    inner: F,
+    id: RequestId,
+    level: Level,
+}
+
+impl<F> Future for LoggingFuture<F>
+where
+    F: Future<Item = Value, Error = Error>,
+{
+    type Item = Value;
+    type Error = Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        match self.inner.poll() {
+            Ok(Async::NotReady) => Ok(Async::NotReady),
+            result => {
+                log!(
+                    self.level,
+                    "request ID {} completed with result: {:?}",
+                    self.id,
+                    result
+                );
+                result
+            }
+        }
+    }
+}

--- a/driver/src/transport.rs
+++ b/driver/src/transport.rs
@@ -71,7 +71,7 @@ where
                 self.id,
                 value
             ),
-            Err(ref err) => log!(self.level, "request ID {} error: {:?}", self.id, err),
+            Err(ref err) => log!(self.level, "request ID {} failed: {:?}", self.id, err),
             _ => {}
         }
         result


### PR DESCRIPTION
Adds a logging transport implementation that logs JSON RPC requests and results to assist debugging.

### Test Plan

CI and take a look at the dumped rinkeby logs. 