### PR TITLE
Use estimated gas amount and price

### DIFF
--- a/driver/src/contracts/mod.rs
+++ b/driver/src/contracts/mod.rs
@@ -28,8 +28,8 @@ fn method_defaults(network_id: u64) -> Result<MethodDefaults, DriverError> {
     let account = Account::Offline(key, Some(network_id));
     let defaults = MethodDefaults {
         from: Some(account),
-        gas: Some(100_000.into()),
-        gas_price: Some(1_000_000_000.into()),
+        gas: None,
+        gas_price: None,
     };
 
     Ok(defaults)

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -128,7 +128,7 @@ impl StableXContract for BatchExchange {
             prices,
             token_ids_for_price,
         )
-        .gas_price(GasPrice::high())
+        .gas_price(GasPrice::Scaled(3.0))
         .send()
         .wait()?;
 

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::env;
 
+use ethcontract::transaction::GasPrice;
 use lazy_static::lazy_static;
 #[cfg(test)]
 use mockall::automock;
@@ -102,7 +103,6 @@ impl StableXContract for BatchExchange {
                 prices,
                 token_ids_for_price,
             )
-            .gas(5_000_000.into())
             .call()
             .wait()?;
 
@@ -128,8 +128,7 @@ impl StableXContract for BatchExchange {
             prices,
             token_ids_for_price,
         )
-        .gas(5_000_000.into())
-        .gas_price(20_000_000_000u64.into())
+        .gas_price(GasPrice::high())
         .send()
         .wait()?;
 


### PR DESCRIPTION
Closes #369 

With the update to ethcontract-rs 0.3.0 we can use the estimated gas amount and price (with a factor to ensure we are getting fast execution speed).

This should prevent us from drastically overpaying tx fees by using a fixed gas price of 20GWEI (the avg. solution submission costs between 5-10$ atm). We will now be using 3x the avg. gas price. At the time of testing this was about 3x6GWEI

### Test Plan

E2E tests, check submission times as soon as it's in staging.

Get average gas price (in hex) from full node:

```
curl -H "Content-type:application/json" -X POST --data '{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":7398897897897}' https://node.mainnet.gnosisdev.com
```