### PR TITLE
[Easy] Remove `Error::description`

### DIFF
--- a/driver/src/error.rs
+++ b/driver/src/error.rs
@@ -21,13 +21,13 @@ pub enum ErrorKind {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct DriverError {
-    details: String,
+    pub details: String,
     pub kind: ErrorKind,
 }
 
 impl From<std::io::Error> for DriverError {
     fn from(error: std::io::Error) -> Self {
-        DriverError::new(error.description(), ErrorKind::IoError)
+        DriverError::new(error, ErrorKind::IoError)
     }
 }
 
@@ -39,25 +39,25 @@ impl From<ethcontract::web3::Error> for DriverError {
 
 impl From<serde_json::Error> for DriverError {
     fn from(error: serde_json::Error) -> Self {
-        DriverError::new(error.description(), ErrorKind::JsonError)
+        DriverError::new(error, ErrorKind::JsonError)
     }
 }
 
 impl From<rustc_hex::FromHexError> for DriverError {
     fn from(error: rustc_hex::FromHexError) -> Self {
-        DriverError::new(error.description(), ErrorKind::HexError)
+        DriverError::new(error, ErrorKind::HexError)
     }
 }
 
 impl From<std::env::VarError> for DriverError {
     fn from(error: std::env::VarError) -> Self {
-        DriverError::new(error.description(), ErrorKind::EnvError)
+        DriverError::new(error, ErrorKind::EnvError)
     }
 }
 
 impl From<std::num::ParseIntError> for DriverError {
     fn from(error: std::num::ParseIntError) -> Self {
-        DriverError::new(error.description(), ErrorKind::ParseIntError)
+        DriverError::new(error, ErrorKind::ParseIntError)
     }
 }
 
@@ -69,36 +69,36 @@ impl From<&str> for DriverError {
 
 impl From<PriceFindingError> for DriverError {
     fn from(error: PriceFindingError) -> Self {
-        DriverError::new(&format!("{}", error), ErrorKind::PriceFindingError)
+        DriverError::new(format!("{}", error), ErrorKind::PriceFindingError)
     }
 }
 
 impl From<ethcontract::errors::InvalidPrivateKey> for DriverError {
     fn from(error: ethcontract::errors::InvalidPrivateKey) -> Self {
-        DriverError::new(&error.to_string(), ErrorKind::PrivateKeyError)
+        DriverError::new(error, ErrorKind::PrivateKeyError)
     }
 }
 
 impl From<ethcontract::errors::DeployError> for DriverError {
     fn from(error: ethcontract::errors::DeployError) -> Self {
-        DriverError::new(&error.to_string(), ErrorKind::ContractDeployedError)
+        DriverError::new(error, ErrorKind::ContractDeployedError)
     }
 }
 
 impl From<ethcontract::errors::MethodError> for DriverError {
     fn from(error: ethcontract::errors::MethodError) -> Self {
-        DriverError::new(&error.to_string(), ErrorKind::ContractMethodError)
+        DriverError::new(error, ErrorKind::ContractMethodError)
     }
 }
 
 impl From<isahc::Error> for DriverError {
     fn from(error: isahc::Error) -> Self {
-        DriverError::new(&error.to_string(), ErrorKind::HttpError)
+        DriverError::new(error, ErrorKind::HttpError)
     }
 }
 
 impl DriverError {
-    pub fn new(msg: &str, kind: ErrorKind) -> DriverError {
+    pub fn new(msg: impl ToString, kind: ErrorKind) -> DriverError {
         DriverError {
             details: msg.to_string(),
             kind,
@@ -112,8 +112,4 @@ impl fmt::Display for DriverError {
     }
 }
 
-impl Error for DriverError {
-    fn description(&self) -> &str {
-        &self.details
-    }
-}
+impl Error for DriverError {}

--- a/driver/src/price_finding/error.rs
+++ b/driver/src/price_finding/error.rs
@@ -12,23 +12,23 @@ pub enum ErrorKind {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PriceFindingError {
-    details: String,
+    pub details: String,
     pub kind: ErrorKind,
 }
 
 impl From<std::io::Error> for PriceFindingError {
     fn from(error: std::io::Error) -> Self {
-        PriceFindingError::new(error.description(), ErrorKind::IoError)
+        PriceFindingError::new(error, ErrorKind::IoError)
     }
 }
 impl From<serde_json::Error> for PriceFindingError {
     fn from(error: serde_json::Error) -> Self {
-        PriceFindingError::new(error.description(), ErrorKind::JsonError)
+        PriceFindingError::new(error, ErrorKind::JsonError)
     }
 }
 impl From<std::num::ParseIntError> for PriceFindingError {
     fn from(error: std::num::ParseIntError) -> Self {
-        PriceFindingError::new(error.description(), ErrorKind::ParseIntError)
+        PriceFindingError::new(error, ErrorKind::ParseIntError)
     }
 }
 impl From<&str> for PriceFindingError {
@@ -38,7 +38,7 @@ impl From<&str> for PriceFindingError {
 }
 
 impl PriceFindingError {
-    pub fn new(msg: &str, kind: ErrorKind) -> PriceFindingError {
+    pub fn new(msg: impl ToString, kind: ErrorKind) -> PriceFindingError {
         PriceFindingError {
             details: msg.to_string(),
             kind,
@@ -50,8 +50,4 @@ impl fmt::Display for PriceFindingError {
         write!(f, "{}", self.details)
     }
 }
-impl Error for PriceFindingError {
-    fn description(&self) -> &str {
-        &self.details
-    }
-}
+impl Error for PriceFindingError {}

--- a/driver/src/price_finding/optimization_price_finder.rs
+++ b/driver/src/price_finding/optimization_price_finder.rs
@@ -184,7 +184,7 @@ fn parse_token(key: &str) -> Result<u16, PriceFindingError> {
     if key.starts_with('T') {
         return key[1..].parse::<u16>().map_err(|err| {
             PriceFindingError::new(
-                format!("Failed to parse token id: {}", err).as_ref(),
+                format!("Failed to parse token id: {}", err),
                 ErrorKind::ParseIntError,
             )
         });
@@ -306,7 +306,6 @@ pub mod tests {
     use crate::util::test_util::map_from_slice;
     use ethcontract::{H256, U256};
     use serde_json::json;
-    use std::error::Error;
 
     #[test]
     fn test_parse_prices() {
@@ -409,7 +408,7 @@ pub mod tests {
             },
         });
         let err = deserialize_result(json.to_string()).expect_err("Should fail to parse");
-        assert_eq!(err.description(), "Token keys expected to start with \"T\"");
+        assert_eq!(err.details, "Token keys expected to start with \"T\"");
 
         let json = json!({
             "orders": [],
@@ -419,7 +418,7 @@ pub mod tests {
         });
         let err = deserialize_result(json.to_string()).expect_err("Should fail to parse");
         assert_eq!(
-            err.description(),
+            err.details,
             "Failed to parse token id: invalid digit found in string"
         );
 
@@ -431,7 +430,7 @@ pub mod tests {
         });
         let err = deserialize_result(json.to_string()).expect_err("Should fail to parse");
         assert_eq!(
-            err.description(),
+            err.to_string(),
             "Failed to parse token id: number too large to fit in target type"
         );
     }


### PR DESCRIPTION
`Error::description` is soft-deprecated as per the standard docs:https://doc.rust-lang.org/std/error/trait.Error.html#method.description. This PR removes all references to it.

### Test Plan

CI