### PR TITLE
Use Dexag in addition to Kraken as price source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,6 +484,7 @@ dependencies = [
  "log 0.4.8",
  "mockall",
  "prometheus",
+ "rayon",
  "rouille",
  "rustc-hex",
  "serde",
@@ -1858,6 +1859,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rayon"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098"
+dependencies = [
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-queue",
+ "crossbeam-utils 0.7.0",
+ "lazy_static",
+ "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,7 @@ dependencies = [
  "anyhow",
  "byteorder",
  "chrono",
+ "crossbeam-utils 0.7.0",
  "ethcontract",
  "ethcontract-generate",
  "futures 0.3.4",
@@ -484,7 +485,6 @@ dependencies = [
  "log 0.4.8",
  "mockall",
  "prometheus",
- "rayon",
  "rouille",
  "rustc-hex",
  "serde",
@@ -1859,30 +1859,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
  "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rayon"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098"
-dependencies = [
- "crossbeam-deque",
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-queue",
- "crossbeam-utils 0.7.0",
- "lazy_static",
- "num_cpus",
 ]
 
 [[package]]

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -8,13 +8,13 @@ edition = "2018"
 anyhow = "1"
 byteorder = "1.3.4"
 chrono = "0.4.10"
+crossbeam-utils = "0.7"
 ethcontract = "0.4.2"
 futures = { version = "0.3.4", features = ["compat"] }
 isahc = { version = "0.8.2", features = ["json"] }
 lazy_static = "1.4.0"
 log = "0.4.8"
 prometheus = "0.8.0"
-rayon = "1"
 rouille = "3.0.0"
 rustc-hex = "2.1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -14,6 +14,7 @@ isahc = { version = "0.8.2", features = ["json"] }
 lazy_static = "1.4.0"
 log = "0.4.8"
 prometheus = "0.8.0"
+rayon = "1"
 rouille = "3.0.0"
 rustc-hex = "2.1.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -25,9 +26,9 @@ slog-envlogger = "2.2.0"
 slog-scope = "4.3.0"
 slog-stdlog = "4.0.0"
 slog-term = "2.5.0"
-uint = "0.8"
 structopt = "0.3.11"
 thiserror = "1.0"
+uint = "0.8"
 url = "2.1.1"
 
 [dev-dependencies]

--- a/driver/src/price_estimation/average_price_source.rs
+++ b/driver/src/price_estimation/average_price_source.rs
@@ -1,0 +1,78 @@
+use super::{PriceSource, Token};
+use crate::models::TokenId;
+use anyhow::{anyhow, Result};
+use std::collections::HashMap;
+
+/// Combines two prices into one average.
+pub struct AveragePriceSource<T0, T1> {
+    source_0: T0,
+    source_1: T1,
+}
+
+impl<T0, T1> AveragePriceSource<T0, T1> {
+    pub fn new(source_0: T0, source_1: T1) -> Self {
+        Self { source_0, source_1 }
+    }
+}
+
+impl<T0: PriceSource, T1: PriceSource> PriceSource for AveragePriceSource<T0, T1> {
+    fn get_prices(&self, tokens: &[Token]) -> Result<HashMap<TokenId, u128>> {
+        match (
+            self.source_0.get_prices(tokens),
+            self.source_1.get_prices(tokens),
+        ) {
+            (Ok(p0), Ok(p1)) => Ok(average_prices(p0, p1)),
+            (Ok(p), Err(e)) | (Err(e), Ok(p)) => {
+                log::warn!("one price source failed: {}", e);
+                Ok(p)
+            }
+            (Err(e0), Err(e1)) => Err(anyhow!("both price sources failed: {}, {}", e0, e1)),
+        }
+    }
+}
+
+fn average_prices(
+    prices_0: HashMap<TokenId, u128>,
+    mut prices_1: HashMap<TokenId, u128>,
+) -> HashMap<TokenId, u128> {
+    for (token_id, price_1) in prices_0 {
+        prices_1
+            .entry(token_id)
+            .and_modify(|price| *price = (*price + price_1) / 2)
+            .or_insert(price_1);
+    }
+    prices_1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn average_prices_() {
+        let p0 = hash_map! {
+            TokenId(0) => 0,
+            TokenId(1) => 5,
+            TokenId(2) => 10,
+            TokenId(3) => 20,
+            TokenId(5) => 0,
+        };
+        let p1 = hash_map! {
+            TokenId(0) => 0,
+            TokenId(1) => 5,
+            TokenId(2) => 20,
+            TokenId(4) => 30,
+            TokenId(5) => 100,
+        };
+        let result = average_prices(p0, p1);
+        let expected = hash_map! {
+            TokenId(0) => 0,
+            TokenId(1) => 5,
+            TokenId(2) => 15,
+            TokenId(3) => 20,
+            TokenId(4) => 30,
+            TokenId(5) => 50,
+        };
+        assert_eq!(result, expected);
+    }
+}

--- a/driver/src/price_estimation/dexag/mod.rs
+++ b/driver/src/price_estimation/dexag/mod.rs
@@ -16,7 +16,6 @@ pub struct DexagClient<Api> {
 
 impl DexagClient<DexagHttpApi> {
     /// Create a DexagClient using DexagHttpApi as the api implementation.
-    #[allow(dead_code)]
     pub fn new() -> Result<Self> {
         let api = DexagHttpApi::new()?;
         Self::with_api(api)

--- a/driver/src/price_estimation/dexag/mod.rs
+++ b/driver/src/price_estimation/dexag/mod.rs
@@ -4,10 +4,8 @@ use super::{PriceSource, Token};
 use crate::models::TokenId;
 use anyhow::{anyhow, Result};
 use api::{DexagApi, DexagHttpApi};
-use futures::future;
+use futures::future::{self, BoxFuture};
 use std::collections::HashMap;
-use std::future::Future;
-use std::pin::Pin;
 
 pub struct DexagClient<Api> {
     api: Api,
@@ -63,7 +61,7 @@ where
         // position.
         // We need separate vectors because `join_all` takes a vector.
         let mut tokens_ = Vec::<&Token>::new();
-        let mut futures = Vec::<Pin<Box<dyn Future<Output = Result<f64>>>>>::new();
+        let mut futures = Vec::<BoxFuture<Result<f64>>>::new();
         for token in tokens {
             if token.symbol() == self.stable_coin.symbol {
                 tokens_.push(token);

--- a/driver/src/price_estimation/dexag/mod.rs
+++ b/driver/src/price_estimation/dexag/mod.rs
@@ -70,13 +70,17 @@ where
             tokens
                 .par_iter()
                 .filter_map(|token| {
-                    let stable_coin_price = if token.symbol() == self.stable_coin.symbol {
-                        1.0
-                    } else {
-                        let dexag_token = self.tokens.get(token.symbol())?;
-                        self.api.get_price(&self.stable_coin, dexag_token).ok()?
-                    };
-                    Some((token.id, token.get_owl_price(stable_coin_price)))
+                    let usd_price_of_token_approximated_by_stable_coin =
+                        if token.symbol() == self.stable_coin.symbol {
+                            1.0
+                        } else {
+                            let dexag_token = self.tokens.get(token.symbol())?;
+                            self.api.get_price(dexag_token, &self.stable_coin).ok()?
+                        };
+                    Some((
+                        token.id,
+                        token.get_owl_price(usd_price_of_token_approximated_by_stable_coin),
+                    ))
                 })
                 .collect()
         });

--- a/driver/src/price_estimation/mod.rs
+++ b/driver/src/price_estimation/mod.rs
@@ -1,14 +1,17 @@
 //! Module responsible for aggregating price estimates from various sources to
 //! give good price estimates to the solver for better results.
 
+mod average_price_source;
 pub mod data;
 mod dexag;
 mod kraken;
 
 pub use self::data::TokenData;
+use self::dexag::DexagClient;
 use self::kraken::KrakenClient;
 use crate::models::{Order, TokenId, TokenInfo};
 use anyhow::Result;
+use average_price_source::AveragePriceSource;
 use lazy_static::lazy_static;
 use log::warn;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -38,7 +41,10 @@ pub struct PriceOracle {
 impl PriceOracle {
     /// Creates a new price oracle from a token whitelist data.
     pub fn new(tokens: TokenData) -> Result<Self> {
-        Ok(PriceOracle::with_source(tokens, KrakenClient::new()?))
+        Ok(PriceOracle::with_source(
+            tokens,
+            AveragePriceSource::new(KrakenClient::new()?, DexagClient::new()?),
+        ))
     }
 
     fn with_source(tokens: TokenData, source: impl PriceSource + 'static) -> Self {


### PR DESCRIPTION
If we get two prices they are averaged together.

Also parallelize dexag requests with Rayon (see comment in source code) because Dexag requires one request per token which can take tens of seconds otherwise.