### PR TITLE
[Easy] Use tini as docker entrypoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - '9586:9586'
     depends_on:
       - ganache-cli
-    command: cargo run
+    command: ["/tini", "-v", "--", "cargo", "run"]
     volumes:
       # Sync src folder to allow development without rebuilding on each change
       - ./driver:/app/driver

--- a/docker/rust/Dockerfile
+++ b/docker/rust/Dockerfile
@@ -36,3 +36,8 @@ ONBUILD COPY target/debug/driver stablex
 
 # Trigger actual build
 FROM ${RUST_BASE}
+
+# Add Tini
+ENV TINI_VERSION v0.18.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini


### PR DESCRIPTION
We have been seeing some pretty long delays when restarting our containers (e.g. [today](https://dashboard-projects.gnosisdev.com/d/Vl7CKCUWz/dfusion-solver?orgId=1&from=1582199944401&to=1582201136126&var-network=mainnet&refresh=5s) around 1pm).

Looking at the logs I could see that the container that is syncing our instance/result files terminates immediately. However our stableX container keeps on doing requests for a long time before eventually being killed.

Even locally this can be seen when running the container. `dcoker-compose down` takes quite a while to execute.

@denisgranha pointed me to [this article](https://hynek.me/articles/docker-signals/) which suggested this could be caused by being PID 1 and that we should use [tini](https://github.com/krallin/tini) to wrap around our entrypoint.

This PR adds tini to the docker setup and replaces the entry point for the local build. Once merged, I will also update the kubernetes config.

### Test Plan

In one shell:

`docker-compose up stablex`

In another shell:

`docker-compose down`

Observe that container terminates immediately (whereas before it would keep running for a few seconds)