### PR TITLE
[Easy] Update Cargo.lock to reflect graph-node-reader tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
  "array-macro 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.17.0 (git+https://github.com/graphprotocol/graph-node?tag=v0.17.0)",
- "graph-node-reader 0.17.0 (git+https://github.com/gnosis/graph-node-reader?rev=3ed038a)",
+ "graph-node-reader 0.17.0 (git+https://github.com/gnosis/graph-node-reader?tag=v0.17.0)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mock-it 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -696,7 +696,7 @@ dependencies = [
  "ethereum-tx-sign 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.17.0 (git+https://github.com/graphprotocol/graph-node?tag=v0.17.0)",
- "graph-node-reader 0.17.0 (git+https://github.com/gnosis/graph-node-reader?rev=3ed038a)",
+ "graph-node-reader 0.17.0 (git+https://github.com/gnosis/graph-node-reader?tag=v0.17.0)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1218,7 +1218,7 @@ dependencies = [
 [[package]]
 name = "graph-node-reader"
 version = "0.17.0"
-source = "git+https://github.com/gnosis/graph-node-reader?rev=3ed038a#3ed038a5cdcaa8a074a0b6afacd38d87cdf44287"
+source = "git+https://github.com/gnosis/graph-node-reader?tag=v0.17.0#5700710050d6428309aa3b9dcf2d8fb2fb21944f"
 dependencies = [
  "Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1662,7 +1662,7 @@ dependencies = [
  "graph-chain-ethereum 0.17.0 (git+https://github.com/graphprotocol/graph-node?tag=v0.17.0)",
  "graph-core 0.17.0 (git+https://github.com/graphprotocol/graph-node?tag=v0.17.0)",
  "graph-mock 0.17.0 (git+https://github.com/graphprotocol/graph-node?tag=v0.17.0)",
- "graph-node-reader 0.17.0 (git+https://github.com/gnosis/graph-node-reader?rev=3ed038a)",
+ "graph-node-reader 0.17.0 (git+https://github.com/gnosis/graph-node-reader?tag=v0.17.0)",
  "graph-server-http 0.17.0 (git+https://github.com/graphprotocol/graph-node?tag=v0.17.0)",
  "graph-server-websocket 0.17.0 (git+https://github.com/graphprotocol/graph-node?tag=v0.17.0)",
  "graph-store-postgres 0.17.0 (git+https://github.com/graphprotocol/graph-node?tag=v0.17.0)",
@@ -3909,7 +3909,7 @@ dependencies = [
 "checksum graph-core 0.17.0 (git+https://github.com/graphprotocol/graph-node?tag=v0.17.0)" = "<none>"
 "checksum graph-graphql 0.17.0 (git+https://github.com/graphprotocol/graph-node?tag=v0.17.0)" = "<none>"
 "checksum graph-mock 0.17.0 (git+https://github.com/graphprotocol/graph-node?tag=v0.17.0)" = "<none>"
-"checksum graph-node-reader 0.17.0 (git+https://github.com/gnosis/graph-node-reader?rev=3ed038a)" = "<none>"
+"checksum graph-node-reader 0.17.0 (git+https://github.com/gnosis/graph-node-reader?tag=v0.17.0)" = "<none>"
 "checksum graph-server-http 0.17.0 (git+https://github.com/graphprotocol/graph-node?tag=v0.17.0)" = "<none>"
 "checksum graph-server-websocket 0.17.0 (git+https://github.com/graphprotocol/graph-node?tag=v0.17.0)" = "<none>"
 "checksum graph-store-postgres 0.17.0 (git+https://github.com/graphprotocol/graph-node?tag=v0.17.0)" = "<none>"

--- a/listener/src/main.rs
+++ b/listener/src/main.rs
@@ -201,13 +201,6 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
                 generic_store.clone(),
             );
 
-            // let mut index_node_server = IndexNodeServer::new(
-            //     &logger_factory,
-            //     graphql_runner.clone(),
-            //     generic_store.clone(),
-            //     node_id.clone(),
-            // );
-
             // BlockIngestor must be configured to keep at least REORG_THRESHOLD ancestors,
             // otherwise BlockStream will not work properly.
             // BlockStream expects the blocks after the reorg threshold to be present in the


### PR DESCRIPTION
PR #385 was accidentally merged without updating the Cargo.lock file to include the updated `graph-node-reader` tags. This PR addresses that.

We should consider failing the build if the Cargo.lock file is not in sync with the Cargo.toml file to avoid this in the future.

### Test Plan

Build still passes.