### PR TITLE
[Easy] Change e2e test to use same private key variable as the driver

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -15,7 +15,7 @@ cargo test -p e2e ganache -- --nocapture
 
 ```sh
 # T1:
-export PK=... # Some private key with Rinkeby OWL, DAI and ETH (for gas)
+export PRIVATE_KEY=... # Some private key with Rinkeby OWL, DAI and ETH (for gas)
 docker-compose down && docker-compose -f docker-compose.yml -f docker-compose.rinkeby.yml up stablex
 # T2:
 cargo test -p e2e rinkeby -- --nocapture

--- a/e2e/tests/stablex_test.rs
+++ b/e2e/tests/stablex_test.rs
@@ -104,7 +104,7 @@ fn test_rinkeby() {
     let mut instance =
         BatchExchange::deployed(&web3).wait_and_expect("Cannot get deployed Batch Exchange");
     let secret = {
-        let private_key = env::var("PK").expect("PK env var not set");
+        let private_key = env::var("PRIVATE_KEY").expect("PRIVATE_KEY env var not set");
         PrivateKey::from_hex_str(&private_key).expect("Cannot derive key")
     };
     let account = Account::Offline(secret, None);


### PR DESCRIPTION
The driver uses `PRIVATE_KEY` but the e2e tests use `PK`, switch to use the same environment variable as the driver.

### Test Plan

CI.