### PR TITLE
Do not run solver if previous solution validation and submission failed.

### DIFF
--- a/driver/src/driver/stablex_driver.rs
+++ b/driver/src/driver/stablex_driver.rs
@@ -111,7 +111,6 @@ impl<'a> StableXDriver<'a> {
             self.metrics.auction_skipped(batch_to_solve);
             false
         };
-        self.past_auctions.insert(batch_to_solve);
         Ok(submitted)
     }
 }

--- a/driver/src/driver/stablex_driver.rs
+++ b/driver/src/driver/stablex_driver.rs
@@ -366,6 +366,7 @@ mod tests {
         let mut driver = StableXDriver::new(&mut pf, &reader, &submitter, metrics);
         assert!(driver.run().is_ok());
     }
+
     #[test]
     fn test_does_not_submit_solution_for_which_validation_failed() {
         let mut reader = MockStableXOrderBookReading::default();
@@ -404,5 +405,50 @@ mod tests {
 
         let mut driver = StableXDriver::new(&mut pf, &reader, &submitter, metrics);
         assert!(driver.run().is_err());
+    }
+
+    #[test]
+    fn test_do_not_invoke_solver_when_validation_previously_failed() {
+        let mut reader = MockStableXOrderBookReading::default();
+        let mut submitter = MockStableXSolutionSubmitting::default();
+        let mut pf = MockPriceFinding::default();
+        let metrics = StableXMetrics::default();
+
+        let orders = vec![create_order_for_test(), create_order_for_test()];
+        let state = create_account_state_with_balance_for(&orders);
+
+        let batch = U256::from(42);
+        reader.expect_get_auction_index().return_const(Ok(batch));
+
+        reader
+            .expect_get_auction_data()
+            .with(eq(batch))
+            .return_const(Ok((state.clone(), orders.clone())));
+
+        submitter
+            .expect_get_solution_objective_value()
+            .with(eq(batch), eq(orders.clone()), always())
+            .return_const(Err(DriverError::new(
+                "get_solution_objective_value failed",
+                ErrorKind::Unknown,
+            )));
+        submitter.expect_submit_solution().times(0);
+
+        let solution = Solution {
+            prices: map_from_slice(&[(0, 1), (1, 2)]),
+            executed_sell_amounts: vec![0, 2],
+            executed_buy_amounts: vec![0, 2],
+        };
+        pf.expect_find_prices()
+            .withf(move |o, s| o == orders.as_slice() && *s == state)
+            .return_const(Ok(solution));
+
+        let mut driver = StableXDriver::new(&mut pf, &reader, &submitter, metrics);
+
+        // First run fails
+        assert!(driver.run().is_err());
+
+        // Second run is skipped
+        assert_eq!(driver.run().expect("should have succeeded"), false);
     }
 }


### PR DESCRIPTION
This was causing the driver to get "out of sync" with batches. More detailed description of the issue is found here: #475 

This PR is a temporary solution to the issue, in the long run a solution where we have separate threads for each batch that gets cancelled once the batch submission time is up might be a more robust solution.

### Test Plan

New unit test.