### PR TITLE
remove gas limit for orders query

### DIFF
--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -68,11 +68,9 @@ impl StableXContract for BatchExchange {
     }
 
     fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
-        let packed_auction_bytes = self
-            .get_encoded_orders()
-            .gas(10_000_000.into())
-            .call()
-            .wait()?;
+        let mut orders_builder = self.get_encoded_orders();
+        orders_builder.m.tx.gas = None;
+        let packed_auction_bytes = orders_builder.call().wait()?;
         let auction_data = parse_auction_data(packed_auction_bytes, index);
         Ok(auction_data)
     }

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -69,6 +69,9 @@ impl StableXContract for BatchExchange {
 
     fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
         let mut orders_builder = self.get_encoded_orders();
+        // NOTE: we need to override the gas limit which was set by the method
+        //   defaults - large number of orders was causing this `eth_call`
+        //   request to run into the gas limit
         orders_builder.m.tx.gas = None;
         let packed_auction_bytes = orders_builder.call().wait()?;
         let auction_data = parse_auction_data(packed_auction_bytes, index);


### PR DESCRIPTION
:point_up: 

We were running into a gas limit on `eth_call` requests because the number of orders was getting too large.

### Test Plan

See that the driver is no longer failing to get all orders on mainnet.