### PR TITLE
Custom HTTP Transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "curl"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06aa71e9208a54def20792d877bc663d6aae0732b9852e612c4a933177c31283"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c38ca47d60b86d0cc9d42caa90a0885669c2abc9791f871c81f58cdf39e979b"
+dependencies = [
+ "cc",
+ "libc",
+ "libnghttp2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "deflate"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +454,7 @@ dependencies = [
  "ethcontract",
  "ethcontract-generate",
  "futures 0.3.4",
+ "isahc",
  "lazy_static",
  "log 0.4.8",
  "mockall",
@@ -985,6 +1017,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "isahc"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c45d8c41e6f0b5aa495fd2577e6068e100f57eb87c4b353b0dab20bb53a56035"
+dependencies = [
+ "bytes",
+ "chrono",
+ "crossbeam-channel 0.4.0",
+ "crossbeam-utils 0.7.0",
+ "curl",
+ "curl-sys",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "http",
+ "lazy_static",
+ "log 0.4.8",
+ "serde",
+ "serde_json",
+ "slab 0.4.2",
+ "sluice",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,6 +1086,28 @@ name = "libc"
 version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
+
+[[package]]
+name = "libnghttp2-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02254d44f4435dd79e695f2c2b83cd06a47919adea30216ceaf0c57ca0a72463"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "lock_api"
@@ -2044,6 +2122,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sluice"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6428a51b12f86b02672d0aabc26141e37828d4f05dfeb3b6f45831de9f292360"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+]
+
+[[package]]
 name = "smallvec"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2057,6 +2147,18 @@ name = "smallvec"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
+
+[[package]]
+name = "socket2"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.8",
+]
 
 [[package]]
 name = "spin"

--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ The following environment variables can be used to configure the behavior of the
 - *NETWORK_ID*: Network ID (e.g. 1 for mainnet, 4 for rinkeby, 5777 for ganache)
 - *OPTIMIZATION_MODEL*: Which style of solver to use (NAIVE for naive, MIP for mixed integer programming and NLP for the  non-linear programming solver)
 - *ORDERBOOK_FILTER*: json encoded object of which tokens/filters to ignore. See below for example filter.
-- *PRIVATE_KEY*: THe key with which to sign transactions
+- *PRIVATE_KEY*: The key with which to sign transactions
+- *WEB3_RPC_TIMEOUT*: The timeout in milliseconds of web3 JSON RPC calls, defaults to 10000ms
 
 ### Orderbook Filter Example
 

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -9,6 +9,7 @@ byteorder = "1.3.4"
 chrono = "0.4.10"
 ethcontract = "0.4.0"
 futures = { version = "0.3.4", features = ["compat"] }
+isahc = { version = "0.8.2", features = ["json"] }
 lazy_static = "1.4.0"
 log = "0.4.8"
 prometheus = "0.7.0"

--- a/driver/src/contracts/mod.rs
+++ b/driver/src/contracts/mod.rs
@@ -2,21 +2,20 @@ pub mod stablex_auction_element;
 pub mod stablex_contract;
 
 use crate::error::DriverError;
-use crate::transport::LoggingTransport;
+use crate::transport::HttpTransport;
 use ethcontract::contract::MethodDefaults;
-use ethcontract::web3::transports::{EventLoopHandle, Http};
 use ethcontract::{Account, PrivateKey};
 use log::Level;
 use std::env;
+use std::time::Duration;
 
-pub type Web3 = ethcontract::web3::api::Web3<LoggingTransport<Http>>;
+pub type Web3 = ethcontract::web3::api::Web3<HttpTransport>;
 
-pub fn web3_provider(url: &str) -> Result<(Web3, EventLoopHandle), DriverError> {
-    let (event_loop, http) = Http::new(&url)?;
-    let logging = LoggingTransport::new(http, Level::Debug);
-    let web3 = Web3::new(logging);
+pub fn web3_provider(url: &str) -> Result<Web3, DriverError> {
+    let http = HttpTransport::new(url, Level::Debug, Duration::from_secs(10))?;
+    let web3 = Web3::new(http);
 
-    Ok((web3, event_loop))
+    Ok(web3)
 }
 
 fn method_defaults(network_id: u64) -> Result<MethodDefaults, DriverError> {

--- a/driver/src/contracts/mod.rs
+++ b/driver/src/contracts/mod.rs
@@ -5,14 +5,13 @@ use crate::error::DriverError;
 use crate::transport::HttpTransport;
 use ethcontract::contract::MethodDefaults;
 use ethcontract::{Account, PrivateKey};
-use log::Level;
 use std::env;
 use std::time::Duration;
 
 pub type Web3 = ethcontract::web3::api::Web3<HttpTransport>;
 
 pub fn web3_provider(url: &str) -> Result<Web3, DriverError> {
-    let http = HttpTransport::new(url, Level::Debug, Duration::from_secs(10))?;
+    let http = HttpTransport::new(url, Duration::from_secs(10))?;
     let web3 = Web3::new(http);
 
     Ok(web3)

--- a/driver/src/contracts/mod.rs
+++ b/driver/src/contracts/mod.rs
@@ -10,8 +10,16 @@ use std::time::Duration;
 
 pub type Web3 = ethcontract::web3::api::Web3<HttpTransport>;
 
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
+
 pub fn web3_provider(url: &str) -> Result<Web3, DriverError> {
-    let http = HttpTransport::new(url, Duration::from_secs(10))?;
+    let timeout = env::var("WEB3_RPC_TIMEOUT")
+        .map_err(DriverError::from)
+        .and_then(|timeout| Ok(timeout.parse()?))
+        .map(Duration::from_millis)
+        .unwrap_or(DEFAULT_TIMEOUT);
+
+    let http = HttpTransport::new(url, timeout)?;
     let web3 = Web3::new(http);
 
     Ok(web3)

--- a/driver/src/error.rs
+++ b/driver/src/error.rs
@@ -16,6 +16,7 @@ pub enum ErrorKind {
     PrivateKeyError,
     ContractDeployedError,
     ContractMethodError,
+    HttpError,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -87,6 +88,12 @@ impl From<ethcontract::errors::DeployError> for DriverError {
 impl From<ethcontract::errors::MethodError> for DriverError {
     fn from(error: ethcontract::errors::MethodError) -> Self {
         DriverError::new(&error.to_string(), ErrorKind::ContractMethodError)
+    }
+}
+
+impl From<isahc::Error> for DriverError {
+    fn from(error: isahc::Error) -> Self {
+        DriverError::new(&error.to_string(), ErrorKind::HttpError)
     }
 }
 

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -54,7 +54,7 @@ fn main() {
         env::var("OPTIMIZATION_MODEL").unwrap_or_else(|_| String::from("NAIVE"));
     let optimization_model = OptimizationModel::from(optimization_model_string.as_str());
 
-    let (web3, _event_loop_handle) = web3_provider(&ethereum_node_url).unwrap();
+    let web3 = web3_provider(&ethereum_node_url).unwrap();
     let contract = BatchExchange::new(&web3, network_id).unwrap();
     info!("Using contract at {}", contract.address());
     info!("Using account {}", contract.account());

--- a/driver/src/transport.rs
+++ b/driver/src/transport.rs
@@ -44,20 +44,16 @@ impl HttpTransport {
 
 impl HttpTransportInner {
     async fn execute(self: Arc<Self>, id: RequestId, request: Call) -> Result<Value, Web3Error> {
-        log!(
-            self.log_level,
-            "sending request ID {}: {}",
-            id,
-            serde_json::to_string(&request).expect("request is invalid JSON")
-        );
-
         let request = serde_json::to_string(&request)?;
+        log!(self.log_level, "sending request ID {}: {}", id, &request);
+
         let mut response: Value = self
             .client
             .post_async(&self.url, request)
             .await
             .map_err(|err| Web3Error::Transport(err.to_string()))?
             .json()?;
+        log!(self.log_level, "received response ID {}: {}", id, &response);
 
         if let Some(map) = response.as_object_mut() {
             // NOTE: Ganache sometimes returns errors inlined with responses,

--- a/driver/src/transport.rs
+++ b/driver/src/transport.rs
@@ -59,7 +59,11 @@ impl HttpTransportInner {
     }
 
     /// Execute an HTTP JSON RPC request.
-    async fn execute_rpc(self: Arc<Self>, id: RequestId, request: Call) -> Result<Value, Web3Error> {
+    async fn execute_rpc(
+        self: Arc<Self>,
+        id: RequestId,
+        request: Call,
+    ) -> Result<Value, Web3Error> {
         let request = serde_json::to_string(&request)?;
         debug!("[id:{}] sending request: '{}'", id, &request,);
 

--- a/driver/src/transport.rs
+++ b/driver/src/transport.rs
@@ -6,7 +6,7 @@ use futures::compat::Compat;
 use futures::future::{BoxFuture, FutureExt, TryFutureExt};
 use isahc::config::VersionNegotiation;
 use isahc::prelude::{HttpClient, Request, ResponseExt};
-use log::{log, warn, Level};
+use log::{debug, warn};
 use serde::Deserialize;
 use serde_json::Value;
 use std::fmt::{self, Debug, Formatter};
@@ -21,18 +21,13 @@ pub struct HttpTransport(Arc<HttpTransportInner>);
 
 struct HttpTransportInner {
     url: String,
-    log_level: Level,
     client: HttpClient,
     id: AtomicUsize,
 }
 
 impl HttpTransport {
     /// Creates a new HTTP transport with settings.
-    pub fn new(
-        url: impl Into<String>,
-        log_level: Level,
-        timeout: Duration,
-    ) -> Result<HttpTransport, DriverError> {
+    pub fn new(url: impl Into<String>, timeout: Duration) -> Result<HttpTransport, DriverError> {
         let client = HttpClient::builder()
             .timeout(timeout)
             .version_negotiation(VersionNegotiation::http11())
@@ -40,7 +35,6 @@ impl HttpTransport {
 
         Ok(HttpTransport(Arc::new(HttpTransportInner {
             url: url.into(),
-            log_level,
             client,
             id: AtomicUsize::default(),
         })))
@@ -48,27 +42,21 @@ impl HttpTransport {
 }
 
 impl HttpTransportInner {
+    /// Execute an HTTP JSON RPC request.
     async fn execute(self: Arc<Self>, id: RequestId, request: Call) -> Result<Value, Web3Error> {
         let request = serde_json::to_string(&request)?;
-        log!(
-            self.log_level,
-            "[id:{}] sending request: '{}'",
-            id,
-            &request,
-        );
+        debug!("[id:{}] sending request: '{}'", id, &request,);
 
         let http_request = Request::post(&self.url)
             .header("Content-Type", "application/json")
             .body(request)
-            .map_err(|err| Web3Error::Transport(err.to_string()))?;
+            .map_err(transport_err)?;
         let mut response = self
             .client
             .send_async(http_request)
             .await
-            .map_err(|err| Web3Error::Transport(err.to_string()))?;
-        let body = response
-            .text()
-            .map_err(|err| Web3Error::Transport(err.to_string()))?;
+            .map_err(transport_err)?;
+        let body = response.text().map_err(transport_err)?;
 
         if !response.status().is_success() {
             warn!(
@@ -84,7 +72,7 @@ impl HttpTransportInner {
                 body.trim(),
             )));
         }
-        log!(self.log_level, "received response ID {}: '{}'", id, &body);
+        debug!("[id:{}] received response: '{}'", id, &body);
 
         let mut json = Value::from_str(&body)?;
         if let Some(map) = json.as_object_mut() {
@@ -123,4 +111,9 @@ impl Transport for HttpTransport {
     fn send(&self, id: RequestId, request: Call) -> Self::Out {
         self.0.clone().execute(id, request).boxed().compat()
     }
+}
+
+/// Error conversion method for wrapping an HTTP error in a `web3` error.
+fn transport_err(err: impl std::error::Error) -> Web3Error {
+    Web3Error::Transport(err.to_string())
 }

--- a/driver/src/transport.rs
+++ b/driver/src/transport.rs
@@ -121,7 +121,6 @@ impl Transport for HttpTransport {
     }
 
     fn send(&self, id: RequestId, request: Call) -> Self::Out {
-        let send = self.0.clone().execute(id, request);
-        send.boxed().compat()
+        self.0.clone().execute(id, request).boxed().compat()
     }
 }

--- a/driver/src/transport.rs
+++ b/driver/src/transport.rs
@@ -30,6 +30,8 @@ impl HttpTransport {
     pub fn new(url: impl Into<String>, timeout: Duration) -> Result<HttpTransport, DriverError> {
         let client = HttpClient::builder()
             .timeout(timeout)
+            // NOTE: This is needed as curl with try to upgrade to HTTP/2 which
+            //   causes a HTTP 400 error with Ganache.
             .version_negotiation(VersionNegotiation::http11())
             .build()?;
 
@@ -48,6 +50,8 @@ impl HttpTransportInner {
         debug!("[id:{}] sending request: '{}'", id, &request,);
 
         let http_request = Request::post(&self.url)
+            // NOTE: This is needed as Parity clients will respond with a HTTP
+            //   error when no content type is provided.
             .header("Content-Type", "application/json")
             .body(request)
             .map_err(transport_err)?;


### PR DESCRIPTION
Implements a custom HTTP transport with logging and a 10s timeout. Timeout can be made configurable and `eth_call` prometheus metrics can be added as well (in separate PRs :cactus:).

The custom HTTP transport was implemented because:
- better logging (we will be able to log the full response instead of just the result JSON / parsed error)
- allows us to work around the Ganache issue where immediately mined transactions that reverted were returning a result (with the Tx hash, as expected by the protocol) and an error
- allows us to use an HTTP client implementation's timeout functionality instead of rolling our own using timers (since there is no way to get access to the underlying HTTP client in the current transport implementation).

Closes #542 

### Test Plan

CI