### PR TITLE
[Easy] increase async logger buffer size

### DIFF
--- a/driver/src/logging.rs
+++ b/driver/src/logging.rs
@@ -12,11 +12,16 @@ const FILTER_KEY: &str = "DFUSION_LOG";
 /// supplied by the environment.
 const DEFAULT_FILTER: &str = "info";
 
+/// The channel size for async logging.
+const BUFFER_SIZE: usize = 1024;
+
 /// Initialize driver logging.
 pub fn init() -> (Logger, GlobalLoggerGuard) {
     let filter = env::var(FILTER_KEY).unwrap_or_else(|_| DEFAULT_FILTER.to_owned());
     let format = CustomFormatter::new(TermDecorator::new().stderr().build()).fuse();
-    let drain = Async::default(LogBuilder::new(format).parse(&filter).build());
+    let drain = Async::new(LogBuilder::new(format).parse(&filter).build())
+        .chan_size(BUFFER_SIZE)
+        .build();
     let logger = Logger::root(drain.fuse(), o!());
 
     let guard = slog_scope::set_global_logger(logger.clone());


### PR DESCRIPTION
When there is a lot of logging happening, we can see "channel overflow" errors (cf. [here](https://logs.gnosisdev.com/goto/a859e0d7fbe28cf3daba1c924bbc2c8c))

This can be mitigated by setting a larger channel size (the default is 128). I'm not sure if 1kb is sufficient, but we can observe and adjust.

### Test Plan

Expect to see no more channel overflow errors.