### PR TITLE
[Easy] Wait on time forwarding future in e2e test

### DIFF
--- a/e2e/src/common.rs
+++ b/e2e/src/common.rs
@@ -89,10 +89,13 @@ where
 
 pub fn wait_for(web3: &Web3<Http>, seconds: u32) {
     web3.transport()
-        .execute("evm_increaseTime", vec![seconds.into()]);
+        .execute("evm_increaseTime", vec![seconds.into()])
         .wait()
-        .expect();
-    web3.transport().execute("evm_mine", vec![]).wait().expect();
+        .expect("Cannot increase time");
+    web3.transport()
+        .execute("evm_mine", vec![])
+        .wait()
+        .expect("Cannot mine to increase time");
 }
 
 pub fn wait_for_condition<C>(condition: C) -> Result<(), Error>

--- a/e2e/src/common.rs
+++ b/e2e/src/common.rs
@@ -90,7 +90,9 @@ where
 pub fn wait_for(web3: &Web3<Http>, seconds: u32) {
     web3.transport()
         .execute("evm_increaseTime", vec![seconds.into()]);
-    web3.transport().execute("evm_mine", vec![]);
+        .wait()
+        .expect();
+    web3.transport().execute("evm_mine", vec![]).wait().expect();
 }
 
 pub fn wait_for_condition<C>(condition: C) -> Result<(), Error>


### PR DESCRIPTION
I assume this is the reason for #467 

We are not actually waiting on moving the time forward and thus might end up calling `evm_increaseTime` more than once in parallel, which is likely not going to increase the time twice. Thus we are getting stuck at an old time and do not observe any state transitions. 

Cf. e.g. that in the failing tests, the solver is waiting for the auction 0's bidding phase to end:

```
driver_1_a5e41de77ffa | Jan 30 02:47:43.042 INFO [driver::contracts::snapp_contract] objective value: 0
driver_1_a5e41de77ffa | Jan 30 02:47:48.312 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:47:53.445 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:47:58.576 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:48:03.719 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:48:08.847 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:48:13.967 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:48:19.149 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:48:24.337 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:48:29.467 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:48:34.623 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:48:39.757 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:48:44.891 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:48:50.015 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:48:55.159 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:49:00.309 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:49:05.438 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:49:10.656 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:49:15.811 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:49:20.983 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:49:26.261 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:49:31.511 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:49:36.731 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:49:42.007 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:49:47.248 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:49:52.468 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:49:58.078 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:50:03.316 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:50:08.552 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:50:13.805 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:50:19.035 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:50:24.264 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:50:30.160 INFO [driver::driver::order_driver] Already bid for auction slot 0
driver_1_a5e41de77ffa | Jan 30 02:50:35.399 INFO [driver::driver::order_driver] Already bid for auction slot 0
```


### Test Plan

E2E should no longer be flaky