### PR TITLE
[Fix Orderbook filter] No longer requiring the ODERBOOK_FILTER env to be set

### DIFF
--- a/common.env
+++ b/common.env
@@ -6,4 +6,3 @@ POSTGRES_URL=postgresql://dfusion:let-me-in@postgres/dfusion
 GRAPHQL_PORT=8000
 WS_PORT=8001
 REORG_THRESHOLD=0
-ORDERBOOK_FILTER={}

--- a/driver/src/bin/stablex.rs
+++ b/driver/src/bin/stablex.rs
@@ -34,7 +34,7 @@ fn main() {
     let mut price_finder = driver::util::create_price_finder(fee);
 
     let orderbook = StableXOrderBookReader::new(&contract);
-    let filter = env::var("ORDERBOOK_FILTER").unwrap_or_default();
+    let filter = env::var("ORDERBOOK_FILTER").unwrap_or_else(|_| String::from("{}"));
     let parsed_filter = serde_json::from_str(&filter)
         .map_err(|e| {
             error!("Error parsing orderbook filter: {}", &e);


### PR DESCRIPTION
The PR https://github.com/gnosis/dex-services/pull/476 is currently throwing errors in production.

Due to the fact, that we do not set the env: ORDERBOOK_FILTER, the code runs the fallback and sets ORDERBOOK_FILTER=""; Due to this, we are receiving the following error: 
`ERRO [stablex] Error parsing orderbook filter: EOF while parsing a value at line 1 column 0`

This PR changes the fallback for the env from "" to "{}". Now the parsing is fine and we don't get any error logs.

We could have also set ORDERBOOK_FILTER in production, but I would prefer this fallback solution to work.