### PR TITLE
Reset processing times between batches

### DIFF
--- a/driver/src/metrics/stablex_metrics.rs
+++ b/driver/src/metrics/stablex_metrics.rs
@@ -74,6 +74,12 @@ impl StableXMetrics {
     }
 
     pub fn auction_processing_started(&self, res: &Result<U256>) {
+        // Reset values from previous batch
+        for stage in ProcessingStage::ALL_STAGES {
+            self.processing_times
+                .with_label_values(&[stage.as_ref()])
+                .set(0);
+        }
         let stage_label = &[ProcessingStage::Started.as_ref()];
         match res {
             Ok(batch) => {


### PR DESCRIPTION
At the moment we "carry over" the processing times of previous batches. That is, if a certain stage (e.g. verification or submission) is not performed in the current batch its time from the last batch it was carried out is kept (cf. the red line for "solution submission" in this image):

<img width="254" alt="Screen Shot 2020-03-10 at 15 07 30" src="https://user-images.githubusercontent.com/1200333/76320393-ed339b00-62e0-11ea-95b2-51e8bdedf024.png">

This PR makes it so that processing times get reset to 0 whenever a batch is started.

### Test Plan

<a href="https://gitme.me/image?url=https%3A%2F%2Fmedia1.giphy.com%2Fmedia%2FCDZwopbecAbIc%2Fgiphy-downsized-medium.gif&token=production" data-gitmeme-token="production"><img src="https://media1.giphy.com/media/CDZwopbecAbIc/giphy-downsized-medium.gif" title="Created by gitme.me with /production"/></a>

