### PR TITLE
[E2E] StableX Rinkeby test in rust

### DIFF
--- a/docker/rust/Dockerfile
+++ b/docker/rust/Dockerfile
@@ -21,6 +21,7 @@ ONBUILD COPY dex-contracts/build ./dex-contracts/build
 ONBUILD COPY dfusion_rust_core ./dfusion_rust_core
 ONBUILD COPY driver ./driver
 ONBUILD COPY listener ./listener
+ONBUILD COPY e2e ./e2e
 
 ONBUILD COPY Cargo.* ./
 ONBUILD RUN cargo build

--- a/e2e/tests/stablex_test.rs
+++ b/e2e/tests/stablex_test.rs
@@ -1,12 +1,21 @@
 use ethcontract::web3::api::Web3;
-use ethcontract::web3::transports::Http;
+use ethcontract::web3::futures::Future as F;
+use ethcontract::web3::transports::{Http, WebSocket};
 use ethcontract::web3::types::U256;
-use ethcontract::Account;
+use ethcontract::{ethsign, Account, SecretKey, H256};
+
+use futures::future::join_all;
 
 use e2e::common::{close_auction, setup, wait_for_condition, FutureWaitExt};
 
+use std::env;
+use std::process::Command;
+use std::time::Duration;
+
+ethcontract::contract!("dex-contracts/build/contracts/IERC20.json");
+
 #[test]
-fn test_stablex() {
+fn test_with_ganache() {
     let (eloop, http) = Http::new("http://localhost:8545").expect("transport failed");
     eloop.into_remote();
     let web3 = Web3::new(http);
@@ -110,4 +119,125 @@ fn test_stablex() {
         .wait()
         .expect("Cannot get balance after");
     assert_eq!(balance_after - balance_before, 999_000.into())
+}
+
+ethcontract::contract!("dex-contracts/build/contracts/BatchExchange.json");
+
+#[test]
+fn test_rinkeby() {
+    // Setup instance and default tx params
+    let (eloop, http) = Http::new("https://node.rinkeby.gnosisdev.com/").expect("transport failed");
+    eloop.into_remote();
+    let web3 = Web3::new(http);
+    let mut instance = BatchExchange::deployed(&web3)
+        .wait()
+        .expect("Cannot get deployed Batch Exchange");
+    let secret = {
+        let private_key: H256 = env::var("PK")
+            .expect("PK env var not set")
+            .parse()
+            .expect("PK not parseable");
+        SecretKey::from_raw(&private_key[..])
+            .map_err(ethsign::Error::from)
+            .expect("Cannot derive key")
+    };
+    let account = Account::Offline(secret, None);
+    instance.defaults_mut().from = Some(account.clone());
+    instance.defaults_mut().gas = Some(1_000_000.into());
+    instance.defaults_mut().gas_price = Some(8_000_000_000u64.into());
+
+    let nonce = web3
+        .eth()
+        .transaction_count(account.address(), None)
+        .wait()
+        .expect("Cannot get nonce");
+    println!("Using account {:x} with nonce {}", account.address(), nonce);
+
+    // Gather token and batch info
+    let token_a = instance
+        .token_id_to_address_map(0)
+        .call()
+        .wait()
+        .expect("Cannot get first Token address");
+    let token_b = instance
+        .token_id_to_address_map(7)
+        .call()
+        .wait()
+        .expect("Cannot get second Token address");
+    let batch = instance
+        .get_current_batch_id()
+        .call()
+        .wait()
+        .expect("Cannot get batchId");
+
+    // Approve Funds
+    let first_approve = IERC20::at(&web3, token_a)
+        .approve(instance.address(), 1_000_000.into())
+        .nonce(nonce)
+        .gas(1_000_000.into())
+        .gas_price(8_000_000_000u64.into())
+        .from(account.clone())
+        .send_and_confirm(Duration::from_secs(1), 1);
+    let second_approve = IERC20::at(&web3, token_b)
+        .approve(instance.address(), 1_000_000.into())
+        .nonce(nonce + 1)
+        .gas(1_000_000.into())
+        .gas_price(8_000_000_000u64.into())
+        .from(account.clone())
+        .send_and_confirm(Duration::from_secs(1), 1);
+
+    // Deposit Funds
+    let first_deposit = instance
+        .deposit(token_a, 1_000_000.into())
+        .nonce(nonce + 2)
+        .send_and_confirm(Duration::from_secs(1), 1);
+    let second_deposit = instance
+        .deposit(token_b, 1_000_000.into())
+        .nonce(nonce + 3)
+        .send_and_confirm(Duration::from_secs(1), 1);
+
+    // Place orders
+    let first_order = instance
+        .place_order(0, 7, batch + 2, 1_000_000.into(), 10_000_000.into())
+        .nonce(nonce + 4)
+        .send_and_confirm(Duration::from_secs(1), 1);
+    let second_order = instance
+        .place_order(7, 0, batch + 1, 1_000_000.into(), 10_000_000.into())
+        .nonce(nonce + 5)
+        .send_and_confirm(Duration::from_secs(1), 1);
+
+    // Wait for all transactions to be confirmed
+    println!("Waiting for transactions to be confirmed");
+    let results = join_all(vec![
+        first_approve,
+        second_approve,
+        first_deposit,
+        second_deposit,
+        first_order,
+        second_order,
+    ])
+    .wait();
+    for (index, result) in results.into_iter().enumerate() {
+        result.unwrap_or_else(|_| panic!("Tx #{} failed", index));
+    }
+
+    // Wait for solution to be applied
+    let sleep_time = instance
+        .get_seconds_remaining_in_batch()
+        .call()
+        .wait()
+        .expect("Cannot get seconds remaining in batch")
+        .low_u64()
+        + 30;
+
+    println!("Sleeping {} seconds...", sleep_time);
+    std::thread::sleep(Duration::from_secs(sleep_time));
+
+    // Make sure there was no error
+    let output = Command::new("docker-compose")
+        .arg("logs")
+        .output()
+        .expect("failed to execute process");
+    let logs = String::from_utf8(output.stdout).expect("failed to read logs");
+    assert!(!logs.to_lowercase().contains("error"));
 }

--- a/e2e/tests/stablex_test.rs
+++ b/e2e/tests/stablex_test.rs
@@ -1,6 +1,6 @@
 use ethcontract::web3::api::Web3;
 use ethcontract::web3::futures::Future as F;
-use ethcontract::web3::transports::{Http, WebSocket};
+use ethcontract::web3::transports::Http;
 use ethcontract::web3::types::U256;
 use ethcontract::{ethsign, Account, SecretKey, H256};
 

--- a/e2e/tests/stablex_test.rs
+++ b/e2e/tests/stablex_test.rs
@@ -183,7 +183,7 @@ fn test_rinkeby() {
         .nonce(nonce + 1)
         .gas(1_000_000.into())
         .gas_price(8_000_000_000u64.into())
-        .from(account.clone())
+        .from(account)
         .send_and_confirm(Duration::from_secs(1), 1);
 
     // Deposit Funds


### PR DESCRIPTION
Converting the e2e test that actually runs an entire auction on Rinkeby. It requires waiting for up to 5 minutes (depending on when the batch will finish), but other than the existing javascript test we  actually wait on the confirmations for deposits/and order placements making it more reliable than the one we have today.

It's not yet being used on travis, only locally

### Test Plan

run 
```
docker-compose down && docker-compose -f docker-compose.yml -f docker-compose.rinkeby.yml up stablex
```

and then
```
cargo test -p e2e rinkeby -- --nocapture
```

and see the spectacle unfold...