### PR TITLE
Fix travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ matrix:
         - $(aws ecr get-login --no-include-email --region $AWS_REGION)
         - docker pull $REGISTRY_URI:$TRAVIS_COMMIT
         - docker tag $REGISTRY_URI:$TRAVIS_COMMIT stablex-binary
+        - (cd dex-contracts && yarn --frozen-lockfile)
         - ./test/setup_contracts.sh
       script:
         - docker-compose -f docker-compose.yml -f docker-compose.binary.yml up -d driver graph-listener
@@ -94,6 +95,7 @@ matrix:
         - $(aws ecr get-login --no-include-email --region $AWS_REGION)
         - docker pull $REGISTRY_URI:$TRAVIS_COMMIT
         - docker tag $REGISTRY_URI:$TRAVIS_COMMIT stablex-binary
+        - (cd dex-contracts && yarn --frozen-lockfile)
         - ./test/setup_contracts.sh
       script:
         - docker-compose -f docker-compose.yml -f docker-compose.binary.yml up -d stablex
@@ -111,7 +113,7 @@ matrix:
         - $(aws ecr get-login --no-include-email --region $AWS_REGION)
         - docker pull $REGISTRY_URI:$TRAVIS_COMMIT
         - docker tag $REGISTRY_URI:$TRAVIS_COMMIT stablex-binary
-        - (cd dex-contracts && yarn run prepack)
+        - (cd dex-contracts && yarn --frozen-lockfile && yarn run prepack)
       script:
         - docker-compose -f docker-compose.yml -f docker-compose.rinkeby.yml -f docker-compose.binary.yml up -d stablex
         - ./test/e2e-tests-stablex-rinkeby.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ matrix:
       name: "Build"
       cache:
         directories:
-          - dex-contracts/node_modules/
           - $HOME/.cache/yarn
           - $HOME/.cache/sccache
           - $HOME/.cargo
@@ -43,7 +42,6 @@ matrix:
       language: rust
       cache:
         directories:
-          - dex-contracts/node_modules/
           - $HOME/.cache/yarn
           - $HOME/.cache/sccache
           - $HOME/.cargo
@@ -69,7 +67,6 @@ matrix:
       name: "dƒusion e2e Tests"
       cache:
         directories:
-          - dex-contracts/node_modules/
           - $HOME/.cache/yarn
       install:
         - sudo apt-get update && sudo apt-get install -y python-pip && sudo pip install awscli
@@ -91,7 +88,6 @@ matrix:
       name: "StableX e2e Tests (Ganache)"
       cache:
         directories:
-          - dex-contracts/node_modules/
           - $HOME/.cache/yarn
       install:
         - sudo apt-get update && sudo apt-get install -y python-pip && sudo pip install awscli
@@ -109,7 +105,6 @@ matrix:
       name: "StableX e2e Tests (Rinkeby)"
       cache:
         directories:
-          - dex-contracts/node_modules/
           - $HOME/.cache/yarn
       install:
         - sudo apt-get update && sudo apt-get install -y python-pip && sudo pip install awscli

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,6 @@
 if: (branch = master) OR (type = pull_request) OR (tag IS present)
 language: rust
 rust: stable
-cache:
-  directories:
-    - $HOME/.cache/sccache
-    - $HOME/.cargo
-    - $HOME/.rustup
-before_cache:
-  - rm -rf "$TRAVIS_HOME/.cargo/registry/src"
 env:
   global:
     - CARGO_INCREMENTAL=0
@@ -22,6 +15,11 @@ matrix:
         directories:
           - dex-contracts/node_modules/
           - $HOME/.cache/yarn
+          - $HOME/.cache/sccache
+          - $HOME/.cargo
+          - $HOME/.rustup
+      before_cache:
+        - rm -rf "$TRAVIS_HOME/.cargo/registry/src"
       before_install:
         - sudo apt-get update && sudo apt-get install -y python-pip && sudo pip install awscli
         - $(aws ecr get-login --no-include-email --region $AWS_REGION)
@@ -47,6 +45,11 @@ matrix:
         directories:
           - dex-contracts/node_modules/
           - $HOME/.cache/yarn
+          - $HOME/.cache/sccache
+          - $HOME/.cargo
+          - $HOME/.rustup
+      before_cache:
+        - rm -rf "$TRAVIS_HOME/.cargo/registry/src"
       install:
         - (cd dex-contracts && yarn --frozen-lockfile && yarn run prepack)
         - ./test/setup_contracts.sh


### PR DESCRIPTION
I noticed that our rust build are no longer cached.

The rust cache was defined in the global section on top of the `travis.yml` (above the individual sections for each build stage). 
This worked fine as long as the rust stages (build/unit tests) did not define their own cache directories themselves (it overrides instead of merges the list from the global section).

This PR moves the cached directories into the respective section.

### Test Plan

Expecting to see shorter build times as of the second build.