### PR TITLE
[Easy] Set the gas limit on the transaction and not the call

### DIFF
--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -128,8 +128,6 @@ impl<'a> StableXContract for StableXContractImpl<'a> {
                 prices,
                 token_ids_for_price,
             )
-            // Gas estimate might be off, as we race with other solution submissions and thus might have to revert trades which costs more gas than expected.
-            .gas(5_500_000.into())
             .call()
             .wait()?;
 
@@ -168,6 +166,10 @@ impl<'a> StableXContract for StableXContractImpl<'a> {
                     .map(|gas_price| GasPrice::Value(gas_price.fast))
                     .unwrap_or(GasPrice::Scaled(3.0)),
             )
+            // NOTE: Gas estimate might be off, as we race with other solution
+            //   submissions and thus might have to revert trades which costs
+            //   more gas than expected.
+            .gas(5_500_000.into())
             .send()
             .wait()?;
 


### PR DESCRIPTION
Seems to have slipped by us all!

### Test Plan

CI, check that the TX is being sent with the actual gas limit in the logs:
```
$ ./scripts/setup_contracts.sh
$ DFUSION_LOGS=driver::transport=trace cargo run
$ cargo test -p e2e ganache
```

Observe the log:
```
Feb 24 15:35:59.745 DEBG [driver::transport] [id:10] sending request: '{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0xf902eb2185028fa6ae018353ec60949b1f7f645351af3631a656421ed2e40f2802e6c080b902842e4c83bd0000000000000000000000000000000000000000000000000000000000507e3b00000000000000000000000000000000000000000000000037782cdd005ff75400000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000001a000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000240000000000000000000000000000000000000000000000000000000000000000200000000000000000000000090f8bf6a479f320ead074411a4b0e7944ea8c9c1000000000000000000000000ffcf8fdee72ac11b5c542428b35eef5769c409f0000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000f3e5800000000000000000000000000000000000000000000000000000000001e74e100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000001bc16b952e29bfae0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000177a0d8a2dc34b36f270148ec3bc89275156c0845c16738c1fe2a8e7d229f841adfbda00930432730547fc0311ccc73b26247a2852ddc8a6cd61401581b3872dafc3080"],"id":10}'
```

Use something like https://codechain-io.github.io/rlp-debugger/ to verify that the 3rd element in the RLP encoded list is `5500000`, which in the case of the above log it is.