### PR TITLE
Adding an oncall email to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 notifications:
   email:
-    - dfusion-oncall@gnosis.io
+    - oncall-dfusion@gnosis.io
   if: (branch = master) OR (tag IS present)
 if: (branch = master) OR (type = pull_request) OR (tag IS present)
 language: rust

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 notifications:
   email:
     - dfusion-oncall@gnosis.io
+  if: (branch = master) OR (tag IS present)
 if: (branch = master) OR (type = pull_request) OR (tag IS present)
 language: rust
 rust: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+notifications:
+  email:
+    - dfusion-oncall@gnosis.io
 if: (branch = master) OR (type = pull_request) OR (tag IS present)
 language: rust
 rust: stable


### PR DESCRIPTION
This PR makes it so that build status failures and changes (when a failure changes back to green) are submitted to our oncall email address. @denisgranha can you let me know when the address is created?

### Test Plan

After merging failing build see email notification being sent.