### PR TITLE
[Trivial] Move create_price_finder to price_finding module

### DIFF
--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -20,8 +20,7 @@ use crate::gas_station::GnosisSafeGasStation;
 use crate::metrics::{MetricsServer, StableXMetrics};
 use crate::models::TokenData;
 use crate::orderbook::{FilteredOrderbookReader, OrderbookFilter, PaginatedStableXOrderBookReader};
-use crate::price_finding::price_finder_interface::SolverType;
-use crate::price_finding::Fee;
+use crate::price_finding::{Fee, SolverType};
 use crate::solution_submission::StableXSolutionSubmitter;
 
 use ethcontract::PrivateKey;
@@ -132,7 +131,7 @@ fn main() {
 
     let fee = Some(Fee::default());
     let mut price_finder =
-        util::create_price_finder(fee, options.solver_type, options.backup_token_data);
+        price_finding::create_price_finder(fee, options.solver_type, options.backup_token_data);
 
     let orderbook = PaginatedStableXOrderBookReader::new(&contract, options.auction_data_page_size);
     info!("Orderbook filter: {:?}", options.orderbook_filter);

--- a/driver/src/price_finding/mod.rs
+++ b/driver/src/price_finding/mod.rs
@@ -2,6 +2,25 @@ pub mod naive_solver;
 pub mod optimization_price_finder;
 pub mod price_finder_interface;
 
+use crate::models::TokenData;
 pub use crate::price_finding::naive_solver::NaiveSolver;
 pub use crate::price_finding::optimization_price_finder::OptimisationPriceFinder;
 pub use crate::price_finding::price_finder_interface::{Fee, PriceFinding, SolverType};
+use log::info;
+
+pub fn create_price_finder(
+    fee: Option<Fee>,
+    solver_type: SolverType,
+    token_data: TokenData,
+) -> Box<dyn PriceFinding> {
+    if solver_type == SolverType::NaiveSolver {
+        info!("Using naive price finder");
+        Box::new(NaiveSolver::new(fee))
+    } else {
+        info!(
+            "Using optimisation price finder with the args {:}",
+            solver_type.to_args()
+        );
+        Box::new(OptimisationPriceFinder::new(fee, solver_type, token_data))
+    }
+}

--- a/driver/src/util.rs
+++ b/driver/src/util.rs
@@ -1,9 +1,5 @@
 use ethcontract::U256;
-use log::info;
 use std::future::Future;
-
-use crate::models::TokenData;
-use crate::price_finding::{Fee, NaiveSolver, OptimisationPriceFinder, PriceFinding, SolverType};
 
 pub trait CeiledDiv {
     fn ceiled_div(&self, divisor: Self) -> Self;
@@ -34,23 +30,6 @@ impl CheckedConvertU128 for U256 {
         } else {
             None
         }
-    }
-}
-
-pub fn create_price_finder(
-    fee: Option<Fee>,
-    solver_type: SolverType,
-    token_data: TokenData,
-) -> Box<dyn PriceFinding> {
-    if solver_type == SolverType::NaiveSolver {
-        info!("Using naive price finder");
-        Box::new(NaiveSolver::new(fee))
-    } else {
-        info!(
-            "Using optimisation price finder with the args {:}",
-            solver_type.to_args()
-        );
-        Box::new(OptimisationPriceFinder::new(fee, solver_type, token_data))
     }
 }
 


### PR DESCRIPTION
This just moves the `create_price_finder` function to `price_finding` module so it is closer to the structs that it actually instantiates.

### Test Plan

Not needed, just moving code around.