### PR TITLE
[Easy] No longer receiving external price info via solver && clean up for token_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The following environment variables can be used to configure the behavior of the
 - *ORDERBOOK_FILTER*: json encoded object of which tokens/filters to ignore. See below for example filter.
 - *PRIVATE_KEY*: The key with which to sign transactions
 - *WEB3_RPC_TIMEOUT*: The timeout in milliseconds of web3 JSON RPC calls, defaults to 10000ms
-- _TOKEN_DATA_: Allows to set token data - i.e symbol name, decimals, a default external price and a flag for indicating whether updated external prices should be fetched.
+- *TOKEN_DATA*: Allows to set token data - i.e symbol name, decimals, a default external price and a flag for indicating whether updated external prices should be fetched.
 
 ### Orderbook Filter Example
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ The following environment variables can be used to configure the behavior of the
 - *ORDERBOOK_FILTER*: json encoded object of which tokens/filters to ignore. See below for example filter.
 - *PRIVATE_KEY*: The key with which to sign transactions
 - *WEB3_RPC_TIMEOUT*: The timeout in milliseconds of web3 JSON RPC calls, defaults to 10000ms
+- _TOKEN_DATA_: Allows to set token data - i.e symbol name, decimals, a default external price and a flag for indicating whether updated external prices should be fetched.
 
 ### Orderbook Filter Example
 

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -81,7 +81,7 @@ struct Options {
     ///   }
     /// }'
     #[structopt(long, env = "TOKEN_DATA", default_value = "{}")]
-    backup_token_data: TokenData,
+    token_data: TokenData,
 
     /// Number of seconds the solver should maximally use for the optimization process
     #[structopt(long, env = "SOLVER_TIME_LIMIT", default_value = "150")]

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -153,7 +153,7 @@ fn main() {
     });
 
     let fee = Some(Fee::default());
-    let price_oracle = PriceOracle::new(options.backup_token_data).unwrap();
+    let price_oracle = PriceOracle::new(options.token_data).unwrap();
     let mut price_finder = price_finding::create_price_finder(fee, solver_config, price_oracle);
 
     let orderbook = PaginatedStableXOrderBookReader::new(&contract, options.auction_data_page_size);

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -70,16 +70,17 @@ struct Options {
     ///   "T0001": {
     ///     "alias": "WETH",
     ///     "decimals": 18,
-    ///     "external_price": 200000000000000000000
+    ///     "externalPrice": 200000000000000000000,
+    ///     "shouldEstimatePrice": false
     ///   },
     ///   "T0004": {
     ///     "alias": "USDC",
     ///     "decimals": 6,
-    ///     "external_price": 1000000000000000000000000000000,
-    ///     "should_estimate_price": true
+    ///     "externalPrice": 1000000000000000000000000000000,
+    ///     "shouldEstimatePrice": true
     ///   }
     /// }'
-    #[structopt(long, env = "PRICE_FEED_INFORMATION", default_value = "{}")]
+    #[structopt(long, env = "TOKEN_DATA", default_value = "{}")]
     backup_token_data: TokenData,
 
     /// Number of seconds the solver should maximally use for the optimization process

--- a/driver/src/price_finding/optimization_price_finder.rs
+++ b/driver/src/price_finding/optimization_price_finder.rs
@@ -238,8 +238,7 @@ fn write_input(input_file: &str, input: &str) -> std::io::Result<()> {
 }
 
 fn run_solver(input_file: &str, result_folder: &str, solver_config: SolverConfig) -> Result<()> {
-    let output;
-    output = Command::new("python")
+    let output = Command::new("python")
         .args(&["-m", "batchauctions.scripts.e2e._run"])
         .arg(result_folder)
         .args(&["--jsonFile", input_file])

--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -46,6 +46,7 @@ impl SolverConfig {
             SolverConfig::FallbackSolver { solver_time_limit } => vec![
                 format!("--solverTimeLimit={:}", solver_time_limit),
                 String::from("--tokenInfo=/app/batchauctions/scripts/token_info_mainnet.json"),
+                String::from("--useExternalPrices"),
             ],
             SolverConfig::NaiveSolver => {
                 panic!("OptimizationSolver should not be called with naive solver")

--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -46,7 +46,6 @@ impl SolverConfig {
             SolverConfig::FallbackSolver { solver_time_limit } => vec![
                 format!("--solverTimeLimit={:}", solver_time_limit),
                 String::from("--tokenInfo=/app/batchauctions/scripts/token_info_mainnet.json"),
-                String::from("--useExternalPrices"),
             ],
             SolverConfig::NaiveSolver => {
                 panic!("OptimizationSolver should not be called with naive solver")


### PR DESCRIPTION
- No longer receiving external price info via solver 
- Updating documentation and a small renaming of the env PRICE_INFORMATION to TOKEN_DATA. 
