### PR TITLE
Refactoring components in the e2e project

### DIFF
--- a/e2e/src/common.rs
+++ b/e2e/src/common.rs
@@ -78,7 +78,7 @@ pub fn create_accounts_with_funded_tokens(
     (accounts, tokens)
 }
 
-pub fn approve(tokens: &Vec<IERC20>, address: H160, accounts: &Vec<H160>) {
+pub fn approve(tokens: &[IERC20], address: H160, accounts: &[H160]) {
     for account in accounts {
         for token in tokens {
             token
@@ -86,7 +86,7 @@ pub fn approve(tokens: &Vec<IERC20>, address: H160, accounts: &Vec<H160>) {
                 .from(Account::Local(*account, None))
                 .send()
                 .wait()
-                .expect(&format!("Cannot approve token {:x}", token.address()));
+                .unwrap_or_else(|_| panic!("Cannot approve token {:x}", token.address()));
         }
     }
 }

--- a/e2e/src/common.rs
+++ b/e2e/src/common.rs
@@ -1,3 +1,5 @@
+use crate::*;
+
 use ethcontract::web3::api::Web3;
 use ethcontract::web3::futures::Future as F;
 use ethcontract::web3::transports::Http;
@@ -8,12 +10,8 @@ use ethcontract::Account;
 use std::future::Future;
 use std::io::{Error, ErrorKind};
 
-ethcontract::contract!("dex-contracts/build/contracts/BatchExchange.json");
-ethcontract::contract!("dex-contracts/build/contracts/IERC20.json");
-ethcontract::contract!("dex-contracts/build/contracts/IdToAddressBiMap.json");
-ethcontract::contract!("dex-contracts/build/contracts/IterableAppendOnlySet.json");
-ethcontract::contract!("dex-contracts/build/contracts/TokenOWL.json");
-ethcontract::contract!("dex-contracts/build/contracts/ERC20Mintable.json");
+pub const TOKEN_MINTED: u32 = 100;
+pub const MAX_GAS: u32 = 6_000_000;
 
 pub trait FutureWaitExt: Future {
     fn wait(self) -> Self::Output;
@@ -28,95 +26,10 @@ where
     }
 }
 
-const TOKEN_MINTED: u32 = 100;
-const MAX_GAS: u32 = 6_000_000;
-
-pub fn setup(
-    web3: &Web3<Http>,
-    num_tokens: usize,
-    num_users: usize,
-) -> (BatchExchange, Vec<H160>, Vec<IERC20>) {
-    let accounts: Vec<H160> =
-        web3.eth().accounts().wait().expect("get accounts failed")[..num_users].to_vec();
-
-    let mut instance = BatchExchange::deployed(&web3)
-        .wait()
-        .expect("Cannot get deployed BatchExchange");
-    instance.defaults_mut().gas = Some(MAX_GAS.into());
-
-    let owl_address = instance
-        .token_id_to_address_map(0)
-        .call()
-        .wait()
-        .expect("Cannot get address of OWL Token");
-    let owl = TokenOWL::at(web3, owl_address);
-    owl.set_minter(accounts[0])
-        .send()
-        .wait()
-        .expect("Cannot set minter");
-    for account in &accounts {
-        owl.mint_owl(*account, U256::exp10(18) * TOKEN_MINTED)
-            .send()
-            .wait()
-            .expect("Cannot mint OWl");
-    }
-
-    let tokens: Vec<IERC20> = vec![IERC20::at(&web3, owl_address)]
-        .into_iter()
-        .chain((1..num_tokens).map(|_| {
-            let token = ERC20Mintable::builder(web3)
-                .gas(MAX_GAS.into())
-                .confirmations(0)
-                .deploy()
-                .wait()
-                .expect("Cannot deploy Mintable Token");
-            for account in &accounts {
-                token
-                    .mint(*account, U256::exp10(18) * TOKEN_MINTED)
-                    .send()
-                    .wait()
-                    .expect("Cannot mint token");
-            }
-            IERC20::at(&web3, token.address())
-        }))
-        .collect();
-
-    for account in &accounts {
-        for token in &tokens {
-            token
-                .approve(instance.address(), U256::exp10(18) * TOKEN_MINTED)
-                .from(Account::Local(*account, None))
-                .send()
-                .wait()
-                .expect("Cannot approve OWL for burning");
-        }
-    }
-
-    // token[0] is already added in constructor
-    for token in &tokens[1..] {
-        instance
-            .add_token(token.address())
-            .gas(MAX_GAS.into())
-            .send()
-            .wait()
-            .expect("Cannot add token");
-    }
-    (instance, accounts, tokens)
-}
-
 pub fn wait_for(web3: &Web3<Http>, seconds: u32) {
     web3.transport()
         .execute("evm_increaseTime", vec![seconds.into()]);
     web3.transport().execute("evm_mine", vec![]);
-}
-
-pub fn close_auction(web3: &Web3<Http>, instance: &BatchExchange) {
-    let seconds_remaining = instance
-        .get_seconds_remaining_in_batch()
-        .call()
-        .wait()
-        .expect("Cannot get seconds remaining in batch");
-    wait_for(web3, seconds_remaining.as_u32());
 }
 
 pub fn wait_for_condition<C>(condition: C) -> Result<(), Error>
@@ -134,4 +47,46 @@ where
         ErrorKind::TimedOut,
         "Condition not met before time limit",
     ))
+}
+
+pub fn create_accounts_with_funded_tokens(
+    web3: &Web3<Http>,
+    num_tokens: usize,
+    num_users: usize,
+) -> (Vec<H160>, Vec<IERC20>) {
+    let accounts: Vec<H160> =
+        web3.eth().accounts().wait().expect("get accounts failed")[..num_users].to_vec();
+
+    let tokens: Vec<IERC20> = (1..num_tokens)
+        .map(|_| {
+            let token = ERC20Mintable::builder(web3)
+                .gas(MAX_GAS.into())
+                .confirmations(0)
+                .deploy()
+                .wait()
+                .expect("Cannot deploy Mintable Token");
+            for account in &accounts {
+                token
+                    .mint(*account, U256::exp10(18) * TOKEN_MINTED)
+                    .send()
+                    .wait()
+                    .expect("Cannot mint token");
+            }
+            IERC20::at(&web3, token.address())
+        })
+        .collect();
+    (accounts, tokens)
+}
+
+pub fn approve(tokens: &Vec<IERC20>, address: H160, accounts: &Vec<H160>) {
+    for account in accounts {
+        for token in tokens {
+            token
+                .approve(address, U256::exp10(18) * TOKEN_MINTED)
+                .from(Account::Local(*account, None))
+                .send()
+                .wait()
+                .expect(&format!("Cannot approve token {:x}", token.address()));
+        }
+    }
 }

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -1,1 +1,9 @@
+ethcontract::contract!("dex-contracts/build/contracts/BatchExchange.json");
+ethcontract::contract!("dex-contracts/build/contracts/IERC20.json");
+ethcontract::contract!("dex-contracts/build/contracts/IdToAddressBiMap.json");
+ethcontract::contract!("dex-contracts/build/contracts/IterableAppendOnlySet.json");
+ethcontract::contract!("dex-contracts/build/contracts/TokenOWL.json");
+ethcontract::contract!("dex-contracts/build/contracts/ERC20Mintable.json");
+
 pub mod common;
+pub mod stablex;

--- a/e2e/src/stablex.rs
+++ b/e2e/src/stablex.rs
@@ -1,0 +1,69 @@
+use crate::*;
+
+use ethcontract::web3::api::Web3;
+use ethcontract::web3::transports::Http;
+use ethcontract::web3::types::{H160, U256};
+use ethcontract::Account;
+
+use crate::common::{
+    approve, create_accounts_with_funded_tokens, wait_for, FutureWaitExt, MAX_GAS, TOKEN_MINTED,
+};
+
+pub fn setup_stablex(
+    web3: &Web3<Http>,
+    num_tokens: usize,
+    num_users: usize,
+) -> (BatchExchange, Vec<H160>, Vec<IERC20>) {
+    // Get all tokens but OWL in a generic way
+    let (accounts, mut tokens) =
+        create_accounts_with_funded_tokens(&web3, num_tokens - 1, num_users);
+    let mut instance = BatchExchange::deployed(&web3)
+        .wait()
+        .expect("Cannot get deployed BatchExchange");
+    instance.defaults_mut().gas = Some(MAX_GAS.into());
+    approve(&tokens, instance.address(), &accounts);
+
+    // Set up OWL manually
+    let owl_address = instance
+        .token_id_to_address_map(0)
+        .call()
+        .wait()
+        .expect("Cannot get address of OWL Token");
+    let owl = TokenOWL::at(web3, owl_address);
+    owl.set_minter(accounts[0])
+        .send()
+        .wait()
+        .expect("Cannot set minter");
+    for account in &accounts {
+        owl.mint_owl(*account, U256::exp10(18) * TOKEN_MINTED)
+            .send()
+            .wait()
+            .expect("Cannot mint OWl");
+        owl.approve(instance.address(), U256::exp10(18) * TOKEN_MINTED)
+            .from(Account::Local(*account, None))
+            .send()
+            .wait()
+            .expect("Cannot approve OWL for burning");
+    }
+
+    // token[0] is already added in constructor
+    for token in &tokens {
+        instance
+            .add_token(token.address())
+            .gas(MAX_GAS.into())
+            .send()
+            .wait()
+            .expect("Cannot add token");
+    }
+    tokens.insert(0, IERC20::at(&web3, owl_address));
+    (instance, accounts, tokens)
+}
+
+pub fn close_auction(web3: &Web3<Http>, instance: &BatchExchange) {
+    let seconds_remaining = instance
+        .get_seconds_remaining_in_batch()
+        .call()
+        .wait()
+        .expect("Cannot get seconds remaining in batch");
+    wait_for(web3, seconds_remaining.as_u32());
+}

--- a/e2e/tests/stablex_test.rs
+++ b/e2e/tests/stablex_test.rs
@@ -6,20 +6,20 @@ use ethcontract::{ethsign, Account, SecretKey, H256};
 
 use futures::future::join_all;
 
-use e2e::common::{close_auction, setup, wait_for_condition, FutureWaitExt};
+use e2e::common::{wait_for_condition, FutureWaitExt};
+use e2e::stablex::{close_auction, setup_stablex};
+use e2e::IERC20;
 
 use std::env;
 use std::process::Command;
 use std::time::Duration;
-
-ethcontract::contract!("dex-contracts/build/contracts/IERC20.json");
 
 #[test]
 fn test_with_ganache() {
     let (eloop, http) = Http::new("http://localhost:8545").expect("transport failed");
     eloop.into_remote();
     let web3 = Web3::new(http);
-    let (instance, accounts, tokens) = setup(&web3, 3, 3);
+    let (instance, accounts, tokens) = setup_stablex(&web3, 3, 3);
 
     // Dynamically fetching the id allows the test to be run multiple times,
     // even if other tokens have already been added


### PR DESCRIPTION
This should help implementing the three e2e tests to test the SnappAuction contract while reusing the common pieces from the StableX tests. In particular this PR
- moves generated contract artifacts into top-level crate
- creates stablex.rs for methods related only to stablex (expecting a similar snapp.rs module to come)
- keeps the common part in common.rs and factoring the token generation, minting and approve logic out of the setup function into a separate function that can be reused for snapp e2e tests.

### Test Plan

```
docker-compose down && docker-compose up stablex
(cd dex-contracts && npx truffle migrate)
cargo test -p e2e ganache

docker-compose down && docker-compose -f docker-compose.yml -f docker-compose.rinkeby.yml up stablex
cargo test -p e2e rinkeby -- --nocapture
```