### PR TITLE
[Easy] Bump ethcontract to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5f84a37fda5cc81423486c7892134816f2d1284baf30321a4d4247d187fcf1c"
+checksum = "cf2c5abb978a523ea91d48c228b34c3065df1f5a9cba8d28a31410a61bb95e38"
 dependencies = [
  "ethcontract-common",
  "ethcontract-derive",
@@ -516,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-common"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bc3dfa18c03fefdb53c909f7282dc3bd035039ea0c2d480cdfeaf9e7a7813b"
+checksum = "cfc21b18d517a8db7c975625879cd23e98f040ed78ac7cbb450bd7cddd4dac1e"
 dependencies = [
  "ethabi",
  "hex",
@@ -531,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-derive"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b27b7e083dabb96c8dde3ed2f902b167848ca572c21918a9a21b1acf2f9cfb"
+checksum = "9ce0a222bdcafd5c5423b8ef87e9fb2e158b52877938b9fab288085ec3687585"
 dependencies = [
  "ethcontract-generate",
  "proc-macro2",
@@ -542,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-generate"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f6fe95eeb39e3ecff0b666fc1d2b360a664996a4735cfd9a2b19792a18bce6"
+checksum = "f7c3baaa9d3a5e2565ef56c58521beafffd298c7ea33616c39d4bd6626e0c664"
 dependencies = [
  "Inflector",
  "anyhow",

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 byteorder = "1.3.4"
 chrono = "0.4.10"
-ethcontract = "0.4.0"
+ethcontract = "0.4.1"
 futures = { version = "0.3.4", features = ["compat"] }
 lazy_static = "1.4.0"
 log = "0.4.8"
@@ -27,4 +27,4 @@ slog-term = "2.5.0"
 mockall = "0.6.0"
 
 [build-dependencies]
-ethcontract-generate = "0.4.0"
+ethcontract-generate = "0.4.1"

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -4,5 +4,5 @@ version = "1.0.0"
 edition = "2018"
 
 [dependencies]
-ethcontract = "0.4.0"
+ethcontract = "0.4.1"
 futures = { version = "0.3.4", features = ["compat"] }


### PR DESCRIPTION
:point_up:

This incorporates some minor fixes from yesterday.