### PR TITLE
[Trivial] Remove stray `package-lock.json` file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
This PR removes a stray and mostly empty `package-lock.json` file that managed to sneak past all of us.

### Test Plan

None