### PR TITLE
Use a shared HTTP client implementation

### DIFF
--- a/driver/src/contracts/mod.rs
+++ b/driver/src/contracts/mod.rs
@@ -1,17 +1,17 @@
 pub mod stablex_auction_element;
 pub mod stablex_contract;
 
+use crate::http::HttpFactory;
 use crate::transport::HttpTransport;
 use anyhow::Result;
 use ethcontract::contract::MethodDefaults;
-
 use ethcontract::{Account, PrivateKey};
 use std::time::Duration;
 
 pub type Web3 = ethcontract::web3::api::Web3<HttpTransport>;
 
-pub fn web3_provider(url: &str, timeout: Duration) -> Result<Web3> {
-    let http = HttpTransport::new(url, timeout)?;
+pub fn web3_provider(http_factory: &HttpFactory, url: &str, timeout: Duration) -> Result<Web3> {
+    let http = HttpTransport::new(http_factory, url, timeout)?;
     let web3 = Web3::new(http);
 
     Ok(web3)

--- a/driver/src/gas_station.rs
+++ b/driver/src/gas_station.rs
@@ -70,7 +70,6 @@ fn uint_error_to_string(err: FromDecStrErr) -> &'static str {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::http::TEST_FACTORY;
 
     #[test]
     fn deserialize() {
@@ -97,7 +96,7 @@ pub mod tests {
     #[test]
     #[ignore]
     fn real_request() {
-        let gas_station = GnosisSafeGasStation::new(&*TEST_FACTORY, DEFAULT_URI).unwrap();
+        let gas_station = GnosisSafeGasStation::new(&HttpFactory::default(), DEFAULT_URI).unwrap();
         let gas_price = gas_station.estimate_gas_price().unwrap();
         println!("{:?}", gas_price);
     }

--- a/driver/src/http.rs
+++ b/driver/src/http.rs
@@ -80,4 +80,13 @@ impl HttpClient {
     {
         Ok(self.inner.get(url)?.json()?)
     }
+
+    /// Async HTTP GET request that parses the result as JSON.
+    pub async fn get_json_async<U, T>(&self, url: U) -> Result<T>
+    where
+        Uri: HttpTryFrom<U>,
+        T: DeserializeOwned,
+    {
+        Ok(self.inner.get_async(url).await?.json()?)
+    }
 }

--- a/driver/src/http.rs
+++ b/driver/src/http.rs
@@ -8,12 +8,6 @@ use isahc::{HttpClientBuilder, ResponseExt};
 use serde::de::DeserializeOwned;
 use std::time::Duration;
 
-#[cfg(test)]
-lazy_static::lazy_static! {
-    /// An HTTP factory used for testing.
-    pub static ref TEST_FACTORY: HttpFactory = HttpFactory::new(Duration::from_secs(10));
-}
-
 /// A factory type for creating HTTP clients.
 #[derive(Debug)]
 pub struct HttpFactory {
@@ -38,6 +32,13 @@ impl HttpFactory {
     ) -> Result<HttpClient> {
         let inner = configure(isahc::HttpClient::builder()).build()?;
         Ok(HttpClient { inner })
+    }
+}
+
+#[cfg(test)]
+impl Default for HttpFactory {
+    fn default() -> Self {
+        HttpFactory::new(Duration::from_secs(10))
     }
 }
 

--- a/driver/src/http/mod.rs
+++ b/driver/src/http/mod.rs
@@ -1,0 +1,82 @@
+//! Module contains the implementation for a shared HTTP client for various
+//! driver components.
+
+use anyhow::{anyhow, Result};
+use isahc::http::{HttpTryFrom, Uri};
+use isahc::prelude::Request;
+use isahc::{HttpClientBuilder, ResponseExt};
+use serde::de::DeserializeOwned;
+use std::time::Duration;
+
+#[cfg(test)]
+lazy_static::lazy_static! {
+    /// An HTTP factory used for testing.
+    pub static ref TEST_FACTORY: HttpFactory = HttpFactory::new(Duration::from_secs(10));
+}
+
+/// A factory type for creating HTTP clients.
+#[derive(Debug)]
+pub struct HttpFactory {
+    default_timeout: Duration,
+}
+
+impl HttpFactory {
+    /// Creates a new HTTP client factory.
+    pub fn new(default_timeout: Duration) -> Self {
+        HttpFactory { default_timeout }
+    }
+
+    /// Creates a new HTTP client with the default configuration.
+    pub fn create(&self) -> Result<HttpClient> {
+        self.with_config(|builder| builder)
+    }
+
+    /// Creates a new HTTP Client with the given configuration.
+    pub fn with_config(
+        &self,
+        configure: impl FnOnce(HttpClientBuilder) -> HttpClientBuilder,
+    ) -> Result<HttpClient> {
+        let inner = configure(isahc::HttpClient::builder()).build()?;
+        Ok(HttpClient { inner })
+    }
+}
+
+/// An HTTP client instance.
+#[derive(Debug)]
+pub struct HttpClient {
+    inner: isahc::HttpClient,
+}
+
+impl HttpClient {
+    /// Post raw JSON data and return a future that resolves once the HTTP
+    /// request has been completed.
+    pub async fn post_raw_json_async<U>(&self, url: U, data: impl Into<String>) -> Result<String>
+    where
+        Uri: HttpTryFrom<U>,
+    {
+        let http_request = Request::post(url)
+            .header("Content-Type", "application/json")
+            .body(data.into())?;
+        let mut response = self.inner.send_async(http_request).await?;
+        let content = response.text()?;
+
+        if response.status().is_success() {
+            Ok(content)
+        } else {
+            Err(anyhow!(
+                "HTTP error status {}: '{}'",
+                response.status(),
+                content.trim()
+            ))
+        }
+    }
+
+    /// Standard HTTP GET request that parses the result as JSON.
+    pub fn get_json<U, T>(&self, url: U) -> Result<T>
+    where
+        Uri: HttpTryFrom<U>,
+        T: DeserializeOwned,
+    {
+        Ok(self.inner.get(url)?.json()?)
+    }
+}

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -5,6 +5,7 @@ mod contracts;
 mod driver;
 mod eth_rpc;
 mod gas_station;
+mod http;
 mod logging;
 mod metrics;
 mod models;
@@ -19,6 +20,7 @@ use crate::contracts::{stablex_contract::StableXContractImpl, web3_provider};
 use crate::driver::stablex_driver::StableXDriver;
 use crate::eth_rpc::Web3EthRpc;
 use crate::gas_station::GnosisSafeGasStation;
+use crate::http::HttpFactory;
 use crate::metrics::{MetricsServer, StableXMetrics};
 use crate::orderbook::{FilteredOrderbookReader, OrderbookFilter, PaginatedStableXOrderBookReader};
 use crate::price_estimation::{PriceOracle, TokenData};
@@ -116,14 +118,16 @@ struct Options {
     )]
     rpc_timeout: Duration,
 
-    /// The timeout in milliseconds of gas station calls, defaults to 10000ms
+    /// The default timeout in milliseconds of HTTP requests to remote services
+    /// such as the Gnosis Safe gas station and exchange REST APIs for fetching
+    /// price estimates.
     #[structopt(
         long,
-        env = "GAS_STATION_TIMEOUT",
+        env = "HTTP_TIMEOUT",
         default_value = "10000",
         parse(try_from_str = duration_millis),
     )]
-    gas_station_timeout: Duration,
+    http_timeout: Duration,
 }
 
 fn main() {
@@ -131,9 +135,27 @@ fn main() {
     let (_, _guard) = logging::init(&options.log_filter);
     info!("Starting driver with runtime options: {:#?}", options);
     let solver_config = SolverConfig::new(&options.solver_type, options.solver_time_limit).unwrap();
-    let web3 = web3_provider(options.node_url.as_str(), options.rpc_timeout).unwrap();
-    let gas_station =
-        GnosisSafeGasStation::new(options.gas_station_timeout, gas_station::DEFAULT_URI).unwrap();
+
+    // Set up metrics and serve in separate thread.
+    let prometheus_registry = Arc::new(Registry::new());
+    let stablex_metrics = StableXMetrics::new(prometheus_registry.clone());
+    let metric_server = MetricsServer::new(prometheus_registry);
+    thread::spawn(move || {
+        metric_server.serve(9586);
+    });
+
+    // Set up shared HTTP client and HTTP services.
+    let http_factory = HttpFactory::new(options.http_timeout);
+    let web3 = web3_provider(
+        &http_factory,
+        options.node_url.as_str(),
+        options.rpc_timeout,
+    )
+    .unwrap();
+    let gas_station = GnosisSafeGasStation::new(&http_factory, gas_station::DEFAULT_URI).unwrap();
+    let price_oracle = PriceOracle::new(&http_factory, options.token_data).unwrap();
+
+    // Set up web3 and contract connection.
     let contract = StableXContractImpl::new(
         &web3,
         options.private_key.clone(),
@@ -144,25 +166,20 @@ fn main() {
     info!("Using contract at {:?}", contract.address());
     info!("Using account {:?}", contract.account());
 
-    // Set up metrics and serve in separate thread
-    let prometheus_registry = Arc::new(Registry::new());
-    let stablex_metrics = StableXMetrics::new(prometheus_registry.clone());
-    let metric_server = MetricsServer::new(prometheus_registry);
-    thread::spawn(move || {
-        metric_server.serve(9586);
-    });
-
+    // Set up solver.
     let fee = Some(Fee::default());
-    let price_oracle = PriceOracle::new(options.token_data).unwrap();
     let mut price_finder = price_finding::create_price_finder(fee, solver_config, price_oracle);
 
+    // Create the orderbook reader.
     let orderbook = PaginatedStableXOrderBookReader::new(&contract, options.auction_data_page_size);
     info!("Orderbook filter: {:?}", options.orderbook_filter);
     let filtered_orderbook = FilteredOrderbookReader::new(&orderbook, options.orderbook_filter);
 
+    // Set up solution submitter.
     let eth_rpc = Web3EthRpc::new(&web3);
-
     let solution_submitter = StableXSolutionSubmitter::new(&contract, &eth_rpc);
+
+    // Set up the driver and start the run-loop.
     let mut driver = StableXDriver::new(
         &mut *price_finder,
         &filtered_orderbook,

--- a/driver/src/price_estimation/dexag/api.rs
+++ b/driver/src/price_estimation/dexag/api.rs
@@ -78,9 +78,10 @@ impl DexagApi for DexagHttpApi {
         async move {
             Ok(self
                 .client
-                .get_json_async(url.as_str())
+                .get_json_async::<_, Price>(url.as_str())
                 .await
-                .context("failed to parse price json from dexag")?)
+                .context("failed to parse price json from dexag")?
+                .price)
         }
         .boxed()
     }
@@ -120,14 +121,15 @@ mod tests {
         assert!(token.address.is_none());
     }
 
-    // Run with `cargo test online_dexag_api -- --include-ignored --nocapture`.
+    // Run with `cargo test online_dexag_api -- --ignored --nocapture`.
     #[test]
     #[ignore]
     fn online_dexag_api() {
         let api = DexagHttpApi::new(&HttpFactory::default()).unwrap();
         let tokens = api.get_token_list().unwrap();
-        println!("{:?}", tokens);
+        println!("{:#?}", tokens);
+
         let price = futures::executor::block_on(api.get_price(&tokens[0], &tokens[1])).unwrap();
-        println!("{:?}", price);
+        println!("{:#?}", price);
     }
 }

--- a/driver/src/price_estimation/dexag/mod.rs
+++ b/driver/src/price_estimation/dexag/mod.rs
@@ -1,6 +1,7 @@
 mod api;
 
 use super::{PriceSource, Token};
+use crate::http::HttpFactory;
 use crate::models::TokenId;
 use anyhow::{anyhow, Context, Result};
 use api::{DexagApi, DexagHttpApi};
@@ -24,8 +25,8 @@ pub struct DexagClient<Api> {
 
 impl DexagClient<DexagHttpApi> {
     /// Create a DexagClient using DexagHttpApi as the api implementation.
-    pub fn new() -> Result<Self> {
-        let api = DexagHttpApi::new()?;
+    pub fn new(http_factory: &HttpFactory) -> Result<Self> {
+        let api = DexagHttpApi::new(http_factory)?;
         Ok(Self::with_api(api))
     }
 }
@@ -280,7 +281,7 @@ mod tests {
             Token::new(15, "SNX", 18),
         ];
 
-        let client = DexagClient::new().unwrap();
+        let client = DexagClient::new(&HttpFactory::default()).unwrap();
         let before = Instant::now();
         let prices = client.get_prices(tokens).unwrap();
         let after = Instant::now();

--- a/driver/src/price_estimation/dexag/mod.rs
+++ b/driver/src/price_estimation/dexag/mod.rs
@@ -262,7 +262,7 @@ mod tests {
         );
     }
 
-    // Run with `cargo test online_dexag_client -- --include-ignored --nocapture`.
+    // Run with `cargo test online_dexag_client -- --ignored --nocapture`.
     #[test]
     #[ignore]
     fn online_dexag_client() {

--- a/driver/src/price_estimation/kraken.rs
+++ b/driver/src/price_estimation/kraken.rs
@@ -4,6 +4,7 @@ mod api;
 
 use self::api::{Asset, AssetPair, KrakenApi, KrakenHttpApi};
 use super::{PriceSource, Token};
+use crate::http::HttpFactory;
 use crate::models::TokenId;
 use anyhow::{anyhow, Context, Result};
 use std::collections::HashMap;
@@ -18,8 +19,8 @@ pub struct KrakenClient<Api> {
 impl KrakenClient<KrakenHttpApi> {
     /// Creates a new client instance using an HTTP API instance and the default
     /// Kraken API base URL.
-    pub fn new() -> Result<Self> {
-        let api = KrakenHttpApi::new()?;
+    pub fn new(http_factory: &HttpFactory) -> Result<Self> {
+        let api = KrakenHttpApi::new(http_factory)?;
         Ok(KrakenClient::with_api(api))
     }
 }
@@ -117,6 +118,7 @@ fn find_asset_pair<'a>(
 mod tests {
     use super::api::{MockKrakenApi, TickerInfo};
     use super::*;
+    use crate::http::TEST_FACTORY;
     use std::collections::HashSet;
     use std::time::Instant;
 
@@ -192,7 +194,7 @@ mod tests {
 
         let start_time = Instant::now();
         {
-            let client = KrakenClient::new().unwrap();
+            let client = KrakenClient::new(&*TEST_FACTORY).unwrap();
             let prices = client.get_prices(&tokens).unwrap();
 
             println!("{:#?}", prices);

--- a/driver/src/price_estimation/kraken.rs
+++ b/driver/src/price_estimation/kraken.rs
@@ -118,7 +118,6 @@ fn find_asset_pair<'a>(
 mod tests {
     use super::api::{MockKrakenApi, TickerInfo};
     use super::*;
-    use crate::http::TEST_FACTORY;
     use std::collections::HashSet;
     use std::time::Instant;
 
@@ -194,7 +193,7 @@ mod tests {
 
         let start_time = Instant::now();
         {
-            let client = KrakenClient::new(&*TEST_FACTORY).unwrap();
+            let client = KrakenClient::new(&HttpFactory::default()).unwrap();
             let prices = client.get_prices(&tokens).unwrap();
 
             println!("{:#?}", prices);

--- a/driver/src/price_estimation/kraken/api.rs
+++ b/driver/src/price_estimation/kraken/api.rs
@@ -1,9 +1,8 @@
+use crate::http::{HttpClient, HttpFactory};
 use anyhow::{anyhow, Context, Result};
-use isahc::prelude::*;
 use serde::Deserialize;
 use serde_with::rust::display_fromstr;
 use std::collections::HashMap;
-use std::time::Duration;
 
 /// A trait representing a Kraken API client.
 ///
@@ -32,19 +31,13 @@ pub struct KrakenHttpApi {
 /// The default Kraken API base URL.
 pub const DEFAULT_API_BASE_URL: &str = "https://api.kraken.com/0/public";
 
-/// The default timeout used for HTTP requests to Kraken.
-pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
-
 impl KrakenHttpApi {
-    pub fn new() -> Result<Self> {
-        KrakenHttpApi::with_url(DEFAULT_API_BASE_URL, DEFAULT_TIMEOUT)
+    pub fn new(http_factory: &HttpFactory) -> Result<Self> {
+        KrakenHttpApi::with_url(http_factory, DEFAULT_API_BASE_URL)
     }
 
-    pub fn with_url(base_url: &str, timeout: Duration) -> Result<Self> {
-        let client = HttpClient::builder()
-            .timeout(timeout)
-            .build()
-            .context("failed to initialize HTTP client")?;
+    pub fn with_url(http_factory: &HttpFactory, base_url: &str) -> Result<Self> {
+        let client = http_factory.create()?;
         Ok(KrakenHttpApi {
             base_url: base_url.into(),
             client,
@@ -55,27 +48,25 @@ impl KrakenHttpApi {
 impl KrakenApi for KrakenHttpApi {
     fn assets(&self) -> Result<HashMap<String, Asset>> {
         self.client
-            .get(format!("{}/Assets", self.base_url))
-            .context("failed to retrieve list of assets from Kraken")?
-            .json::<KrakenResult<_>>()
+            .get_json::<_, KrakenResult<_>>(format!("{}/Assets", self.base_url))
             .context("failed to parse assets JSON")?
             .into_result()
     }
 
     fn asset_pairs(&self) -> Result<HashMap<String, AssetPair>> {
         self.client
-            .get(format!("{}/AssetPairs", self.base_url))
-            .context("failed to retrieve list of asset pairs from Kraken")?
-            .json::<KrakenResult<_>>()
+            .get_json::<_, KrakenResult<_>>(format!("{}/AssetPairs", self.base_url))
             .context("failed to parse asset pairs JSON")?
             .into_result()
     }
 
     fn ticker(&self, pairs: &[&str]) -> Result<HashMap<String, TickerInfo>> {
         self.client
-            .get(format!("{}/Ticker?pair={}", self.base_url, pairs.join(",")))
-            .context("failed to retrieve ticker infos from Kraken")?
-            .json::<KrakenResult<_>>()
+            .get_json::<_, KrakenResult<_>>(format!(
+                "{}/Ticker?pair={}",
+                self.base_url,
+                pairs.join(",")
+            ))
             .context("failed to parse ticker JSON")?
             .into_result()
     }
@@ -186,6 +177,7 @@ impl PricePair {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::http::TEST_FACTORY;
     use serde::de::DeserializeOwned;
 
     fn deserialize<T: DeserializeOwned>(json: &str) -> T {
@@ -253,7 +245,7 @@ mod tests {
         // cargo test online_kraken_api -- --ignored --nocapture
         // ```
 
-        let api = KrakenHttpApi::new().unwrap();
+        let api = KrakenHttpApi::new(&*TEST_FACTORY).unwrap();
 
         let assets = api.assets().unwrap();
         println!("GNO asset information: {:?}", assets["GNO"]);

--- a/driver/src/price_estimation/kraken/api.rs
+++ b/driver/src/price_estimation/kraken/api.rs
@@ -177,7 +177,6 @@ impl PricePair {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::http::TEST_FACTORY;
     use serde::de::DeserializeOwned;
 
     fn deserialize<T: DeserializeOwned>(json: &str) -> T {
@@ -245,7 +244,7 @@ mod tests {
         // cargo test online_kraken_api -- --ignored --nocapture
         // ```
 
-        let api = KrakenHttpApi::new(&*TEST_FACTORY).unwrap();
+        let api = KrakenHttpApi::new(&HttpFactory::default()).unwrap();
 
         let assets = api.assets().unwrap();
         println!("GNO asset information: {:?}", assets["GNO"]);

--- a/driver/src/price_estimation/mod.rs
+++ b/driver/src/price_estimation/mod.rs
@@ -9,6 +9,7 @@ mod kraken;
 pub use self::data::TokenData;
 use self::dexag::DexagClient;
 use self::kraken::KrakenClient;
+use crate::http::HttpFactory;
 use crate::models::{Order, TokenId, TokenInfo};
 use anyhow::Result;
 use average_price_source::AveragePriceSource;
@@ -40,10 +41,13 @@ pub struct PriceOracle {
 
 impl PriceOracle {
     /// Creates a new price oracle from a token whitelist data.
-    pub fn new(tokens: TokenData) -> Result<Self> {
+    pub fn new(http_factory: &HttpFactory, tokens: TokenData) -> Result<Self> {
         Ok(PriceOracle::with_source(
             tokens,
-            AveragePriceSource::new(KrakenClient::new()?, DexagClient::new()?),
+            AveragePriceSource::new(
+                KrakenClient::new(http_factory)?,
+                DexagClient::new(http_factory)?,
+            ),
         ))
     }
 

--- a/driver/src/transport.rs
+++ b/driver/src/transport.rs
@@ -1,3 +1,4 @@
+use crate::http::{HttpClient, HttpFactory};
 use anyhow::Error;
 use ethcontract::jsonrpc::types::{Call, Output};
 use ethcontract::web3::helpers;
@@ -5,9 +6,7 @@ use ethcontract::web3::{Error as Web3Error, RequestId, Transport};
 use futures::compat::Compat;
 use futures::future::{BoxFuture, FutureExt, TryFutureExt};
 use isahc::config::VersionNegotiation;
-use isahc::prelude::{Body, Request, Response};
-use isahc::{Error as HttpError, HttpClient, ResponseExt};
-use log::{debug, warn};
+use log::{debug, info, warn};
 use serde::Deserialize;
 use serde_json::Value;
 use std::fmt::{self, Debug, Formatter};
@@ -28,13 +27,18 @@ struct HttpTransportInner {
 
 impl HttpTransport {
     /// Creates a new HTTP transport with settings.
-    pub fn new(url: impl Into<String>, timeout: Duration) -> Result<HttpTransport, Error> {
-        let client = HttpClient::builder()
-            .timeout(timeout)
-            // NOTE: This is needed as curl will try to upgrade to HTTP/2 which
-            //   causes a HTTP 400 error with Ganache.
-            .version_negotiation(VersionNegotiation::http11())
-            .build()?;
+    pub fn new(
+        http_factory: &HttpFactory,
+        url: impl Into<String>,
+        timeout: Duration,
+    ) -> Result<HttpTransport, Error> {
+        let client = http_factory.with_config(|builder| {
+            builder
+                .timeout(timeout)
+                // NOTE: This is needed as curl will try to upgrade to HTTP/2 which
+                //   causes a HTTP 400 error with Ganache.
+                .version_negotiation(VersionNegotiation::http11())
+        })?;
 
         Ok(HttpTransport(Arc::new(HttpTransportInner {
             url: url.into(),
@@ -45,19 +49,6 @@ impl HttpTransport {
 }
 
 impl HttpTransportInner {
-    /// Performs an HTTP POST with the given data.
-    async fn post_json(&self, data: String) -> Result<(Response<Body>, String), HttpError> {
-        let http_request = Request::post(&self.url)
-            // NOTE: This is needed as Parity clients will respond with a HTTP
-            //   error when no content type is provided.
-            .header("Content-Type", "application/json")
-            .body(data)?;
-        let mut response = self.client.send_async(http_request).await?;
-        let content = response.text()?;
-
-        Ok((response, content))
-    }
-
     /// Execute an HTTP JSON RPC request.
     async fn execute_rpc(
         self: Arc<Self>,
@@ -67,24 +58,14 @@ impl HttpTransportInner {
         let request = serde_json::to_string(&request)?;
         debug!("[id:{}] sending request: '{}'", id, &request);
 
-        let (response, content) = self.post_json(request).await.map_err(|err| {
-            warn!("[id:{}] returned an error: '{}'", id, err.to_string());
-            Web3Error::Transport(err.to_string())
-        })?;
-        if !response.status().is_success() {
-            warn!(
-                "[id:{}] HTTP error code {}: '{}' {:?}",
-                id,
-                response.status(),
-                content.trim(),
-                response,
-            );
-            return Err(Web3Error::Transport(format!(
-                "HTTP error status {}: '{}'",
-                response.status(),
-                content.trim(),
-            )));
-        }
+        let content = self
+            .client
+            .post_raw_json_async(&self.url, request)
+            .await
+            .map_err(|err| {
+                warn!("[id:{}] returned an error: '{}'", id, err.to_string());
+                Web3Error::Transport(err.to_string())
+            })?;
 
         debug!("[id:{}] received response: '{}'", id, content.trim());
         let mut json = Value::from_str(&content)?;
@@ -93,7 +74,7 @@ impl HttpTransportInner {
             //   filter those out.
             if map.contains_key("result") {
                 if let Some(error) = map.remove("error") {
-                    warn!("[id:{}] received Ganache auxiliary error {}", id, error);
+                    info!("[id:{}] received Ganache auxiliary error {}", id, error);
                 }
             }
         }


### PR DESCRIPTION
Use a shared HTTP client implementation. This is the first step for #581 so we can share metrics across HTTP services.

### Test Plan

CI