### PR TITLE
[Easy] Print failing request ID when we time out

### DIFF
--- a/driver/src/transport.rs
+++ b/driver/src/transport.rs
@@ -67,10 +67,10 @@ impl HttpTransportInner {
         let request = serde_json::to_string(&request)?;
         debug!("[id:{}] sending request: '{}'", id, &request,);
 
-        let (response, content) = self
-            .post_json(request)
-            .await
-            .map_err(|err| Web3Error::Transport(err.to_string()))?;
+        let (response, content) = self.post_json(request).await.map_err(|err| {
+            warn!("[id:{}] returned an error: '{}'", id, err.to_string());
+            Web3Error::Transport(err.to_string())
+        })?;
         if !response.status().is_success() {
             warn!(
                 "[id:{}] HTTP error code {}: '{}' {:?}",


### PR DESCRIPTION
Timeout errors currently show up like this:

> ERROR (pod: dev-dfusion-mainnet-fallback-solver-master-cc98769b8-djgr4): 
Feb 17 17:11:41.702 WARN [isahc::handler] request completed with error [id=AtomicCell { value: 0 }]: Timeout: request took longer than the configured timeout

Note, that id is not actually populated. This comes from the isahc repo https://github.com/sagebind/isahc/blob/eb2d1c04b60b2d1783e3e6d978c14a788459fd48/src/handler.rs and is likely a bug in their code (I wasn't able to figure it out at first glance and am a bit swamped to spend a lot of time reproducing).

This PR makes it so that we print a warning in our module which allows to surface the ID properly. We shouldn't be relying on external warnings anyways.

### Test Plan

- run the container
- disconnect from the internet
- see warning statements