### PR TITLE
Sort tokenIds and filter out 0 balances

### DIFF
--- a/driver/src/price_finding/optimization_price_finder.rs
+++ b/driver/src/price_finding/optimization_price_finder.rs
@@ -123,7 +123,7 @@ impl OptimisationPriceFinder {
 }
 
 fn token_id(token: u16) -> String {
-    format!("token{}", token)
+    format!("token{:04}", token)
 }
 
 fn account_id(account: H160) -> String {

--- a/driver/src/price_finding/optimization_price_finder.rs
+++ b/driver/src/price_finding/optimization_price_finder.rs
@@ -71,11 +71,11 @@ mod solver_input {
         pub fee: Option<Fee>,
     }
 
-    fn ordered_tokens<S>(value: &Vec<String>, serializer: S) -> Result<S::Ok, S::Error>
+    fn ordered_tokens<S>(value: &[String], serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let mut sorted = value.clone();
+        let mut sorted = value.to_owned();
         sorted.sort();
         sorted.serialize(serializer)
     }

--- a/driver/src/price_finding/optimization_price_finder.rs
+++ b/driver/src/price_finding/optimization_price_finder.rs
@@ -327,8 +327,8 @@ pub mod tests {
             buy_amount: 200,
         };
         let result = serialize_order(&order);
-        assert_eq!(result.sell_token, "token1");
-        assert_eq!(result.buy_token, "token2");
+        assert_eq!(result.sell_token, "token0001");
+        assert_eq!(result.buy_token, "token0002");
         assert_eq!(result.sell_amount, "100");
         assert_eq!(result.buy_amount, "200");
         assert_eq!(
@@ -353,7 +353,7 @@ pub mod tests {
         ];
         let mut result = serialize_tokens(&orders);
         result.sort_unstable();
-        let expected = vec!["token0", "token2", "token4"];
+        let expected = vec!["token0000", "token0002", "token0004"];
         assert_eq!(result, expected);
     }
 
@@ -361,9 +361,9 @@ pub mod tests {
     fn test_deserialize_result() {
         let json = json!({
             "prices": {
-                "token0": "14024052566155238000",
-                "token1": "170141183460469231731687303715884105728", // greater than max value of u64
-                "token2": null,
+                "token0000": "14024052566155238000",
+                "token0001": "170141183460469231731687303715884105728", // greater than max value of u64
+                "token0002": null,
             },
             "orders": [
                 {
@@ -452,7 +452,7 @@ pub mod tests {
     fn serialize_result_fails_if_orders_missing() {
         let json = json!({
             "prices": {
-                "token0": "100",
+                "token0000": "100",
             },
         });
         let err = deserialize_result(json.to_string()).expect_err("Should fail to parse");
@@ -479,7 +479,7 @@ pub mod tests {
     fn serialize_result_fails_if_order_sell_volume_not_parsable() {
         let json = json!({
             "prices": {
-                "token0": "100",
+                "token0000": "100",
             },
             "orders": [
                 {
@@ -496,7 +496,7 @@ pub mod tests {
     fn serialize_result_assumes_zero_if_order_does_not_have_buy_amount() {
         let json = json!({
             "prices": {
-                "token0": "100",
+                "token0000": "100",
             },
             "orders": [
                 {
@@ -512,7 +512,7 @@ pub mod tests {
     fn serialize_result_fails_if_order_buy_volume_not_parsable() {
         let json = json!({
             "prices": {
-                "token0": "100",
+                "token0000": "100",
             },
             "orders": [
                 {
@@ -554,15 +554,15 @@ pub mod tests {
         let result = serialize_balances(&state, &orders);
         let mut expected = solver_input::Accounts::new();
         let mut first = HashMap::new();
-        first.insert("token1".to_string(), "200".to_string());
-        first.insert("token2".to_string(), "300".to_string());
+        first.insert("token0001".to_string(), "200".to_string());
+        first.insert("token0002".to_string(), "300".to_string());
         expected.insert(
             "0000000000000000000000000000000000000000".to_string(),
             first,
         );
         let mut second = HashMap::new();
-        second.insert("token1".to_string(), "500".to_string());
-        second.insert("token2".to_string(), "600".to_string());
+        second.insert("token0001".to_string(), "500".to_string());
+        second.insert("token0002".to_string(), "600".to_string());
         expected.insert(
             "0000000000000000000000000000000000000001".to_string(),
             second,
@@ -582,7 +582,7 @@ pub mod tests {
                 assert_eq!(
                     json["fee"],
                     json!({
-                        "token": "token0",
+                        "token": "token0000",
                         "ratio": 0.001
                     })
                 );
@@ -605,14 +605,14 @@ pub mod tests {
 
         // Balances should end up ordered by token ID
         let mut user1_balances = HashMap::new();
-        user1_balances.insert("token3".to_owned(), "100".to_owned());
-        user1_balances.insert("token2".to_owned(), "100".to_owned());
-        user1_balances.insert("token1".to_owned(), "100".to_owned());
-        user1_balances.insert("token0".to_owned(), "100".to_owned());
+        user1_balances.insert("token0003".to_owned(), "100".to_owned());
+        user1_balances.insert("token0002".to_owned(), "100".to_owned());
+        user1_balances.insert("token0001".to_owned(), "100".to_owned());
+        user1_balances.insert("token0000".to_owned(), "100".to_owned());
 
         // Zero amounts should be filtered out
         let mut user2_balances = HashMap::new();
-        user2_balances.insert("token0".to_owned(), "0".to_owned());
+        user2_balances.insert("token0000".to_owned(), "0".to_owned());
 
         // Accounts should end up sorted by account ID
         accounts.insert(
@@ -631,12 +631,12 @@ pub mod tests {
         let input = solver_input::Input {
             // tokens should also end up sorted in the end
             tokens: vec![
-                "token3".to_owned(),
-                "token2".to_owned(),
-                "token1".to_owned(),
-                "token0".to_owned(),
+                "token0003".to_owned(),
+                "token0002".to_owned(),
+                "token0001".to_owned(),
+                "token0000".to_owned(),
             ],
-            ref_token: "token0".to_owned(),
+            ref_token: "token0000".to_owned(),
             accounts,
             orders: vec![],
             fee: None,
@@ -644,7 +644,7 @@ pub mod tests {
         let result = serde_json::to_string(&input).expect("Unable to serialize account state");
         assert_eq!(
             result,
-            r#"{"tokens":["token0","token1","token2","token3"],"refToken":"token0","accounts":{"13a0b42b9c180065510615972858bf41d1972a55":{},"4fd7c947ca0aba9d8678885e2b8c4d6a4e946984":{"token0":"100","token1":"100","token2":"100","token3":"100"},"52a67f22d628c84c1f1e73ebb0e9ae272e302dd9":{}},"orders":[],"fee":null}"#
+            r#"{"tokens":["token0000","token0001","token0002","token0003"],"refToken":"token0000","accounts":{"13a0b42b9c180065510615972858bf41d1972a55":{},"4fd7c947ca0aba9d8678885e2b8c4d6a4e946984":{"token0000":"100","token0001":"100","token0002":"100","token0003":"100"},"52a67f22d628c84c1f1e73ebb0e9ae272e302dd9":{}},"orders":[],"fee":null}"#
         );
     }
 }


### PR DESCRIPTION
Closes #473 

Requested by @twalth3r .
I'm making this an implementation detail of the serialisation logic as it doesn't seem as if it has to be enforced on a higher level.

### Test Plan

Added a unit test. 

Also checked an instance files after running the mainnet solver by running:

```
docker-compose down && docker-compose -f docker-compose.yml -f docker-compose.mainnet.yml run stablex bash
cargo run --bin stablex
# After one batch is processed
cat instances/*
```