### PR TITLE
[Easy] Adding tini as entrypoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - '9586:9586'
     depends_on:
       - ganache-cli
-    command: ["/tini", "-v", "--", "cargo", "run"]
+    command: ["cargo", "run"]
     volumes:
       # Sync src folder to allow development without rebuilding on each change
       - ./driver:/app/driver

--- a/docker/rust/Dockerfile
+++ b/docker/rust/Dockerfile
@@ -41,3 +41,4 @@ FROM ${RUST_BASE}
 ENV TINI_VERSION v0.18.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--"]


### PR DESCRIPTION
Instead of turning tini to the command, we can make it an entry point of the top level docker, which makes the change in the staging repo unnecessary.