### PR TITLE
Use latest version of yarn and node10 for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
           curl -LO https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz
           tar -C bin -xvf sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz --wildcards '*/sccache' --strip 1
           popd
-        - nvm use 10 && npm install -g yarn@latest && yarn --version
+        - nvm install 10 && nvm alias default 10 && npm install -g yarn@latest && yarn --version
       install:
         - (cd dex-contracts && yarn --frozen-lockfile && yarn run prepack)
         - ./test/setup_contracts.sh
@@ -50,7 +50,7 @@ matrix:
       before_cache:
         - rm -rf "$TRAVIS_HOME/.cargo/registry/src"
       before_install:
-        - nvm use 10 && npm install -g yarn@latest && yarn --version
+        - nvm install 10 && nvm alias default 10 && npm install -g yarn@latest && yarn --version
       install:
         - (cd dex-contracts && yarn --frozen-lockfile && yarn run prepack)
         - ./test/setup_contracts.sh
@@ -72,7 +72,7 @@ matrix:
         directories:
           - $HOME/.cache/yarn
       before_install:
-        - nvm use 10 && npm install -g yarn@latest && yarn --version
+        - nvm install 10 && nvm alias default 10 && npm install -g yarn@latest && yarn --version
       install:
         - sudo apt-get update && sudo apt-get install -y python-pip && sudo pip install awscli
         - $(aws ecr get-login --no-include-email --region $AWS_REGION)
@@ -95,7 +95,7 @@ matrix:
         directories:
           - $HOME/.cache/yarn
       before_install:
-        - nvm use 10 && npm install -g yarn@latest && yarn --version
+        - nvm install 10 && nvm alias default 10 && npm install -g yarn@latest && yarn --version
       install:
         - sudo apt-get update && sudo apt-get install -y python-pip && sudo pip install awscli
         - $(aws ecr get-login --no-include-email --region $AWS_REGION)
@@ -114,7 +114,7 @@ matrix:
         directories:
           - $HOME/.cache/yarn
       before_install:
-        - nvm use 10 && npm install -g yarn@latest && yarn --version
+        - nvm install 10 && nvm alias default 10 && npm install -g yarn@latest && yarn --version
       install:
         - sudo apt-get update && sudo apt-get install -y python-pip && sudo pip install awscli
         - $(aws ecr get-login --no-include-email --region $AWS_REGION)

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ matrix:
           curl -LO https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz
           tar -C bin -xvf sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz --wildcards '*/sccache' --strip 1
           popd
+        - nvm use 10 && npm install -g yarn@latest && yarn --version
       install:
         - (cd dex-contracts && yarn --frozen-lockfile && yarn run prepack)
         - ./test/setup_contracts.sh
@@ -48,6 +49,8 @@ matrix:
           - $HOME/.rustup
       before_cache:
         - rm -rf "$TRAVIS_HOME/.cargo/registry/src"
+      before_install:
+        - nvm use 10 && npm install -g yarn@latest && yarn --version
       install:
         - (cd dex-contracts && yarn --frozen-lockfile && yarn run prepack)
         - ./test/setup_contracts.sh
@@ -68,6 +71,8 @@ matrix:
       cache:
         directories:
           - $HOME/.cache/yarn
+      before_install:
+        - nvm use 10 && npm install -g yarn@latest && yarn --version
       install:
         - sudo apt-get update && sudo apt-get install -y python-pip && sudo pip install awscli
         - $(aws ecr get-login --no-include-email --region $AWS_REGION)
@@ -89,6 +94,8 @@ matrix:
       cache:
         directories:
           - $HOME/.cache/yarn
+      before_install:
+        - nvm use 10 && npm install -g yarn@latest && yarn --version
       install:
         - sudo apt-get update && sudo apt-get install -y python-pip && sudo pip install awscli
         - $(aws ecr get-login --no-include-email --region $AWS_REGION)
@@ -106,6 +113,8 @@ matrix:
       cache:
         directories:
           - $HOME/.cache/yarn
+      before_install:
+        - nvm use 10 && npm install -g yarn@latest && yarn --version
       install:
         - sudo apt-get update && sudo apt-get install -y python-pip && sudo pip install awscli
         - $(aws ecr get-login --no-include-email --region $AWS_REGION)

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
       cache:
         directories:
           - $HOME/.cache/yarn
+          - $HOME/.cache/node-gyp
           - $HOME/.cache/sccache
           - $HOME/.cargo
           - $HOME/.rustup
@@ -44,6 +45,7 @@ matrix:
       cache:
         directories:
           - $HOME/.cache/yarn
+          - $HOME/.cache/node-gyp
           - $HOME/.cache/sccache
           - $HOME/.cargo
           - $HOME/.rustup
@@ -71,6 +73,7 @@ matrix:
       cache:
         directories:
           - $HOME/.cache/yarn
+          - $HOME/.cache/node-gyp
       before_install:
         - nvm install 10 && nvm alias default 10 && npm install -g yarn@latest && yarn --version
       install:
@@ -94,6 +97,7 @@ matrix:
       cache:
         directories:
           - $HOME/.cache/yarn
+          - $HOME/.cache/node-gyp
       before_install:
         - nvm install 10 && nvm alias default 10 && npm install -g yarn@latest && yarn --version
       install:
@@ -113,6 +117,7 @@ matrix:
       cache:
         directories:
           - $HOME/.cache/yarn
+          - $HOME/.cache/node-gyp
       before_install:
         - nvm install 10 && nvm alias default 10 && npm install -g yarn@latest && yarn --version
       install:


### PR DESCRIPTION
We are seeing some flaky tests (e.g. [[1]](https://travis-ci.com/gnosis/dex-services/jobs/271235595) & [[2]](https://travis-ci.com/gnosis/dex-services/jobs/271380142)) which seem to stem from the fact that `~/.node-gyp/8.12.0/include/node/common.gypi` is empty where it should have a valid configuration inside. My hunch is that it is some kind of race condition with parallelising the build of the sha package and node-gyp.

This PR updates node to use the stable version we actually support (v10) and also the latest version of yarn. If this doesn't fix the issue, we likely have to enable verbose yarn logging to see in which order things are installed.

My hope is however that the issue is already fixed on the latest version.

### Test Plan

CI and observing if we keep getting random failures.