### PR TITLE
Revert "[Deploy] Allow multiple services to be restarted on master commit"

### DIFF
--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -2,17 +2,6 @@
 
 set -euo pipefail
 
-function autodeploy {
-    # Notifying webhook
-    curl -s \
-      --output /dev/null \
-      --write-out "%{http_code}" \
-      -H "Content-Type: application/json" \
-      -X POST \
-      -d '{"token": "'$AUTODEPLOY_TOKEN'", "push_data": {"tag": "'$AUTODEPLOY_TAG'" }}' \
-      $1
-}
-
 image_name=$1
 
 sudo apt-get update && sudo apt-get install -y python-pip && sudo pip install awscli
@@ -29,10 +18,11 @@ docker push $REGISTRY_URI:$image_name
 echo "The image has been pushed";
 rm -rf .ssh/*
 
-if [ "$image_name" == "master" ] && [ -n "$AUTODEPLOY_URLS" ] && [ -n "$AUTODEPLOY_TOKEN" ]; then
-    IFS=';'
-    read -ra AUTODEPLOY_URL_LIST <<< "$AUTODEPLOY_URLS"
-    for url in "${AUTODEPLOY_URL_LIST[@]}"; do
-      autodeploy "$url"
-    done
+if [ "$image_name" == "master" ] && [ -n "$AUTODEPLOY_URL" ] && [ -n "$AUTODEPLOY_TOKEN" ]; then
+    # Notifying webhook
+    curl -s --output /dev/null --write-out "%{http_code}" \
+    -H "Content-Type: application/json" \
+    -X POST \
+    -d '{"token": "'$AUTODEPLOY_TOKEN'", "push_data": {"tag": "'$AUTODEPLOY_TAG'" }}' \
+    $AUTODEPLOY_URL
 fi


### PR DESCRIPTION
Reverts gnosis/dex-services#373

No longer needed, due to the fact that we can encode two target services in a single URL.

https://dfusion.auto.gnosisdev.com/services/dfusion-mainnet-master,dfusion-rinkeby-master/restart