### PR TITLE
Update dex-contract to 0.2.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - '8545:8545'
     image: 'trufflesuite/ganache-cli:v6.7.0'
-    command: ["-d", "-i", "5777"]
+    command: ["-d", "-i", "5777", "-l", "0x7a1200"]
     logging:
       driver: "none"
 

--- a/listener/subgraph_definition/dfusion
+++ b/listener/subgraph_definition/dfusion
@@ -8,7 +8,7 @@ dataSources:
     network: dev
     name: SnappBaseEvents
     source:
-      address: '0xe982E462b094850F12AF94d21D470e21bE9D0E9C'
+      address: '0x9561C133DD8580860B6b7E504bC5Aa500f0f06a7'
       abi: EmptyAbi.json
     mapping:
       kind: Mapping


### PR DESCRIPTION
This PR updates to the most recent released contracts.

The older version 0.1.3 will still be driven by separate AWS jobs for the next couple of days/weeks until it is fully deprecated.

### Test Plan

CI and afterwards trying a first trade on the new version.