### PR TITLE
[Easy] Use a fixed ganache CLI version to make workaround signed tx issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   ganache-cli:
     ports:
       - '8545:8545'
-    image: 'trufflesuite/ganache-cli:latest'
+    image: 'trufflesuite/ganache-cli:v6.7.0'
     command: ["-d", "-i", "5777"]
     logging:
       driver: "none"


### PR DESCRIPTION
Work around the issue reported here: trufflesuite/ganache-cli#706.

### Test Plan

CI starts working again.