### PR TITLE
[Trivial] Specify version for rustc-hex

### DIFF
--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -19,7 +19,7 @@ lazy_static = "1.4.0"
 log = "0.4.8"
 prometheus = "0.7.0"
 rouille = "3.0.0"
-rustc-hex = "*"
+rustc-hex = "2.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 slog = "2.5.2"


### PR DESCRIPTION
Specify `rustc-hex` version, it was the only dependency without one. Note that this does not change the version being used - the `Cargo.lock` file is unchanged.

### Test Plan

CI