### PR TITLE
[Logging] Custom Format that prints module

### DIFF
--- a/driver/src/logging.rs
+++ b/driver/src/logging.rs
@@ -62,9 +62,7 @@ impl<D: Decorator> Drain for CustomFormatter<D> {
             write!(decorator, " ")?;
 
             decorator.start_msg()?;
-            write!(decorator, "{}", record.msg())?;
-
-            write!(decorator, "\n")?;
+            writeln!(decorator, "{}", record.msg())?;
             decorator.flush()?;
 
             Ok(())

--- a/driver/src/logging.rs
+++ b/driver/src/logging.rs
@@ -1,8 +1,8 @@
-use slog::{o, Drain, Logger};
+use slog::{o, Drain, Logger, OwnedKVList, Record};
 use slog_async::Async;
 use slog_envlogger::LogBuilder;
 use slog_scope::GlobalLoggerGuard;
-use slog_term::{CompactFormat, TermDecorator};
+use slog_term::{Decorator, TermDecorator};
 use std::env;
 
 /// The logging filter environment variable key.
@@ -15,9 +15,7 @@ const DEFAULT_FILTER: &str = "info";
 /// Initialize driver logging.
 pub fn init() -> (Logger, GlobalLoggerGuard) {
     let filter = env::var(FILTER_KEY).unwrap_or_else(|_| DEFAULT_FILTER.to_owned());
-    let format = CompactFormat::new(TermDecorator::new().stderr().build())
-        .build()
-        .fuse();
+    let format = CustomFormatter::new(TermDecorator::new().stderr().build()).fuse();
     let drain = Async::default(LogBuilder::new(format).parse(&filter).build());
     let logger = Logger::root(drain.fuse(), o!());
 
@@ -25,4 +23,51 @@ pub fn init() -> (Logger, GlobalLoggerGuard) {
     slog_stdlog::init().expect("failed to register logger");
 
     (logger, guard)
+}
+
+pub struct CustomFormatter<D: Decorator> {
+    decorator: D,
+}
+
+impl<D: Decorator> CustomFormatter<D> {
+    fn new(decorator: D) -> Self {
+        Self { decorator }
+    }
+}
+
+impl<D: Decorator> Drain for CustomFormatter<D> {
+    type Ok = ();
+    type Err = std::io::Error;
+    fn log(
+        &self,
+        record: &Record,
+        values: &OwnedKVList,
+    ) -> std::result::Result<Self::Ok, Self::Err> {
+        self.decorator.with_record(record, values, |mut decorator| {
+            decorator.start_timestamp()?;
+            slog_term::timestamp_utc(&mut decorator)?;
+
+            decorator.start_whitespace()?;
+            write!(decorator, " ")?;
+
+            decorator.start_level()?;
+            write!(decorator, "{}", record.level())?;
+
+            decorator.start_whitespace()?;
+            write!(decorator, " ")?;
+
+            write!(decorator, "[{}]", record.module())?;
+
+            decorator.start_whitespace()?;
+            write!(decorator, " ")?;
+
+            decorator.start_msg()?;
+            write!(decorator, "{}", record.msg())?;
+
+            write!(decorator, "\n")?;
+            decorator.flush()?;
+
+            Ok(())
+        })
+    }
 }


### PR DESCRIPTION
This makes the logs more readable and easier to filter. Unfortunately it requires a bunch of boilerplate code just for adding the `record.module`.

### Test Plan

```
DFUSION_LOG="info,driver=debug,dfusion_core=debug" cargo run --bin stablex

Dec 27 16:17:00.114 DEBG [driver::transport] sending request ID 0: {"jsonrpc":"2.0","method":"net_version","params":[],"id":0}
Dec 27 16:17:00.124 DEBG [driver::transport] request ID 0 completed with result: "5777"
Dec 27 16:17:00.124 INFO [stablex] Using contract at 0x419d…0c34
Dec 27 16:17:00.125 INFO [stablex] Using account 0x90f8…c9c1
...
```