### PR TITLE
Implement a Kraken price source for tokens.

### DIFF
--- a/driver/src/price_estimation/kraken.rs
+++ b/driver/src/price_estimation/kraken.rs
@@ -175,7 +175,7 @@ mod tests {
         // to and the values are unpredictable. To run this test and output the
         // retrieved price estimates:
         // ```
-        // cargo test get_real_token_prices -- --ignored --nocapture
+        // cargo test online_kraken_prices -- --ignored --nocapture
         // ```
 
         let tokens = vec![

--- a/driver/src/price_estimation/kraken.rs
+++ b/driver/src/price_estimation/kraken.rs
@@ -14,9 +14,6 @@ pub struct KrakenClient<Api> {
     api: Api,
 }
 
-/// The default Kraken API base URL.
-const DEFAULT_API_BASE_URL: &str = "https://api.kraken.com/0/public";
-
 impl KrakenClient<KrakenHttpApi> {
     /// Creates a new client instance using an HTTP API instance and the default
     /// Kraken API base URL.

--- a/driver/src/price_estimation/kraken.rs
+++ b/driver/src/price_estimation/kraken.rs
@@ -1,4 +1,203 @@
 //! Implementation of a price source for Kraken.
 
-#[allow(dead_code)]
 mod api;
+
+use self::api::{Asset, AssetPair, KrakenApi, KrakenHttpApi};
+use super::{PriceSource, Token, TokenId};
+use anyhow::{anyhow, Context, Result};
+use std::collections::HashMap;
+
+/// A client to the Kraken exchange.
+pub struct KrakenClient<Api> {
+    /// A Kraken API implementation. This allows for mocked Kraken APIs to be
+    /// used for testing.
+    api: Api,
+}
+
+/// The default Kraken API base URL.
+const DEFAULT_API_BASE_URL: &str = "https://api.kraken.com/0/public";
+
+impl KrakenClient<KrakenHttpApi> {
+    /// Creates a new client instance using an HTTP API instance and the default
+    /// Kraken API base URL.
+    pub fn new() -> Result<Self> {
+        let api = KrakenHttpApi::new()?;
+        Ok(KrakenClient::with_api(api))
+    }
+}
+
+impl<Api> KrakenClient<Api>
+where
+    Api: KrakenApi,
+{
+    /// Create a new client instance from an API.
+    pub fn with_api(api: Api) -> Self {
+        KrakenClient { api }
+    }
+
+    /// Generates a mapping between Kraken asset pair identifiers and tokens
+    /// that are used when computing the price map.
+    fn get_token_asset_pairs<'a>(&self, tokens: &'a [Token]) -> Result<HashMap<String, &'a Token>> {
+        // TODO(nlordell): If these calls start taking too long, we can consider
+        //   caching this information somehow. The only thing that is
+        //   complicated is determining when the cache needs to be invalidated
+        //   as new assets get added to Kraken.
+
+        let assets = self.api.assets()?;
+        let asset_pairs = self.api.asset_pairs()?;
+
+        let usd =
+            find_asset("USD", &assets).ok_or_else(|| anyhow!("unable to locate USD asset"))?;
+
+        let token_assets = tokens
+            .iter()
+            .flat_map(|token| {
+                let asset = find_asset(&token.symbol, &assets)?;
+                let pair = find_asset_pair(asset, usd, &asset_pairs)?;
+                Some((pair.to_owned(), token))
+            })
+            .collect();
+
+        Ok(token_assets)
+    }
+}
+
+impl<Api> PriceSource for KrakenClient<Api>
+where
+    Api: KrakenApi,
+{
+    fn get_prices(&self, tokens: &[Token]) -> Result<HashMap<TokenId, u128>> {
+        let token_asset_pairs = self
+            .get_token_asset_pairs(tokens)
+            .context("failed to generate asset pairs mapping for tokens")?;
+
+        let asset_pairs: Vec<_> = token_asset_pairs.keys().map(String::as_str).collect();
+        let ticker_infos = self.api.ticker(&asset_pairs)?;
+
+        let prices = ticker_infos
+            .iter()
+            .flat_map(|(pair, info)| {
+                let token = token_asset_pairs.get(pair)?;
+                let price = token.get_owl_price(info.p.last_24h());
+
+                Some((token.id, price))
+            })
+            .collect();
+
+        Ok(prices)
+    }
+}
+
+/// Finds the Kraken asset identifier given a token symbol.
+fn find_asset<'a>(symbol: &'a str, assets: &'a HashMap<String, Asset>) -> Option<&'a str> {
+    if assets.contains_key(symbol) {
+        Some(symbol)
+    } else if let Some((asset_name, _)) = assets.iter().find(|(_, asset)| asset.altname == symbol) {
+        Some(asset_name)
+    } else {
+        None
+    }
+}
+
+/// Finds an asset pair from two Kraken asset identifiers.
+fn find_asset_pair<'a>(
+    asset: &str,
+    to: &str,
+    asset_pairs: &'a HashMap<String, AssetPair>,
+) -> Option<&'a str> {
+    let (pair_name, _) = asset_pairs
+        .iter()
+        // NOTE: Filter out pairs ending in ".d" as they dont' seem to work for
+        //   retrieving ticker info.
+        .filter(|&(name, _)| !name.ends_with(".d"))
+        .find(|&(_, pair)| pair.base == asset && pair.quote == to)?;
+
+    Some(pair_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::api::{MockKrakenApi, TickerInfo};
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn get_token_prices() {
+        let tokens = vec![
+            Token::test(1, "ETH", 18),
+            Token::test(4, "USDC", 6),
+            Token::test(5, "PAX", 18),
+        ];
+
+        let mut api = MockKrakenApi::new();
+        api.expect_assets().returning(|| {
+            Ok(hash_map! {
+                "USDC" => Asset::new("USDC"),
+                "XETH" => Asset::new("ETH"),
+                "ZUSD" => Asset::new("USD"),
+            })
+        });
+        api.expect_asset_pairs().returning(|| {
+            Ok(hash_map! {
+                "USDCUSD" => AssetPair::new("USDC", "ZUSD"),
+                "XETHZUSD" => AssetPair::new("XETH", "ZUSD"),
+            })
+        });
+        api.expect_ticker()
+            .withf(|pairs| {
+                let unordered_pairs: HashSet<_> = pairs.iter().collect();
+                unordered_pairs == ["USDCUSD", "XETHZUSD"].iter().collect()
+            })
+            .returning(|_| {
+                Ok(hash_map! {
+                    "USDCUSD" => TickerInfo::new(1.0, 1.01),
+                    "XETHZUSD" => TickerInfo::new(100.0, 99.0),
+                })
+            });
+
+        let client = KrakenClient::with_api(api);
+        let prices = client.get_prices(&tokens).unwrap();
+
+        assert_eq!(
+            prices,
+            hash_map! {
+                TokenId(1) => (99.0 * 10f64.powi(18)) as u128,
+                TokenId(4) => (1.01 * 10f64.powi(30)) as u128,
+            }
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn online_kraken_prices() {
+        // Retrieve real token prices from Kraken, this test is ignored by
+        // default as there is no way to guarantee the service can be connected
+        // to and the values are unpredictable. To run this test and output the
+        // retrieved price estimates:
+        // ```
+        // cargo test get_real_token_prices -- --ignored --nocapture
+        // ```
+
+        let tokens = vec![
+            Token::test(1, "ETH", 18),
+            Token::test(2, "USDT", 6),
+            Token::test(3, "TUSD", 18),
+            Token::test(4, "USDC", 6),
+            Token::test(5, "PAX", 18),
+            Token::test(6, "GUSD", 2),
+            Token::test(7, "DAI", 18),
+            Token::test(8, "sETH", 18),
+            Token::test(9, "sUSD", 18),
+            Token::test(15, "SNX", 18),
+        ];
+
+        let client = KrakenClient::new().unwrap();
+        let prices = client.get_prices(&tokens).unwrap();
+
+        println!("{:#?}", prices);
+        assert!(
+            prices.contains_key(&TokenId(1)),
+            "expected ETH price to be found"
+        );
+    }
+}

--- a/driver/src/price_estimation/mod.rs
+++ b/driver/src/price_estimation/mod.rs
@@ -1,4 +1,71 @@
 //! Module responsible for aggregating price estimates from various sources to
 //! give good price estimates to the solver for better results.
 
+#[allow(dead_code)]
 mod kraken;
+
+pub use crate::price_finding::TokenId;
+use anyhow::Result;
+use ethcontract::H160;
+use std::collections::HashMap;
+
+/// A token reprensentation.
+///
+/// This is a duplicate definition of `TokenInfo` and will be removed once #556
+/// is merged.
+#[cfg_attr(test, derive(Eq, PartialEq))]
+#[derive(Clone, Debug)]
+struct Token {
+    id: TokenId,
+    address: H160,
+    symbol: String,
+    decimals: u8,
+}
+
+impl Token {
+    /// Converts the prices from USD into the unit expected by the contract.
+    /// This price is relative to the OWL token which is considered pegged at
+    /// exactly 1 USD with 18 decimals.
+    fn get_owl_price(&self, usd_price: f64) -> u128 {
+        let pow = 36 - (self.decimals as i32);
+        (usd_price * 10f64.powi(pow)) as _
+    }
+
+    /// Creates a new token with a fictional address for testing.
+    #[cfg(test)]
+    fn test(index: u16, symbol: &str, decimals: u8) -> Token {
+        Token {
+            id: TokenId(index),
+            address: H160::repeat_byte(index as _),
+            symbol: symbol.into(),
+            decimals,
+        }
+    }
+}
+
+/// An abstraction around a type that retrieves price estimate from a source
+/// such as an exchange.
+#[cfg_attr(test, mockall::automock)]
+trait PriceSource {
+    /// Retrieve current prices for the current tokens. Returns a sparce price
+    /// array as being unable to find a price is not considered an error.
+    fn get_prices(&self, tokens: &[Token]) -> Result<HashMap<TokenId, u128>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_get_price() {
+        for (token, usd_price, expected) in &[
+            (Token::test(4, "USDC", 6), 0.99, 0.99 * 10f64.powi(30)),
+            (Token::test(7, "DAI", 18), 1.01, 1.01 * 10f64.powi(18)),
+            (Token::test(42, "FAKE", 32), 1.0, 10f64.powi(4)),
+            (Token::test(99, "SCAM", 42), 10f64.powi(10), 10f64.powi(4)),
+        ] {
+            let owl_price = token.get_owl_price(*usd_price);
+            assert_eq!(owl_price, *expected as u128);
+        }
+    }
+}

--- a/driver/src/price_estimation/mod.rs
+++ b/driver/src/price_estimation/mod.rs
@@ -47,8 +47,10 @@ impl Token {
 /// such as an exchange.
 #[cfg_attr(test, mockall::automock)]
 trait PriceSource {
-    /// Retrieve current prices for the current tokens. Returns a sparce price
-    /// array as being unable to find a price is not considered an error.
+    /// Retrieve current prices relative to the OWL token for the specified
+    /// tokens. The OWL token is peged at 1 USD with 18 decimals. Returns a
+    /// sparce price array as being unable to find a price is not considered an
+    /// error.
     fn get_prices(&self, tokens: &[Token]) -> Result<HashMap<TokenId, u128>>;
 }
 

--- a/driver/src/price_finding/mod.rs
+++ b/driver/src/price_finding/mod.rs
@@ -4,5 +4,5 @@ pub mod optimization_price_finder;
 pub mod price_finder_interface;
 
 pub use crate::price_finding::naive_solver::NaiveSolver;
-pub use crate::price_finding::optimization_price_finder::OptimisationPriceFinder;
+pub use crate::price_finding::optimization_price_finder::{OptimisationPriceFinder, TokenId};
 pub use crate::price_finding::price_finder_interface::{Fee, PriceFinding, SolverType};


### PR DESCRIPTION
This PR uses the Kraken API implemented in #562 in order to retrieve prices from a list of token infos.

### Test Plan

New unit tests. Also, a test that does not run by default is included and can be run by:
```
cargo test online_kraken_prices -- --ignored --nocapture
```