### PR TITLE
Query revert reason when tx fails

### DIFF
--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 use ethcontract::transaction::GasPrice;
-use ethcontract::{Address, PrivateKey, U256};
+use ethcontract::{Address, BlockNumber, PrivateKey, U256};
 use lazy_static::lazy_static;
 #[cfg(test)]
 use mockall::automock;
@@ -77,6 +77,7 @@ pub trait StableXContract {
         batch_index: U256,
         orders: Vec<Order>,
         solution: Solution,
+        block_number: Option<BlockNumber>,
     ) -> Result<U256>;
     fn submit_solution(
         &self,
@@ -113,11 +114,12 @@ impl<'a> StableXContract for StableXContractImpl<'a> {
         batch_index: U256,
         orders: Vec<Order>,
         solution: Solution,
+        block_number: Option<BlockNumber>,
     ) -> Result<U256> {
         let (prices, token_ids_for_price) = encode_prices_for_contract(&solution.prices);
         let (owners, order_ids, volumes) =
             encode_execution_for_contract(orders, solution.executed_buy_amounts);
-        let objective_value = self
+        let builder = self
             .instance
             .submit_solution(
                 batch_index.low_u32(),
@@ -128,9 +130,14 @@ impl<'a> StableXContract for StableXContractImpl<'a> {
                 prices,
                 token_ids_for_price,
             )
-            .call()
-            .wait()?;
+            .view();
 
+        let builder = if let Some(block_number) = block_number {
+            builder.block(block_number)
+        } else {
+            builder
+        };
+        let objective_value = builder.call().wait()?;
         Ok(objective_value)
     }
 

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -119,7 +119,7 @@ impl<'a> StableXContract for StableXContractImpl<'a> {
         let (prices, token_ids_for_price) = encode_prices_for_contract(&solution.prices);
         let (owners, order_ids, volumes) =
             encode_execution_for_contract(orders, solution.executed_buy_amounts);
-        let builder = self
+        let mut builder = self
             .instance
             .submit_solution(
                 batch_index.low_u32(),
@@ -131,12 +131,7 @@ impl<'a> StableXContract for StableXContractImpl<'a> {
                 token_ids_for_price,
             )
             .view();
-
-        let builder = if let Some(block_number) = block_number {
-            builder.block(block_number)
-        } else {
-            builder
-        };
+        builder.block = block_number;
         let objective_value = builder.call().wait()?;
         Ok(objective_value)
     }

--- a/driver/src/eth_rpc.rs
+++ b/driver/src/eth_rpc.rs
@@ -7,11 +7,14 @@ use ethcontract::H256;
 #[cfg(test)]
 use mockall::automock;
 
+/// Interface defining possible interactions via Ethereum RPCs
+/// Main purpose it to allow mocking the concrete Web3 implementation
 #[cfg_attr(test, automock)]
 pub trait EthRpc {
     fn get_transaction_receipts(&self, tx_hash: H256) -> Result<Option<TransactionReceipt>, Error>;
 }
 
+/// Ethereum RPC implementation via Web3
 pub struct Web3EthRpc<'a> {
     web3: &'a contracts::Web3,
 }

--- a/driver/src/eth_rpc.rs
+++ b/driver/src/eth_rpc.rs
@@ -1,0 +1,29 @@
+use crate::contracts;
+
+use ethcontract::web3::error::Error;
+use ethcontract::web3::futures::Future;
+use ethcontract::web3::types::TransactionReceipt;
+use ethcontract::H256;
+#[cfg(test)]
+use mockall::automock;
+
+#[cfg_attr(test, automock)]
+pub trait EthRpc {
+    fn get_transaction_receipts(&self, tx_hash: H256) -> Result<Option<TransactionReceipt>, Error>;
+}
+
+pub struct Web3EthRpc<'a> {
+    web3: &'a contracts::Web3,
+}
+
+impl<'a> Web3EthRpc<'a> {
+    pub fn new(web3: &'a contracts::Web3) -> Self {
+        Self { web3 }
+    }
+}
+
+impl<'a> EthRpc for Web3EthRpc<'a> {
+    fn get_transaction_receipts(&self, tx_hash: H256) -> Result<Option<TransactionReceipt>, Error> {
+        self.web3.eth().transaction_receipt(tx_hash).wait()
+    }
+}

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -157,7 +157,7 @@ fn main() {
     info!("Orderbook filter: {:?}", options.orderbook_filter);
     let filtered_orderbook = FilteredOrderbookReader::new(&orderbook, options.orderbook_filter);
 
-    let solution_submitter = StableXSolutionSubmitter::new(&contract);
+    let solution_submitter = StableXSolutionSubmitter::new(&contract, &web3);
     let mut driver = StableXDriver::new(
         &mut *price_finder,
         &filtered_orderbook,

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -3,6 +3,7 @@ mod macros;
 
 mod contracts;
 mod driver;
+mod eth_rpc;
 mod gas_station;
 mod logging;
 mod metrics;
@@ -16,6 +17,7 @@ mod util;
 
 use crate::contracts::{stablex_contract::StableXContractImpl, web3_provider};
 use crate::driver::stablex_driver::StableXDriver;
+use crate::eth_rpc::Web3EthRpc;
 use crate::gas_station::GnosisSafeGasStation;
 use crate::metrics::{MetricsServer, StableXMetrics};
 use crate::orderbook::{FilteredOrderbookReader, OrderbookFilter, PaginatedStableXOrderBookReader};
@@ -157,7 +159,9 @@ fn main() {
     info!("Orderbook filter: {:?}", options.orderbook_filter);
     let filtered_orderbook = FilteredOrderbookReader::new(&orderbook, options.orderbook_filter);
 
-    let solution_submitter = StableXSolutionSubmitter::new(&contract, &web3);
+    let eth_rpc = Web3EthRpc::new(&web3);
+
+    let solution_submitter = StableXSolutionSubmitter::new(&contract, &eth_rpc);
     let mut driver = StableXDriver::new(
         &mut *price_finder,
         &filtered_orderbook,

--- a/driver/src/solution_submission/mod.rs
+++ b/driver/src/solution_submission/mod.rs
@@ -1,12 +1,11 @@
 #![allow(clippy::ptr_arg)] // required for automock
 
-use crate::contracts;
 use crate::contracts::stablex_contract::StableXContract;
+use crate::eth_rpc::EthRpc;
 use crate::models::{Order, Solution};
 
 use anyhow::{Error, Result};
 use ethcontract::errors::{ExecutionError, MethodError};
-use ethcontract::web3::futures::Future as F;
 use ethcontract::{H256, U256};
 #[cfg(test)]
 use mockall::automock;
@@ -80,12 +79,12 @@ impl From<Error> for SolutionSubmissionError {
 
 pub struct StableXSolutionSubmitter<'a> {
     contract: &'a dyn StableXContract,
-    web3: &'a contracts::Web3,
+    rpc: &'a dyn EthRpc,
 }
 
 impl<'a> StableXSolutionSubmitter<'a> {
-    pub fn new(contract: &'a dyn StableXContract, web3: &'a contracts::Web3) -> Self {
-        Self { contract, web3 }
+    pub fn new(contract: &'a dyn StableXContract, rpc: &'a dyn EthRpc) -> Self {
+        Self { contract, rpc }
     }
 }
 
@@ -118,7 +117,7 @@ impl<'a> StableXSolutionSubmitting for StableXSolutionSubmitter<'a> {
             .map_err(|err| {
                 extract_transaction_hash(&err)
                     .and_then(|hash| {
-                        let receipt = self.web3.eth().transaction_receipt(hash).wait().ok()??;
+                        let receipt = self.rpc.get_transaction_receipts(hash).ok()??;
                         let block_number = receipt.block_number?;
                         match self.contract.get_solution_objective_value(
                             batch_index,
@@ -141,4 +140,101 @@ fn extract_transaction_hash(err: &Error) -> Option<H256> {
             ExecutionError::Failure(tx_hash) => Some(*tx_hash),
             _ => None,
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contracts::stablex_contract::MockStableXContract;
+    use crate::eth_rpc::MockEthRpc;
+
+    use anyhow::anyhow;
+    use ethcontract::web3::types::{TransactionReceipt, H2048};
+    use mockall::predicate::{always, eq};
+
+    #[test]
+    fn test_benign_verification_failure() {
+        let eth_rpc = MockEthRpc::new();
+        let mut contract = MockStableXContract::new();
+
+        contract
+            .expect_get_solution_objective_value()
+            .return_once(move |_, _, _, _| {
+                Err(anyhow!(MethodError::from_parts(
+                "submitSolution(uint32,uint256,address[],uint16[],uint128[],uint128[],uint16[])"
+                    .to_owned(),
+                ExecutionError::Revert(Some("SafeMath: subtraction overflow".to_owned())),
+            )))
+            });
+
+        let submitter = StableXSolutionSubmitter::new(&contract, &eth_rpc);
+        let result =
+            submitter.get_solution_objective_value(U256::zero(), vec![], Solution::trivial(0));
+
+        match result.expect_err("Should have errored") {
+            SolutionSubmissionError::Benign(_) => (),
+            SolutionSubmissionError::Unexpected(err) => {
+                panic!("Expecting benign failure, but got {}", err)
+            }
+        };
+    }
+
+    #[test]
+    fn test_benign_solution_submission_failure() {
+        let mut eth_rpc = MockEthRpc::new();
+        let mut contract = MockStableXContract::new();
+
+        let tx_hash = H256::zero();
+        let block_number = 42.into();
+        let receipt = TransactionReceipt {
+            transaction_hash: tx_hash,
+            transaction_index: 0.into(),
+            block_hash: None,
+            block_number: Some(block_number),
+            cumulative_gas_used: U256::zero(),
+            gas_used: None,
+            contract_address: None,
+            logs: vec![],
+            status: None,
+            logs_bloom: H2048::zero(),
+        };
+
+        eth_rpc
+            .expect_get_transaction_receipts()
+            .with(eq(tx_hash))
+            .return_const(Ok(Some(receipt)));
+
+        // Submit Solution returns failed tx
+        contract
+            .expect_submit_solution()
+            .return_once(move |_, _, _, _| {
+                Err(anyhow!(MethodError::from_parts(
+                "submitSolution(uint32,uint256,address[],uint16[],uint128[],uint128[],uint16[])"
+                    .to_owned(),
+                ExecutionError::Failure(tx_hash),
+            )))
+            });
+        // Get objective value on old block number returns revert reason
+        contract
+            .expect_get_solution_objective_value()
+            .with(always(), always(), always(), eq(Some(block_number.into())))
+            .return_once(move |_, _, _, _| {
+                Err(anyhow!(MethodError::from_parts(
+                "submitSolution(uint32,uint256,address[],uint16[],uint128[],uint128[],uint16[])"
+                    .to_owned(),
+                ExecutionError::Revert(Some("Claimed objective doesn't sufficiently improve current solution".to_owned())),
+            )))
+            });
+
+        let submitter = StableXSolutionSubmitter::new(&contract, &eth_rpc);
+        let result =
+            submitter.submit_solution(U256::zero(), vec![], Solution::trivial(0), U256::zero());
+
+        match result.expect_err("Should have errored") {
+            SolutionSubmissionError::Benign(_) => (),
+            SolutionSubmissionError::Unexpected(err) => {
+                panic!("Expecting benign failure, but got {}", err)
+            }
+        };
+    }
 }


### PR DESCRIPTION
This PR is the first step to ignoring benign failures even when they happen upon actual solution submission (not just verification). This can happen in a race condition where two solvers verified their solution is better than the current best one and each submit their solution. They might end up mined in the same block and the later one could get reverted as it is not sufficiently better than the first one (e.g. https://etherscan.io/tx/0x9d6e7954efd1fa7c35ccd9022308b2a9ecb890cdc472e374b9d3220c6aa4a6b9)

ethcontracts only gives us the failed TX hash and not the revert reason. Therefore, we have to identify the block number in which this tx was mined and reissue `submit_solution` as a call (not a tx). This will give us the underlying revert reason.

In the next PR I will make it so that we treat benign errors similar as to how we do for verification failures.

### Test Plan

Added a unit test. 

Also changing the smart contract to revert with a benign reason if the objective value is small:

```solidity
require(claimedObjectiveValue > 1146456329082338568550207772363246612408613709560797663757005782256565639990, "Claimed objective doesn't sufficiently improve current solution");
```

We also need to change the code [here](https://github.com/gnosis/dex-services/blob/814920b265c8065cd914298f07e0ef00a0741b80/driver/src/contracts/stablex_contract.rs#L126) to that we don't supply the MAX_OBJECTIVE_VALUE if a block_number is specified (otherwise we won't get the same revert reason when we replay the verification)

Then we can run a ganache with "ERROR ON TRANSACTION FAILURE" disabled and the following e2e test:

`cargo test -p e2e ganache -- --nocapture`

In the logs we can then see:

> Feb 26 18:30:45.035 ERRO [driver] StableXDriver error: Benign Error: Claimed objective doesn't sufficiently improve current solution