### PR TITLE
Implement PriceSource for Dexag

### DIFF
--- a/driver/src/price_estimation/dexag/api.rs
+++ b/driver/src/price_estimation/dexag/api.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use anyhow::{anyhow, Context, Result};
 use ethcontract::Address;
 use isahc::prelude::*;

--- a/driver/src/price_estimation/dexag/api.rs
+++ b/driver/src/price_estimation/dexag/api.rs
@@ -12,7 +12,8 @@ pub trait DexagApi {
     /// https://docs.dex.ag/api/tokens
     fn get_token_list(&self) -> Result<Vec<Token>>;
     /// https://docs.dex.ag/api/price
-    /// Returns the price of one unit of `to` expressed in `from`.
+    /// Returns the price of one unit of `from` expressed in `to`.
+    /// For example `get_price("ETH", "DAI")` is ~220.
     fn get_price(&self, from: &Token, to: &Token) -> Result<f64>;
 }
 

--- a/driver/src/price_estimation/dexag/api.rs
+++ b/driver/src/price_estimation/dexag/api.rs
@@ -14,10 +14,11 @@ pub trait DexagApi {
     /// https://docs.dex.ag/api/tokens
     fn get_token_list(&self) -> Result<Vec<Token>>;
     /// https://docs.dex.ag/api/price
-    fn get_price(&self, from: &Token, to: &Token, amount: EitherAmount) -> Result<Price>;
+    /// Returns the price of one unit of `to` expressed in `from`.
+    fn get_price(&self, from: &Token, to: &Token) -> Result<f64>;
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct Token {
     pub name: String,
     pub symbol: String,
@@ -27,9 +28,9 @@ pub struct Token {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-pub struct Price {
+struct Price {
     #[serde(with = "display_fromstr")]
-    pub price: f64,
+    price: f64,
 }
 
 fn deserialize_address<'de, D>(deserializer: D) -> Result<Option<Address>, D::Error>
@@ -53,11 +54,6 @@ where
     } else {
         None
     })
-}
-
-pub enum EitherAmount {
-    From(f64),
-    To(f64),
 }
 
 #[derive(Debug)]
@@ -97,7 +93,7 @@ impl DexagApi for DexagHttpApi {
             .context("failed to parse token list json from dexag response")
     }
 
-    fn get_price(&self, from: &Token, to: &Token, amount: EitherAmount) -> Result<Price> {
+    fn get_price(&self, from: &Token, to: &Token) -> Result<f64> {
         let mut url = self.base_url.clone();
         url.set_path("price");
         {
@@ -105,10 +101,7 @@ impl DexagApi for DexagHttpApi {
             let mut q = url.query_pairs_mut();
             q.append_pair("from", &from.symbol);
             q.append_pair("to", &to.symbol);
-            match amount {
-                EitherAmount::From(amount) => q.append_pair("fromAmount", &amount.to_string()),
-                EitherAmount::To(amount) => q.append_pair("toAmount", &amount.to_string()),
-            };
+            q.append_pair("fromAmount", "1");
             q.append_pair("dex", "ag");
         }
         self.client
@@ -116,6 +109,7 @@ impl DexagApi for DexagHttpApi {
             .context("failed to retrieve price from dexag")?
             .json::<Price>()
             .context("failed to parse price json from dexag")
+            .map(|price| price.price)
     }
 }
 
@@ -160,9 +154,7 @@ mod tests {
         let api = DexagHttpApi::new().unwrap();
         let tokens = api.get_token_list().unwrap();
         println!("{:?}", tokens);
-        let price = api
-            .get_price(&tokens[0], &tokens[1], EitherAmount::From(1.0))
-            .unwrap();
+        let price = api.get_price(&tokens[0], &tokens[1]).unwrap();
         println!("{:?}", price);
     }
 }

--- a/driver/src/price_estimation/dexag/mod.rs
+++ b/driver/src/price_estimation/dexag/mod.rs
@@ -15,6 +15,7 @@ pub struct DexagClient<Api> {
 }
 
 impl DexagClient<DexagHttpApi> {
+    /// Create a DexagClient using DexagHttpApi as the api implementation.
     pub fn new() -> Result<Self> {
         let api = DexagHttpApi::new()?;
         Self::with_api(api)

--- a/driver/src/price_estimation/dexag/mod.rs
+++ b/driver/src/price_estimation/dexag/mod.rs
@@ -3,7 +3,7 @@ mod api;
 use super::{PriceSource, Token};
 use crate::models::TokenId;
 use anyhow::{anyhow, Result};
-use api::{DexagApi, DexagApiImpl};
+use api::{DexagApi, DexagHttpApi};
 use std::collections::HashMap;
 
 pub struct DexagClient<Api> {
@@ -14,9 +14,9 @@ pub struct DexagClient<Api> {
     stable_coin: api::Token,
 }
 
-impl DexagClient<DexagApiImpl> {
+impl DexagClient<DexagHttpApi> {
     pub fn new() -> Result<Self> {
-        let api = DexagApiImpl::new()?;
+        let api = DexagHttpApi::new()?;
         Self::with_api(api)
     }
 }
@@ -55,6 +55,7 @@ where
     Api: DexagApi,
 {
     fn get_prices(&self, tokens: &[Token]) -> Result<HashMap<TokenId, u128>> {
+        // TODO: parallel requests
         Ok(tokens
             .iter()
             .filter_map(|token| {
@@ -139,6 +140,7 @@ mod tests {
         );
     }
 
+    // Run with `cargo test online_dexag_client -- --include-ignored --nocapture`.
     #[test]
     #[ignore]
     fn online_dexag_client() {

--- a/driver/src/price_estimation/dexag/mod.rs
+++ b/driver/src/price_estimation/dexag/mod.rs
@@ -16,6 +16,7 @@ pub struct DexagClient<Api> {
 
 impl DexagClient<DexagHttpApi> {
     /// Create a DexagClient using DexagHttpApi as the api implementation.
+    #[allow(dead_code)]
     pub fn new() -> Result<Self> {
         let api = DexagHttpApi::new()?;
         Self::with_api(api)
@@ -56,7 +57,6 @@ where
     Api: DexagApi,
 {
     fn get_prices(&self, tokens: &[Token]) -> Result<HashMap<TokenId, u128>> {
-        // TODO: parallel requests
         Ok(tokens
             .iter()
             .filter_map(|token| {
@@ -126,7 +126,13 @@ mod tests {
             .with(eq(api_tokens[0].clone()), eq(api_tokens[3].clone()))
             .returning(|_, _| Err(anyhow!("")));
         api.expect_get_price()
-            .with(eq(api_tokens[0].clone()), eq(api_tokens[0].clone()))
+            .with(
+                eq(api_tokens[0].clone()),
+                // Clippy claims we can remove the clone here but compilation
+                // actually fails if we follow the suggestion.
+                #[allow(clippy::redundant_clone)]
+                eq(api_tokens[0].clone()),
+            )
             .returning(|_, _| Ok(1.0));
 
         let client = DexagClient::with_api(api).unwrap();

--- a/driver/src/price_estimation/dexag/mod.rs
+++ b/driver/src/price_estimation/dexag/mod.rs
@@ -79,14 +79,23 @@ mod tests {
     use mockall::predicate::*;
 
     #[test]
+    fn fails_if_stable_coin_does_not_exist() {
+        let mut api = MockDexagApi::new();
+        api.expect_get_token_list()
+            .returning(move || Ok(Vec::new()));
+
+        assert!(DexagClient::with_api(api).is_err());
+    }
+
+    #[test]
     fn get_token_prices() {
         let mut api = MockDexagApi::new();
 
         let tokens = [
+            Token::new(6, "DAI", 18),
             Token::new(1, "ETH", 18),
             Token::new(4, "USDC", 6),
             Token::new(5, "PAX", 18),
-            Token::new(6, "DAI", 18),
         ];
 
         let api_tokens = [
@@ -140,9 +149,11 @@ mod tests {
         assert_eq!(
             prices,
             hash_map! {
-                TokenId(1) => tokens[0].get_owl_price(0.7) as u128,
-                TokenId(4) => tokens[1].get_owl_price(1.2) as u128,
-                TokenId(6) => tokens[3].get_owl_price(1.0) as u128,
+                TokenId(1) => tokens[1].get_owl_price(0.7) as u128,
+                TokenId(4) => tokens[2].get_owl_price(1.2) as u128,
+                TokenId(6) => tokens[0].get_owl_price(1.0) as u128,
+                // No TokenId(5) because we set return an error for this in the
+                // mock api above.
             }
         );
     }

--- a/driver/src/price_estimation/dexag/mod.rs
+++ b/driver/src/price_estimation/dexag/mod.rs
@@ -2,18 +2,22 @@ mod api;
 
 use super::{PriceSource, Token};
 use crate::models::TokenId;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use api::{DexagApi, DexagApiImpl};
 use std::collections::HashMap;
 
 pub struct DexagClient<Api> {
     api: Api,
+    // Maps Token::symbol to Token.
+    // This is cached in the struct because we don't expect it to change often.
+    tokens: HashMap<String, api::Token>,
+    stable_coin: api::Token,
 }
 
 impl DexagClient<DexagApiImpl> {
     pub fn new() -> Result<Self> {
         let api = DexagApiImpl::new()?;
-        Ok(Self::with_api(api))
+        Self::with_api(api)
     }
 }
 
@@ -21,8 +25,28 @@ impl<Api> DexagClient<Api>
 where
     Api: DexagApi,
 {
-    pub fn with_api(api: Api) -> Self {
-        Self { api }
+    pub fn with_api(api: Api) -> Result<Self> {
+        // We need to return prices in OWL but Dexag does not track it. OWL tracks
+        // USD so we use another stable coin as an approximate USD price.
+        const STABLE_COIN: &str = "DAI";
+
+        let tokens = api.get_token_list()?;
+        let mut tokens: HashMap<String, api::Token> = tokens
+            .into_iter()
+            .map(|token| (token.symbol.clone(), token))
+            .collect();
+        let stable_coin = tokens.remove(STABLE_COIN).ok_or_else(|| {
+            anyhow!(
+                "dexag exchange does not track our stable coin {}",
+                STABLE_COIN
+            )
+        })?;
+
+        Ok(Self {
+            api,
+            tokens,
+            stable_coin,
+        })
     }
 }
 
@@ -31,6 +55,115 @@ where
     Api: DexagApi,
 {
     fn get_prices(&self, tokens: &[Token]) -> Result<HashMap<TokenId, u128>> {
-        unimplemented!();
+        Ok(tokens
+            .iter()
+            .filter_map(|token| {
+                let stable_coin_price = if token.symbol() == self.stable_coin.symbol {
+                    1.0
+                } else {
+                    let dexag_token = self.tokens.get(token.symbol())?;
+                    self.api.get_price(&self.stable_coin, dexag_token).ok()?
+                };
+                Some((token.id, token.get_owl_price(stable_coin_price)))
+            })
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::api::MockDexagApi;
+    use super::*;
+    use mockall::predicate::*;
+
+    #[test]
+    fn get_token_prices() {
+        let mut api = MockDexagApi::new();
+
+        let tokens = [
+            Token::new(1, "ETH", 18),
+            Token::new(4, "USDC", 6),
+            Token::new(5, "PAX", 18),
+            Token::new(6, "DAI", 18),
+        ];
+
+        let api_tokens = [
+            super::api::Token {
+                name: String::new(),
+                symbol: "DAI".to_string(),
+                address: None,
+            },
+            super::api::Token {
+                name: String::new(),
+                symbol: "ETH".to_string(),
+                address: None,
+            },
+            super::api::Token {
+                name: String::new(),
+                symbol: "USDC".to_string(),
+                address: None,
+            },
+            super::api::Token {
+                name: String::new(),
+                symbol: "PAX".to_string(),
+                address: None,
+            },
+        ];
+
+        let api_tokens_ = api_tokens.clone();
+        api.expect_get_token_list()
+            .returning(move || Ok(api_tokens_.to_vec()));
+
+        api.expect_get_price()
+            .with(eq(api_tokens[0].clone()), eq(api_tokens[1].clone()))
+            .returning(|_, _| Ok(0.7));
+        api.expect_get_price()
+            .with(eq(api_tokens[0].clone()), eq(api_tokens[2].clone()))
+            .returning(|_, _| Ok(1.2));
+        api.expect_get_price()
+            .with(eq(api_tokens[0].clone()), eq(api_tokens[3].clone()))
+            .returning(|_, _| Err(anyhow!("")));
+        api.expect_get_price()
+            .with(eq(api_tokens[0].clone()), eq(api_tokens[0].clone()))
+            .returning(|_, _| Ok(1.0));
+
+        let client = DexagClient::with_api(api).unwrap();
+        let prices = client.get_prices(&tokens).unwrap();
+        assert_eq!(
+            prices,
+            hash_map! {
+                TokenId(1) => tokens[0].get_owl_price(0.7) as u128,
+                TokenId(4) => tokens[1].get_owl_price(1.2) as u128,
+                TokenId(6) => tokens[3].get_owl_price(1.0) as u128,
+            }
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn online_dexag_client() {
+        let tokens = &[
+            Token::new(1, "WETH", 18),
+            Token::new(2, "USDT", 6),
+            Token::new(3, "TUSD", 18),
+            Token::new(4, "USDC", 6),
+            Token::new(5, "PAX", 18),
+            Token::new(6, "GUSD", 2),
+            Token::new(7, "DAI", 18),
+            Token::new(8, "sETH", 18),
+            Token::new(9, "sUSD", 18),
+            Token::new(15, "SNX", 18),
+        ];
+
+        let client = DexagClient::new().unwrap();
+        let prices = client.get_prices(tokens).unwrap();
+
+        for token in tokens {
+            if let Some(price) = prices.get(&token.id) {
+                println!("Token {} has OWL price of {}.", token.symbol(), price);
+            } else {
+                println!("Token {} price could not be determined.", token.symbol());
+            }
+        }
     }
 }

--- a/driver/src/price_estimation/dexag/mod.rs
+++ b/driver/src/price_estimation/dexag/mod.rs
@@ -1,1 +1,36 @@
 mod api;
+
+use super::{PriceSource, Token};
+use crate::models::TokenId;
+use anyhow::Result;
+use api::{DexagApi, DexagApiImpl};
+use std::collections::HashMap;
+
+pub struct DexagClient<Api> {
+    api: Api,
+}
+
+impl DexagClient<DexagApiImpl> {
+    pub fn new() -> Result<Self> {
+        let api = DexagApiImpl::new()?;
+        Ok(Self::with_api(api))
+    }
+}
+
+impl<Api> DexagClient<Api>
+where
+    Api: DexagApi,
+{
+    pub fn with_api(api: Api) -> Self {
+        Self { api }
+    }
+}
+
+impl<Api> PriceSource for DexagClient<Api>
+where
+    Api: DexagApi,
+{
+    fn get_prices(&self, tokens: &[Token]) -> Result<HashMap<TokenId, u128>> {
+        unimplemented!();
+    }
+}

--- a/driver/src/price_estimation/mod.rs
+++ b/driver/src/price_estimation/mod.rs
@@ -181,8 +181,8 @@ impl Token {
 #[cfg_attr(test, mockall::automock)]
 trait PriceSource {
     /// Retrieve current prices relative to the OWL token for the specified
-    /// tokens. The OWL token is peged at 1 USD with 18 decimals. Returns a
-    /// sparce price array as being unable to find a price is not considered an
+    /// tokens. The OWL token is pegged at 1 USD with 18 decimals. Returns a
+    /// sparse price array as being unable to find a price is not considered an
     /// error.
     fn get_prices(&self, tokens: &[Token]) -> Result<HashMap<TokenId, u128>>;
 }


### PR DESCRIPTION
Now that we have the http api we can turn it into a price source.

After this PR I still need to enable this as a price source and move price estimation out of the main loop.
Depending how the latter is implemented we might not need to parallelize the requests to Dexag anymore which we originally wanted to do because here we need one request per token.

I removed some parts from the dexag api because it turns out we do not need them.