### PR TITLE
Use master instead of latest for SOLVER_BASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $(aws ecr get-login --no-include-email)
 Then specify the solver image you want to use as a build argument, e.g.: 
 
 ```sh
-docker-compose build --build-arg SOLVER_BASE=163030813197.dkr.ecr.us-east-1.amazonaws.com/dex-solver:latest stablex
+docker-compose build --build-arg SOLVER_BASE=163030813197.dkr.ecr.us-east-1.amazonaws.com/dex-solver:master stablex
 ```
 
 and add the following line to you `common.env` file:


### PR DESCRIPTION
When attempting to run the optimizing solver on mainnet I was getting import errors in the python code. I noticed that we use `master` in gnosis-staging while the readme uses `latest`. Changing to `master` fixed my issue but I am not sure what this change actually means.