### PR TITLE
Inlcude batchID in instance/result file name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,4 +35,3 @@ services:
     volumes:
       # Sync src folder to allow development without rebuilding on each change
       - ./driver:/app/driver
-      - ./dex-contracts:/app/dex-contracts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,3 +35,4 @@ services:
     volumes:
       # Sync src folder to allow development without rebuilding on each change
       - ./driver:/app/driver
+      - ./dex-contracts:/app/dex-contracts

--- a/driver/src/price_finding/optimization_price_finder.rs
+++ b/driver/src/price_finding/optimization_price_finder.rs
@@ -224,7 +224,8 @@ impl PriceFinding for OptimisationPriceFinder {
         };
 
         let now = Utc::now();
-        let batch_id = now.timestamp() / 300;
+        // We are solving the batch before the current one
+        let batch_id = (now.timestamp() / 300) - 1;
         let date = now.format("%Y-%m-%d");
         // We only need to create the folder for the input, the output
         // folder is created by the python script

--- a/driver/src/price_finding/optimization_price_finder.rs
+++ b/driver/src/price_finding/optimization_price_finder.rs
@@ -176,7 +176,6 @@ impl OptimisationPriceFinder {
         solver_type: SolverConfig,
         price_oracle: impl PriceEstimating + 'static,
     ) -> Self {
-        create_dir_all("instances").expect("Could not create instance directory");
         OptimisationPriceFinder {
             write_input,
             run_solver,
@@ -223,9 +222,27 @@ impl PriceFinding for OptimisationPriceFinder {
             orders: orders.iter().map(From::from).collect(),
             fee: self.fee.as_ref().map(From::from),
         };
-        let current_time = Utc::now().to_rfc3339();
-        let input_file = format!("instances/instance_{}.json", &current_time);
-        let result_folder = format!("results/instance_{}/", &current_time);
+
+        let now = Utc::now();
+        let batch_id = now.timestamp() / 300;
+        let date = now.format("%Y-%m-%d");
+        // We only need to create the folder for the input, the output
+        // folder is created by the python script
+        let input_folder = format!("instances/{}", &date);
+        create_dir_all(&input_folder)?;
+        let input_file = format!(
+            "{}/instance_{}_{}.json",
+            &input_folder,
+            &batch_id,
+            &now.to_rfc3339()
+        );
+        let result_folder = format!(
+            "results/{}/instance_{}_{}/",
+            &date,
+            &batch_id,
+            &now.to_rfc3339()
+        );
+
         (self.write_input)(&input_file, &serde_json::to_string(&input)?)?;
         (self.run_solver)(&input_file, &result_folder, self.solver_type)?;
         let result = (self.read_output)(&result_folder)?;


### PR DESCRIPTION
This PR makes it so that our instance/result files include the batchID and are also split up by date. We now create instance filenames in the following format:

`instances/{day}/instance_{batchId}_{datetime}.json`

and results in the following format:

`results/{day}/instance_{batchId}_{datetime}/<json|visualization>`

### Test Plan

Tested locally that files are created and read accordingly. For synchronisation with S3 I have to slightly adjust the sync script to not be too strict about the matching.