### PR TITLE
[Easy] Don't log an error when we ignore a batch due to late start

### DIFF
--- a/driver/src/driver/stablex_driver.rs
+++ b/driver/src/driver/stablex_driver.rs
@@ -68,7 +68,6 @@ impl<'a> StableXDriver<'a> {
         //   spill over into the second batch.
         if self.past_auctions.is_empty() {
             self.past_auctions.insert(batch_to_solve);
-            self.metrics.auction_ignored();
             return Ok(false);
         }
 

--- a/driver/src/metrics/stablex_metrics.rs
+++ b/driver/src/metrics/stablex_metrics.rs
@@ -73,11 +73,6 @@ impl StableXMetrics {
         }
     }
 
-    pub fn auction_ignored(&self) {
-        let stage_label = &[ProcessingStage::Started.as_ref()];
-        self.failures.with_label_values(stage_label).inc();
-    }
-
     pub fn auction_processing_started(&self, res: &Result<U256>) {
         let stage_label = &[ProcessingStage::Started.as_ref()];
         match res {


### PR DESCRIPTION
This causes alerts in our slack channel at the moment (when the service restarts late in a batch), although these errors are somewhat expected. We therefore don't want to actually log an error. 

Not serving batches is still captured in our "success" metric as there we count the "successful processed" increments. Since ignoring a batch doesn't mark it as successfully processed, we will still see the gap (cf. e.g. today at 15:40 https://dashboard-projects.gnosisdev.com/d/Vl7CKCUWz/dfusion-solver?refresh=5s&orgId=1)

### Test Plan

Expect to now see false alerts in the slack channel anymore