### PR TITLE
Implementing a blacklist for the order book

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,32 @@ LINEAR_OPTIMIZATION_SOLVER=1
 
 Afterwards, when you run your environment e.g. with `docker-compose up stablex` the linear optimizer should be automatically used. Note that the e2e tests might no longer work, as their resolution depends on the naive and not the optimal solving strategy.
 
+## Configuration
+
+The following environment variables can be used to configure the behavior of the services:
+
+### Common parameters:
+- *ETHEREUM_NODE_URL*: Full-Node to connect to. Make sure the node allows view queries without a gas limit in order to fetch the entire orderbook at once.
+- *NETWORK_ID*: Network ID (e.g. 1 for mainnet, 4 for rinkeby, 5777 for ganache)
+- *LINEAR_OPTIMIZATION_SOLVER*: Which style of solver to use (0 for naive, 1 for non-public linear solver)
+- *PRIVATE_KEY*: THe key with which to sign transactions
+
+### BatchExchange only
+- *DFUSION_LOG*: Log-level (e.g. `info,driver=debug,dfusion_core=debug`)
+- *ORDERBOOK_FILTER*: json encoded object of which tokens/filters to ignore. E.g.
+
+```json
+{
+  "tokens": [1, 2],
+  "users": {
+    "0x7b60655Ca240AC6c76dD29c13C45BEd969Ee6F0A": { "OrderIds": [0, 1] },
+    "0x7b60655Ca240AC6c76dD29c13C45BEd969Ee6F0B": "All"
+  }
+}
+```
+
+blacklists all orders that contain token 1 & 2, all orders of _0x...B_ and orderId 0 & 1 or _0x...A_
+
 ## Troubleshooting
 
 ### Logging

--- a/common.env
+++ b/common.env
@@ -6,3 +6,4 @@ POSTGRES_URL=postgresql://dfusion:let-me-in@postgres/dfusion
 GRAPHQL_PORT=8000
 WS_PORT=8001
 REORG_THRESHOLD=0
+ORDERBOOK_FILTER={}

--- a/driver/src/bin/stablex.rs
+++ b/driver/src/bin/stablex.rs
@@ -35,11 +35,14 @@ fn main() {
 
     let orderbook = StableXOrderBookReader::new(&contract);
     let filter = env::var("ORDERBOOK_FILTER").unwrap_or_default();
-    info!("Orderbook filter: {}", filter);
-    let filtered_orderbook = FilteredOrderbookReader::new(
-        &orderbook,
-        serde_json::from_str(&filter).unwrap_or_default(),
-    );
+    let parsed_filter = serde_json::from_str(&filter)
+        .map_err(|e| {
+            error!("Error parsing orderbook filter: {}", &e);
+            e
+        })
+        .unwrap_or_default();
+    info!("Orderbook filter: {:?}", parsed_filter);
+    let filtered_orderbook = FilteredOrderbookReader::new(&orderbook, parsed_filter);
 
     let solution_submitter = StableXSolutionSubmitter::new(&contract);
     let mut driver = StableXDriver::new(

--- a/driver/src/bin/stablex.rs
+++ b/driver/src/bin/stablex.rs
@@ -2,7 +2,7 @@ use driver::contracts::stablex_contract::BatchExchange;
 use driver::driver::stablex_driver::StableXDriver;
 use driver::logging;
 use driver::metrics::{MetricsServer, StableXMetrics};
-use driver::orderbook::StableXOrderBookReader;
+use driver::orderbook::{FilteredOrderbookReader, StableXOrderBookReader};
 use driver::price_finding::Fee;
 use driver::solution_submission::StableXSolutionSubmitter;
 
@@ -10,6 +10,7 @@ use log::{error, info};
 
 use prometheus::Registry;
 
+use std::env;
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
@@ -31,11 +32,19 @@ fn main() {
 
     let fee = Some(Fee::default());
     let mut price_finder = driver::util::create_price_finder(fee);
+
     let orderbook = StableXOrderBookReader::new(&contract);
+    let filter = env::var("ORDERBOOK_FILTER").unwrap_or_default();
+    info!("Orderbook filter: {}", filter);
+    let filtered_orderbook = FilteredOrderbookReader::new(
+        &orderbook,
+        serde_json::from_str(&filter).unwrap_or_default(),
+    );
+
     let solution_submitter = StableXSolutionSubmitter::new(&contract);
     let mut driver = StableXDriver::new(
         &mut *price_finder,
-        &orderbook,
+        &filtered_orderbook,
         &solution_submitter,
         stablex_metrics,
     );

--- a/driver/src/orderbook/filtered_orderbook.rs
+++ b/driver/src/orderbook/filtered_orderbook.rs
@@ -4,13 +4,13 @@ use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use web3::types::{H160, U256};
 
-/// Data structure to specify what type orders to filter
+/// Data structure to specify what type of orders to filter
 #[derive(Debug, Default, Deserialize, PartialEq, Eq)]
 pub struct OrderbookFilter {
     /// The token ids that should be filtered/
     tokens: HashSet<u16>,
 
-    /// User addresses and which of their orders to filter
+    /// User addresses mapped to which of their orders to filter
     users: HashMap<H160, UserOrderFilter>,
 }
 

--- a/driver/src/orderbook/filtered_orderbook.rs
+++ b/driver/src/orderbook/filtered_orderbook.rs
@@ -8,9 +8,11 @@ use web3::types::{H160, U256};
 #[derive(Debug, Default, Deserialize, PartialEq, Eq)]
 pub struct OrderbookFilter {
     /// The token ids that should be filtered/
+    #[serde(default)]
     tokens: HashSet<u16>,
 
     /// User addresses mapped to which of their orders to filter
+    #[serde(default)]
     users: HashMap<H160, UserOrderFilter>,
 }
 

--- a/driver/src/orderbook/filtered_orderbook.rs
+++ b/driver/src/orderbook/filtered_orderbook.rs
@@ -1,0 +1,160 @@
+use super::*;
+
+use serde::Deserialize;
+use std::collections::{HashMap, HashSet};
+use web3::types::{H160, U256};
+
+/// Data structure to specify what type orders to filter
+#[derive(Debug, Default, Deserialize, PartialEq, Eq)]
+pub struct OrderbookFilter {
+    /// The token ids that should be filtered/
+    tokens: HashSet<u16>,
+
+    /// User addresses and which of their orders to filter
+    users: HashMap<H160, UserOrderFilter>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+enum UserOrderFilter {
+    All,
+    OrderIds(HashSet<u16>),
+}
+
+pub struct FilteredOrderbookReader<'a> {
+    orderbook: &'a dyn StableXOrderBookReading,
+    filter: OrderbookFilter,
+}
+
+impl<'a> FilteredOrderbookReader<'a> {
+    pub fn new(orderbook: &'a dyn StableXOrderBookReading, filter: OrderbookFilter) -> Self {
+        Self { orderbook, filter }
+    }
+}
+
+impl<'a> StableXOrderBookReading for FilteredOrderbookReader<'a> {
+    fn get_auction_index(&self) -> Result<U256> {
+        self.orderbook.get_auction_index()
+    }
+
+    fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
+        let (state, orders) = self.orderbook.get_auction_data(index)?;
+        let filtered = orders
+            .into_iter()
+            .filter(|o| {
+                let user_filter = if let Some(user_filter) = self.filter.users.get(&o.account_id) {
+                    match user_filter {
+                        UserOrderFilter::All => true,
+                        UserOrderFilter::OrderIds(ids) => ids.contains(
+                            &o.batch_information
+                                .as_ref()
+                                .expect("StableX orders have batch information")
+                                .slot_index,
+                        ),
+                    }
+                } else {
+                    false
+                };
+                !self.filter.tokens.contains(&o.buy_token)
+                    && !self.filter.tokens.contains(&o.sell_token)
+                    && !user_filter
+            })
+            .collect();
+        Ok((state, filtered))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use dfusion_core::models::order::test_util::create_order_for_test;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_filter_deserialization() {
+        let json = "{
+            \"tokens\": [1,2], 
+            \"users\": {
+                \"0x7b60655Ca240AC6c76dD29c13C45BEd969Ee6F0A\": {\"OrderIds\": [0,1]}
+                \"0x7b60655Ca240AC6c76dD29c13C45BEd969Ee6F0B\": \"All\",
+            }
+        }";
+        let filter = OrderbookFilter {
+            tokens: [1, 2].iter().copied().collect(),
+            users: [
+                (
+                    H160::from_str("7b60655Ca240AC6c76dD29c13C45BEd969Ee6F0B").unwrap(),
+                    UserOrderFilter::All,
+                ),
+                (
+                    H160::from_str("7b60655Ca240AC6c76dD29c13C45BEd969Ee6F0A").unwrap(),
+                    UserOrderFilter::OrderIds([0u16, 1u16].iter().copied().collect()),
+                ),
+            ]
+            .iter()
+            .cloned()
+            .collect(),
+        };
+        assert_eq!(filter, serde_json::from_str(json).expect("Failed to parse"));
+    }
+
+    #[test]
+    fn test_orderbook_filter() {
+        let mut bad_sell_token = create_order_for_test();
+        bad_sell_token.sell_token = 4;
+        let mut bad_buy_token = create_order_for_test();
+        bad_buy_token.buy_token = 5;
+
+        let mut bad_user = create_order_for_test();
+        bad_user.account_id = H160::from_str("7b60655Ca240AC6c76dD29c13C45BEd969Ee6F0B").unwrap();
+
+        let mixed_user = H160::from_str("7b60655Ca240AC6c76dD29c13C45BEd969Ee6F0A").unwrap();
+        let mut mixed_user_good_order = create_order_for_test();
+        mixed_user_good_order.account_id = mixed_user;
+        mixed_user_good_order
+            .batch_information
+            .as_mut()
+            .unwrap()
+            .slot_index = 0;
+
+        let mut mixed_user_bad_order = create_order_for_test();
+        mixed_user_bad_order.account_id = mixed_user;
+        mixed_user_bad_order
+            .batch_information
+            .as_mut()
+            .unwrap()
+            .slot_index = 1;
+
+        let mut inner = MockStableXOrderBookReading::default();
+        inner.expect_get_auction_data().return_const(Ok((
+            AccountState::default(),
+            vec![
+                bad_buy_token.clone(),
+                bad_sell_token.clone(),
+                mixed_user_bad_order,
+                mixed_user_good_order.clone(),
+            ],
+        )));
+
+        let filter = OrderbookFilter {
+            tokens: [bad_sell_token.sell_token, bad_buy_token.buy_token]
+                .iter()
+                .copied()
+                .collect(),
+            users: [
+                (bad_user.account_id, UserOrderFilter::All),
+                (
+                    mixed_user,
+                    UserOrderFilter::OrderIds([1].iter().copied().collect()),
+                ),
+            ]
+            .iter()
+            .cloned()
+            .collect(),
+        };
+
+        let reader = FilteredOrderbookReader::new(&inner, filter);
+
+        let (_, filtered_orders) = reader.get_auction_data(U256::zero()).unwrap();
+        assert_eq!(filtered_orders, vec![mixed_user_good_order]);
+    }
+}

--- a/driver/src/orderbook/filtered_orderbook.rs
+++ b/driver/src/orderbook/filtered_orderbook.rs
@@ -71,13 +71,13 @@ mod test {
 
     #[test]
     fn test_filter_deserialization() {
-        let json = "{
-            \"tokens\": [1,2], 
-            \"users\": {
-                \"0x7b60655Ca240AC6c76dD29c13C45BEd969Ee6F0A\": {\"OrderIds\": [0,1]}
-                \"0x7b60655Ca240AC6c76dD29c13C45BEd969Ee6F0B\": \"All\",
+        let json = r#"{
+            "tokens": [1,2], 
+            "users": {
+                "0x7b60655Ca240AC6c76dD29c13C45BEd969Ee6F0A": {"OrderIds": [0,1]},
+                "0x7b60655Ca240AC6c76dD29c13C45BEd969Ee6F0B": "All"
             }
-        }";
+        }"#;
         let filter = OrderbookFilter {
             tokens: [1, 2].iter().copied().collect(),
             users: [

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -7,6 +7,10 @@ use mockall::automock;
 
 use web3::types::U256;
 
+mod filtered_orderbook;
+pub use filtered_orderbook::FilteredOrderbookReader;
+pub use filtered_orderbook::OrderbookFilter;
+
 type Result<T> = std::result::Result<T, DriverError>;
 
 #[cfg_attr(test, automock)]


### PR DESCRIPTION
Implements #432 

This PR adds another implementation of the orderbook that allows filtering specific orders based on a config string currently passed in via an environment variable.

It mainly allows for three types of filters
- malicious/fake tokens (ignore all orders that have a certain token ID in buy or sell token)
- malicious users (ignore all orders from users with certain addresses)
- malicious orders (ignore specific pairs of user + order id)

The driver is now wired to an orderbook filter, which itself uses a regular on chain order book reader as a source of truth. The source of the filter could theoretically be changed to a off-chain orderbook reader or a paginated reader in the long term.

### Test Plan

Added unit tests.