### PR TITLE
Only count prices > 0 in solution for metrics

### DIFF
--- a/driver/src/metrics/stablex_metrics.rs
+++ b/driver/src/metrics/stablex_metrics.rs
@@ -205,13 +205,17 @@ fn tokens_from_orders(orders: &[Order]) -> i64 {
 }
 
 fn tokens_from_solution(solution: &Solution) -> i64 {
-    solution
-        .prices
-        .iter()
-        .filter(|(_token_id, price)| **price > 0)
-        .count()
-        .try_into()
-        .unwrap_or(std::i64::MAX)
+    if solution.is_non_trivial() {
+        solution
+            .prices
+            .iter()
+            .filter(|(_token_id, price)| **price > 0)
+            .count()
+            .try_into()
+            .unwrap_or(std::i64::MAX)
+    } else {
+        0
+    }
 }
 
 fn users_from_orders(orders: &[Order]) -> i64 {

--- a/driver/src/metrics/stablex_metrics.rs
+++ b/driver/src/metrics/stablex_metrics.rs
@@ -205,7 +205,13 @@ fn tokens_from_orders(orders: &[Order]) -> i64 {
 }
 
 fn tokens_from_solution(solution: &Solution) -> i64 {
-    solution.prices.len().try_into().unwrap_or(std::i64::MAX)
+    solution
+        .prices
+        .iter()
+        .filter(|(_token_id, price)| **price > 0)
+        .count()
+        .try_into()
+        .unwrap_or(std::i64::MAX)
 }
 
 fn users_from_orders(orders: &[Order]) -> i64 {


### PR DESCRIPTION
The solver seems to include 0 prices for tokens when they haven't been
touched. We probably only want to count tokens that have a  nonzero
price in the metric.