### PR TITLE
[Trivial] Add contracts folder to shared volume in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,3 +35,4 @@ services:
     volumes:
       # Sync src folder to allow development without rebuilding on each change
       - ./driver:/app/driver
+      - ./dex-contracts:/app/dex-contracts


### PR DESCRIPTION
Otherwise you are stuck with the contract definitions from the time you built the container, which might be outdated. 

Rebuilding just to get the updated contracts is very time consuming.

### Test Plan

- rm -rf `contracts/build`
- `docker-compose build --build-arg SOLVER_BASE=163030813197.dkr.ecr.us-east-1.amazonaws.com/dex-solver:v0.5.18 stablex`
- `(cd contracts && yarn prepack)`
- `docker-compose -f docker-compose.yml -f docker-compose.mainnet.yml up stablex`

See compilation no longer fails.