### PR TITLE
Solver bump to v0.5.18 (price aggregator fix and using only driver prices)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
         - cargo clippy --all --all-targets -- -D warnings
         - cargo fmt --all -- --check
         # Build and publish compact image with compiled binary
-        - docker build --tag stablex-binary --build-arg SOLVER_BASE=163030813197.dkr.ecr.us-east-1.amazonaws.com/dex-solver:v0.5.17 --build-arg RUST_BASE=rust-binary -f docker/rust/Dockerfile .
+        - docker build --tag stablex-binary --build-arg SOLVER_BASE=163030813197.dkr.ecr.us-east-1.amazonaws.com/dex-solver:v0.5.18 --build-arg RUST_BASE=rust-binary -f docker/rust/Dockerfile .
         # StableX e2e Tests (Ganache)
         - docker-compose -f docker-compose.yml -f docker-compose.binary.yml up -d stablex
         - cargo test -p e2e ganache -- --nocapture

--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -45,7 +45,6 @@ impl SolverConfig {
             }
             SolverConfig::FallbackSolver { solver_time_limit } => vec![
                 format!("--solverTimeLimit={:}", solver_time_limit),
-                String::from("--tokenInfo=/app/batchauctions/scripts/token_info_mainnet.json"),
                 String::from("--useExternalPrices"),
             ],
             SolverConfig::NaiveSolver => {


### PR DESCRIPTION
This solver bump has a fix for:
https://github.com/gnosis/dex-solver/issues/182

and completely eliminates the price fetching by the solver.