### PR TITLE
Revert "Use HashMap for Solution.prices"

### DIFF
--- a/dfusion_rust_core/src/models/account_state.rs
+++ b/dfusion_rust_core/src/models/account_state.rs
@@ -319,7 +319,7 @@ pub mod tests {
         };
 
         let results = Solution {
-            prices: map_from_slice(&[(0, 1), (1, 1)]),
+            prices: vec![1, 1],
             executed_buy_amounts: vec![1, 1],
             executed_sell_amounts: vec![1, 1],
         };

--- a/dfusion_rust_core/src/models/util.rs
+++ b/dfusion_rust_core/src/models/util.rs
@@ -1,10 +1,8 @@
 use byteorder::{BigEndian, ByteOrder};
 use graph::data::store::{Entity, Value};
 use graph::prelude::BigInt;
-use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::convert::TryInto;
-use std::hash::Hash;
 use std::str::FromStr;
 use web3::types::{H160, H256, U256};
 
@@ -221,21 +219,4 @@ pub fn read_amount(bytes: &[u8; 12]) -> u128 {
         .collect::<Vec<u8>>();
 
     BigEndian::read_u128(bytes.as_slice())
-}
-
-pub fn map_from_slice<T: Copy + Eq + Hash, U: Copy>(arr: &[(T, U)]) -> HashMap<T, U> {
-    arr.iter().copied().collect()
-}
-
-#[cfg(test)]
-pub mod tests {
-    use super::*;
-
-    #[test]
-    fn test_map_from_slice() {
-        let mut expected = HashMap::new();
-        expected.insert(0u16, 1u128);
-        expected.insert(1u16, 2u128);
-        assert_eq!(map_from_slice(&[(0, 1), (1, 2)]), expected);
-    }
 }

--- a/driver/src/driver/order_driver.rs
+++ b/driver/src/driver/order_driver.rs
@@ -215,7 +215,6 @@ mod tests {
     use crate::price_finding::price_finder_interface::tests::PriceFindingMock;
     use dfusion_core::database::tests::DbInterfaceMock;
     use dfusion_core::models::order::test_util::create_order_for_test;
-    use dfusion_core::models::util::map_from_slice;
     use dfusion_core::models::NUM_RESERVED_ACCOUNTS;
     use mock_it::Matcher::*;
     use std::str::FromStr;
@@ -287,7 +286,7 @@ mod tests {
 
         let mut pf = PriceFindingMock::default();
         let expected_solution = Solution {
-            prices: map_from_slice(&[(0, 1), (1, 2)]),
+            prices: vec![1, 2],
             executed_sell_amounts: vec![0, 2],
             executed_buy_amounts: vec![0, 2],
         };
@@ -526,7 +525,7 @@ mod tests {
 
         let mut pf = PriceFindingMock::default();
         let expected_solution = Solution {
-            prices: map_from_slice(&[(0, 1), (1, 2)]),
+            prices: vec![1, 2],
             executed_sell_amounts: vec![0, 2],
             executed_buy_amounts: vec![0, 2],
         };
@@ -711,7 +710,7 @@ mod tests {
     fn test_update_balances() {
         let mut state = AccountState::new(H256::zero(), U256::one(), vec![100; 60], NUM_TOKENS);
         let solution = Solution {
-            prices: map_from_slice(&[(0, 1), (1, 2)]),
+            prices: vec![1, 2],
             executed_sell_amounts: vec![1, 1],
             executed_buy_amounts: vec![1, 1],
         };

--- a/driver/src/driver/stablex_driver.rs
+++ b/driver/src/driver/stablex_driver.rs
@@ -84,7 +84,6 @@ mod tests {
 
     use dfusion_core::models::account_state::test_util::*;
     use dfusion_core::models::order::test_util::create_order_for_test;
-    use dfusion_core::models::util::map_from_slice;
 
     use mock_it::Matcher::{Any, Val};
 
@@ -118,7 +117,7 @@ mod tests {
             .will_return(Ok(()));
 
         let solution = Solution {
-            prices: map_from_slice(&[(0, 1), (1, 2)]),
+            prices: vec![1, 2],
             executed_sell_amounts: vec![0, 2],
             executed_buy_amounts: vec![0, 2],
         };
@@ -160,7 +159,7 @@ mod tests {
             .will_return(Ok(()));
 
         let solution = Solution {
-            prices: map_from_slice(&[(0, 1), (1, 2)]),
+            prices: vec![1, 2],
             executed_sell_amounts: vec![0, 2],
             executed_buy_amounts: vec![0, 2],
         };
@@ -311,6 +310,7 @@ mod tests {
                 .was_called_with((batch - 1, Any, Any, Any))
         ));
     }
+
     #[test]
     fn test_does_not_submit_solution_for_which_validation_failed() {
         let contract = StableXContractMock::default();
@@ -339,7 +339,7 @@ mod tests {
             )));
 
         let solution = Solution {
-            prices: map_from_slice(&[(0, 1), (1, 2)]),
+            prices: vec![1, 2],
             executed_sell_amounts: vec![0, 2],
             executed_buy_amounts: vec![0, 2],
         };

--- a/driver/src/price_finding/error.rs
+++ b/driver/src/price_finding/error.rs
@@ -36,7 +36,6 @@ impl From<&str> for PriceFindingError {
         PriceFindingError::new(error, ErrorKind::Unknown)
     }
 }
-
 impl PriceFindingError {
     pub fn new(msg: &str, kind: ErrorKind) -> PriceFindingError {
         PriceFindingError {

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -1,10 +1,10 @@
 use dfusion_core::models::{AccountState, Order, Solution};
+use std::cmp;
 use web3::types::U256;
 
 use crate::price_finding::error::PriceFindingError;
 use crate::price_finding::price_finder_interface::{Fee, PriceFinding};
 use crate::util::{CeiledDiv, CheckedConvertU128};
-use std::collections::HashMap;
 
 const BASE_UNIT: u128 = 1_000_000_000_000_000_000u128;
 const BASE_PRICE: u128 = BASE_UNIT;
@@ -102,8 +102,14 @@ impl PriceFinding for NaiveSolver {
         orders: &[Order],
         state: &AccountState,
     ) -> Result<Solution, PriceFindingError> {
+        // Fetch max_token_id to determine num_tokens
+        let max_token_id = orders
+            .iter()
+            .map(|o| cmp::max(o.buy_token, o.sell_token))
+            .max()
+            .unwrap_or(0);
         // Initialize trivial solution (default of zero indicates untouched token).
-        let mut prices = HashMap::new();
+        let mut prices: Vec<u128> = vec![0; max_token_id as usize + 1];
         let mut exec_buy_amount: Vec<u128> = vec![0; orders.len()];
         let mut exec_sell_amount: Vec<u128> = vec![0; orders.len()];
 
@@ -114,8 +120,8 @@ impl PriceFinding for NaiveSolver {
                 let y = order_with_buffer_for_fee(&orders[j], &self.fee);
                 match x.match_compare(&y, &state, &self.fee) {
                     Some(OrderPairType::LhsFullyFilled) => {
-                        prices.insert(x.buy_token, x.sell_amount);
-                        prices.insert(y.buy_token, x.buy_amount);
+                        prices[x.buy_token as usize] = x.sell_amount;
+                        prices[y.buy_token as usize] = x.buy_amount;
                         exec_sell_amount[i] = x.sell_amount;
                         exec_sell_amount[j] = x.buy_amount;
 
@@ -123,8 +129,8 @@ impl PriceFinding for NaiveSolver {
                         exec_buy_amount[j] = x.sell_amount;
                     }
                     Some(OrderPairType::RhsFullyFilled) => {
-                        prices.insert(x.sell_token, y.sell_amount);
-                        prices.insert(y.sell_token, y.buy_amount);
+                        prices[x.sell_token as usize] = y.sell_amount;
+                        prices[y.sell_token as usize] = y.buy_amount;
 
                         exec_sell_amount[i] = y.buy_amount;
                         exec_sell_amount[j] = y.sell_amount;
@@ -133,8 +139,8 @@ impl PriceFinding for NaiveSolver {
                         exec_buy_amount[j] = y.buy_amount;
                     }
                     Some(OrderPairType::BothFullyFilled) => {
-                        prices.insert(y.buy_token, y.sell_amount);
-                        prices.insert(x.buy_token, x.sell_amount);
+                        prices[y.buy_token as usize] = y.sell_amount;
+                        prices[x.buy_token as usize] = x.sell_amount;
 
                         exec_sell_amount[i] = x.sell_amount;
                         exec_sell_amount[j] = y.sell_amount;
@@ -150,11 +156,11 @@ impl PriceFinding for NaiveSolver {
 
         if let Some(fee) = &self.fee {
             // normalize prices so fee token price is BASE_PRICE
-            let pre_normalized_fee_price = prices.get(&fee.token).copied().unwrap_or(0);
+            let pre_normalized_fee_price = prices.get(fee.token as usize).copied().unwrap_or(0);
             if pre_normalized_fee_price == 0 {
                 return Ok(Solution::trivial(orders.len()));
             }
-            for price in prices.values_mut() {
+            for price in prices.iter_mut() {
                 *price = match normalize_price(*price, pre_normalized_fee_price) {
                     Some(price) => price,
                     None => return Ok(Solution::trivial(orders.len())),
@@ -165,11 +171,11 @@ impl PriceFinding for NaiveSolver {
             // the fee token
             for (i, order) in orders.iter().enumerate() {
                 if order.sell_token == fee.token {
-                    let price_buy = prices[&order.buy_token];
+                    let price_buy = prices[order.buy_token as usize];
                     exec_sell_amount[i] =
                         executed_sell_amount(fee, exec_buy_amount[i], price_buy, BASE_PRICE);
                 } else {
-                    let price_sell = prices[&order.sell_token];
+                    let price_sell = prices[order.sell_token as usize];
                     exec_buy_amount[i] =
                         match executed_buy_amount(fee, exec_sell_amount[i], BASE_PRICE, price_sell)
                         {
@@ -279,8 +285,8 @@ pub mod tests {
             vec![52 * BASE_UNIT, 4 * BASE_UNIT],
             res.executed_sell_amounts
         );
-        assert_eq!(4 * BASE_UNIT, res.prices[&0]);
-        assert_eq!(52 * BASE_UNIT, res.prices[&1]);
+        assert_eq!(4 * BASE_UNIT, res.prices[0]);
+        assert_eq!(52 * BASE_UNIT, res.prices[1]);
 
         check_solution(&orders, res, &None).unwrap();
     }
@@ -316,8 +322,8 @@ pub mod tests {
             vec![4 * BASE_UNIT, 52 * BASE_UNIT],
             res.executed_sell_amounts
         );
-        assert_eq!(4 * BASE_UNIT, res.prices[&0]);
-        assert_eq!(52 * BASE_UNIT, res.prices[&1]);
+        assert_eq!(4 * BASE_UNIT, res.prices[0]);
+        assert_eq!(52 * BASE_UNIT, res.prices[1]);
 
         check_solution(&orders, res, &None).unwrap();
     }
@@ -353,8 +359,8 @@ pub mod tests {
             vec![10 * BASE_UNIT, 16 * BASE_UNIT],
             res.executed_sell_amounts
         );
-        assert_eq!(10 * BASE_UNIT, res.prices[&1]);
-        assert_eq!(16 * BASE_UNIT, res.prices[&2]);
+        assert_eq!(10 * BASE_UNIT, res.prices[1]);
+        assert_eq!(16 * BASE_UNIT, res.prices[2]);
 
         check_solution(&orders, res, &None).unwrap();
     }
@@ -431,8 +437,8 @@ pub mod tests {
 
         assert_eq!(vec![0, 0, 0, 52, 4, 0], res.executed_buy_amounts);
         assert_eq!(vec![0, 0, 0, 4, 52, 0], res.executed_sell_amounts);
-        assert_eq!(4, res.prices[&1]);
-        assert_eq!(52, res.prices[&2]);
+        assert_eq!(4, res.prices[1]);
+        assert_eq!(52, res.prices[2]);
 
         check_solution(&orders, res, &None).unwrap();
     }
@@ -528,8 +534,8 @@ pub mod tests {
 
         assert_eq!(res.executed_sell_amounts, [20000, 9990]);
         assert_eq!(res.executed_buy_amounts, [9990, 19961]);
-        assert_eq!(res.prices[&0], BASE_PRICE);
-        assert_eq!(res.prices[&1], BASE_PRICE * 2);
+        assert_eq!(res.prices[0], BASE_PRICE);
+        assert_eq!(res.prices[1], BASE_PRICE * 2);
 
         check_solution(&orders, res, &fee).unwrap();
     }
@@ -612,7 +618,14 @@ pub mod tests {
 
         let solver = NaiveSolver::new(None);
         let res = solver.find_prices(&orders, &state).unwrap();
-        assert_eq!(res, Solution::trivial(0));
+        assert_eq!(
+            res,
+            Solution {
+                prices: vec![0],
+                executed_buy_amounts: vec![],
+                executed_sell_amounts: vec![]
+            }
+        );
     }
 
     #[test]
@@ -694,19 +707,19 @@ pub mod tests {
             return Ok(());
         }
 
-        if let Some(fee_token) = fee.as_ref().map(|fee| fee.token) {
-            if solution.price(fee_token).unwrap_or_default() != BASE_PRICE {
+        if let Some(fee_token) = fee.as_ref().map(|fee| fee.token as usize) {
+            if solution.prices[fee_token] != BASE_PRICE {
                 return Err(format!(
                     "price of fee token does not match the base price: {} != {}",
-                    solution.prices[&fee_token], BASE_PRICE
+                    solution.prices[fee_token], BASE_PRICE
                 ));
             }
         }
 
         let mut token_conservation = HashMap::new();
         for (i, order) in orders.iter().enumerate() {
-            let buy_token_price = *solution.prices.get(&order.buy_token).unwrap_or(&0u128);
-            let sell_token_price = *solution.prices.get(&order.sell_token).unwrap_or(&0u128);
+            let buy_token_price = solution.prices[order.buy_token as usize];
+            let sell_token_price = solution.prices[order.sell_token as usize];
 
             let exec_buy_amount = solution.executed_buy_amounts[i];
             let exec_sell_amount = if sell_token_price > 0 {
@@ -748,12 +761,12 @@ pub mod tests {
             *token_conservation.entry(order.sell_token).or_insert(0) -= exec_sell_amount as i128;
         }
 
-        for token_id in solution.prices.keys() {
-            let balance = token_conservation.entry(*token_id).or_insert(0);
-            if *balance != 0 && (fee.is_none() || *token_id != fee.as_ref().unwrap().token) {
+        for j in 0..solution.prices.len() {
+            let balance = token_conservation.entry(j as u16).or_insert(0);
+            if *balance != 0 && (fee.is_none() || j as u16 != fee.as_ref().unwrap().token) {
                 return Err(format!(
                     "Token balance of token {} not 0 (was {})",
-                    token_id, balance
+                    j, balance
                 ));
             }
         }

--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -30,7 +30,6 @@ pub trait PriceFinding {
 pub mod tests {
     use super::super::error::ErrorKind;
     use super::*;
-    use dfusion_core::models::util::map_from_slice;
     use dfusion_core::models::Serializable;
     use mock_it::Mock;
 
@@ -65,7 +64,7 @@ pub mod tests {
     #[test]
     fn test_serialize_solution() {
         let solution = models::Solution {
-            prices: map_from_slice(&[(0, 1), (1, 2)]),
+            prices: vec![1, 2],
             executed_sell_amounts: vec![3, 4],
             executed_buy_amounts: vec![5, 6],
         };

--- a/driver/src/snapp.rs
+++ b/driver/src/snapp.rs
@@ -10,6 +10,9 @@ use web3::types::U256;
 /// an implementation to calculating the Snapp objective value which must be
 /// submitted with the solution.
 pub trait SnappSolution {
+    /// Returns the price for a token by ID or None if the token was not found.
+    fn get_token_price(&self, token_id: u16) -> Option<u128>;
+
     /// Returns the objective value for submitting a solution to the Snapp smart
     /// contract. The objective value is calculated as the total executed
     /// utility of all orders.
@@ -30,13 +33,17 @@ pub trait SnappSolution {
 }
 
 impl SnappSolution for Solution {
+    fn get_token_price(&self, token_id: u16) -> Option<u128> {
+        self.prices.get(token_id as usize).cloned()
+    }
+
     fn snapp_objective_value(&self, orders: &[Order]) -> Result<U256, SnappObjectiveError> {
         let mut total_executed_utility = U256::zero();
         for (i, order) in orders.iter().enumerate() {
             total_executed_utility = total_executed_utility
                 .checked_add(
                     order.executed_utility(
-                        self.price(order.buy_token)
+                        self.get_token_price(order.buy_token)
                             .ok_or(SnappObjectiveError::TokenNotFound)?,
                         *self
                             .executed_buy_amounts
@@ -138,7 +145,6 @@ pub enum SnappObjectiveError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dfusion_core::models::util::map_from_slice;
 
     #[test]
     fn solution_objective_value() {
@@ -160,7 +166,7 @@ mod tests {
         ];
 
         let solution = Solution {
-            prices: map_from_slice(&[(0, 10u128.pow(18)), (1, 2_500_000_000_000_000_000)]),
+            prices: vec![10u128.pow(18), 2_500_000_000_000_000_000],
             executed_buy_amounts: vec![2_497_500_000_000_000_000, 10u128.pow(18)],
             executed_sell_amounts: vec![10u128.pow(18), 2_502_502_502_502_502_502],
         };
@@ -217,7 +223,7 @@ mod tests {
         }];
 
         let solution = Solution {
-            prices: map_from_slice(&[(0, 10u128.pow(18))]),
+            prices: vec![10u128.pow(18)],
             executed_buy_amounts: vec![10u128.pow(18)],
             executed_sell_amounts: vec![10u128.pow(18)],
         };
@@ -248,7 +254,7 @@ mod tests {
         ];
 
         let solution = Solution {
-            prices: map_from_slice(&[(0, 10u128.pow(18)), (1, 10u128.pow(18))]),
+            prices: vec![10u128.pow(18), 10u128.pow(18)],
             executed_buy_amounts: vec![10u128.pow(18)],
             executed_sell_amounts: vec![10u128.pow(18)],
         };
@@ -270,7 +276,7 @@ mod tests {
         }];
 
         let solution = Solution {
-            prices: map_from_slice(&[(0, 10u128.pow(18)), (1, 10u128.pow(18))]),
+            prices: vec![10u128.pow(18), 10u128.pow(18)],
             executed_buy_amounts: vec![10u128.pow(18)],
             executed_sell_amounts: vec![10u128.pow(18)],
         };
@@ -301,7 +307,7 @@ mod tests {
         ];
 
         let solution = Solution {
-            prices: map_from_slice(&[(0, u128::max_value()), (1, 10u128.pow(18))]),
+            prices: vec![u128::max_value(), 10u128.pow(18)],
             executed_buy_amounts: vec![u128::max_value(), u128::max_value()],
             executed_sell_amounts: vec![0, 0],
         };

--- a/e2e/tests/stablex_test.rs
+++ b/e2e/tests/stablex_test.rs
@@ -136,7 +136,7 @@ fn test_rinkeby() {
         let private_key: H256 = env::var("PK")
             .expect("PK env var not set")
             .parse()
-            .expect("PK not parsable");
+            .expect("PK not parseable");
         SecretKey::from_raw(&private_key[..])
             .map_err(ethsign::Error::from)
             .expect("Cannot derive key")


### PR DESCRIPTION
Reverts gnosis/dex-services#420


There is a case missed by all the existing tests. This is the proper handling of solution JSONS with prices containing `null` (which happens often). For example;

```
    "prices": {
        "token0": "1000000000000000000",
        "token1": "9989999002997979320",
        "token2": null,
    },
```

TOdo - ensure e2e rinkeby test and unit test for `deserialize_result` handle this scenario.