### PR TITLE
[Easy] sync src code between local and docker filesystem

### DIFF
--- a/docker-compose.binary.yml
+++ b/docker-compose.binary.yml
@@ -1,7 +1,7 @@
 version: "3.6"
 services:
   stablex:
-    command: ./driver
+    command: ./stablex
     build:
       context: .
       dockerfile: docker/rust/Dockerfile

--- a/docker-compose.binary.yml
+++ b/docker-compose.binary.yml
@@ -1,14 +1,13 @@
 version: "3.6"
-x-rust-binary-service: &rust-binary-service
-  build:
-    context: .
-    dockerfile: docker/rust/Dockerfile
-    args:
-      - RUST_BASE=rust-binary
-  image: stablex-binary
-  environment:
-    - RUST_BACKTRACE=1
 services:
   stablex:
-    <<: *rust-binary-service
     command: ./driver
+    build:
+      context: .
+      dockerfile: docker/rust/Dockerfile
+      args:
+        - RUST_BASE=rust-binary
+    image: stablex-binary
+    volumes: # don't mount volumes as name clashes with name of the binary
+    environment:
+      - RUST_BACKTRACE=1

--- a/docker-compose.binary.yml
+++ b/docker-compose.binary.yml
@@ -8,6 +8,5 @@ services:
       args:
         - RUST_BASE=rust-binary
     image: stablex-binary
-    volumes: [] # don't mount volumes as name clashes with name of the binary
     environment:
       - RUST_BACKTRACE=1

--- a/docker-compose.binary.yml
+++ b/docker-compose.binary.yml
@@ -8,6 +8,6 @@ services:
       args:
         - RUST_BASE=rust-binary
     image: stablex-binary
-    volumes: # don't mount volumes as name clashes with name of the binary
+    volumes: [] # don't mount volumes as name clashes with name of the binary
     environment:
       - RUST_BACKTRACE=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,4 @@
 version: '3.6'
-x-rust-service:
-  &rust-service
-  build:
-    context: .
-    dockerfile: docker/rust/Dockerfile
-  restart: always
-  env_file: common.env
-  environment:
-    - RUST_BACKTRACE=1
-
 services:
   ganache-cli:
     ports:
@@ -29,10 +19,18 @@ services:
       - ./dex-contracts:/app/dex-contracts
 
   stablex:
-    << : *rust-service
+    build:
+      context: .
+      dockerfile: docker/rust/Dockerfile
+    restart: always
+    env_file: common.env
+    environment:
+      - RUST_BACKTRACE=1
     image: stablex
     ports:
       - '9586:9586'
     depends_on:
       - ganache-cli
     command: cargo run
+    volumes:
+      - ./driver:/app/driver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,4 +33,5 @@ services:
       - ganache-cli
     command: cargo run
     volumes:
+      # Sync src folder to allow development without rebuilding on each change
       - ./driver:/app/driver

--- a/docker/rust/Dockerfile
+++ b/docker/rust/Dockerfile
@@ -32,7 +32,7 @@ ONBUILD RUN apt-get update \
   && apt-get install -y --no-install-recommends libpq-dev libssl1.0.0 libssl-dev ca-certificates \ 
   && rm -rf /var/lib/apt/lists/*
 
-ONBUILD COPY target/debug/driver driver
+ONBUILD COPY target/debug/driver stablex
 
 # Trigger actual build
 FROM ${RUST_BASE}


### PR DESCRIPTION
This allows for changes to the local filesystem to be directly reflected in the docker container without having to rebuild the entire container. It makes testing changes in a docker setup much faster.

### Test Plan

- docker-compose up stablex
- Make a change inside the driver code
- stop and restart the container
- see change is reflected without having had to docker-compose build.