### PR TITLE
Implement ERC20 token reading

### DIFF
--- a/driver/build.rs
+++ b/driver/build.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 fn main() {
     generate_contract("BatchExchange", "batch_exchange.rs");
+    generate_contract("ERC20Detailed", "erc20_detailed.rs");
 }
 
 fn generate_contract(name: &str, out: &str) {

--- a/driver/src/contracts/erc20.rs
+++ b/driver/src/contracts/erc20.rs
@@ -1,0 +1,63 @@
+//! This module implements the ERC20 smart contract interface as well a trait
+//! and implementation to read it from the block chain.
+
+use super::Web3;
+use crate::models::TokenInfo;
+use crate::util::FutureWaitExt;
+use anyhow::Result;
+use ethcontract::H160;
+use lazy_static::lazy_static;
+use std::collections::HashMap;
+
+/// Trait for reading ERC20 token information from the block chain.
+#[cfg_attr(test, mockall::automock)]
+pub trait TokenReading {
+    /// Retrieve token information by address.
+    fn read_token_info(&self, token_address: H160) -> Result<TokenInfo>;
+}
+
+include!(concat!(env!("OUT_DIR"), "/erc20_detailed.rs"));
+
+/// Web3 `TokenReading` implementation.
+pub struct TokenReader {
+    web3: Web3,
+}
+
+impl TokenReader {
+    /// Create a new token reader from a web3 instnace.
+    #[allow(dead_code)]
+    pub fn new(web3: Web3) -> Self {
+        TokenReader { web3 }
+    }
+}
+
+lazy_static! {
+    static ref SYMBOL_OVERRIDES: HashMap<String, String> = hash_map! {
+        "WETH" => "ETH".to_owned(),
+    };
+}
+
+impl TokenReading for TokenReader {
+    /// Retrieve token information by address.
+    fn read_token_info(&self, token_address: H160) -> Result<TokenInfo> {
+        let erc20 = ERC20Detailed::at(&self.web3, token_address);
+        let alias = {
+            // NOTE: We check if the symbol is part of the overrides map, and
+            //   use the overridden value if it is. This allows ERC20 tokens
+            //   like WETH to be treated by ETH, since exchanges generally only
+            //   track ETH prices and not WETH.
+            let symbol = erc20.symbol().call().wait()?;
+            SYMBOL_OVERRIDES
+                .get(&symbol)
+                .map(|s| s.to_owned())
+                .unwrap_or(symbol)
+        };
+        let decimals = erc20.decimals().call().wait()?;
+
+        Ok(TokenInfo {
+            alias,
+            decimals,
+            external_price: 0,
+        })
+    }
+}

--- a/driver/src/contracts/erc20.rs
+++ b/driver/src/contracts/erc20.rs
@@ -7,7 +7,6 @@ use crate::util::FutureWaitExt;
 use anyhow::Result;
 use ethcontract::H160;
 use lazy_static::lazy_static;
-use std::collections::HashMap;
 
 /// Trait for reading ERC20 token information from the block chain.
 #[cfg_attr(test, mockall::automock)]
@@ -31,33 +30,17 @@ impl TokenReader {
     }
 }
 
-lazy_static! {
-    static ref SYMBOL_OVERRIDES: HashMap<String, String> = hash_map! {
-        "WETH" => "ETH".to_owned(),
-    };
-}
-
 impl TokenReading for TokenReader {
     /// Retrieve token information by address.
     fn read_token_info(&self, token_address: H160) -> Result<TokenInfo> {
         let erc20 = ERC20Detailed::at(&self.web3, token_address);
-        let alias = {
-            // NOTE: We check if the symbol is part of the overrides map, and
-            //   use the overridden value if it is. This allows ERC20 tokens
-            //   like WETH to be treated by ETH, since exchanges generally only
-            //   track ETH prices and not WETH.
-            let symbol = erc20.symbol().call().wait()?;
-            SYMBOL_OVERRIDES
-                .get(&symbol)
-                .map(|s| s.to_owned())
-                .unwrap_or(symbol)
-        };
+        let alias = erc20.symbol().call().wait()?;
         let decimals = erc20.decimals().call().wait()?;
 
         Ok(TokenInfo {
             alias,
             decimals,
-            external_price: 0,
+            external_price: None,
         })
     }
 }

--- a/driver/src/contracts/mod.rs
+++ b/driver/src/contracts/mod.rs
@@ -1,3 +1,4 @@
+pub mod erc20;
 pub mod stablex_auction_element;
 pub mod stablex_contract;
 

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -62,7 +62,7 @@ impl<'a> StableXContractImpl<'a> {
 #[cfg_attr(test, automock)]
 pub trait StableXContract {
     /// Retrieve the address of a token by ID.
-    fn get_token_address(&self, id: u16) -> Result<H160>;
+    fn get_token_address(&self, id: u16) -> Result<Address>;
 
     fn get_current_auction_index(&self) -> Result<U256>;
 
@@ -94,7 +94,7 @@ pub trait StableXContract {
 }
 
 impl<'a> StableXContract for StableXContractImpl<'a> {
-    fn get_token_address(&self, id: u16) -> Result<H160> {
+    fn get_token_address(&self, id: u16) -> Result<Address> {
         let address = self.instance.token_id_to_address_map(id).call().wait()?;
         Ok(address)
     }

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -61,7 +61,11 @@ impl<'a> StableXContractImpl<'a> {
 
 #[cfg_attr(test, automock)]
 pub trait StableXContract {
+    /// Retrieve the address of a token by ID.
+    fn get_token_address(&self, id: u16) -> Result<H160>;
+
     fn get_current_auction_index(&self) -> Result<U256>;
+
     /// Retrieve one page of auction data.
     /// `block` is needed because the state of the smart contract could change
     /// between blocks which would make the returned auction data inconsistent
@@ -72,12 +76,14 @@ pub trait StableXContract {
         previous_page_user: Address,
         previous_page_user_offset: u16,
     ) -> Result<Vec<u8>>;
+
     fn get_solution_objective_value(
         &self,
         batch_index: U256,
         orders: Vec<Order>,
         solution: Solution,
     ) -> Result<U256>;
+
     fn submit_solution(
         &self,
         batch_index: U256,
@@ -88,6 +94,11 @@ pub trait StableXContract {
 }
 
 impl<'a> StableXContract for StableXContractImpl<'a> {
+    fn get_token_address(&self, id: u16) -> Result<H160> {
+        let address = self.instance.token_id_to_address_map(id).call().wait()?;
+        Ok(address)
+    }
+
     fn get_current_auction_index(&self) -> Result<U256> {
         let auction_index = self.instance.get_current_batch_id().call().wait()?;
         Ok(auction_index.into())

--- a/driver/src/macros.rs
+++ b/driver/src/macros.rs
@@ -1,12 +1,27 @@
 //! Module containing utility macros for sharing in the crate.
 
-/// Macro for instanciating a `HashMap`. Note that `ToOwned::to_owned` is called
-/// for keys, so things like `str` keys atomatically get turned into `String`s.
-#[cfg(test)]
+/// Macro for instanciating a `HashMap`.
 macro_rules! hash_map {
-    ($( $key:expr => $value:expr ),* $(,)?) => {{
+    ($($tt:tt)*) => {
+        std_map!(<HashMap> $($tt)*)
+    }
+}
+
+/// Macro for instanciating a `BTreeMap`.
+#[cfg(test)]
+macro_rules! btree_map {
+    ($($tt:tt)*) => {
+        std_map!(<BTreeMap> $($tt)*)
+    }
+}
+
+/// Implementation macro for instanciating a standard library map type like
+/// `HashMap` or `BTreeMap`. Note that `ToOwned::to_owned` is called for keys,
+/// so things like `str` keys atomatically get turned into `String`s.
+macro_rules! std_map {
+    (<$t:ident> $( $key:expr => $value:expr ),* $(,)?) => {{
         #[allow(unused_mut)]
-        let mut map = std::collections::HashMap::new();
+        let mut map = std::collections::$t::new();
         $(
             map.insert(($key).to_owned(), $value);
         )*

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -20,6 +20,7 @@ use crate::gas_station::GnosisSafeGasStation;
 use crate::metrics::{MetricsServer, StableXMetrics};
 use crate::models::TokenData;
 use crate::orderbook::{FilteredOrderbookReader, OrderbookFilter, PaginatedStableXOrderBookReader};
+use crate::price_estimation::PriceOracle;
 use crate::price_finding::price_finder_interface::SolverType;
 use crate::price_finding::Fee;
 use crate::solution_submission::StableXSolutionSubmitter;
@@ -131,8 +132,9 @@ fn main() {
     });
 
     let fee = Some(Fee::default());
+    let price_oracle = PriceOracle::new(options.backup_token_data).unwrap();
     let mut price_finder =
-        util::create_price_finder(fee, options.solver_type, options.backup_token_data);
+        price_finding::create_price_finder(fee, options.solver_type, price_oracle);
 
     let orderbook = PaginatedStableXOrderBookReader::new(&contract, options.auction_data_page_size);
     info!("Orderbook filter: {:?}", options.orderbook_filter);

--- a/driver/src/models/order.rs
+++ b/driver/src/models/order.rs
@@ -12,6 +12,21 @@ pub struct Order {
     pub sell_amount: u128,
 }
 
+impl Order {
+    /// Creates a fake order in between a token pair for unit testing.
+    #[cfg(test)]
+    pub fn for_token_pair(buy_token: u16, sell_token: u16) -> Self {
+        Order {
+            id: 0,
+            account_id: Address::repeat_byte(0x42),
+            buy_token,
+            sell_token,
+            buy_amount: 1_000_000_000_000_000_000,
+            sell_amount: 1_000_000_000_000_000_000,
+        }
+    }
+}
+
 #[cfg(test)]
 pub mod test_util {
     use super::*;

--- a/driver/src/models/tokens.rs
+++ b/driver/src/models/tokens.rs
@@ -60,13 +60,13 @@ impl From<u16> for TokenId {
 pub struct TokenInfo {
     pub alias: String,
     pub decimals: u8,
-    pub external_price: u128,
+    pub external_price: Option<u128>,
 }
 
 impl TokenInfo {
     /// Utility method for creating a token for unit tests.
     #[cfg(test)]
-    pub fn test(alias: &str, decimals: u8, external_price: u128) -> Self {
+    pub fn test(alias: &str, decimals: u8, external_price: Option<u128>) -> Self {
         TokenInfo {
             alias: alias.into(),
             decimals,

--- a/driver/src/models/tokens.rs
+++ b/driver/src/models/tokens.rs
@@ -64,13 +64,17 @@ pub struct TokenInfo {
 }
 
 impl TokenInfo {
-    /// Utility method for creating a token for unit tests.
+    /// Creates a new token from the specified parameters.
     #[cfg(test)]
-    pub fn test(alias: &str, decimals: u8, external_price: Option<u128>) -> Self {
+    pub fn new(
+        alias: impl Into<String>,
+        decimals: u8,
+        external_price: impl Into<Option<u128>>,
+    ) -> Self {
         TokenInfo {
             alias: alias.into(),
             decimals,
-            external_price,
+            external_price: external_price.into(),
         }
     }
 }
@@ -83,10 +87,10 @@ impl TokenData {
     pub fn info(&self, id: impl Into<TokenId>) -> Option<&TokenInfo> {
         self.0.get(&id.into())
     }
+}
 
-    /// Utility method for creating a token for unit tests.
-    #[cfg(test)]
-    pub fn test(tokens: HashMap<TokenId, TokenInfo>) -> Self {
+impl From<HashMap<TokenId, TokenInfo>> for TokenData {
+    fn from(tokens: HashMap<TokenId, TokenInfo>) -> Self {
         TokenData(tokens)
     }
 }

--- a/driver/src/models/tokens.rs
+++ b/driver/src/models/tokens.rs
@@ -64,9 +64,9 @@ pub struct TokenInfo {
 }
 
 impl TokenInfo {
-    /// Utility method for creating a token for unit tests.
+    /// Create new token information from its parameters.
     #[cfg(test)]
-    pub fn test(alias: &str, decimals: u8, external_price: u128) -> Self {
+    pub fn new(alias: impl Into<String>, decimals: u8, external_price: u128) -> Self {
         TokenInfo {
             alias: alias.into(),
             decimals,
@@ -83,10 +83,10 @@ impl TokenData {
     pub fn info(&self, id: impl Into<TokenId>) -> Option<&TokenInfo> {
         self.0.get(&id.into())
     }
+}
 
-    /// Utility method for creating a token for unit tests.
-    #[cfg(test)]
-    pub fn test(tokens: HashMap<TokenId, TokenInfo>) -> Self {
+impl From<HashMap<TokenId, TokenInfo>> for TokenData {
+    fn from(tokens: HashMap<TokenId, TokenInfo>) -> Self {
         TokenData(tokens)
     }
 }

--- a/driver/src/models/tokens.rs
+++ b/driver/src/models/tokens.rs
@@ -12,6 +12,13 @@ use std::str::FromStr;
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialOrd, PartialEq)]
 pub struct TokenId(pub u16);
 
+impl TokenId {
+    /// Returns the token ID of the fee token.
+    pub fn reference() -> Self {
+        TokenId(0)
+    }
+}
+
 impl<'de> Deserialize<'de> for TokenId {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -68,7 +75,7 @@ impl TokenInfo {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct TokenData(HashMap<TokenId, TokenInfo>);
 
 impl TokenData {

--- a/driver/src/price_estimation/kraken.rs
+++ b/driver/src/price_estimation/kraken.rs
@@ -49,7 +49,8 @@ where
 
         let token_assets = tokens
             .iter()
-            .flat_map(|token| {
+            .filter(|token| !token.symbol().is_empty())
+            .filter_map(|token| {
                 let asset = find_asset(&token.symbol(), &assets)?;
                 let pair = find_asset_pair(asset, usd, &asset_pairs)?;
                 Some((pair.to_owned(), token))
@@ -122,9 +123,9 @@ mod tests {
     #[test]
     fn get_token_prices() {
         let tokens = vec![
-            Token::test(1, "ETH", 18),
-            Token::test(4, "USDC", 6),
-            Token::test(5, "PAX", 18),
+            Token::test(1, "ETH", 18, None),
+            Token::test(4, "USDC", 6, None),
+            Token::test(5, "PAX", 18, None),
         ];
 
         let mut api = MockKrakenApi::new();
@@ -177,16 +178,16 @@ mod tests {
         // ```
 
         let tokens = vec![
-            Token::test(1, "WETH", 18),
-            Token::test(2, "USDT", 6),
-            Token::test(3, "TUSD", 18),
-            Token::test(4, "USDC", 6),
-            Token::test(5, "PAX", 18),
-            Token::test(6, "GUSD", 2),
-            Token::test(7, "DAI", 18),
-            Token::test(8, "sETH", 18),
-            Token::test(9, "sUSD", 18),
-            Token::test(15, "SNX", 18),
+            Token::test(1, "WETH", 18, None),
+            Token::test(2, "USDT", 6, None),
+            Token::test(3, "TUSD", 18, None),
+            Token::test(4, "USDC", 6, None),
+            Token::test(5, "PAX", 18, None),
+            Token::test(6, "GUSD", 2, None),
+            Token::test(7, "DAI", 18, None),
+            Token::test(8, "sETH", 18, None),
+            Token::test(9, "sUSD", 18, None),
+            Token::test(15, "SNX", 18, None),
         ];
 
         let client = KrakenClient::new().unwrap();

--- a/driver/src/price_estimation/kraken.rs
+++ b/driver/src/price_estimation/kraken.rs
@@ -123,9 +123,9 @@ mod tests {
     #[test]
     fn get_token_prices() {
         let tokens = vec![
-            Token::test(1, "ETH", 18, None),
-            Token::test(4, "USDC", 6, None),
-            Token::test(5, "PAX", 18, None),
+            Token::new(1, "ETH", 18, None),
+            Token::new(4, "USDC", 6, None),
+            Token::new(5, "PAX", 18, None),
         ];
 
         let mut api = MockKrakenApi::new();
@@ -178,16 +178,16 @@ mod tests {
         // ```
 
         let tokens = vec![
-            Token::test(1, "WETH", 18, None),
-            Token::test(2, "USDT", 6, None),
-            Token::test(3, "TUSD", 18, None),
-            Token::test(4, "USDC", 6, None),
-            Token::test(5, "PAX", 18, None),
-            Token::test(6, "GUSD", 2, None),
-            Token::test(7, "DAI", 18, None),
-            Token::test(8, "sETH", 18, None),
-            Token::test(9, "sUSD", 18, None),
-            Token::test(15, "SNX", 18, None),
+            Token::new(1, "WETH", 18, None),
+            Token::new(2, "USDT", 6, None),
+            Token::new(3, "TUSD", 18, None),
+            Token::new(4, "USDC", 6, None),
+            Token::new(5, "PAX", 18, None),
+            Token::new(6, "GUSD", 2, None),
+            Token::new(7, "DAI", 18, None),
+            Token::new(8, "sETH", 18, None),
+            Token::new(9, "sUSD", 18, None),
+            Token::new(15, "SNX", 18, None),
         ];
 
         let client = KrakenClient::new().unwrap();

--- a/driver/src/price_estimation/kraken.rs
+++ b/driver/src/price_estimation/kraken.rs
@@ -122,9 +122,9 @@ mod tests {
     #[test]
     fn get_token_prices() {
         let tokens = vec![
-            Token::test(1, "ETH", 18),
-            Token::test(4, "USDC", 6),
-            Token::test(5, "PAX", 18),
+            Token::new(1, "ETH", 18),
+            Token::new(4, "USDC", 6),
+            Token::new(5, "PAX", 18),
         ];
 
         let mut api = MockKrakenApi::new();
@@ -177,16 +177,16 @@ mod tests {
         // ```
 
         let tokens = vec![
-            Token::test(1, "WETH", 18),
-            Token::test(2, "USDT", 6),
-            Token::test(3, "TUSD", 18),
-            Token::test(4, "USDC", 6),
-            Token::test(5, "PAX", 18),
-            Token::test(6, "GUSD", 2),
-            Token::test(7, "DAI", 18),
-            Token::test(8, "sETH", 18),
-            Token::test(9, "sUSD", 18),
-            Token::test(15, "SNX", 18),
+            Token::new(1, "WETH", 18),
+            Token::new(2, "USDT", 6),
+            Token::new(3, "TUSD", 18),
+            Token::new(4, "USDC", 6),
+            Token::new(5, "PAX", 18),
+            Token::new(6, "GUSD", 2),
+            Token::new(7, "DAI", 18),
+            Token::new(8, "sETH", 18),
+            Token::new(9, "sUSD", 18),
+            Token::new(15, "SNX", 18),
         ];
 
         let client = KrakenClient::new().unwrap();

--- a/driver/src/price_estimation/kraken.rs
+++ b/driver/src/price_estimation/kraken.rs
@@ -50,7 +50,7 @@ where
         let token_assets = tokens
             .iter()
             .flat_map(|token| {
-                let asset = find_asset(token.symbol(), &assets)?;
+                let asset = find_asset(&token.symbol(), &assets)?;
                 let pair = find_asset_pair(asset, usd, &asset_pairs)?;
                 Some((pair.to_owned(), token))
             })
@@ -177,7 +177,7 @@ mod tests {
         // ```
 
         let tokens = vec![
-            Token::test(1, "ETH", 18),
+            Token::test(1, "WETH", 18),
             Token::test(2, "USDT", 6),
             Token::test(3, "TUSD", 18),
             Token::test(4, "USDC", 6),

--- a/driver/src/price_estimation/kraken/api.rs
+++ b/driver/src/price_estimation/kraken/api.rs
@@ -172,16 +172,11 @@ impl TickerInfo {
 #[derive(Copy, Clone, Debug, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct PricePair(
-    #[serde(with = "display_fromstr")] pub f64,
-    #[serde(with = "display_fromstr")] pub f64,
+    #[serde(with = "display_fromstr")] f64,
+    #[serde(with = "display_fromstr")] f64,
 );
 
 impl PricePair {
-    /// Retrieves the price since midnight.
-    pub fn today(self) -> f64 {
-        self.0
-    }
-
     /// Retrieves the price for the last 24 hours.
     pub fn last_24h(self) -> f64 {
         self.1

--- a/driver/src/price_estimation/mod.rs
+++ b/driver/src/price_estimation/mod.rs
@@ -17,6 +17,7 @@ type Tokens = BTreeMap<TokenId, Option<TokenInfo>>;
 
 /// A trait representing a price oracle that retrieves price estimates for the
 /// tokens included in the current orderbook.
+#[cfg_attr(test, mockall::automock)]
 pub trait PriceEstimating {
     fn get_token_prices(&self, orders: &[Order]) -> Tokens;
 }

--- a/driver/src/price_estimation/mod.rs
+++ b/driver/src/price_estimation/mod.rs
@@ -101,10 +101,7 @@ impl PriceEstimating for PriceOracle {
         tokens_to_price
             .into_iter()
             .map(|token| {
-                let price = prices
-                    .get(&token.id)
-                    .copied()
-                    .unwrap_or(token.info.external_price);
+                let price = prices.get(&token.id).copied().or(token.info.external_price);
                 (
                     token.id,
                     Some(TokenInfo {
@@ -158,13 +155,18 @@ impl Token {
 
     /// Creates a new token with a fictional address for testing.
     #[cfg(test)]
-    pub fn test(index: u16, symbol: &'static str, decimals: u8) -> Self {
+    pub fn test(
+        index: u16,
+        symbol: &'static str,
+        decimals: u8,
+        external_price: Option<u128>,
+    ) -> Self {
         Token {
             id: TokenId(index),
             info: TokenInfo {
                 alias: symbol.into(),
                 decimals,
-                external_price: 0,
+                external_price,
             },
         }
     }
@@ -189,8 +191,8 @@ mod tests {
     #[test]
     fn price_oracle_fetches_token_prices() {
         let tokens = TokenData::test(hash_map! {
-            TokenId(1) => TokenInfo::test("WETH", 18, 0),
-            TokenId(2) => TokenInfo::test("USDT", 6, 0),
+            TokenId(1) => TokenInfo::test("WETH", 18, None),
+            TokenId(2) => TokenInfo::test("USDT", 6, Some(999_999_999_999_999_999)),
         });
 
         let mut source = MockPriceSource::new();
@@ -199,7 +201,11 @@ mod tests {
             .withf(|tokens| {
                 let mut tokens = tokens.to_vec();
                 tokens.sort_unstable_by_key(|token| token.id);
-                tokens == [Token::test(1, "WETH", 18), Token::test(2, "USDT", 6)]
+                tokens
+                    == [
+                        Token::test(1, "WETH", 18, None),
+                        Token::test(2, "USDT", 6, Some(999_999_999_999_999_999)),
+                    ]
             })
             .returning(|_| {
                 Ok(hash_map! {
@@ -220,9 +226,36 @@ mod tests {
             prices,
             btree_map! {
                 TokenId(0) => None,
-                TokenId(1) => Some(TokenInfo::test("WETH", 18, 0)),
-                TokenId(2) => Some(TokenInfo::test("USDT", 6, 1_000_000_000_000_000_000)),
+                TokenId(1) => Some(TokenInfo::test("WETH", 18, None)),
+                TokenId(2) => Some(TokenInfo::test("USDT", 6, Some(1_000_000_000_000_000_000))),
                 TokenId(3) => None,
+            }
+        );
+    }
+
+    #[test]
+    fn price_oracle_without_fallback_price() {
+        let tokens = TokenData::test(hash_map! {
+            TokenId(1) => TokenInfo::test("WETH", 18, None),
+            TokenId(2) => TokenInfo::test("USDT", 6, None),
+        });
+
+        let mut source = MockPriceSource::new();
+        source.expect_get_prices().returning(|_| {
+            Ok(hash_map! {
+                TokenId(2) => 1_000_000_000_000_000_000,
+            })
+        });
+
+        let oracle = PriceOracle::with_source(tokens, source);
+        let prices = oracle.get_token_prices(&[Order::for_token_pair(1, 2)]);
+
+        assert_eq!(
+            prices,
+            btree_map! {
+                TokenId(0) => None,
+                TokenId(1) => Some(TokenInfo::test("WETH", 18, None)),
+                TokenId(2) => Some(TokenInfo::test("USDT", 6, Some(1_000_000_000_000_000_000))),
             }
         );
     }
@@ -230,7 +263,7 @@ mod tests {
     #[test]
     fn price_oracle_ignores_source_error() {
         let tokens = TokenData::test(hash_map! {
-            TokenId(1) => TokenInfo::test("WETH", 18, 0),
+            TokenId(1) => TokenInfo::test("WETH", 18, None),
         });
 
         let mut source = MockPriceSource::new();
@@ -245,7 +278,7 @@ mod tests {
             prices,
             btree_map! {
                 TokenId(0) => None,
-                TokenId(1) => Some(TokenInfo::test("WETH", 18, 0)),
+                TokenId(1) => Some(TokenInfo::test("WETH", 18, None)),
             }
         );
     }
@@ -261,7 +294,7 @@ mod tests {
     #[test]
     fn price_oracle_uses_uses_fallback_prices() {
         let tokens = TokenData::test(hash_map! {
-            TokenId(7) => TokenInfo::test("DAI", 18, 1_000_000_000_000_000_000),
+            TokenId(7) => TokenInfo::test("DAI", 18, Some(1_000_000_000_000_000_000)),
         });
 
         let mut source = MockPriceSource::new();
@@ -274,7 +307,7 @@ mod tests {
             prices,
             btree_map! {
                 TokenId(0) => None,
-                TokenId(7) => Some(TokenInfo::test("DAI", 18, 1_000_000_000_000_000_000)),
+                TokenId(7) => Some(TokenInfo::test("DAI", 18, Some(1_000_000_000_000_000_000))),
             }
         );
     }
@@ -282,10 +315,14 @@ mod tests {
     #[test]
     fn token_get_price() {
         for (token, usd_price, expected) in &[
-            (Token::test(4, "USDC", 6), 0.99, 0.99 * 10f64.powi(30)),
-            (Token::test(7, "DAI", 18), 1.01, 1.01 * 10f64.powi(18)),
-            (Token::test(42, "FAKE", 32), 1.0, 10f64.powi(4)),
-            (Token::test(99, "SCAM", 42), 10f64.powi(10), 10f64.powi(4)),
+            (Token::test(4, "USDC", 6, None), 0.99, 0.99 * 10f64.powi(30)),
+            (Token::test(7, "DAI", 18, None), 1.01, 1.01 * 10f64.powi(18)),
+            (Token::test(42, "FAKE", 32, None), 1.0, 10f64.powi(4)),
+            (
+                Token::test(99, "SCAM", 42, None),
+                10f64.powi(10),
+                10f64.powi(4),
+            ),
         ] {
             let owl_price = token.get_owl_price(*usd_price);
             assert_eq!(owl_price, *expected as u128);
@@ -295,13 +332,13 @@ mod tests {
     #[test]
     fn token_get_price_without_rounding_error() {
         assert_eq!(
-            Token::test(0, "OWL", 18).get_owl_price(1.0),
+            Token::test(0, "OWL", 18, None).get_owl_price(1.0),
             1_000_000_000_000_000_000,
         );
     }
 
     #[test]
     fn weth_token_symbol_is_eth() {
-        assert_eq!(Token::test(1, "WETH", 18).symbol(), "ETH");
+        assert_eq!(Token::test(1, "WETH", 18, None).symbol(), "ETH");
     }
 }

--- a/driver/src/price_estimation/mod.rs
+++ b/driver/src/price_estimation/mod.rs
@@ -1,7 +1,6 @@
 //! Module responsible for aggregating price estimates from various sources to
 //! give good price estimates to the solver for better results.
 
-#[allow(dead_code)]
 mod kraken;
 
 use self::kraken::KrakenClient;

--- a/driver/src/price_estimation/mod.rs
+++ b/driver/src/price_estimation/mod.rs
@@ -4,27 +4,148 @@
 #[allow(dead_code)]
 mod kraken;
 
-use crate::models::{TokenId, TokenInfo};
+use self::kraken::KrakenClient;
+use crate::models::{Order, TokenData, TokenId, TokenInfo};
 use anyhow::Result;
-use ethcontract::H160;
-use std::collections::HashMap;
+use lazy_static::lazy_static;
+use log::warn;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::iter;
+
+/// A type alias for token information map that is passed to the solver.
+type Tokens = BTreeMap<TokenId, Option<TokenInfo>>;
+
+/// A trait representing a price oracle that retrieves price estimates for the
+/// tokens included in the current orderbook.
+pub trait PriceEstimating {
+    fn get_token_prices(&self, orders: &[Order]) -> Tokens;
+}
+
+pub struct PriceOracle {
+    /// The token data supplied by the environment. This ensures that only
+    /// whitelisted tokens get their prices estimated.
+    tokens: TokenData,
+    /// The price source to use.
+    ///
+    /// Note that currently only one price source is supported, but more price
+    /// source are expected to be added in the future.
+    source: Box<dyn PriceSource>,
+}
+
+impl PriceOracle {
+    /// Creates a new price oracle from a token whitelist data.
+    pub fn new(tokens: TokenData) -> Result<Self> {
+        Ok(PriceOracle::with_source(tokens, KrakenClient::new()?))
+    }
+
+    fn with_source(tokens: TokenData, source: impl PriceSource + 'static) -> Self {
+        PriceOracle {
+            tokens,
+            source: Box::new(source),
+        }
+    }
+
+    /// Splits order tokens into a vector of tokens that should be priced based
+    /// on the token whitelist and a vector of unpriced token ids.
+    ///
+    /// Note that all token ids in the returned results are garanteed to be
+    /// unique.
+    fn split_order_tokens(&self, orders: &[Order]) -> (Vec<Token>, Vec<TokenId>) {
+        let unique_token_ids: HashSet<_> = orders
+            .iter()
+            .flat_map(|order| vec![order.buy_token, order.sell_token])
+            .map(TokenId)
+            // NOTE: Always include the reference token. This is done since the
+            //   solver input specifies the reference token, so for correctness
+            //   it should always be considered.
+            .chain(iter::once(TokenId::reference()))
+            .collect();
+
+        unique_token_ids.into_iter().fold(
+            (Vec::new(), Vec::new()),
+            |(mut tokens_to_price, mut unpriced_token_ids), id| {
+                if let Some(info) = self.tokens.info(id) {
+                    tokens_to_price.push(Token {
+                        id,
+                        info: info.clone(),
+                    });
+                } else {
+                    unpriced_token_ids.push(id)
+                }
+                (tokens_to_price, unpriced_token_ids)
+            },
+        )
+    }
+
+    /// Gets price estimates for some tokens
+    fn get_prices(&self, tokens: &[Token]) -> HashMap<TokenId, u128> {
+        if tokens.is_empty() {
+            return HashMap::new();
+        }
+
+        match self.source.get_prices(tokens) {
+            Ok(prices) => prices,
+            Err(err) => {
+                warn!("failed to retrieve token prices: {}", err);
+                HashMap::new()
+            }
+        }
+    }
+}
+
+impl PriceEstimating for PriceOracle {
+    fn get_token_prices(&self, orders: &[Order]) -> Tokens {
+        let (tokens_to_price, unpriced_token_ids) = self.split_order_tokens(orders);
+        let prices = self.get_prices(&tokens_to_price);
+
+        tokens_to_price
+            .into_iter()
+            .map(|token| {
+                let price = prices
+                    .get(&token.id)
+                    .copied()
+                    .unwrap_or(token.info.external_price);
+                (
+                    token.id,
+                    Some(TokenInfo {
+                        external_price: price,
+                        ..token.info
+                    }),
+                )
+            })
+            .chain(unpriced_token_ids.into_iter().map(|id| (id, None)))
+            .collect()
+    }
+}
 
 /// A token reprensentation.
-///
-/// This is a duplicate definition of `TokenInfo` and will be removed once #556
-/// is merged.
 #[cfg_attr(test, derive(Eq, PartialEq))]
 #[derive(Clone, Debug)]
 struct Token {
+    /// The ID of the token.
     id: TokenId,
-    address: H160,
+    /// The token info for this token including, token symbol and number of
+    /// decimals.
     info: TokenInfo,
 }
 
 impl Token {
-    /// Gets the ERC20 token symbol.
+    /// Retrieves the token symbol for this token.
+    ///
+    /// Note that the token info alias is first checked if it is part of a
+    /// symbol override map, and if it is, then that value is used instead. This
+    /// allows ERC20 tokens like WETH to be treated as ETH, since exchanges
+    /// generally only track prices for the latter.
     fn symbol(&self) -> &str {
-        &self.info.alias
+        lazy_static! {
+            static ref SYMBOL_OVERRIDES: HashMap<String, String> = hash_map! {
+                "WETH" => "ETH".to_owned(),
+            };
+        }
+
+        SYMBOL_OVERRIDES
+            .get(&self.info.alias)
+            .unwrap_or(&self.info.alias)
     }
 
     /// Converts the prices from USD into the unit expected by the contract.
@@ -37,10 +158,9 @@ impl Token {
 
     /// Creates a new token with a fictional address for testing.
     #[cfg(test)]
-    pub fn test(index: u16, symbol: &str, decimals: u8) -> Self {
+    pub fn test(index: u16, symbol: &'static str, decimals: u8) -> Self {
         Token {
             id: TokenId(index),
-            address: H160::repeat_byte(index as _),
             info: TokenInfo {
                 alias: symbol.into(),
                 decimals,
@@ -64,6 +184,100 @@ trait PriceSource {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use anyhow::anyhow;
+
+    #[test]
+    fn price_oracle_fetches_token_prices() {
+        let tokens = TokenData::test(hash_map! {
+            TokenId(1) => TokenInfo::test("WETH", 18, 0),
+            TokenId(2) => TokenInfo::test("USDT", 6, 0),
+        });
+
+        let mut source = MockPriceSource::new();
+        source
+            .expect_get_prices()
+            .withf(|tokens| {
+                let mut tokens = tokens.to_vec();
+                tokens.sort_unstable_by_key(|token| token.id);
+                tokens == [Token::test(1, "WETH", 18), Token::test(2, "USDT", 6)]
+            })
+            .returning(|_| {
+                Ok(hash_map! {
+                    TokenId(2) => 1_000_000_000_000_000_000,
+                })
+            });
+
+        let oracle = PriceOracle::with_source(tokens, source);
+        let prices = oracle.get_token_prices(&[
+            Order::for_token_pair(0, 1),
+            Order::for_token_pair(1, 2),
+            Order::for_token_pair(2, 3),
+            Order::for_token_pair(1, 3),
+            Order::for_token_pair(0, 2),
+        ]);
+
+        assert_eq!(
+            prices,
+            btree_map! {
+                TokenId(0) => None,
+                TokenId(1) => Some(TokenInfo::test("WETH", 18, 0)),
+                TokenId(2) => Some(TokenInfo::test("USDT", 6, 1_000_000_000_000_000_000)),
+                TokenId(3) => None,
+            }
+        );
+    }
+
+    #[test]
+    fn price_oracle_ignores_source_error() {
+        let tokens = TokenData::test(hash_map! {
+            TokenId(1) => TokenInfo::test("WETH", 18, 0),
+        });
+
+        let mut source = MockPriceSource::new();
+        source
+            .expect_get_prices()
+            .returning(|_| Err(anyhow!("error")));
+
+        let oracle = PriceOracle::with_source(tokens, source);
+        let prices = oracle.get_token_prices(&[Order::for_token_pair(0, 1)]);
+
+        assert_eq!(
+            prices,
+            btree_map! {
+                TokenId(0) => None,
+                TokenId(1) => Some(TokenInfo::test("WETH", 18, 0)),
+            }
+        );
+    }
+
+    #[test]
+    fn price_oracle_always_includes_reference_token() {
+        let oracle = PriceOracle::with_source(TokenData::default(), MockPriceSource::new());
+        let prices = oracle.get_token_prices(&[]);
+
+        assert_eq!(prices, btree_map! { TokenId(0) => None });
+    }
+
+    #[test]
+    fn price_oracle_uses_uses_fallback_prices() {
+        let tokens = TokenData::test(hash_map! {
+            TokenId(7) => TokenInfo::test("DAI", 18, 1_000_000_000_000_000_000),
+        });
+
+        let mut source = MockPriceSource::new();
+        source.expect_get_prices().returning(|_| Ok(HashMap::new()));
+
+        let oracle = PriceOracle::with_source(tokens, source);
+        let prices = oracle.get_token_prices(&[Order::for_token_pair(0, 7)]);
+
+        assert_eq!(
+            prices,
+            btree_map! {
+                TokenId(0) => None,
+                TokenId(7) => Some(TokenInfo::test("DAI", 18, 1_000_000_000_000_000_000)),
+            }
+        );
+    }
 
     #[test]
     fn token_get_price() {
@@ -76,5 +290,18 @@ mod tests {
             let owl_price = token.get_owl_price(*usd_price);
             assert_eq!(owl_price, *expected as u128);
         }
+    }
+
+    #[test]
+    fn token_get_price_without_rounding_error() {
+        assert_eq!(
+            Token::test(0, "OWL", 18).get_owl_price(1.0),
+            1_000_000_000_000_000_000,
+        );
+    }
+
+    #[test]
+    fn weth_token_symbol_is_eth() {
+        assert_eq!(Token::test(1, "WETH", 18).symbol(), "ETH");
     }
 }

--- a/driver/src/price_finding/mod.rs
+++ b/driver/src/price_finding/mod.rs
@@ -2,6 +2,25 @@ pub mod naive_solver;
 pub mod optimization_price_finder;
 pub mod price_finder_interface;
 
+use crate::price_estimation::PriceEstimating;
 pub use crate::price_finding::naive_solver::NaiveSolver;
 pub use crate::price_finding::optimization_price_finder::OptimisationPriceFinder;
 pub use crate::price_finding::price_finder_interface::{Fee, PriceFinding, SolverType};
+use log::info;
+
+pub fn create_price_finder(
+    fee: Option<Fee>,
+    solver_type: SolverType,
+    price_oracle: impl PriceEstimating + 'static,
+) -> Box<dyn PriceFinding> {
+    if solver_type == SolverType::NaiveSolver {
+        info!("Using naive price finder");
+        Box::new(NaiveSolver::new(fee))
+    } else {
+        info!(
+            "Using optimisation price finder with the args {:}",
+            solver_type.to_args()
+        );
+        Box::new(OptimisationPriceFinder::new(fee, solver_type, price_oracle))
+    }
+}

--- a/driver/src/price_finding/optimization_price_finder.rs
+++ b/driver/src/price_finding/optimization_price_finder.rs
@@ -503,7 +503,7 @@ pub mod tests {
             .withf(|orders| orders == [])
             .returning(|_| {
                 btree_map! {
-                    TokenId(0) => Some(TokenInfo::test("T1", 18, Some(1_000_000_000_000_000_000))),
+                    TokenId(0) => Some(TokenInfo::new("T1", 18, 1_000_000_000_000_000_000)),
                 }
             });
 
@@ -555,8 +555,8 @@ pub mod tests {
 
         let tokens = btree_map! {
             TokenId(1) => None,
-            TokenId(2) => Some(TokenInfo::test("T2", 18, Some(1_000_000_000_000_000_000))),
-            TokenId(4) => Some(TokenInfo::test("T4", 6, None)),
+            TokenId(2) => Some(TokenInfo::new("T2", 18, 1_000_000_000_000_000_000)),
+            TokenId(4) => Some(TokenInfo::new("T4", 6, None)),
         };
 
         let orders = [

--- a/driver/src/price_finding/optimization_price_finder.rs
+++ b/driver/src/price_finding/optimization_price_finder.rs
@@ -503,7 +503,7 @@ pub mod tests {
             .withf(|orders| orders == [])
             .returning(|_| {
                 btree_map! {
-                    TokenId(0) => Some(TokenInfo::test("T1", 18, 1_000_000_000_000_000_000)),
+                    TokenId(0) => Some(TokenInfo::test("T1", 18, Some(1_000_000_000_000_000_000))),
                 }
             });
 
@@ -539,6 +539,7 @@ pub mod tests {
         let mut user1_balances = BTreeMap::new();
         user1_balances.insert(TokenId(3), Num(100));
         user1_balances.insert(TokenId(2), Num(100));
+        user1_balances.insert(TokenId(4), Num(100));
         user1_balances.insert(TokenId(1), Num(100));
         user1_balances.insert(TokenId(0), Num(100));
 
@@ -554,7 +555,8 @@ pub mod tests {
 
         let tokens = btree_map! {
             TokenId(1) => None,
-            TokenId(2) => Some(TokenInfo::test("T1", 18, 1_000_000_000_000_000_000)),
+            TokenId(2) => Some(TokenInfo::test("T2", 18, Some(1_000_000_000_000_000_000))),
+            TokenId(4) => Some(TokenInfo::test("T4", 6, None)),
         };
 
         let orders = [
@@ -587,7 +589,7 @@ pub mod tests {
         let result = serde_json::to_string(&input).expect("Unable to serialize account state");
         assert_eq!(
             result,
-            r#"{"tokens":{"T0001":null,"T0002":{"alias":"T1","decimals":18,"externalPrice":1000000000000000000}},"refToken":"T0000","accounts":{"0x13a0b42b9c180065510615972858bf41d1972a55":{},"0x4fd7c947ca0aba9d8678885e2b8c4d6a4e946984":{"T0000":"100","T0001":"100","T0002":"100","T0003":"100"}},"orders":[{"accountID":"0x0000000000000000000000000000000000000000","sellToken":"T0001","buyToken":"T0002","sellAmount":"100","buyAmount":"200","orderId":0},{"accountID":"0x0000000000000000000000000000000000000001","sellToken":"T0002","buyToken":"T0001","sellAmount":"200","buyAmount":"100","orderId":0}],"fee":null}"#
+            r#"{"tokens":{"T0001":null,"T0002":{"alias":"T2","decimals":18,"externalPrice":1000000000000000000},"T0004":{"alias":"T4","decimals":6,"externalPrice":null}},"refToken":"T0000","accounts":{"0x13a0b42b9c180065510615972858bf41d1972a55":{},"0x4fd7c947ca0aba9d8678885e2b8c4d6a4e946984":{"T0000":"100","T0001":"100","T0002":"100","T0003":"100","T0004":"100"}},"orders":[{"accountID":"0x0000000000000000000000000000000000000000","sellToken":"T0001","buyToken":"T0002","sellAmount":"100","buyAmount":"200","orderId":0},{"accountID":"0x0000000000000000000000000000000000000001","sellToken":"T0002","buyToken":"T0001","sellAmount":"200","buyAmount":"100","orderId":0}],"fee":null}"#
         );
     }
 }

--- a/driver/src/price_finding/optimization_price_finder.rs
+++ b/driver/src/price_finding/optimization_price_finder.rs
@@ -503,7 +503,7 @@ pub mod tests {
             .withf(|orders| orders == [])
             .returning(|_| {
                 btree_map! {
-                    TokenId(0) => Some(TokenInfo::test("T1", 18, 1_000_000_000_000_000_000)),
+                    TokenId(0) => Some(TokenInfo::new("T1", 18, 1_000_000_000_000_000_000)),
                 }
             });
 
@@ -554,7 +554,7 @@ pub mod tests {
 
         let tokens = btree_map! {
             TokenId(1) => None,
-            TokenId(2) => Some(TokenInfo::test("T1", 18, 1_000_000_000_000_000_000)),
+            TokenId(2) => Some(TokenInfo::new("T1", 18, 1_000_000_000_000_000_000)),
         };
 
         let orders = [

--- a/driver/src/price_finding/optimization_price_finder.rs
+++ b/driver/src/price_finding/optimization_price_finder.rs
@@ -610,7 +610,7 @@ pub mod tests {
         let input = solver_input::Input {
             // tokens should also end up sorted in the end
             tokens: serialize_tokens(&orders, &token_data),
-            ref_token: TokenId(0),
+            ref_token: TokenId::reference(),
             accounts,
             orders: orders.iter().map(From::from).collect(),
             fee: None,

--- a/driver/src/util.rs
+++ b/driver/src/util.rs
@@ -1,9 +1,5 @@
 use ethcontract::U256;
-use log::info;
 use std::future::Future;
-
-use crate::models::TokenData;
-use crate::price_finding::{Fee, NaiveSolver, OptimisationPriceFinder, PriceFinding, SolverType};
 
 pub trait CeiledDiv {
     fn ceiled_div(&self, divisor: Self) -> Self;
@@ -34,23 +30,6 @@ impl CheckedConvertU128 for U256 {
         } else {
             None
         }
-    }
-}
-
-pub fn create_price_finder(
-    fee: Option<Fee>,
-    solver_type: SolverType,
-    token_data: TokenData,
-) -> Box<dyn PriceFinding> {
-    if solver_type == SolverType::NaiveSolver {
-        info!("Using naive price finder");
-        Box::new(NaiveSolver::new(fee))
-    } else {
-        info!(
-            "Using optimisation price finder with the args {:}",
-            solver_type.to_args()
-        );
-        Box::new(OptimisationPriceFinder::new(fee, solver_type, token_data))
     }
 }
 


### PR DESCRIPTION
This PR implements token reading from the block chain. This token information will be used by price estimations. Specifically the number of decimals and token symbols (used in order to search exchanges for prices).

### Test Plan

None