### PR TITLE
Do not set block number when reading order book

### DIFF
--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::env;
 
 use ethcontract::transaction::GasPrice;
-use ethcontract::{Address as H160, BlockNumber, U256};
+use ethcontract::{Address as H160, U256};
 use lazy_static::lazy_static;
 #[cfg(test)]
 use mockall::automock;
@@ -52,7 +52,6 @@ pub trait StableXContract {
     /// between calls.
     fn get_auction_data_paginated(
         &self,
-        block: u64,
         page_size: u16,
         previous_page_user: H160,
         previous_page_user_offset: u16,
@@ -80,7 +79,6 @@ impl StableXContract for BatchExchange {
 
     fn get_auction_data_paginated(
         &self,
-        block: u64,
         page_size: u16,
         previous_page_user: H160,
         previous_page_user_offset: u16,
@@ -91,7 +89,6 @@ impl StableXContract for BatchExchange {
             page_size,
         );
         orders_builder.m.tx.gas = None;
-        orders_builder.block = Some(BlockNumber::Number(block.into()));
         orders_builder.call().wait().map_err(From::from)
     }
 

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -70,8 +70,7 @@ fn main() {
     let fee = Some(Fee::default());
     let mut price_finder = util::create_price_finder(fee, optimization_model);
 
-    let orderbook =
-        PaginatedStableXOrderBookReader::new(&contract, auction_data_page_size(), &web3);
+    let orderbook = PaginatedStableXOrderBookReader::new(&contract, auction_data_page_size());
     let parsed_filter = serde_json::from_str(&filter)
         .map_err(|e| {
             error!("Error parsing orderbook filter: {}", &e);

--- a/driver/src/orderbook/paginated_auction_data_reader.rs
+++ b/driver/src/orderbook/paginated_auction_data_reader.rs
@@ -110,10 +110,8 @@ impl PaginatedAuctionDataReader {
                 |x| {
                     if *x == 0 {
                         *x = element.sell_token_balance
-                    } else {
-                        assert_eq!(
-                            *x,
-                            element.sell_token_balance,
+                    } else if *x != element.sell_token_balance {
+                        log::warn!(
                             "got order which sets user {}'s sell token {} \
                              balance to {} but sell_token_balance has already \
                              been set to {}",
@@ -324,18 +322,5 @@ pub mod tests {
         assert_eq!(reader.orders, []);
         assert_eq!(reader.pagination.previous_page_user, ORDER_1.account_id);
         assert_eq!(reader.pagination.previous_page_user_offset, 2);
-    }
-
-    #[test]
-    #[should_panic]
-    fn paginated_auction_data_reader_panics() {
-        let mut reader = PaginatedAuctionDataReader::new(U256::from(3));
-        let mut bytes = Vec::new();
-        bytes.extend(ORDER_1_BYTES);
-        assert_eq!(reader.apply_page(&bytes), 1);
-        bytes[51] += 1;
-        // Incremented sell_token_balance which should cause a panic because it
-        // does not match the previous balance.
-        reader.apply_page(&bytes);
     }
 }


### PR DESCRIPTION
We are currently having an issue where the node does not support queries
with block numbers in the past because it is pruning the state.
Until we decide whether this is fixable on the node's side we decided to
remove the fixed block number. This can in theory lead to reading the
orderbook in an inconsisent state when two pages come from different
batches. If this happens then we already cannot solve the auction
because there is no time left seeing as the batch changed.
A consequence of this is that we previously had a panic in the page
reading code when we notice that despite fixing the block number there
is still an inconsistency. The panic has been turned into a warning.
We could instead keep the check and return an error instad of panicking
but this makes the code more convoluted and there can still be
inconsistencies we cannot detect like including orders that no longer
exist.

related to #544 