### PR TITLE
Upgrade to crates.io ethcontract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,15 +45,6 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
-
-[[package]]
-name = "arrayvec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
@@ -99,15 +90,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
@@ -125,13 +107,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993f74b4c99c1908d156b8d2e0fb6277736b0ecbd833982fd1241d39b2766a6"
+
+[[package]]
 name = "blake2b_simd"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.1",
+ "arrayvec",
  "constant_time_eq",
 ]
 
@@ -164,6 +152,12 @@ dependencies = [
  "memchr",
  "safemem",
 ]
+
+[[package]]
+name = "byte-slice-cast"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
 
 [[package]]
 name = "byteorder"
@@ -366,16 +360,13 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.15.0"
+version = "0.99.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a141330240c921ec6d074a3e188a7c7ef95668bb95e7d44fa0e5778ec2a7afe"
+checksum = "2159be042979966de68315bce7034bb000c775f22e3e834e1c52ff78f041cae8"
 dependencies = [
- "lazy_static",
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "regex",
- "rustc_version",
- "syn 0.15.44",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -432,7 +423,6 @@ dependencies = [
  "ethcontract",
  "ethcontract-generate",
  "futures 0.3.4",
- "jsonrpc-core",
  "lazy_static",
  "log 0.4.8",
  "mockall",
@@ -447,7 +437,6 @@ dependencies = [
  "slog-scope",
  "slog-stdlog",
  "slog-term",
- "web3",
 ]
 
 [[package]]
@@ -475,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "ethabi"
-version = "8.0.1"
+version = "9.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebdeeea85a6d217b9fcc862906d7e283c047e04114165c433756baf5dce00a6c"
+checksum = "965126c64662832991f5a748893577630b558e47fa94e7f35aefcd20d737cef7"
 dependencies = [
  "error-chain",
  "ethereum-types",
@@ -490,31 +479,34 @@ dependencies = [
 
 [[package]]
 name = "ethbloom"
-version = "0.6.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3932e82d64d347a045208924002930dc105a138995ccdc1479d0f05f0359f17c"
+checksum = "32cfe1c169414b709cf28aa30c74060bdb830a03a8ba473314d079ac79d80a5f"
 dependencies = [
  "crunchy",
  "fixed-hash",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.2.3",
  "tiny-keccak 1.5.0",
 ]
 
 [[package]]
 name = "ethcontract"
-version = "0.3.0"
-source = "git+https://github.com/gnosis/ethcontract-rs?branch=graph-patches-v0.3.0#11861ba3c3e20b34c6be944db36e67e2e0b53404"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5f84a37fda5cc81423486c7892134816f2d1284baf30321a4d4247d187fcf1c"
 dependencies = [
  "ethcontract-common",
  "ethcontract-derive",
  "futures 0.3.4",
  "futures-timer",
+ "hex",
  "jsonrpc-core",
  "lazy_static",
  "pin-project",
  "rlp",
  "secp256k1",
+ "serde",
  "serde_json",
  "thiserror",
  "tiny-keccak 2.0.1",
@@ -524,8 +516,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-common"
-version = "0.3.0"
-source = "git+https://github.com/gnosis/ethcontract-rs?branch=graph-patches-v0.3.0#11861ba3c3e20b34c6be944db36e67e2e0b53404"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13bc3dfa18c03fefdb53c909f7282dc3bd035039ea0c2d480cdfeaf9e7a7813b"
 dependencies = [
  "ethabi",
  "hex",
@@ -538,37 +531,39 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-derive"
-version = "0.3.0"
-source = "git+https://github.com/gnosis/ethcontract-rs?branch=graph-patches-v0.3.0#11861ba3c3e20b34c6be944db36e67e2e0b53404"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b27b7e083dabb96c8dde3ed2f902b167848ca572c21918a9a21b1acf2f9cfb"
 dependencies = [
  "ethcontract-generate",
- "proc-macro2 1.0.8",
- "syn 1.0.14",
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
 name = "ethcontract-generate"
-version = "0.3.0"
-source = "git+https://github.com/gnosis/ethcontract-rs?branch=graph-patches-v0.3.0#11861ba3c3e20b34c6be944db36e67e2e0b53404"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f6fe95eeb39e3ecff0b666fc1d2b360a664996a4735cfd9a2b19792a18bce6"
 dependencies = [
  "Inflector",
  "anyhow",
  "ethcontract-common",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "ethereum-types"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d1bc682337e2c5ec98930853674dd2b4bd5d0d246933a9e98e5280f7c76c5f"
+checksum = "ba744248e3553a393143d5ebb68939fc3a4ec0c22a269682535f5ffe7fed728c"
 dependencies = [
  "ethbloom",
  "fixed-hash",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.2.3",
  "primitive-types",
  "uint",
 ]
@@ -587,13 +582,12 @@ dependencies = [
 
 [[package]]
 name = "fixed-hash"
-version = "0.3.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a683d1234507e4f3bf2736eeddf0de1dc65996dc0164d57eba0a74bcf29489"
+checksum = "3367952ceb191f4ab95dd5685dc163ac539e36202f9fcfd0cb22f9f9c542fefc"
 dependencies = [
  "byteorder",
- "heapsize",
- "rand 0.5.6",
+ "rand 0.7.3",
  "rustc-hex",
  "static_assertions",
 ]
@@ -727,9 +721,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -809,15 +803,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "heapsize"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
-dependencies = [
- "winapi 0.3.8",
-]
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -877,7 +862,7 @@ dependencies = [
  "traitobject",
  "typeable",
  "unicase",
- "url",
+ "url 1.7.2",
 ]
 
 [[package]]
@@ -935,12 +920,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-codec"
+name = "idna"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2050d823639fbeae26b2b5ba09aca8907793117324858070ade0673c49f793b"
+checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 dependencies = [
- "parity-codec",
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1be51a921b067b0eaca2fad532d9400041561aa922221cc65f95a85641c6bf53"
+dependencies = [
+ "parity-scale-codec",
 ]
 
 [[package]]
@@ -957,6 +953,15 @@ name = "impl-serde"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58e3cae7e99c7ff5a995da2cf78dd0a5383740eda71d98cf7b1910c301ac69b8"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bbe9ea9b182f0fb1cabbd61f4ff9b7b7b9197955e95a7e4c27de5055eb29ff8"
 dependencies = [
  "serde",
 ]
@@ -987,9 +992,9 @@ checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 
 [[package]]
 name = "jsonrpc-core"
-version = "13.2.0"
+version = "14.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d767c183a7e58618a609499d359ce3820700b3ebb4823a18c343b4a2a41a0d"
+checksum = "fe3b688648f1ef5d5072229e2d672ecb92cbff7d1c79bcf3fd5898f3f3df0970"
 dependencies = [
  "futures 0.1.29",
  "log 0.4.8",
@@ -1165,9 +1170,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5a615a1ad92048ad5d9633251edb7492b8abc057d7a679a9898476aef173935"
 dependencies = [
  "cfg-if",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1216,12 +1221,6 @@ dependencies = [
  "libc",
  "winapi 0.3.8",
 ]
-
-[[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "normalize-line-endings"
@@ -1292,12 +1291,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "parity-codec"
-version = "3.5.4"
+name = "parity-scale-codec"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b9df1283109f542d8852cd6b30e9341acc2137481eb6157d2e62af68b0afec9"
+checksum = "f747c06d9f3b2ad387ac881b9667298c81b1243aa9833f086e05996937c35507"
 dependencies = [
- "arrayvec 0.4.12",
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
  "serde",
 ]
 
@@ -1308,8 +1309,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.6.2",
  "rustc_version",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.7.0",
 ]
 
 [[package]]
@@ -1328,10 +1339,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot_core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
+dependencies = [
+ "cfg-if",
+ "cloudabi",
+ "libc",
+ "redox_syscall",
+ "smallvec 1.2.0",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "phf"
@@ -1387,9 +1418,9 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "385322a45f2ecf3410c68d2a549a4a2685e8051d0f278e39743ff4e451cb9b3f"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1441,14 +1472,14 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.3.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2288eb2a39386c4bc817974cc413afe173010dc80e470fcb1e9a35580869f024"
+checksum = "e4336f4f5d5524fa60bcbd6fe626f9223d8142a50e7053e979acdf0da41ab975"
 dependencies = [
  "fixed-hash",
  "impl-codec",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.3.0",
  "uint",
 ]
 
@@ -1458,9 +1489,9 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1471,20 +1502,11 @@ checksum = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
 dependencies = [
- "unicode-xid 0.2.0",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1515,20 +1537,11 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 dependencies = [
- "proc-macro2 1.0.8",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -1788,7 +1801,7 @@ dependencies = [
  "threadpool",
  "time",
  "tiny_http",
- "url",
+ "url 1.7.2",
 ]
 
 [[package]]
@@ -1921,9 +1934,9 @@ version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2053,9 +2066,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "static_assertions"
-version = "0.2.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19be23126415861cb3a23e501d34a708f7f9b2183c5252d690941c2e69199d5"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string"
@@ -2068,24 +2081,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "unicode-xid 0.2.0",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2154,9 +2156,9 @@ version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57e4d2e50ca050ed44fb58309bdce3efa79948f84f9993ad1978de5eebdce5a7"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2216,7 +2218,7 @@ dependencies = [
  "chrono",
  "chunked_transfer",
  "log 0.4.8",
- "url",
+ "url 1.7.2",
 ]
 
 [[package]]
@@ -2338,7 +2340,7 @@ dependencies = [
  "log 0.4.8",
  "mio",
  "num_cpus",
- "parking_lot",
+ "parking_lot 0.9.0",
  "slab 0.4.2",
  "tokio-executor",
  "tokio-io",
@@ -2504,14 +2506,14 @@ checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 
 [[package]]
 name = "uint"
-version = "0.7.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2143cded94692b156c356508d92888acc824db5bffc0b4089732264c6fcf86d4"
+checksum = "e75a4cdd7b87b28840dba13c483b9a88ee6bbf16ba5c951ee1ecfcf723078e0d"
 dependencies = [
  "byteorder",
  "crunchy",
- "heapsize",
  "rustc-hex",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2543,12 +2545,6 @@ dependencies = [
 
 [[package]]
 name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
@@ -2559,9 +2555,20 @@ version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 dependencies = [
- "idna",
+ "idna 0.1.5",
  "matches",
- "percent-encoding",
+ "percent-encoding 1.0.1",
+]
+
+[[package]]
+name = "url"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+dependencies = [
+ "idna 0.2.0",
+ "matches",
+ "percent-encoding 2.1.0",
 ]
 
 [[package]]
@@ -2595,11 +2602,12 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "web3"
-version = "0.8.0"
-source = "git+https://github.com/graphprotocol/rust-web3?branch=graph-patches#1a5caf30d9c540a1f4f72775c0050273ba8fc831"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0631c83208cf420eeb2ed9b6cb2d5fc853aa76a43619ccec2a3d52d741f1261"
 dependencies = [
- "arrayvec 0.4.12",
- "base64 0.10.1",
+ "arrayvec",
+ "base64 0.11.0",
  "derive_more",
  "ethabi",
  "ethereum-types",
@@ -2609,7 +2617,7 @@ dependencies = [
  "jsonrpc-core",
  "log 0.4.8",
  "native-tls",
- "parking_lot",
+ "parking_lot 0.10.0",
  "rustc-hex",
  "serde",
  "serde_json",
@@ -2617,7 +2625,7 @@ dependencies = [
  "tokio-io",
  "tokio-timer 0.1.2",
  "tokio-uds 0.1.7",
- "url",
+ "url 2.1.1",
  "websocket",
 ]
 
@@ -2640,7 +2648,7 @@ dependencies = [
  "tokio-io",
  "tokio-tls",
  "unicase",
- "url",
+ "url 1.7.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,3 @@ members = [
 default-members = [
     "driver",
 ]
-
-[patch.crates-io]
-web3 = { git = "https://github.com/graphprotocol/rust-web3", branch = "graph-patches" }

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -7,9 +7,8 @@ edition = "2018"
 [dependencies]
 byteorder = "1.3.4"
 chrono = "0.4.10"
-ethcontract = { git = "https://github.com/gnosis/ethcontract-rs", branch = "graph-patches-v0.3.0" }
+ethcontract = "0.4.0"
 futures = { version = "0.3.4", features = ["compat"] }
-jsonrpc-core = "13.2.0"
 lazy_static = "1.4.0"
 log = "0.4.8"
 prometheus = "0.7.0"
@@ -23,10 +22,9 @@ slog-envlogger = "2.2.0"
 slog-scope = "4.3.0"
 slog-stdlog = "4.0.0"
 slog-term = "2.5.0"
-web3 = "0.8.0"
 
 [dev-dependencies]
 mockall = "0.6.0"
 
 [build-dependencies]
-ethcontract-generate = { git = "https://github.com/gnosis/ethcontract-rs", branch = "graph-patches-v0.3.0" }
+ethcontract-generate = "0.4.0"

--- a/driver/src/contracts/mod.rs
+++ b/driver/src/contracts/mod.rs
@@ -4,12 +4,12 @@ pub mod stablex_contract;
 use crate::error::DriverError;
 use crate::transport::LoggingTransport;
 use ethcontract::contract::MethodDefaults;
+use ethcontract::web3::transports::{EventLoopHandle, Http};
 use ethcontract::{Account, PrivateKey};
 use log::Level;
 use std::env;
-use web3::transports::{EventLoopHandle, Http};
 
-pub type Web3 = web3::api::Web3<LoggingTransport<Http>>;
+pub type Web3 = ethcontract::web3::api::Web3<LoggingTransport<Http>>;
 
 pub fn web3_provider(url: &str) -> Result<(Web3, EventLoopHandle), DriverError> {
     let (event_loop, http) = Http::new(&url)?;

--- a/driver/src/contracts/stablex_auction_element.rs
+++ b/driver/src/contracts/stablex_auction_element.rs
@@ -1,6 +1,6 @@
 use crate::models::Order;
 use byteorder::{BigEndian, ByteOrder};
-use web3::types::{H160, U256};
+use ethcontract::{Address as H160, U256};
 
 use crate::util::CeiledDiv;
 

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -4,8 +4,7 @@ use std::collections::HashMap;
 use std::env;
 
 use ethcontract::transaction::GasPrice;
-use ethcontract::web3::types::{H160, U256};
-use ethcontract::BlockNumber;
+use ethcontract::{Address as H160, BlockNumber, U256};
 use lazy_static::lazy_static;
 #[cfg(test)]
 use mockall::automock;

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -4,10 +4,11 @@ use std::collections::HashMap;
 use std::env;
 
 use ethcontract::transaction::GasPrice;
+use ethcontract::web3::types::{H160, U256};
+use ethcontract::BlockNumber;
 use lazy_static::lazy_static;
 #[cfg(test)]
 use mockall::automock;
-use web3::types::{H160, U128, U256};
 
 use crate::contracts;
 use crate::error::DriverError;
@@ -53,9 +54,9 @@ pub trait StableXContract {
     fn get_auction_data_paginated(
         &self,
         block: u64,
-        page_size: u64,
+        page_size: u16,
         previous_page_user: H160,
-        previous_page_user_offset: u64,
+        previous_page_user_offset: u16,
     ) -> Result<Vec<u8>>;
     fn get_solution_objective_value(
         &self,
@@ -81,9 +82,9 @@ impl StableXContract for BatchExchange {
     fn get_auction_data_paginated(
         &self,
         block: u64,
-        page_size: u64,
+        page_size: u16,
         previous_page_user: H160,
-        previous_page_user_offset: u64,
+        previous_page_user_offset: u16,
     ) -> Result<Vec<u8>> {
         let mut orders_builder = self.get_encoded_users_paginated(
             previous_page_user,
@@ -91,7 +92,7 @@ impl StableXContract for BatchExchange {
             page_size,
         );
         orders_builder.m.tx.gas = None;
-        orders_builder.block = Some(web3::types::BlockNumber::Number(block));
+        orders_builder.block = Some(BlockNumber::Number(block.into()));
         orders_builder.call().wait().map_err(From::from)
     }
 
@@ -106,7 +107,7 @@ impl StableXContract for BatchExchange {
             encode_execution_for_contract(orders, solution.executed_buy_amounts);
         let objective_value = self
             .submit_solution(
-                batch_index.low_u64(),
+                batch_index.low_u32(),
                 *MAX_OBJECTIVE_VALUE,
                 owners,
                 order_ids,
@@ -131,7 +132,7 @@ impl StableXContract for BatchExchange {
         let (owners, order_ids, volumes) =
             encode_execution_for_contract(orders, solution.executed_buy_amounts);
         self.submit_solution(
-            batch_index.low_u64(),
+            batch_index.low_u32(),
             claimed_objective_value,
             owners,
             order_ids,
@@ -147,7 +148,7 @@ impl StableXContract for BatchExchange {
     }
 }
 
-fn encode_prices_for_contract(price_map: &HashMap<u16, u128>) -> (Vec<U128>, Vec<u64>) {
+fn encode_prices_for_contract(price_map: &HashMap<u16, u128>) -> (Vec<u128>, Vec<u16>) {
     // Representing the solution's price vector as:
     // sorted_touched_token_ids, non_zero_prices (excluding price at token with id 0)
     let mut token_ids: Vec<u16> = price_map
@@ -158,15 +159,15 @@ fn encode_prices_for_contract(price_map: &HashMap<u16, u128>) -> (Vec<U128>, Vec
     token_ids.sort_unstable();
     let prices = token_ids
         .iter()
-        .map(|token_id| U128::from(price_map[token_id]))
+        .map(|token_id| price_map[token_id])
         .collect();
-    (prices, token_ids.iter().map(|t| *t as u64).collect())
+    (prices, token_ids)
 }
 
 fn encode_execution_for_contract(
     orders: Vec<Order>,
     executed_buy_amounts: Vec<u128>,
-) -> (Vec<H160>, Vec<u64>, Vec<U128>) {
+) -> (Vec<H160>, Vec<u16>, Vec<u128>) {
     assert_eq!(
         orders.len(),
         executed_buy_amounts.len(),
@@ -180,8 +181,8 @@ fn encode_execution_for_contract(
             // order was touched!
             // Note that above condition is only holds for sell orders.
             owners.push(orders[order_index].account_id);
-            order_ids.push(orders[order_index].id as _);
-            volumes.push(U128::from(buy_amount.to_be_bytes()));
+            order_ids.push(orders[order_index].id);
+            volumes.push(buy_amount);
         }
     }
     (owners, order_ids, volumes)
@@ -232,7 +233,7 @@ pub mod tests {
 
         let expected_owners = vec![address_1];
         let expected_order_ids = vec![0];
-        let expected_volumes = vec![U128::from(1)];
+        let expected_volumes = vec![1];
 
         let expected_results = (expected_owners, expected_order_ids, expected_volumes);
 
@@ -246,7 +247,7 @@ pub mod tests {
     fn generic_price_encoding() {
         let price_map = map_from_slice(&[(0, u128::max_value()), (1, 0), (2, 1), (3, 2)]);
         // Only contain non fee-tokens and non zero prices
-        let expected_prices = vec![1.into(), 2.into()];
+        let expected_prices = vec![1, 2];
         let expected_token_ids = vec![2, 3];
 
         assert_eq!(
@@ -260,8 +261,8 @@ pub mod tests {
         let unordered_price_map = map_from_slice(&[(4, 2), (1, 3), (5, 0), (0, 2), (3, 1)]);
 
         // Only contain non fee-token and non zero prices
-        let expected_prices = vec![3.into(), 1.into(), 2.into()];
-        let expected_token_ids = vec![1u64, 3u64, 4u64];
+        let expected_prices = vec![3, 1, 2];
+        let expected_token_ids = vec![1, 3, 4];
         assert_eq!(
             encode_prices_for_contract(&unordered_price_map),
             (expected_prices, expected_token_ids)

--- a/driver/src/driver/stablex_driver.rs
+++ b/driver/src/driver/stablex_driver.rs
@@ -9,7 +9,7 @@ use log::info;
 
 use std::collections::HashSet;
 
-use web3::types::U256;
+use ethcontract::U256;
 
 pub struct StableXDriver<'a> {
     past_auctions: HashSet<U256>,

--- a/driver/src/error.rs
+++ b/driver/src/error.rs
@@ -12,7 +12,6 @@ pub enum ErrorKind {
     HexError,
     EnvError,
     ParseIntError,
-    TryFromIntError,
     PriceFindingError,
     PrivateKeyError,
     ContractDeployedError,
@@ -58,12 +57,6 @@ impl From<std::env::VarError> for DriverError {
 impl From<std::num::ParseIntError> for DriverError {
     fn from(error: std::num::ParseIntError) -> Self {
         DriverError::new(error.description(), ErrorKind::ParseIntError)
-    }
-}
-
-impl From<std::num::TryFromIntError> for DriverError {
-    fn from(error: std::num::TryFromIntError) -> Self {
-        DriverError::new(error.description(), ErrorKind::TryFromIntError)
     }
 }
 

--- a/driver/src/error.rs
+++ b/driver/src/error.rs
@@ -12,6 +12,7 @@ pub enum ErrorKind {
     HexError,
     EnvError,
     ParseIntError,
+    TryFromIntError,
     PriceFindingError,
     PrivateKeyError,
     ContractDeployedError,
@@ -57,6 +58,12 @@ impl From<std::env::VarError> for DriverError {
 impl From<std::num::ParseIntError> for DriverError {
     fn from(error: std::num::ParseIntError) -> Self {
         DriverError::new(error.description(), ErrorKind::ParseIntError)
+    }
+}
+
+impl From<std::num::TryFromIntError> for DriverError {
+    fn from(error: std::num::TryFromIntError) -> Self {
+        DriverError::new(error.description(), ErrorKind::TryFromIntError)
     }
 }
 

--- a/driver/src/error.rs
+++ b/driver/src/error.rs
@@ -7,11 +7,12 @@ use std::fmt;
 pub enum ErrorKind {
     MiscError,
     IoError,
-    ContractError,
+    Web3Error,
     JsonError,
     HexError,
     EnvError,
     ParseIntError,
+    TryFromIntError,
     PriceFindingError,
     PrivateKeyError,
     ContractDeployedError,
@@ -30,15 +31,9 @@ impl From<std::io::Error> for DriverError {
     }
 }
 
-impl From<web3::contract::Error> for DriverError {
-    fn from(error: web3::contract::Error) -> Self {
-        DriverError::new(&format!("{}", error), ErrorKind::ContractError)
-    }
-}
-
-impl From<web3::Error> for DriverError {
-    fn from(error: web3::Error) -> Self {
-        DriverError::new(&format!("{}", error), ErrorKind::ContractError)
+impl From<ethcontract::web3::Error> for DriverError {
+    fn from(error: ethcontract::web3::Error) -> Self {
+        DriverError::new(&format!("{}", error), ErrorKind::Web3Error)
     }
 }
 
@@ -63,6 +58,12 @@ impl From<std::env::VarError> for DriverError {
 impl From<std::num::ParseIntError> for DriverError {
     fn from(error: std::num::ParseIntError) -> Self {
         DriverError::new(error.description(), ErrorKind::ParseIntError)
+    }
+}
+
+impl From<std::num::TryFromIntError> for DriverError {
+    fn from(error: std::num::TryFromIntError) -> Self {
+        DriverError::new(error.description(), ErrorKind::TryFromIntError)
     }
 }
 

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -27,9 +27,9 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
-fn auction_data_page_size() -> u64 {
+fn auction_data_page_size() -> u16 {
     const KEY: &str = "AUCTION_DATA_PAGE_SIZE";
-    const DEFAULT: u64 = 100;
+    const DEFAULT: u16 = 100;
     env::var(KEY)
         .map(|str| {
             str.parse()

--- a/driver/src/metrics/stablex_metrics.rs
+++ b/driver/src/metrics/stablex_metrics.rs
@@ -3,11 +3,11 @@ use crate::price_finding::error::PriceFindingError;
 
 use crate::models::{AccountState, Order, Solution};
 use chrono::Utc;
+use ethcontract::U256;
 use prometheus::{IntCounterVec, IntGaugeVec, Opts, Registry};
 use std::collections::HashSet;
 use std::convert::TryInto;
 use std::sync::Arc;
-use web3::types::U256;
 
 pub struct StableXMetrics {
     processing_times: IntGaugeVec,

--- a/driver/src/models/account_state.rs
+++ b/driver/src/models/account_state.rs
@@ -1,6 +1,6 @@
+use ethcontract::{Address as H160, H256, U256};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use web3::types::{H160, H256, U256};
 
 #[derive(Serialize, Default, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -90,7 +90,7 @@ mod test_util {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use web3::types::H256;
+    use ethcontract::H256;
 
     #[test]
     #[should_panic]

--- a/driver/src/models/order.rs
+++ b/driver/src/models/order.rs
@@ -1,5 +1,5 @@
+use ethcontract::Address as H160;
 use serde::Deserialize;
-use web3::types::H160;
 
 #[derive(Debug, Clone, Default, Deserialize, Eq, Ord, PartialEq, PartialOrd)]
 #[serde(rename_all = "camelCase")]

--- a/driver/src/orderbook/filtered_orderbook.rs
+++ b/driver/src/orderbook/filtered_orderbook.rs
@@ -1,9 +1,9 @@
 use super::*;
 
 use crate::models::{AccountState, Order};
+use ethcontract::{Address as H160, U256};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
-use web3::types::{H160, U256};
 
 /// Data structure to specify what type of orders to filter
 #[derive(Debug, Default, Deserialize, PartialEq, Eq)]

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -61,13 +61,20 @@ impl<'a> StableXOrderBookReading for PaginatedStableXOrderBookReader<'a> {
         let mut reader = PaginatedAuctionDataReader::new(index);
         loop {
             let number_of_orders: u16 = reader
-                .apply_page(&self.contract.get_auction_data_paginated(
-                    block,
-                    self.page_size,
-                    reader.pagination().previous_page_user,
-                    reader.pagination().previous_page_user_offset.try_into()?,
-                )?)
-                .try_into()?;
+                .apply_page(
+                    &self.contract.get_auction_data_paginated(
+                        block,
+                        self.page_size,
+                        reader.pagination().previous_page_user,
+                        reader
+                            .pagination()
+                            .previous_page_user_offset
+                            .try_into()
+                            .expect("user cannot have more than u16::MAX orders"),
+                    )?,
+                )
+                .try_into()
+                .expect("number of orders per page should never overflow a u16");
             if number_of_orders < self.page_size {
                 return Ok(reader.get_auction_data());
             }

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -61,20 +61,13 @@ impl<'a> StableXOrderBookReading for PaginatedStableXOrderBookReader<'a> {
         let mut reader = PaginatedAuctionDataReader::new(index);
         loop {
             let number_of_orders: u16 = reader
-                .apply_page(
-                    &self.contract.get_auction_data_paginated(
-                        block,
-                        self.page_size,
-                        reader.pagination().previous_page_user,
-                        reader
-                            .pagination()
-                            .previous_page_user_offset
-                            .try_into()
-                            .expect("user cannot have more than u16::MAX orders"),
-                    )?,
-                )
-                .try_into()
-                .expect("number of orders per page should never overflow a u16");
+                .apply_page(&self.contract.get_auction_data_paginated(
+                    block,
+                    self.page_size,
+                    reader.pagination().previous_page_user,
+                    reader.pagination().previous_page_user_offset.try_into()?,
+                )?)
+                .try_into()?;
             if number_of_orders < self.page_size {
                 return Ok(reader.get_auction_data());
             }

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -2,11 +2,12 @@ use crate::contracts::{stablex_contract::StableXContract, Web3};
 use crate::error::DriverError;
 use crate::models::{AccountState, Order};
 
+use ethcontract::web3::futures::Future;
+use ethcontract::U256;
 #[cfg(test)]
 use mockall::automock;
 use paginated_auction_data_reader::PaginatedAuctionDataReader;
-use web3::futures::Future;
-use web3::types::U256;
+use std::convert::TryInto;
 
 mod filtered_orderbook;
 mod paginated_auction_data_reader;
@@ -34,12 +35,12 @@ pub trait StableXOrderBookReading {
 /// This avoid hitting gas limits when the total amount of orders is large.
 pub struct PaginatedStableXOrderBookReader<'a> {
     contract: &'a dyn StableXContract,
-    page_size: u64,
+    page_size: u16,
     web3: &'a Web3,
 }
 
 impl<'a> PaginatedStableXOrderBookReader<'a> {
-    pub fn new(contract: &'a dyn StableXContract, page_size: u64, web3: &'a Web3) -> Self {
+    pub fn new(contract: &'a dyn StableXContract, page_size: u16, web3: &'a Web3) -> Self {
         Self {
             contract,
             page_size,
@@ -59,13 +60,15 @@ impl<'a> StableXOrderBookReading for PaginatedStableXOrderBookReader<'a> {
         let block = self.web3.eth().block_number().wait()?.as_u64();
         let mut reader = PaginatedAuctionDataReader::new(index);
         loop {
-            let number_of_orders = reader.apply_page(&self.contract.get_auction_data_paginated(
-                block,
-                self.page_size,
-                reader.pagination().previous_page_user,
-                reader.pagination().previous_page_user_offset as u64,
-            )?);
-            if (number_of_orders as u64) < self.page_size {
+            let number_of_orders: u16 = reader
+                .apply_page(&self.contract.get_auction_data_paginated(
+                    block,
+                    self.page_size,
+                    reader.pagination().previous_page_user,
+                    reader.pagination().previous_page_user_offset.try_into()?,
+                )?)
+                .try_into()?;
+            if number_of_orders < self.page_size {
                 return Ok(reader.get_auction_data());
             }
         }

--- a/driver/src/orderbook/paginated_auction_data_reader.rs
+++ b/driver/src/orderbook/paginated_auction_data_reader.rs
@@ -1,7 +1,7 @@
 use crate::contracts::stablex_auction_element::{StableXAuctionElement, AUCTION_ELEMENT_WIDTH};
 use crate::models::{AccountState, Order};
+use ethcontract::{Address as H160, U256};
 use std::collections::HashMap;
-use web3::types::{H160, U256};
 
 /// Handles reading of auction data that has been encoded with the smart
 /// contract's `encodeAuctionElement` function.

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -5,7 +5,7 @@ use crate::util::{CeiledDiv, CheckedConvertU128};
 
 use std::collections::HashMap;
 
-use web3::types::U256;
+use ethcontract::U256;
 
 const BASE_UNIT: u128 = 1_000_000_000_000_000_000u128;
 const BASE_PRICE: u128 = BASE_UNIT;
@@ -261,8 +261,8 @@ fn executed_buy_amount(
 pub mod tests {
     use super::*;
     use crate::models::AccountState;
+    use ethcontract::{Address as H160, H256, U256};
     use std::collections::HashMap;
-    use web3::types::{H160, H256, U256};
 
     #[test]
     fn test_type_left_fully_matched_no_fee() {

--- a/driver/src/price_finding/optimization_price_finder.rs
+++ b/driver/src/price_finding/optimization_price_finder.rs
@@ -3,12 +3,12 @@ use crate::price_finding::error::{ErrorKind, PriceFindingError};
 use crate::price_finding::price_finder_interface::{Fee, OptimizationModel, PriceFinding};
 
 use chrono::Utc;
+use ethcontract::Address as H160;
 use log::{debug, error};
 use std::collections::{HashMap, HashSet};
 use std::fs::{create_dir_all, File};
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::process::Command;
-use web3::types::H160;
 
 const RESULT_FOLDER: &str = "./results/tmp/";
 
@@ -303,9 +303,9 @@ pub mod tests {
     use super::*;
     use crate::models::AccountState;
     use crate::util::test_util::map_from_slice;
+    use ethcontract::{H256, U256};
     use serde_json::json;
     use std::error::Error;
-    use web3::types::{H256, U256};
 
     #[test]
     fn test_parse_prices() {

--- a/driver/src/solution_submission/mod.rs
+++ b/driver/src/solution_submission/mod.rs
@@ -7,7 +7,7 @@ use crate::models::{Order, Solution};
 #[cfg(test)]
 use mockall::automock;
 
-use web3::types::U256;
+use ethcontract::U256;
 
 type Result<T> = std::result::Result<T, DriverError>;
 

--- a/driver/src/transport.rs
+++ b/driver/src/transport.rs
@@ -1,9 +1,9 @@
-use jsonrpc_core::types::request::Call;
+use ethcontract::jsonrpc::types::request::Call;
+use ethcontract::web3::error::Error;
+use ethcontract::web3::futures::{Async, Future, Poll};
+use ethcontract::web3::{RequestId, Transport};
 use log::{log, Level};
 use serde_json::Value;
-use web3::error::Error;
-use web3::futures::{Async, Future, Poll};
-use web3::{RequestId, Transport};
 
 /// A `Transport` wrapper that logs RPC messages
 #[derive(Clone, Debug)]

--- a/driver/src/util.rs
+++ b/driver/src/util.rs
@@ -1,6 +1,6 @@
+use ethcontract::U256;
 use log::info;
 use std::future::Future;
-use web3::types::U256;
 
 use crate::price_finding::{
     Fee, NaiveSolver, OptimisationPriceFinder, OptimizationModel, PriceFinding,

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -4,5 +4,5 @@ version = "1.0.0"
 edition = "2018"
 
 [dependencies]
-ethcontract = { git = "https://github.com/gnosis/ethcontract-rs", branch = "graph-patches-v0.3.0" }
+ethcontract = "0.4.0"
 futures = { version = "0.3.4", features = ["compat"] }

--- a/e2e/src/common.rs
+++ b/e2e/src/common.rs
@@ -8,9 +8,8 @@ use ethcontract::web3::api::Web3;
 use ethcontract::web3::contract::tokens::Detokenize;
 use ethcontract::web3::futures::Future as F;
 use ethcontract::web3::transports::Http;
-use ethcontract::web3::types::{H160, U256};
 use ethcontract::web3::Transport;
-use ethcontract::Account;
+use ethcontract::{Account, Address as H160, U256};
 
 use std::fmt::Debug;
 use std::future::Future;

--- a/e2e/src/stablex.rs
+++ b/e2e/src/stablex.rs
@@ -2,8 +2,7 @@ use crate::*;
 
 use ethcontract::web3::api::Web3;
 use ethcontract::web3::transports::Http;
-use ethcontract::web3::types::{H160, U256};
-use ethcontract::Account;
+use ethcontract::{Account, Address as H160, U256};
 
 use crate::common::{
     approve, create_accounts_with_funded_tokens, wait_for, FutureBuilderExt, FutureWaitExt, MAX_GAS,

--- a/e2e/tests/stablex_test.rs
+++ b/e2e/tests/stablex_test.rs
@@ -1,8 +1,7 @@
 use ethcontract::web3::api::Web3;
 use ethcontract::web3::futures::Future as F;
 use ethcontract::web3::transports::Http;
-use ethcontract::web3::types::U256;
-use ethcontract::{Account, PrivateKey};
+use ethcontract::{Account, PrivateKey, U256};
 
 use futures::future::join_all;
 

--- a/e2e/tests/stablex_test.rs
+++ b/e2e/tests/stablex_test.rs
@@ -49,8 +49,8 @@ fn test_with_ganache() {
             second_token_id,
             first_token_id,
             batch + 20,
-            999_000.into(),
-            2_000_000.into(),
+            999_000,
+            2_000_000,
         )
         .from(Account::Local(accounts[0], None))
         .wait_and_expect("Cannot place first order");
@@ -60,8 +60,8 @@ fn test_with_ganache() {
             first_token_id,
             second_token_id,
             batch + 20,
-            1_996_000.into(),
-            999_000.into(),
+            1_996_000,
+            999_000,
         )
         .from(Account::Local(accounts[1], None))
         .wait_and_expect("Cannot place first order");
@@ -159,11 +159,11 @@ fn test_rinkeby() {
 
     // Place orders
     let first_order = instance
-        .place_order(0, 7, batch + 2, 1_000_000.into(), 10_000_000.into())
+        .place_order(0, 7, batch + 2, 1_000_000, 10_000_000)
         .nonce(nonce + 4)
         .send();
     let second_order = instance
-        .place_order(7, 0, batch + 1, 1_000_000.into(), 10_000_000.into())
+        .place_order(7, 0, batch + 1, 1_000_000, 10_000_000)
         .nonce(nonce + 5)
         .send();
 


### PR DESCRIPTION
This PR upgrades to use the most recent version of the crates.io `ethcontract` crate. This means we will no longer have to maintain the special compatibility branch for `dex-services`. Because of this update, the version of some of the shared dependencies have changed, and the generated contract bindings use the correct primitive integer types (no longer coerced to `u64`, `U128` and `U256`). This PR:
- Updates code to use re-exported `web3` and `jsonrpc_core` crates, reducing the dependency update burden in `dex-services`
- Updates code to use the correct contract primitive integer types. Specifically, there are no more `u16` to `u64` and `u128` to `U128` conversions.

The main benefit of this update is that:
- Dependabot will automatically create PRs when ethcontract updates again
- No longer required to managed dependencies for web3 related things as that is all part of `ethcontract`
- Hopefully fixed some error message decoding for Parity nodes so we can create better filters for mainnet client

### Test Plan

CI and :pray: