### PR TITLE
Decoupling the StableX contract and driver

### DIFF
--- a/driver/src/bin/stablex.rs
+++ b/driver/src/bin/stablex.rs
@@ -2,7 +2,9 @@ use driver::contracts::stablex_contract::BatchExchange;
 use driver::driver::stablex_driver::StableXDriver;
 use driver::logging;
 use driver::metrics::{MetricsServer, StableXMetrics};
+use driver::orderbook::StableXOrderBookReader;
 use driver::price_finding::Fee;
+use driver::solution_submission::StableXSolutionSubmitter;
 
 use log::{error, info};
 
@@ -29,7 +31,14 @@ fn main() {
 
     let fee = Some(Fee::default());
     let mut price_finder = driver::util::create_price_finder(fee);
-    let mut driver = StableXDriver::new(&contract, &mut *price_finder, stablex_metrics);
+    let orderbook = StableXOrderBookReader::new(&contract);
+    let solution_submitter = StableXSolutionSubmitter::new(&contract);
+    let mut driver = StableXDriver::new(
+        &mut *price_finder,
+        &orderbook,
+        &solution_submitter,
+        stablex_metrics,
+    );
     loop {
         if let Err(e) = driver.run() {
             error!("StableXDriver error: {}", e);

--- a/driver/src/driver/stablex_driver.rs
+++ b/driver/src/driver/stablex_driver.rs
@@ -1,7 +1,8 @@
-use crate::contracts::stablex_contract::StableXContract;
 use crate::error::DriverError;
 use crate::metrics::StableXMetrics;
+use crate::orderbook::StableXOrderBookReading;
 use crate::price_finding::PriceFinding;
+use crate::solution_submission::StableXSolutionSubmitting;
 
 use dfusion_core::models::Solution;
 
@@ -13,31 +14,31 @@ use web3::types::U256;
 
 pub struct StableXDriver<'a> {
     past_auctions: HashSet<U256>,
-    contract: &'a dyn StableXContract,
     price_finder: &'a mut dyn PriceFinding,
+    orderbook_reader: &'a dyn StableXOrderBookReading,
+    solution_submitter: &'a dyn StableXSolutionSubmitting,
     metrics: StableXMetrics,
 }
 
 impl<'a> StableXDriver<'a> {
     pub fn new(
-        contract: &'a dyn StableXContract,
         price_finder: &'a mut dyn PriceFinding,
+        orderbook_reader: &'a dyn StableXOrderBookReading,
+        solution_submitter: &'a dyn StableXSolutionSubmitting,
         metrics: StableXMetrics,
     ) -> Self {
         StableXDriver {
             past_auctions: HashSet::new(),
-            contract,
             price_finder,
+            orderbook_reader,
+            solution_submitter,
             metrics,
         }
     }
 
     pub fn run(&mut self) -> Result<bool, DriverError> {
         // Try to process previous batch auction
-        let batch_to_solve_result = self
-            .contract
-            .get_current_auction_index()
-            .map(|batch_collecting_orders| batch_collecting_orders - 1);
+        let batch_to_solve_result = self.orderbook_reader.get_auction_index();
 
         if batch_to_solve_result
             .as_ref()
@@ -51,7 +52,7 @@ impl<'a> StableXDriver<'a> {
             .auction_processing_started(&batch_to_solve_result);
         let batch_to_solve = batch_to_solve_result?;
 
-        let get_auction_data_result = self.contract.get_auction_data(batch_to_solve);
+        let get_auction_data_result = self.orderbook_reader.get_auction_data(batch_to_solve);
         self.metrics
             .auction_orders_fetched(batch_to_solve, &get_auction_data_result);
         let (account_state, orders) = get_auction_data_result?;
@@ -76,11 +77,11 @@ impl<'a> StableXDriver<'a> {
         };
 
         let submitted = if solution.is_non_trivial() {
-            // NOTE: in retrieving the objective value from the contract the
+            // NOTE: in retrieving the objective value from the reader the
             //   solution gets validated, ensured that it is better than the
             //   latest submitted solution, and that solutions are still being
             //   accepted for this batch ID.
-            let verification_result = self.contract.get_solution_objective_value(
+            let verification_result = self.solution_submitter.get_solution_objective_value(
                 batch_to_solve,
                 orders.clone(),
                 solution.clone(),
@@ -93,9 +94,12 @@ impl<'a> StableXDriver<'a> {
                 "Verified solution with objective value: {}",
                 objective_value
             );
-            let submission_result =
-                self.contract
-                    .submit_solution(batch_to_solve, orders, solution, objective_value);
+            let submission_result = self.solution_submitter.submit_solution(
+                batch_to_solve,
+                orders,
+                solution,
+                objective_value,
+            );
             self.metrics
                 .auction_solution_submitted(batch_to_solve, &submission_result);
             submission_result?;
@@ -118,9 +122,10 @@ impl<'a> StableXDriver<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::contracts::stablex_contract::tests::StableXContractMock;
     use crate::error::ErrorKind;
+    use crate::orderbook::tests::StableXOrderBookReadingMock;
     use crate::price_finding::price_finder_interface::tests::PriceFindingMock;
+    use crate::solution_submission::tests::StableXSolutionSubmittingMock;
 
     use dfusion_core::models::account_state::test_util::*;
     use dfusion_core::models::order::test_util::create_order_for_test;
@@ -129,8 +134,9 @@ mod tests {
     use mock_it::Matcher::{Any, Val};
 
     #[test]
-    fn invokes_solver_with_contract_data_for_unprocessed_auction() {
-        let contract = StableXContractMock::default();
+    fn invokes_solver_with_reader_data_for_unprocessed_auction() {
+        let reader = StableXOrderBookReadingMock::default();
+        let submitter = StableXSolutionSubmittingMock::default();
         let mut pf = PriceFindingMock::default();
         let metrics = StableXMetrics::default();
 
@@ -138,24 +144,21 @@ mod tests {
         let state = create_account_state_with_balance_for(&orders);
 
         let batch = U256::from(42);
-        contract
-            .get_current_auction_index
-            .given(())
-            .will_return(Ok(batch));
+        reader.get_auction_index.given(()).will_return(Ok(batch));
 
-        contract
+        reader
             .get_auction_data
-            .given(batch - 1)
+            .given(batch)
             .will_return(Ok((state.clone(), orders.clone())));
 
-        contract
+        submitter
             .get_solution_objective_value
-            .given((batch - 1, Val(orders.clone()), Any))
+            .given((batch, Val(orders.clone()), Any))
             .will_return(Ok(U256::from(1337)));
 
-        contract
+        submitter
             .submit_solution
-            .given((batch - 1, Val(orders.clone()), Any, Val(U256::from(1337))))
+            .given((batch, Val(orders.clone()), Any, Val(U256::from(1337))))
             .will_return(Ok(()));
 
         let solution = Solution {
@@ -167,13 +170,14 @@ mod tests {
             .given((orders, state))
             .will_return(Ok(solution));
 
-        let mut driver = StableXDriver::new(&contract, &mut pf, metrics);
+        let mut driver = StableXDriver::new(&mut pf, &reader, &submitter, metrics);
         assert!(driver.run().unwrap());
     }
 
     #[test]
     fn does_not_process_previously_processed_auction_again() {
-        let contract = StableXContractMock::default();
+        let reader = StableXOrderBookReadingMock::default();
+        let submitter = StableXSolutionSubmittingMock::default();
         let mut pf = PriceFindingMock::default();
         let metrics = StableXMetrics::default();
 
@@ -181,24 +185,21 @@ mod tests {
         let state = create_account_state_with_balance_for(&orders);
 
         let batch = U256::from(42);
-        contract
-            .get_current_auction_index
-            .given(())
-            .will_return(Ok(batch));
+        reader.get_auction_index.given(()).will_return(Ok(batch));
 
-        contract
+        reader
             .get_auction_data
-            .given(batch - 1)
+            .given(batch)
             .will_return(Ok((state.clone(), orders.clone())));
 
-        contract
+        submitter
             .get_solution_objective_value
-            .given((batch - 1, Val(orders.clone()), Any))
+            .given((batch, Val(orders.clone()), Any))
             .will_return(Ok(U256::from(1337)));
 
-        contract
+        submitter
             .submit_solution
-            .given((batch - 1, Val(orders.clone()), Any, Val(U256::from(1337))))
+            .given((batch, Val(orders.clone()), Any, Val(U256::from(1337))))
             .will_return(Ok(()));
 
         let solution = Solution {
@@ -210,7 +211,7 @@ mod tests {
             .given((orders, state))
             .will_return(Ok(solution));
 
-        let mut driver = StableXDriver::new(&contract, &mut pf, metrics);
+        let mut driver = StableXDriver::new(&mut pf, &reader, &submitter, metrics);
 
         // First auction
         assert_eq!(driver.run().unwrap(), true);
@@ -220,19 +221,21 @@ mod tests {
     }
 
     #[test]
-    fn test_errors_on_failing_contract() {
-        let contract = StableXContractMock::default();
+    fn test_errors_on_failing_reader() {
+        let reader = StableXOrderBookReadingMock::default();
+        let submitter = StableXSolutionSubmittingMock::default();
         let mut pf = PriceFindingMock::default();
         let metrics = StableXMetrics::default();
 
-        let mut driver = StableXDriver::new(&contract, &mut pf, metrics);
+        let mut driver = StableXDriver::new(&mut pf, &reader, &submitter, metrics);
 
         assert!(driver.run().is_err())
     }
 
     #[test]
     fn test_errors_on_failing_price_finder() {
-        let contract = StableXContractMock::default();
+        let reader = StableXOrderBookReadingMock::default();
+        let submitter = StableXSolutionSubmittingMock::default();
         let mut pf = PriceFindingMock::default();
         let metrics = StableXMetrics::default();
 
@@ -240,34 +243,32 @@ mod tests {
         let state = create_account_state_with_balance_for(&orders);
 
         let batch = U256::from(42);
-        contract
-            .get_current_auction_index
-            .given(())
-            .will_return(Ok(batch));
+        reader.get_auction_index.given(()).will_return(Ok(batch));
 
-        contract
+        reader
             .get_auction_data
-            .given(batch - 1)
+            .given(batch)
             .will_return(Ok((state, orders.clone())));
 
-        contract
+        submitter
             .get_solution_objective_value
-            .given((batch - 1, Val(orders.clone()), Any))
+            .given((batch, Val(orders.clone()), Any))
             .will_return(Ok(U256::from(1337)));
 
-        contract
+        submitter
             .submit_solution
-            .given((batch - 1, Val(orders), Any, Val(U256::from(1337))))
+            .given((batch, Val(orders), Any, Val(U256::from(1337))))
             .will_return(Ok(()));
 
-        let mut driver = StableXDriver::new(&contract, &mut pf, metrics);
+        let mut driver = StableXDriver::new(&mut pf, &reader, &submitter, metrics);
 
         assert!(driver.run().is_err())
     }
 
     #[test]
     fn test_do_not_invoke_solver_when_no_orders() {
-        let contract = StableXContractMock::default();
+        let reader = StableXOrderBookReadingMock::default();
+        let submitter = StableXSolutionSubmittingMock::default();
         let mut pf = PriceFindingMock::default();
         let metrics = StableXMetrics::default();
 
@@ -275,17 +276,14 @@ mod tests {
         let state = create_account_state_with_balance_for(&orders);
 
         let batch = U256::from(42);
-        contract
-            .get_current_auction_index
-            .given(())
-            .will_return(Ok(batch));
+        reader.get_auction_index.given(()).will_return(Ok(batch));
 
-        contract
+        reader
             .get_auction_data
-            .given(batch - 1)
+            .given(batch)
             .will_return(Ok((state.clone(), orders.clone())));
 
-        let mut driver = StableXDriver::new(&contract, &mut pf, metrics);
+        let mut driver = StableXDriver::new(&mut pf, &reader, &submitter, metrics);
 
         assert!(driver.run().is_ok());
         assert!(!mock_it::verify(
@@ -295,7 +293,8 @@ mod tests {
 
     #[test]
     fn test_do_not_invoke_solver_when_previously_failed() {
-        let contract = StableXContractMock::default();
+        let reader = StableXOrderBookReadingMock::default();
+        let submitter = StableXSolutionSubmittingMock::default();
         let mut pf = PriceFindingMock::default();
         let metrics = StableXMetrics::default();
 
@@ -303,17 +302,14 @@ mod tests {
         let state = create_account_state_with_balance_for(&orders);
 
         let batch = U256::from(42);
-        contract
-            .get_current_auction_index
-            .given(())
-            .will_return(Ok(batch));
+        reader.get_auction_index.given(()).will_return(Ok(batch));
 
-        contract
+        reader
             .get_auction_data
-            .given(batch - 1)
+            .given(batch)
             .will_return(Ok((state.clone(), orders.clone())));
 
-        let mut driver = StableXDriver::new(&contract, &mut pf, metrics);
+        let mut driver = StableXDriver::new(&mut pf, &reader, &submitter, metrics);
 
         // First run fails
         assert!(driver.run().is_err());
@@ -327,7 +323,8 @@ mod tests {
 
     #[test]
     fn test_does_not_submit_empty_solution() {
-        let contract = StableXContractMock::default();
+        let reader = StableXOrderBookReadingMock::default();
+        let submitter = StableXSolutionSubmittingMock::default();
         let mut pf = PriceFindingMock::default();
         let metrics = StableXMetrics::default();
 
@@ -335,14 +332,11 @@ mod tests {
         let state = create_account_state_with_balance_for(&orders);
 
         let batch = U256::from(42);
-        contract
-            .get_current_auction_index
-            .given(())
-            .will_return(Ok(batch));
+        reader.get_auction_index.given(()).will_return(Ok(batch));
 
-        contract
+        reader
             .get_auction_data
-            .given(batch - 1)
+            .given(batch)
             .will_return(Ok((state.clone(), orders.clone())));
 
         let solution = Solution::trivial(orders.len());
@@ -350,17 +344,18 @@ mod tests {
             .given((orders, state))
             .will_return(Ok(solution));
 
-        let mut driver = StableXDriver::new(&contract, &mut pf, metrics);
+        let mut driver = StableXDriver::new(&mut pf, &reader, &submitter, metrics);
         assert!(driver.run().is_ok());
         assert!(!mock_it::verify(
-            contract
+            submitter
                 .submit_solution
-                .was_called_with((batch - 1, Any, Any, Any))
+                .was_called_with((batch, Any, Any, Any))
         ));
     }
     #[test]
     fn test_does_not_submit_solution_for_which_validation_failed() {
-        let contract = StableXContractMock::default();
+        let reader = StableXOrderBookReadingMock::default();
+        let submitter = StableXSolutionSubmittingMock::default();
         let mut pf = PriceFindingMock::default();
         let metrics = StableXMetrics::default();
 
@@ -368,19 +363,16 @@ mod tests {
         let state = create_account_state_with_balance_for(&orders);
 
         let batch = U256::from(42);
-        contract
-            .get_current_auction_index
-            .given(())
-            .will_return(Ok(batch));
+        reader.get_auction_index.given(()).will_return(Ok(batch));
 
-        contract
+        reader
             .get_auction_data
-            .given(batch - 1)
+            .given(batch)
             .will_return(Ok((state.clone(), orders.clone())));
 
-        contract
+        submitter
             .get_solution_objective_value
-            .given((batch - 1, Val(orders.clone()), Any))
+            .given((batch, Val(orders.clone()), Any))
             .will_return(Err(DriverError::new(
                 "get_solution_objective_value failed",
                 ErrorKind::Unknown,
@@ -395,12 +387,12 @@ mod tests {
             .given((orders, state))
             .will_return(Ok(solution));
 
-        let mut driver = StableXDriver::new(&contract, &mut pf, metrics);
+        let mut driver = StableXDriver::new(&mut pf, &reader, &submitter, metrics);
         assert!(driver.run().is_err());
         assert!(!mock_it::verify(
-            contract
+            submitter
                 .submit_solution
-                .was_called_with((batch - 1, Any, Any, Any))
+                .was_called_with((batch, Any, Any, Any))
         ));
     }
 }

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -21,8 +21,10 @@ pub mod driver;
 pub mod error;
 pub mod logging;
 pub mod metrics;
+pub mod orderbook;
 pub mod price_finding;
 pub mod snapp;
+pub mod solution_submission;
 pub mod transport;
 pub mod util;
 

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -8,11 +8,11 @@ use web3::types::U256;
 type Result<T> = std::result::Result<T, DriverError>;
 
 pub trait StableXOrderBookReading {
-    /// Retunrs the index of the auction that is currently being solved
+    /// Returns the index of the auction that is currently being solved
     /// or an error in case it cannot get this information.
     fn get_auction_index(&self) -> Result<U256>;
 
-    /// Returns the current state of the order book, inclducing account balances
+    /// Returns the current state of the order book, including account balances
     /// and open orders or an error in case it cannot get this information.
     ///
     /// # Arguments

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -1,0 +1,82 @@
+use crate::contracts::stablex_contract::StableXContract;
+use crate::error::DriverError;
+
+use dfusion_core::models::{AccountState, Order};
+
+use web3::types::U256;
+
+type Result<T> = std::result::Result<T, DriverError>;
+
+pub trait StableXOrderBookReading {
+    /// Retunrs the index of the auction that is currently being solved
+    /// or an error in case it cannot get this information.
+    fn get_auction_index(&self) -> Result<U256>;
+
+    /// Returns the current state of the order book, inclducing account balances
+    /// and open orders or an error in case it cannot get this information.
+    ///
+    /// # Arguments
+    /// * `index` - the auction index for which returned orders should be valid
+    fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)>;
+}
+
+/// A simple implementation of the order book trait that forwards calls
+/// directly to the smart contract.
+pub struct StableXOrderBookReader<'a> {
+    contract: &'a dyn StableXContract,
+}
+
+impl<'a> StableXOrderBookReader<'a> {
+    pub fn new(contract: &'a dyn StableXContract) -> Self {
+        Self { contract }
+    }
+}
+
+impl<'a> StableXOrderBookReading for StableXOrderBookReader<'a> {
+    fn get_auction_index(&self) -> Result<U256> {
+        self.contract
+            .get_current_auction_index()
+            .map(|batch_collecting_orders| batch_collecting_orders - 1)
+    }
+
+    fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
+        self.contract.get_auction_data(index)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::error::ErrorKind;
+    use mock_it::Mock;
+
+    #[derive(Clone)]
+    pub struct StableXOrderBookReadingMock {
+        pub get_auction_index: Mock<(), Result<U256>>,
+        pub get_auction_data: Mock<U256, Result<(AccountState, Vec<Order>)>>,
+    }
+
+    impl Default for StableXOrderBookReadingMock {
+        fn default() -> Self {
+            Self {
+                get_auction_index: Mock::new(Err(DriverError::new(
+                    "Unexpected call to get_auction_index",
+                    ErrorKind::Unknown,
+                ))),
+                get_auction_data: Mock::new(Err(DriverError::new(
+                    "Unexpected call to get_auction_data",
+                    ErrorKind::Unknown,
+                ))),
+            }
+        }
+    }
+
+    impl StableXOrderBookReading for StableXOrderBookReadingMock {
+        fn get_auction_index(&self) -> Result<U256> {
+            self.get_auction_index.called(())
+        }
+        fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
+            self.get_auction_data.called(index)
+        }
+    }
+}

--- a/driver/src/solution_submission/mod.rs
+++ b/driver/src/solution_submission/mod.rs
@@ -12,9 +12,9 @@ pub trait StableXSolutionSubmitting {
     /// batch or an error.
     ///
     /// # Arguments
-    /// - `batch_index` - the auction for which this solutions should be evaluated
-    /// - `orders` - the list of orders for which this solution is applicable
-    /// - `solution` - the solution to be evaluated
+    /// * `batch_index` - the auction for which this solutions should be evaluated
+    /// * `orders` - the list of orders for which this solution is applicable
+    /// * `solution` - the solution to be evaluated
     fn get_solution_objective_value(
         &self,
         batch_index: U256,
@@ -25,10 +25,10 @@ pub trait StableXSolutionSubmitting {
     /// Submits the provided solution and returns the result of the submission
     ///
     /// # Arguments
-    /// - `batch_index` - the auction for which this solutions should be evaluated
-    /// - `orders` - the list of orders for which this solution is applicable
-    /// - `solution` - the solution to be evaluated
-    /// - `claimed_objective_value` - the objective value of the provided solution.
+    /// * `batch_index` - the auction for which this solutions should be evaluated
+    /// * `orders` - the list of orders for which this solution is applicable
+    /// * `solution` - the solution to be evaluated
+    /// * `claimed_objective_value` - the objective value of the provided solution.
     fn submit_solution(
         &self,
         batch_index: U256,

--- a/driver/src/solution_submission/mod.rs
+++ b/driver/src/solution_submission/mod.rs
@@ -1,0 +1,132 @@
+use crate::contracts::stablex_contract::StableXContract;
+use crate::error::DriverError;
+
+use dfusion_core::models::{Order, Solution};
+
+use web3::types::U256;
+
+type Result<T> = std::result::Result<T, DriverError>;
+
+pub trait StableXSolutionSubmitting {
+    /// Return the objective value for the given solution in the given
+    /// batch or an error.
+    ///
+    /// # Arguments
+    /// - `batch_index` - the auction for which this solutions should be evaluated
+    /// - `orders` - the list of orders for which this solution is applicable
+    /// - `solution` - the solution to be evaluated
+    fn get_solution_objective_value(
+        &self,
+        batch_index: U256,
+        orders: Vec<Order>,
+        solution: Solution,
+    ) -> Result<U256>;
+
+    /// Submits the provided solution and returns the result of the submission
+    ///
+    /// # Arguments
+    /// - `batch_index` - the auction for which this solutions should be evaluated
+    /// - `orders` - the list of orders for which this solution is applicable
+    /// - `solution` - the solution to be evaluated
+    /// - `claimed_objective_value` - the objective value of the provided solution.
+    fn submit_solution(
+        &self,
+        batch_index: U256,
+        orders: Vec<Order>,
+        solution: Solution,
+        claimed_objective_value: U256,
+    ) -> Result<()>;
+}
+
+pub struct StableXSolutionSubmitter<'a> {
+    contract: &'a dyn StableXContract,
+}
+
+impl<'a> StableXSolutionSubmitter<'a> {
+    pub fn new(contract: &'a dyn StableXContract) -> Self {
+        Self { contract }
+    }
+}
+
+impl<'a> StableXSolutionSubmitting for StableXSolutionSubmitter<'a> {
+    fn get_solution_objective_value(
+        &self,
+        batch_index: U256,
+        orders: Vec<Order>,
+        solution: Solution,
+    ) -> Result<U256> {
+        self.contract
+            .get_solution_objective_value(batch_index, orders, solution)
+    }
+
+    fn submit_solution(
+        &self,
+        batch_index: U256,
+        orders: Vec<Order>,
+        solution: Solution,
+        claimed_objective_value: U256,
+    ) -> Result<()> {
+        self.contract
+            .submit_solution(batch_index, orders, solution, claimed_objective_value)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::error::ErrorKind;
+    use mock_it::{Matcher, Mock};
+
+    type GetSolutionObjectiveValueArguments = (U256, Matcher<Vec<Order>>, Matcher<Solution>);
+    type SubmitSolutionArguments = (U256, Matcher<Vec<Order>>, Matcher<Solution>, Matcher<U256>);
+
+    #[derive(Clone)]
+    pub struct StableXSolutionSubmittingMock {
+        pub get_solution_objective_value: Mock<GetSolutionObjectiveValueArguments, Result<U256>>,
+        pub submit_solution: Mock<SubmitSolutionArguments, Result<()>>,
+    }
+
+    impl Default for StableXSolutionSubmittingMock {
+        fn default() -> Self {
+            Self {
+                get_solution_objective_value: Mock::new(Err(DriverError::new(
+                    "Unexpected call to get_solution_objective_value",
+                    ErrorKind::Unknown,
+                ))),
+                submit_solution: Mock::new(Err(DriverError::new(
+                    "Unexpected call to submit_solution",
+                    ErrorKind::Unknown,
+                ))),
+            }
+        }
+    }
+
+    impl StableXSolutionSubmitting for StableXSolutionSubmittingMock {
+        fn get_solution_objective_value(
+            &self,
+            batch_index: U256,
+            orders: Vec<Order>,
+            solution: Solution,
+        ) -> Result<U256> {
+            self.get_solution_objective_value.called((
+                batch_index,
+                Matcher::Val(orders),
+                Matcher::Val(solution),
+            ))
+        }
+        fn submit_solution(
+            &self,
+            batch_index: U256,
+            orders: Vec<Order>,
+            solution: Solution,
+            claimed_objective_value: U256,
+        ) -> Result<()> {
+            self.submit_solution.called((
+                batch_index,
+                Matcher::Val(orders),
+                Matcher::Val(solution),
+                Matcher::Val(claimed_objective_value),
+            ))
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a layer of abstraction between the StableX driver and StableX contract. In particular, it separates the potential interactions in reading (OrderBookReading trait) and writing (SolutionSubmitting trait).

This allows us to implement more sophisticated logic for the two (e.g. an order book reader based on the graph instead of the contracts, a paginated reader, a reader that is using a blacklist of users or tokens, etc.) and decouples the driver from the smart contract.

In the next step I will implement a FilterinOrderBookReader that reads a blacklist from an environment variable.

Most of the added lines is boilerplate code. In particular I will look into replacing our mocking framework into something less verbose.

### Test Plan

Unit test.