### PR TITLE
First draft of fallback and standard solver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
         - cargo clippy --all --all-targets -- -D warnings
         - cargo fmt --all -- --check
         # Build and publish compact image with compiled binary
-        - docker build --tag stablex-binary --build-arg SOLVER_BASE=163030813197.dkr.ecr.us-east-1.amazonaws.com/dex-solver:v0.5.10 --build-arg RUST_BASE=rust-binary -f docker/rust/Dockerfile .
+        - docker build --tag stablex-binary --build-arg SOLVER_BASE=163030813197.dkr.ecr.us-east-1.amazonaws.com/dex-solver:v0.5.11 --build-arg RUST_BASE=rust-binary -f docker/rust/Dockerfile .
         # StableX e2e Tests (Ganache)
         - docker-compose -f docker-compose.yml -f docker-compose.binary.yml up -d stablex
         - cargo test -p e2e ganache -- --nocapture

--- a/common-mainnet.env
+++ b/common-mainnet.env
@@ -1,4 +1,4 @@
 ETHEREUM_NODE_URL=https://mainnet.infura.io/v3/9408f47dedf04716a03ef994182cf150
 NETWORK_NAME=mainnet
 NETWORK_ID=1
-OPTIMIZATION_MODEL=MIP
+SOLVER_TYPE=standard-solver

--- a/common-rinkeby.env
+++ b/common-rinkeby.env
@@ -1,4 +1,4 @@
 ETHEREUM_NODE_URL=https://node.rinkeby.gnosisdev.com/
 NETWORK_NAME=rinkeby
 NETWORK_ID=4
-OPTIMIZATION_MODEL=MIP
+SOLVER_TYPE=standard-solver

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -14,7 +14,7 @@ use crate::contracts::{stablex_contract::BatchExchange, web3_provider};
 use crate::driver::stablex_driver::StableXDriver;
 use crate::metrics::{MetricsServer, StableXMetrics};
 use crate::orderbook::{FilteredOrderbookReader, PaginatedStableXOrderBookReader};
-use crate::price_finding::price_finder_interface::OptimizationModel;
+use crate::price_finding::price_finder_interface::SolverType;
 use crate::price_finding::Fee;
 use crate::solution_submission::StableXSolutionSubmitter;
 
@@ -51,8 +51,8 @@ fn main() {
         .expect("NETWORK_ID env var not set");
 
     let optimization_model_string: String =
-        env::var("OPTIMIZATION_MODEL").unwrap_or_else(|_| String::from("NAIVE"));
-    let optimization_model = OptimizationModel::from(optimization_model_string.as_str());
+        env::var("SOLVER_TYPE").unwrap_or_else(|_| String::from("NaiveSolver"));
+    let optimization_model = SolverType::from(optimization_model_string.as_str());
 
     let web3 = web3_provider(&ethereum_node_url).unwrap();
     let contract = BatchExchange::new(&web3, network_id).unwrap();

--- a/driver/src/price_finding/mod.rs
+++ b/driver/src/price_finding/mod.rs
@@ -5,4 +5,4 @@ pub mod price_finder_interface;
 
 pub use crate::price_finding::naive_solver::NaiveSolver;
 pub use crate::price_finding::optimization_price_finder::OptimisationPriceFinder;
-pub use crate::price_finding::price_finder_interface::{Fee, OptimizationModel, PriceFinding};
+pub use crate::price_finding::price_finder_interface::{Fee, PriceFinding, SolverType};

--- a/driver/src/price_finding/optimization_price_finder.rs
+++ b/driver/src/price_finding/optimization_price_finder.rs
@@ -1,6 +1,6 @@
 use crate::models;
 use crate::price_finding::error::{ErrorKind, PriceFindingError};
-use crate::price_finding::price_finder_interface::{Fee, OptimizationModel, PriceFinding};
+use crate::price_finding::price_finder_interface::{Fee, PriceFinding, SolverType};
 
 use chrono::Utc;
 use ethcontract::Address as H160;
@@ -100,14 +100,14 @@ mod solver_input {
 pub struct OptimisationPriceFinder {
     // default IO methods can be replaced for unit testing
     write_input: fn(&str, &str) -> std::io::Result<()>,
-    run_solver: fn(&str, &str, OptimizationModel) -> Result<(), PriceFindingError>,
+    run_solver: fn(&str, &str, SolverType) -> Result<(), PriceFindingError>,
     read_output: fn(&str) -> std::io::Result<String>,
     fee: Option<Fee>,
-    optimization_model: OptimizationModel,
+    optimization_model: SolverType,
 }
 
 impl OptimisationPriceFinder {
-    pub fn new(fee: Option<Fee>, optimization_model: OptimizationModel) -> Self {
+    pub fn new(fee: Option<Fee>, optimization_model: SolverType) -> Self {
         create_dir_all("instances").expect("Could not create instance directory");
         OptimisationPriceFinder {
             write_input,
@@ -266,7 +266,7 @@ fn write_input(input_file: &str, input: &str) -> std::io::Result<()> {
 fn run_solver(
     input_file: &str,
     result_folder: &str,
-    optimization_model: OptimizationModel,
+    optimization_model: SolverType,
 ) -> Result<(), PriceFindingError> {
     let optimization_model_str = optimization_model.to_args();
     let output = Command::new("python")
@@ -588,7 +588,7 @@ pub mod tests {
             run_solver: |_, _, _| Ok(()),
             read_output: |_| Err(std::io::Error::last_os_error()),
             fee: Some(fee),
-            optimization_model: OptimizationModel::MIP,
+            optimization_model: SolverType::StandardSolver,
         };
         let orders = vec![];
         assert!(solver

--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -48,7 +48,9 @@ impl SolverType {
 
             // The fallback solver is also running --optModel=mip, as this is the default value
             // although it is not handed over in the next line
-            SolverType::FallbackSolver => &"--tokenInfo=scripts/e2e/token_info_mainnet.json",
+            SolverType::FallbackSolver => {
+                &"--tokenInfo=/app/batchauctions/scripts/e2e/token_info_mainnet.json"
+            }
             SolverType::NaiveSolver => {
                 panic!("OptimizationSolver should not be called with naive solver")
             }

--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -23,29 +23,33 @@ impl Default for Fee {
 }
 
 #[derive(Clone, Copy, PartialEq)]
-pub enum OptimizationModel {
-    NAIVE,
-    MIP,
-    NLP,
+pub enum SolverType {
+    NaiveSolver,
+    StandardSolver,
+    FallbackSolver,
 }
 
-impl From<&str> for OptimizationModel {
-    fn from(optimization_model_str: &str) -> OptimizationModel {
+impl From<&str> for SolverType {
+    fn from(optimization_model_str: &str) -> SolverType {
         match optimization_model_str.to_lowercase().as_str() {
-            "mip" => OptimizationModel::MIP,
-            "nlp" => OptimizationModel::NLP,
+            "standard-solver" => SolverType::StandardSolver,
+            "fallback-solver" => SolverType::FallbackSolver,
             // the naive solver is the standard solver.
-            _ => OptimizationModel::NAIVE,
+            _ => SolverType::NaiveSolver,
         }
     }
 }
 
-impl OptimizationModel {
+impl SolverType {
     pub fn to_args(self) -> &'static str {
         match self {
-            OptimizationModel::MIP => &"--optModel=mip",
-            OptimizationModel::NLP => &"--optModel=nlp",
-            OptimizationModel::NAIVE => {
+            SolverType::StandardSolver => &"--optModel=mip",
+            // TODO: Allow to hand over several args for the optimizer
+
+            // The fallback solver is also running --optModel=mip, as this is the default value
+            // although it is not handed over in the next line
+            SolverType::FallbackSolver => &"--tokenInfo=scripts/e2e/token_info_mainnet.json",
+            SolverType::NaiveSolver => {
                 panic!("OptimizationSolver should not be called with naive solver")
             }
         }

--- a/driver/src/util.rs
+++ b/driver/src/util.rs
@@ -2,9 +2,7 @@ use ethcontract::U256;
 use log::info;
 use std::future::Future;
 
-use crate::price_finding::{
-    Fee, NaiveSolver, OptimisationPriceFinder, OptimizationModel, PriceFinding,
-};
+use crate::price_finding::{Fee, NaiveSolver, OptimisationPriceFinder, PriceFinding, SolverType};
 
 pub trait CeiledDiv {
     fn ceiled_div(&self, divisor: Self) -> Self;
@@ -40,9 +38,9 @@ impl CheckedConvertU128 for U256 {
 
 pub fn create_price_finder(
     fee: Option<Fee>,
-    optimization_model: OptimizationModel,
+    optimization_model: SolverType,
 ) -> Box<dyn PriceFinding> {
-    if optimization_model == OptimizationModel::NAIVE {
+    if optimization_model == SolverType::NaiveSolver {
         info!("Using naive price finder");
         Box::new(NaiveSolver::new(fee))
     } else {


### PR DESCRIPTION
The current choices between the optimization models MIP and NLP are not good, as the benchmarks have shown that NLP kind of always underperforms MIP.

This PR implements a real fallback solver: which uses as well the MIP and price feed queried by the solver.
Later on, we will use the query price feeds from the driver, this is really just an intermediate step for the trading challenge this evening.

The PR https://gitlab.gnosisdev.com/devops/gnosis-staging/merge_requests/181
does the necessary changes in the deployment configs 

---
testplan:
```
T1: docker-compose build --build-arg SOLVER_BASE=163030813197.dkr.ecr.us-east-1.amazonaws.com/dex-solver:v0.5.11 stablex
```
put SOLVER_TYPE=fallback-solver into common.env
```
docker-compose up stablex

T2: cargo test -p e2e ganache -- --nocapture
```
Check that a solution is provided.


PS: pricefeed work currently only for mainnet in dex-solver.