### PR TITLE
Make e2e test solvable with standard-solver

### DIFF
--- a/e2e/src/common.rs
+++ b/e2e/src/common.rs
@@ -131,7 +131,7 @@ pub fn create_accounts_with_funded_tokens(
                 .wait_and_expect("Cannot deploy Mintable Token");
             for account in &accounts {
                 token
-                    .mint(*account, U256::exp10(18) * token_minted)
+                    .mint(*account, U256::exp10(22) * token_minted)
                     .wait_and_expect("Cannot mint token");
             }
             IERC20::at(&web3, token.address())
@@ -144,7 +144,7 @@ pub fn approve(tokens: &[IERC20], address: Address, accounts: &[Address], approv
     for account in accounts {
         for token in tokens {
             token
-                .approve(address, U256::exp10(18) * approval_amount)
+                .approve(address, U256::exp10(22) * approval_amount)
                 .from(Account::Local(*account, None))
                 .wait()
                 .unwrap_or_else(|_| panic!("Cannot approve token {:x}", token.address()));

--- a/e2e/src/stablex.rs
+++ b/e2e/src/stablex.rs
@@ -30,9 +30,9 @@ pub fn setup_stablex(
     owl.set_minter(accounts[0])
         .wait_and_expect("Cannot set minter");
     for account in &accounts {
-        owl.mint_owl(*account, U256::exp10(18) * token_minted)
+        owl.mint_owl(*account, U256::exp10(22) * token_minted)
             .wait_and_expect("Cannot mint OWl");
-        owl.approve(instance.address(), U256::exp10(18) * token_minted)
+        owl.approve(instance.address(), U256::exp10(22) * token_minted)
             .from(Account::Local(*account, None))
             .wait_and_expect("Cannot approve OWL for burning");
     }

--- a/e2e/tests/stablex_test.rs
+++ b/e2e/tests/stablex_test.rs
@@ -97,10 +97,13 @@ fn test_with_ganache() {
     let balance_after = tokens[1]
         .balance_of(accounts[0])
         .wait_and_expect("Cannot get balance after");
-    assert_eq!(
-        balance_after - balance_before,
-        (999 * usd_price_in_fee).into()
-    )
+    let balance_change = (balance_after - balance_before).as_u128();
+    let expected_balance_change = 999 * usd_price_in_fee;
+    // With a non naive solver it is possible that the trade does not exactly
+    // match what is expected.
+    let allowed_difference = usd_price_in_fee;
+    let difference = ((balance_change as i128) - (expected_balance_change as i128)).abs();
+    assert!(difference < allowed_difference as i128);
 }
 
 #[test]


### PR DESCRIPTION
The standard solver expects 10**18 units of the fee token to be worth
roughly 1 USD so very low amounts as have been used in the test get
filtered out.

Test Plan: Run the ganache e2e the test with the real solver.