### PR TITLE
[Easy] Cache node-gyp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
       name: "Build and Local Testing"
       cache:
         directories:
+          - $HOME/.cache/node-gyp
           - $HOME/.cache/yarn
           - $HOME/.cargo/bin
       before_cache:


### PR DESCRIPTION
#485 removed caching including `node-gyp` cache. Adding it back in as I saw some intermittent build failures tonight that were corrected by a re-build.

It would be nice to understand exactly why this error is happening and fix the root cause.

Here is an example failure: https://travis-ci.com/gnosis/dex-services/builds/147873838#L320

### Test Plan

See if intermittent failures go away.