### PR TITLE
Don't error on benign verification failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,6 +496,7 @@ dependencies = [
  "slog-stdlog",
  "slog-term",
  "structopt",
+ "thiserror",
  "uint",
  "url 2.1.1",
 ]

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -27,6 +27,7 @@ slog-stdlog = "4.0.0"
 slog-term = "2.5.0"
 uint = "0.8"
 structopt = "0.3.9"
+thiserror = "1.0"
 url = "2.1.1"
 
 [dev-dependencies]

--- a/driver/src/contracts/mod.rs
+++ b/driver/src/contracts/mod.rs
@@ -2,11 +2,13 @@ pub mod stablex_auction_element;
 pub mod stablex_contract;
 
 use crate::transport::HttpTransport;
-use anyhow::{Error, Result};
+use anyhow::{anyhow, Error, Result};
 use ethcontract::contract::MethodDefaults;
 use ethcontract::errors::{ExecutionError, MethodError};
 
 use ethcontract::{Account, PrivateKey};
+use std::convert::TryFrom;
+use std::fmt;
 use std::time::Duration;
 
 pub type Web3 = ethcontract::web3::api::Web3<HttpTransport>;
@@ -29,21 +31,45 @@ fn method_defaults(key: PrivateKey, network_id: u64) -> Result<MethodDefaults> {
     Ok(defaults)
 }
 
-const EXPECTED_ERRORS: &[&str; 3] = &[
-    "New objective doesn\'t sufficiently improve current solution",
-    "Claimed objective doesn't sufficiently improve current solution",
-    "SafeMath: subtraction overflow",
-];
+pub enum BenignSolutionFailure {
+    BetterSolutionAlreadySubmitted,
+    NegativeUtility,
+}
 
-pub fn extract_benign_submission_failure(err: &Error) -> Option<String> {
+impl fmt::Display for BenignSolutionFailure {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            BenignSolutionFailure::BetterSolutionAlreadySubmitted => {
+                write!(f, "Better solution already submitted")
+            }
+            BenignSolutionFailure::NegativeUtility => write!(f, "Negative Utility"),
+        }
+    }
+}
+
+impl TryFrom<&str> for BenignSolutionFailure {
+    type Error = anyhow::Error;
+
+    fn try_from(reason: &str) -> Result<Self, Self::Error> {
+        match reason {
+            "New objective doesn\'t sufficiently improve current solution" => {
+                Ok(BenignSolutionFailure::BetterSolutionAlreadySubmitted)
+            }
+            "Claimed objective doesn't sufficiently improve current solution" => {
+                Ok(BenignSolutionFailure::BetterSolutionAlreadySubmitted)
+            }
+            "SafeMath: subtraction overflow" => Ok(BenignSolutionFailure::NegativeUtility),
+            _ => Err(anyhow!("Unexpected error")),
+        }
+    }
+}
+
+pub fn extract_benign_submission_failure(err: &Error) -> Option<BenignSolutionFailure> {
     err.downcast_ref::<MethodError>()
         .and_then(|method_error| match &method_error.inner {
             ExecutionError::Revert(Some(reason)) => {
-                if EXPECTED_ERRORS.contains(&&reason[..]) {
-                    Some(reason.clone())
-                } else {
-                    None
-                }
+                let reason_slice: &str = &*reason;
+                BenignSolutionFailure::try_from(reason_slice).ok()
             }
             _ => None,
         })

--- a/driver/src/contracts/mod.rs
+++ b/driver/src/contracts/mod.rs
@@ -2,9 +2,8 @@ pub mod stablex_auction_element;
 pub mod stablex_contract;
 
 use crate::transport::HttpTransport;
-use anyhow::{anyhow, Error, Result};
+use anyhow::{anyhow, Result};
 use ethcontract::contract::MethodDefaults;
-use ethcontract::errors::{ExecutionError, MethodError};
 
 use ethcontract::{Account, PrivateKey};
 use std::convert::TryFrom;
@@ -61,29 +60,5 @@ impl TryFrom<&str> for BenignSolutionFailure {
             "SafeMath: subtraction overflow" => Ok(BenignSolutionFailure::NegativeUtility),
             _ => Err(anyhow!("Unexpected error")),
         }
-    }
-}
-
-pub fn extract_benign_submission_failure(err: &Error) -> Option<BenignSolutionFailure> {
-    err.downcast_ref::<MethodError>()
-        .and_then(|method_error| match &method_error.inner {
-            ExecutionError::Revert(Some(reason)) => {
-                let reason_slice: &str = &*reason;
-                BenignSolutionFailure::try_from(reason_slice).ok()
-            }
-            _ => None,
-        })
-}
-
-#[cfg(test)]
-pub mod tests {
-    use super::{ExecutionError, MethodError};
-    use anyhow::anyhow;
-    pub fn benign_error() -> anyhow::Error {
-        anyhow!(MethodError::from_parts(
-            "submitSolution(uint32,uint256,address[],uint16[],uint128[],uint128[],uint16[])"
-                .to_owned(),
-            ExecutionError::Revert(Some("SafeMath: subtraction overflow".to_owned())),
-        ))
     }
 }

--- a/driver/src/metrics/stablex_metrics.rs
+++ b/driver/src/metrics/stablex_metrics.rs
@@ -1,3 +1,4 @@
+use crate::contracts::extract_benign_submission_failure;
 use crate::models::{AccountState, Order, Solution};
 use anyhow::Result;
 use chrono::Utc;
@@ -141,7 +142,11 @@ impl StableXMetrics {
             .set(time_elapsed_since_batch_start(batch));
         match res {
             Ok(_) => (),
-            Err(_) => self.failures.with_label_values(stage_label).inc(),
+            Err(err) => {
+                if extract_benign_submission_failure(err).is_none() {
+                    self.failures.with_label_values(stage_label).inc()
+                }
+            }
         }
     }
 

--- a/driver/src/metrics/stablex_metrics.rs
+++ b/driver/src/metrics/stablex_metrics.rs
@@ -1,5 +1,5 @@
-use crate::contracts::extract_benign_submission_failure;
 use crate::models::{AccountState, Order, Solution};
+use crate::solution_submission::SolutionSubmissionError;
 use anyhow::Result;
 use chrono::Utc;
 use ethcontract::U256;
@@ -135,22 +135,31 @@ impl StableXMetrics {
         }
     }
 
-    pub fn auction_solution_verified(&self, batch: U256, res: &Result<U256>) {
+    pub fn auction_solution_verified(
+        &self,
+        batch: U256,
+        res: &Result<U256, SolutionSubmissionError>,
+    ) {
         let stage_label = &[ProcessingStage::Solved.as_ref()];
         self.processing_times
             .with_label_values(stage_label)
             .set(time_elapsed_since_batch_start(batch));
         match res {
             Ok(_) => (),
-            Err(err) => {
-                if extract_benign_submission_failure(err).is_none() {
+            Err(err) => match err {
+                SolutionSubmissionError::Benign(_) => (),
+                SolutionSubmissionError::Unexpected(_) => {
                     self.failures.with_label_values(stage_label).inc()
                 }
-            }
+            },
         }
     }
 
-    pub fn auction_solution_submitted(&self, batch: U256, res: &Result<()>) {
+    pub fn auction_solution_submitted(
+        &self,
+        batch: U256,
+        res: &Result<(), SolutionSubmissionError>,
+    ) {
         let stage_label = &[ProcessingStage::Submitted.as_ref()];
         self.processing_times
             .with_label_values(stage_label)


### PR DESCRIPTION
First part of #580 

This PR makes it so that for somewhat "expected" failures during solution verification we don't emit an error but instead treat the batch as skipped. Those failures are for now

1. `Claimed objective doesn't sufficiently improve current solution` (when a better or evenly good solution is already applied - happens when the objective Value is provided in the submitSolution tx)
2. `New objective doesn\'t sufficiently improve current solution` (same as above but this happens when objectiveValue is estimated) 
3. `SafeMath: subtraction overflow` (when the solver produces a solution with negative overall objective value)

We still log those error into kibana and thus can get an idea of how often they happen. They should however not affect our success ratio as the batch was successfully processed.

As a next step we have to apply similar logic to the submitSolution transaction (this PR is for the call), which will be slightly more involved as the revert message only contains the failed tx hash and not a revert reason.

### Test Plan
Added a unit test.

Change the smart contract to always fail with an expected error inside submitSolution. Then run the ganache e2e tests and see the following output: 

```
Feb 25 11:13:31.787 INFO [driver] Using contract at 0xf204a4ef082f5c04bb89f7d5e6568b796096735a
Feb 25 11:13:31.788 INFO [driver] Using account 0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1
Feb 25 11:13:31.790 INFO [driver::price_finding] Using naive price finder
Feb 25 11:13:31.790 INFO [driver] Orderbook filter: OrderbookFilter { tokens: {}, users: {} }
Feb 25 11:13:31.904 INFO [driver::driver::stablex_driver] Computed solution: Solution { prices: {1: 1999997997997997998, 0: 1000000000000000000}, executed_buy_amounts: [999000, 1996001], executed_sell_amounts: [1999997, 999000] }
Feb 25 11:13:31.923 INFO [driver::driver::stablex_driver] Benign failure while verifying solution: Claimed objective doesn't sufficiently improve current solution
```

Lastly, we would expect none of the benign error to show up in our alerts channel as soon as this PR is merged.