### PR TITLE
Handle sparse solver output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
         - cargo clippy --all --all-targets -- -D warnings
         - cargo fmt --all -- --check
         # Build and publish compact image with compiled binary
-        - docker build --tag stablex-binary --build-arg SOLVER_BASE=163030813197.dkr.ecr.us-east-1.amazonaws.com/dex-solver:v0.5.PR163 --build-arg RUST_BASE=rust-binary -f docker/rust/Dockerfile .
+        - docker build --tag stablex-binary --build-arg SOLVER_BASE=163030813197.dkr.ecr.us-east-1.amazonaws.com/dex-solver:v0.5.17 --build-arg RUST_BASE=rust-binary -f docker/rust/Dockerfile .
         # StableX e2e Tests (Ganache)
         - docker-compose -f docker-compose.yml -f docker-compose.binary.yml up -d stablex
         - cargo test -p e2e ganache -- --nocapture

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
         - cargo clippy --all --all-targets -- -D warnings
         - cargo fmt --all -- --check
         # Build and publish compact image with compiled binary
-        - docker build --tag stablex-binary --build-arg SOLVER_BASE=163030813197.dkr.ecr.us-east-1.amazonaws.com/dex-solver:v0.5.15 --build-arg RUST_BASE=rust-binary -f docker/rust/Dockerfile .
+        - docker build --tag stablex-binary --build-arg SOLVER_BASE=163030813197.dkr.ecr.us-east-1.amazonaws.com/dex-solver:v0.5.PR163 --build-arg RUST_BASE=rust-binary -f docker/rust/Dockerfile .
         # StableX e2e Tests (Ganache)
         - docker-compose -f docker-compose.yml -f docker-compose.binary.yml up -d stablex
         - cargo test -p e2e ganache -- --nocapture

--- a/driver/src/driver/stablex_driver.rs
+++ b/driver/src/driver/stablex_driver.rs
@@ -276,7 +276,7 @@ mod tests {
             .expect_get_auction_data()
             .with(eq(batch))
             .return_once({
-                let result = (state, orders.clone());
+                let result = (state, orders);
                 |_| Ok(result)
             });
 

--- a/driver/src/metrics/stablex_metrics.rs
+++ b/driver/src/metrics/stablex_metrics.rs
@@ -107,7 +107,7 @@ impl StableXMetrics {
         }
     }
 
-    pub fn auction_solution_computed(&self, batch: U256, orders: &[Order], res: &Result<Solution>) {
+    pub fn auction_solution_computed(&self, batch: U256, res: &Result<Solution>) {
         let stage_label = &[ProcessingStage::Solved.as_ref()];
         let book_label = &[BookType::Solution.as_ref()];
         self.processing_times
@@ -115,21 +115,19 @@ impl StableXMetrics {
             .set(time_elapsed_since_batch_start(batch));
         match res {
             Ok(solution) => {
-                let touched_orders = orders
-                    .iter()
-                    .zip(&solution.executed_buy_amounts)
-                    .filter(|(_, &amount)| amount > 0u128)
-                    .map(|(o, _)| o.clone())
-                    .collect::<Vec<Order>>();
-                self.orders
-                    .with_label_values(book_label)
-                    .set(touched_orders.len().try_into().unwrap_or(std::i64::MAX));
+                self.orders.with_label_values(book_label).set(
+                    solution
+                        .executed_orders
+                        .len()
+                        .try_into()
+                        .unwrap_or(std::i64::MAX),
+                );
                 self.tokens
                     .with_label_values(book_label)
-                    .set(tokens_from_orders(&touched_orders));
+                    .set(tokens_from_solution(solution));
                 self.users
                     .with_label_values(book_label)
-                    .set(users_from_orders(&touched_orders));
+                    .set(users_from_solution(solution));
             }
             Err(_) => self.failures.with_label_values(stage_label).inc(),
         }
@@ -196,8 +194,23 @@ fn tokens_from_orders(orders: &[Order]) -> i64 {
         .unwrap_or(std::i64::MAX)
 }
 
+fn tokens_from_solution(solution: &Solution) -> i64 {
+    solution.prices.len().try_into().unwrap_or(std::i64::MAX)
+}
+
 fn users_from_orders(orders: &[Order]) -> i64 {
     orders
+        .iter()
+        .map(|order| order.account_id)
+        .collect::<HashSet<_>>()
+        .len()
+        .try_into()
+        .unwrap_or(std::i64::MAX)
+}
+
+fn users_from_solution(solution: &Solution) -> i64 {
+    solution
+        .executed_orders
         .iter()
         .map(|order| order.account_id)
         .collect::<HashSet<_>>()

--- a/driver/src/models/mod.rs
+++ b/driver/src/models/mod.rs
@@ -5,5 +5,6 @@ pub mod tokens;
 
 pub use self::account_state::AccountState;
 pub use self::order::Order;
+pub use self::solution::ExecutedOrder;
 pub use self::solution::Solution;
 pub use self::tokens::{TokenId, TokenInfo};

--- a/driver/src/models/order.rs
+++ b/driver/src/models/order.rs
@@ -30,6 +30,7 @@ impl Order {
 #[cfg(test)]
 pub mod test_util {
     use super::*;
+    use crate::models::ExecutedOrder;
 
     pub fn create_order_for_test() -> Order {
         Order {
@@ -39,6 +40,19 @@ pub mod test_util {
             sell_token: 2,
             buy_amount: 5,
             sell_amount: 4,
+        }
+    }
+
+    pub fn order_to_executed_order(
+        order: &Order,
+        sell_amount: u128,
+        buy_amount: u128,
+    ) -> ExecutedOrder {
+        ExecutedOrder {
+            account_id: order.account_id,
+            order_id: order.id,
+            sell_amount,
+            buy_amount,
         }
     }
 }

--- a/driver/src/models/solution.rs
+++ b/driver/src/models/solution.rs
@@ -1,25 +1,34 @@
+use ethcontract::Address;
 use std::collections::HashMap;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExecutedOrder {
+    pub account_id: Address,
+    pub order_id: u16,
+    pub sell_amount: u128,
+    pub buy_amount: u128,
+}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Solution {
     /// token_id => price
     pub prices: HashMap<u16, u128>,
-    pub executed_buy_amounts: Vec<u128>,
-    pub executed_sell_amounts: Vec<u128>,
+    pub executed_orders: Vec<ExecutedOrder>,
 }
 
 impl Solution {
-    pub fn trivial(num_orders: usize) -> Self {
+    pub fn trivial() -> Self {
         Solution {
             prices: HashMap::new(),
-            executed_buy_amounts: vec![0; num_orders],
-            executed_sell_amounts: vec![0; num_orders],
+            executed_orders: Vec::new(),
         }
     }
 
     /// Returns true if a solution is non-trivial and false otherwise
     pub fn is_non_trivial(&self) -> bool {
-        self.executed_sell_amounts.iter().any(|&amt| amt > 0)
+        self.executed_orders
+            .iter()
+            .any(|order| order.sell_amount > 0)
     }
 }
 
@@ -48,20 +57,38 @@ pub mod tests {
     fn generic_non_trivial_solution() -> Solution {
         Solution {
             prices: map_from_slice(&[(0, 42), (2, 42)]),
-            executed_buy_amounts: vec![4, 5, 6],
-            executed_sell_amounts: vec![1, 2, 3],
+            executed_orders: vec![
+                ExecutedOrder {
+                    account_id: Address::zero(),
+                    order_id: 0,
+                    sell_amount: 1,
+                    buy_amount: 4,
+                },
+                ExecutedOrder {
+                    account_id: Address::zero(),
+                    order_id: 1,
+                    sell_amount: 2,
+                    buy_amount: 5,
+                },
+                ExecutedOrder {
+                    account_id: Address::zero(),
+                    order_id: 2,
+                    sell_amount: 3,
+                    buy_amount: 6,
+                },
+            ],
         }
     }
 
     #[test]
     fn test_is_non_trivial() {
         assert!(generic_non_trivial_solution().is_non_trivial());
-        assert!(!Solution::trivial(1).is_non_trivial());
+        assert!(!Solution::trivial().is_non_trivial());
     }
 
     #[test]
     fn test_max_token() {
         assert_eq!(generic_non_trivial_solution().max_token().unwrap(), 2);
-        assert_eq!(Solution::trivial(1).max_token(), None);
+        assert_eq!(Solution::trivial().max_token(), None);
     }
 }

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -185,10 +185,12 @@ impl PriceFinding for NaiveSolver {
 
             // apply fee to volumes account for rounding errors, moving them to
             // the fee token
+            let expect_message = "fee price was nonzero so we should have a match";
+            let matching_orders_indices = matching_orders_indices.expect(expect_message);
+            let executed_orders = &mut executed_orders.as_mut().expect(expect_message);
             for i in 0..2 {
-                let expect_message = "fee price was nonzero so we should have a match";
-                let order = &orders[matching_orders_indices.expect(expect_message)[i]];
-                let executed_order = &mut executed_orders.as_mut().expect(expect_message)[i];
+                let order = &orders[matching_orders_indices[i]];
+                let executed_order = &mut executed_orders[i];
                 if order.sell_token == fee.token {
                     let price_buy = prices[&order.buy_token];
                     executed_order.sell_amount =

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -118,8 +118,7 @@ impl PriceFinding for NaiveSolver {
         let mut executed_orders: Option<[ExecutedOrder; 2]> = None;
         let mut matching_orders_indices: Option<[usize; 2]> = None;
         'outer: for (i, x) in orders.iter().enumerate() {
-            for j in i + 1..orders.len() {
-                let y = &orders[j];
+            for (j, y) in orders.iter().enumerate().skip(i + 1) {
                 let mut set_matched_orders = |sell_amounts: [u128; 2], buy_amounts: [u128; 2]| {
                     executed_orders = Some([
                         ExecutedOrder {

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -1,4 +1,4 @@
-use crate::models::{AccountState, Order, Solution};
+use crate::models::{AccountState, ExecutedOrder, Order, Solution};
 use crate::price_finding::price_finder_interface::{Fee, PriceFinding};
 use crate::util::{CeiledDiv, CheckedConvertU128};
 
@@ -115,48 +115,58 @@ impl PriceFinding for NaiveSolver {
     fn find_prices(&self, orders: &[Order], state: &AccountState) -> Result<Solution> {
         // Initialize trivial solution (default of zero indicates untouched token).
         let mut prices = HashMap::new();
-        let mut exec_buy_amount: Vec<u128> = vec![0; orders.len()];
-        let mut exec_sell_amount: Vec<u128> = vec![0; orders.len()];
-
+        let mut executed_orders: Option<[ExecutedOrder; 2]> = None;
         let mut matching_orders_indices: Option<[usize; 2]> = None;
         'outer: for (i, x) in orders.iter().enumerate() {
             for j in i + 1..orders.len() {
+                let y = &orders[j];
+                let mut set_matched_orders = |sell_amounts: [u128; 2], buy_amounts: [u128; 2]| {
+                    executed_orders = Some([
+                        ExecutedOrder {
+                            account_id: x.account_id,
+                            order_id: x.id,
+                            sell_amount: sell_amounts[0],
+                            buy_amount: buy_amounts[0],
+                        },
+                        ExecutedOrder {
+                            account_id: y.account_id,
+                            order_id: y.id,
+                            sell_amount: sell_amounts[1],
+                            buy_amount: buy_amounts[1],
+                        },
+                    ]);
+                    matching_orders_indices = Some([i, j]);
+                };
                 // Preprocess order to leave "space" for fee to be taken
-                let x = order_with_buffer_for_fee(&x, &self.fee);
-                let y = order_with_buffer_for_fee(&orders[j], &self.fee);
+                let x = order_with_buffer_for_fee(x, &self.fee);
+                let y = order_with_buffer_for_fee(y, &self.fee);
                 match x.match_compare(&y, &state, &self.fee) {
                     Some(OrderPairType::LhsFullyFilled) => {
                         prices.insert(x.buy_token, x.sell_amount);
                         prices.insert(y.buy_token, x.buy_amount);
-                        exec_sell_amount[i] = x.sell_amount;
-                        exec_sell_amount[j] = x.buy_amount;
-
-                        exec_buy_amount[i] = x.buy_amount;
-                        exec_buy_amount[j] = x.sell_amount;
+                        set_matched_orders(
+                            [x.sell_amount, x.buy_amount],
+                            [x.buy_amount, x.sell_amount],
+                        );
                     }
                     Some(OrderPairType::RhsFullyFilled) => {
                         prices.insert(x.sell_token, y.sell_amount);
                         prices.insert(y.sell_token, y.buy_amount);
-
-                        exec_sell_amount[i] = y.buy_amount;
-                        exec_sell_amount[j] = y.sell_amount;
-
-                        exec_buy_amount[i] = y.sell_amount;
-                        exec_buy_amount[j] = y.buy_amount;
+                        set_matched_orders(
+                            [y.buy_amount, y.sell_amount],
+                            [y.sell_amount, y.buy_amount],
+                        );
                     }
                     Some(OrderPairType::BothFullyFilled) => {
                         prices.insert(y.buy_token, y.sell_amount);
                         prices.insert(x.buy_token, x.sell_amount);
-
-                        exec_sell_amount[i] = x.sell_amount;
-                        exec_sell_amount[j] = y.sell_amount;
-
-                        exec_buy_amount[i] = y.sell_amount;
-                        exec_buy_amount[j] = x.sell_amount;
+                        set_matched_orders(
+                            [x.sell_amount, y.sell_amount],
+                            [y.sell_amount, x.sell_amount],
+                        );
                     }
                     None => continue,
                 }
-                matching_orders_indices = Some([i, j]);
                 break 'outer;
             }
         }
@@ -165,43 +175,45 @@ impl PriceFinding for NaiveSolver {
             // normalize prices so fee token price is BASE_PRICE
             let pre_normalized_fee_price = prices.get(&fee.token).copied().unwrap_or(0);
             if pre_normalized_fee_price == 0 {
-                return Ok(Solution::trivial(orders.len()));
+                return Ok(Solution::trivial());
             }
             for price in prices.values_mut() {
                 *price = match normalize_price(*price, pre_normalized_fee_price) {
                     Some(price) => price,
-                    None => return Ok(Solution::trivial(orders.len())),
+                    None => return Ok(Solution::trivial()),
                 };
             }
 
             // apply fee to volumes account for rounding errors, moving them to
             // the fee token
-            for i in matching_orders_indices
-                .expect("fee price was nonzero so we should have a match")
-                .iter()
-            {
-                let i = *i;
-                let order = &orders[i];
+            for i in 0..2 {
+                let expect_message = "fee price was nonzero so we should have a match";
+                let order = &orders[matching_orders_indices.expect(expect_message)[i]];
+                let executed_order = &mut executed_orders.as_mut().expect(expect_message)[i];
                 if order.sell_token == fee.token {
                     let price_buy = prices[&order.buy_token];
-                    exec_sell_amount[i] =
-                        executed_sell_amount(fee, exec_buy_amount[i], price_buy, BASE_PRICE);
+                    executed_order.sell_amount =
+                        executed_sell_amount(fee, executed_order.buy_amount, price_buy, BASE_PRICE);
                 } else {
                     let price_sell = prices[&order.sell_token];
-                    exec_buy_amount[i] =
-                        match executed_buy_amount(fee, exec_sell_amount[i], BASE_PRICE, price_sell)
-                        {
-                            Some(exec_buy_amt) => exec_buy_amt,
-                            None => return Ok(Solution::trivial(orders.len())),
-                        };
+                    executed_order.buy_amount = match executed_buy_amount(
+                        fee,
+                        executed_order.sell_amount,
+                        BASE_PRICE,
+                        price_sell,
+                    ) {
+                        Some(exec_buy_amt) => exec_buy_amt,
+                        None => return Ok(Solution::trivial()),
+                    };
                 }
             }
         }
 
         let solution = Solution {
             prices,
-            executed_sell_amounts: exec_sell_amount,
-            executed_buy_amounts: exec_buy_amount,
+            executed_orders: executed_orders
+                .map(|orders| orders.to_vec())
+                .unwrap_or_else(|| vec![]),
         };
         Ok(solution)
     }
@@ -277,7 +289,9 @@ fn executed_buy_amount(
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use crate::models::order::test_util::order_to_executed_order;
     use crate::models::AccountState;
+
     use ethcontract::{Address, H256, U256};
     use std::collections::HashMap;
 
@@ -290,12 +304,11 @@ pub mod tests {
         let res = solver.find_prices(&orders, &state).unwrap();
 
         assert_eq!(
-            vec![4 * BASE_UNIT, 52 * BASE_UNIT],
-            res.executed_buy_amounts
-        );
-        assert_eq!(
-            vec![52 * BASE_UNIT, 4 * BASE_UNIT],
-            res.executed_sell_amounts
+            vec![
+                order_to_executed_order(&orders[0], 52 * BASE_UNIT, 4 * BASE_UNIT),
+                order_to_executed_order(&orders[1], 4 * BASE_UNIT, 52 * BASE_UNIT),
+            ],
+            res.executed_orders
         );
         assert_eq!(4 * BASE_UNIT, res.prices[&0]);
         assert_eq!(52 * BASE_UNIT, res.prices[&1]);
@@ -327,12 +340,11 @@ pub mod tests {
         let res = solver.find_prices(&orders, &state).unwrap();
 
         assert_eq!(
-            vec![52 * BASE_UNIT, 4 * BASE_UNIT],
-            res.executed_buy_amounts
-        );
-        assert_eq!(
-            vec![4 * BASE_UNIT, 52 * BASE_UNIT],
-            res.executed_sell_amounts
+            vec![
+                order_to_executed_order(&orders[0], 4 * BASE_UNIT, 52 * BASE_UNIT),
+                order_to_executed_order(&orders[1], 52 * BASE_UNIT, 4 * BASE_UNIT),
+            ],
+            res.executed_orders
         );
         assert_eq!(4 * BASE_UNIT, res.prices[&0]);
         assert_eq!(52 * BASE_UNIT, res.prices[&1]);
@@ -364,12 +376,21 @@ pub mod tests {
         let res = solver.find_prices(&orders, &state).unwrap();
 
         assert_eq!(
-            vec![16 * BASE_UNIT, 10 * BASE_UNIT],
-            res.executed_buy_amounts
-        );
-        assert_eq!(
-            vec![10 * BASE_UNIT, 16 * BASE_UNIT],
-            res.executed_sell_amounts
+            vec![
+                ExecutedOrder {
+                    account_id: orders[0].account_id,
+                    order_id: orders[0].id,
+                    sell_amount: 10 * BASE_UNIT,
+                    buy_amount: 16 * BASE_UNIT,
+                },
+                ExecutedOrder {
+                    account_id: orders[1].account_id,
+                    order_id: orders[1].id,
+                    sell_amount: 16 * BASE_UNIT,
+                    buy_amount: 10 * BASE_UNIT,
+                }
+            ],
+            res.executed_orders
         );
         assert_eq!(10 * BASE_UNIT, res.prices[&1]);
         assert_eq!(16 * BASE_UNIT, res.prices[&2]);
@@ -447,8 +468,13 @@ pub mod tests {
         let solver = NaiveSolver::new(None);
         let res = solver.find_prices(&orders, &state).unwrap();
 
-        assert_eq!(vec![0, 0, 0, 52, 4, 0], res.executed_buy_amounts);
-        assert_eq!(vec![0, 0, 0, 4, 52, 0], res.executed_sell_amounts);
+        assert_eq!(
+            vec![
+                order_to_executed_order(&orders[3], 4, 52),
+                order_to_executed_order(&orders[4], 52, 4),
+            ],
+            res.executed_orders
+        );
         assert_eq!(4, res.prices[&1]);
         assert_eq!(52, res.prices[&2]);
 
@@ -527,7 +553,7 @@ pub mod tests {
                 buy_amount: 9990,
             },
             Order {
-                id: 0,
+                id: 1,
                 account_id: Address::from_low_u64_be(0),
                 sell_token: 1,
                 buy_token: 0,
@@ -544,8 +570,13 @@ pub mod tests {
         let solver = NaiveSolver::new(fee.clone());
         let res = solver.find_prices(&orders, &state).unwrap();
 
-        assert_eq!(res.executed_sell_amounts, [20000, 9990]);
-        assert_eq!(res.executed_buy_amounts, [9990, 19961]);
+        assert_eq!(
+            vec![
+                order_to_executed_order(&orders[0], 20000, 9990),
+                order_to_executed_order(&orders[1], 9990, 19961)
+            ],
+            res.executed_orders
+        );
         assert_eq!(res.prices[&0], BASE_PRICE);
         assert_eq!(res.prices[&1], BASE_PRICE * 2);
 
@@ -630,7 +661,7 @@ pub mod tests {
 
         let solver = NaiveSolver::new(None);
         let res = solver.find_prices(&orders, &state).unwrap();
-        assert_eq!(res, Solution::trivial(0));
+        assert_eq!(res, Solution::trivial());
     }
 
     #[test]
@@ -778,7 +809,7 @@ pub mod tests {
                 buy_amount: 10 * BASE_UNIT,
             },
             Order {
-                id: 0,
+                id: 1,
                 account_id: Address::from_low_u64_be(1),
                 sell_token: 1,
                 buy_token: 2,
@@ -812,7 +843,15 @@ pub mod tests {
             let buy_token_price = *solution.prices.get(&order.buy_token).unwrap_or(&0u128);
             let sell_token_price = *solution.prices.get(&order.sell_token).unwrap_or(&0u128);
 
-            let exec_buy_amount = solution.executed_buy_amounts[i];
+            let exec_buy_amount = solution
+                .executed_orders
+                .iter()
+                .find(|executed_order| {
+                    executed_order.account_id == order.account_id
+                        && executed_order.order_id == order.id
+                })
+                .map(|executed_order| executed_order.buy_amount)
+                .unwrap_or(0);
             let exec_sell_amount = if sell_token_price > 0 {
                 if let Some(fee) = fee {
                     let fee_denominator = (1.0 / fee.ratio) as u128;

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -376,18 +376,8 @@ pub mod tests {
 
         assert_eq!(
             vec![
-                ExecutedOrder {
-                    account_id: orders[0].account_id,
-                    order_id: orders[0].id,
-                    sell_amount: 10 * BASE_UNIT,
-                    buy_amount: 16 * BASE_UNIT,
-                },
-                ExecutedOrder {
-                    account_id: orders[1].account_id,
-                    order_id: orders[1].id,
-                    sell_amount: 16 * BASE_UNIT,
-                    buy_amount: 10 * BASE_UNIT,
-                }
+                order_to_executed_order(&orders[0], 10 * BASE_UNIT, 16 * BASE_UNIT),
+                order_to_executed_order(&orders[1], 16 * BASE_UNIT, 10 * BASE_UNIT),
             ],
             res.executed_orders
         );


### PR DESCRIPTION
related to #546
The solver is going to output only orders that have been touched instead
of outputting all orders with untouched orders having 0 sell and buy
amount.

Before merging this PR the solver needs to be udpated, tagged and the tag used here changed appropriately.

Test Plan:
Manually build the solver docker from the correct tag like we do in .travis.yml and then run the e2e ganache test with this as the solver. There print out from the solution shows that we get `ExecutedOrder`s. More orders can be added to the test to see that there is no problem if not all are filled.