### PR TITLE
[Easy] check that Cargo lockfile is in sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
         - (cd dex-contracts && yarn --frozen-lockfile && yarn run prepack)
         - ./test/setup_contracts.sh
       script:
-        - cargo build
+        - cargo build --locked
         # Build and publish compact image with compiled binary
         - docker build --tag stablex-binary --build-arg SOLVER_BASE=163030813197.dkr.ecr.us-east-1.amazonaws.com/dex-solver:v0.5.3 --build-arg RUST_BASE=rust-binary -f docker/rust/Dockerfile .
         - docker tag stablex-binary $REGISTRY_URI:$TRAVIS_COMMIT
@@ -68,7 +68,6 @@ matrix:
         - cargo test --all
         - cargo clippy --all --all-targets -- -D warnings
         - cargo fmt --all -- --check
-        - ! git diff --name-only | grep -q Cargo.lock # Make sure Cargo.lock is up to date
     - language: generic
       name: "dƒusion e2e Tests"
       cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,7 @@ matrix:
         - cargo test --all
         - cargo clippy --all --all-targets -- -D warnings
         - cargo fmt --all -- --check
+        - ! git diff --name-only | grep -q Cargo.lock # Make sure Cargo.lock is up to date
     - language: generic
       name: "dƒusion e2e Tests"
       cache:


### PR DESCRIPTION
Closes #411 

Adding a command to the travis config that will fail if the lockfile was updated while building the project.

### Test Plan

Change a version in the Cargo.lock, run tests. Then run

```
 git diff --name-only | grep -q Cargo.lock
```

And see that exit code is not success.