### PR TITLE
Skip first batch

### DIFF
--- a/driver/src/driver/stablex_driver.rs
+++ b/driver/src/driver/stablex_driver.rs
@@ -47,17 +47,20 @@ impl<'a> StableXDriver<'a> {
             return Ok(false);
         }
 
-        // NOTE: As an interim solution, we skip the first batch so we don't
-        //   spill over into the second batch.
-        if let Some(first_batch) = batch_to_solve_result.as_ref().ok().and_then(|batch| {
-            if self.past_auctions.is_empty() {
-                Some(*batch)
-            } else {
-                None
+        #[cfg(not(test))]
+        {
+            // NOTE: As an interim solution, we skip the first batch so we don't
+            //   spill over into the second batch.
+            if let Some(first_batch) = batch_to_solve_result.as_ref().ok().and_then(|batch| {
+                if self.past_auctions.is_empty() {
+                    Some(*batch)
+                } else {
+                    None
+                }
+            }) {
+                self.past_auctions.insert(first_batch);
+                return Ok(false);
             }
-        }) {
-            self.past_auctions.insert(first_batch);
-            return OK(false);
         }
 
         self.metrics

--- a/driver/src/driver/stablex_driver.rs
+++ b/driver/src/driver/stablex_driver.rs
@@ -47,6 +47,19 @@ impl<'a> StableXDriver<'a> {
             return Ok(false);
         }
 
+        // NOTE: As an interim solution, we skip the first batch so we don't
+        //   spill over into the second batch.
+        if let Some(first_batch) = batch_to_solve_result.as_ref().ok().and_then(|batch| {
+            if self.past_auctions.is_empty() {
+                Some(*batch)
+            } else {
+                None
+            }
+        }) {
+            self.past_auctions.insert(first_batch);
+            return OK(false);
+        }
+
         self.metrics
             .auction_processing_started(&batch_to_solve_result);
         let batch_to_solve = batch_to_solve_result?;

--- a/driver/src/driver/stablex_driver.rs
+++ b/driver/src/driver/stablex_driver.rs
@@ -59,6 +59,7 @@ impl<'a> StableXDriver<'a> {
                 }
             }) {
                 self.past_auctions.insert(first_batch);
+                self.metrics.auction_ignored();
                 return Ok(false);
             }
         }

--- a/driver/src/metrics/stablex_metrics.rs
+++ b/driver/src/metrics/stablex_metrics.rs
@@ -73,7 +73,6 @@ impl StableXMetrics {
         }
     }
 
-    #[cfg(not(test))]
     pub fn auction_ignored(&self) {
         let stage_label = &[ProcessingStage::Started.as_ref()];
         self.failures.with_label_values(stage_label).inc();

--- a/driver/src/metrics/stablex_metrics.rs
+++ b/driver/src/metrics/stablex_metrics.rs
@@ -73,6 +73,12 @@ impl StableXMetrics {
         }
     }
 
+    #[cfg(not(test))]
+    pub fn auction_ignored(&self) {
+        let stage_label = &[ProcessingStage::Started.as_ref()];
+        self.failures.with_label_values(stage_label).inc();
+    }
+
     pub fn auction_processing_started(&self, res: &Result<U256>) {
         let stage_label = &[ProcessingStage::Started.as_ref()];
         match res {


### PR DESCRIPTION
As an interim solution, we skip the first batch to avoid missing the solution submission deadline and possibly cause the second batch to fail as well.

Skipped batches do not log errors but will add a increment the "failed" metric counter as we don't want to consider them successes.

A better solution is currently being worked on.

### Test Plan

CI