### PR TITLE
Log only errors to stderr

### DIFF
--- a/driver/src/logging.rs
+++ b/driver/src/logging.rs
@@ -1,3 +1,4 @@
+use slog::Level;
 use slog::{o, Drain, Logger, OwnedKVList, Record};
 use slog_async::Async;
 use slog_envlogger::LogBuilder;
@@ -9,7 +10,12 @@ const BUFFER_SIZE: usize = 1024;
 
 /// Initialize driver logging.
 pub fn init(filter: impl AsRef<str>) -> (Logger, GlobalLoggerGuard) {
-    let format = CustomFormatter::new(TermDecorator::new().stderr().build()).fuse();
+    // Log errors to stderr and lower severities to stdout.
+    let format = CustomFormatter::new(
+        TermDecorator::new().stderr().build(),
+        TermDecorator::new().stdout().build(),
+    )
+    .fuse();
     let drain = Async::new(LogBuilder::new(format).parse(filter.as_ref()).build())
         .chan_size(BUFFER_SIZE)
         .build();
@@ -21,17 +27,23 @@ pub fn init(filter: impl AsRef<str>) -> (Logger, GlobalLoggerGuard) {
     (logger, guard)
 }
 
-pub struct CustomFormatter<D: Decorator> {
-    decorator: D,
+/// Uses one decorator for `Error` and `Critical` log messages and the other for
+/// the rest.
+pub struct CustomFormatter<T0, T1> {
+    err_decorator: T0,
+    rest_decorator: T1,
 }
 
-impl<D: Decorator> CustomFormatter<D> {
-    fn new(decorator: D) -> Self {
-        Self { decorator }
+impl<T0, T1> CustomFormatter<T0, T1> {
+    fn new(err_decorator: T0, rest_decorator: T1) -> Self {
+        Self {
+            err_decorator,
+            rest_decorator,
+        }
     }
 }
 
-impl<D: Decorator> Drain for CustomFormatter<D> {
+impl<T0: Decorator, T1: Decorator> Drain for CustomFormatter<T0, T1> {
     type Ok = ();
     type Err = std::io::Error;
     fn log(
@@ -39,29 +51,40 @@ impl<D: Decorator> Drain for CustomFormatter<D> {
         record: &Record,
         values: &OwnedKVList,
     ) -> std::result::Result<Self::Ok, Self::Err> {
-        self.decorator.with_record(record, values, |mut decorator| {
-            decorator.start_timestamp()?;
-            slog_term::timestamp_utc(&mut decorator)?;
-
-            decorator.start_whitespace()?;
-            write!(decorator, " ")?;
-
-            decorator.start_level()?;
-            write!(decorator, "{}", record.level())?;
-
-            decorator.start_whitespace()?;
-            write!(decorator, " ")?;
-
-            write!(decorator, "[{}]", record.module())?;
-
-            decorator.start_whitespace()?;
-            write!(decorator, " ")?;
-
-            decorator.start_msg()?;
-            writeln!(decorator, "{}", record.msg())?;
-            decorator.flush()?;
-
-            Ok(())
-        })
+        match record.level() {
+            Level::Error | Level::Critical => log_to_decorator(&self.err_decorator, record, values),
+            _ => log_to_decorator(&self.rest_decorator, record, values),
+        }
     }
+}
+
+fn log_to_decorator(
+    decorator: &impl Decorator,
+    record: &Record,
+    values: &OwnedKVList,
+) -> std::result::Result<(), std::io::Error> {
+    decorator.with_record(record, values, |mut decorator| {
+        decorator.start_timestamp()?;
+        slog_term::timestamp_utc(&mut decorator)?;
+
+        decorator.start_whitespace()?;
+        write!(decorator, " ")?;
+
+        decorator.start_level()?;
+        write!(decorator, "{}", record.level())?;
+
+        decorator.start_whitespace()?;
+        write!(decorator, " ")?;
+
+        write!(decorator, "[{}]", record.module())?;
+
+        decorator.start_whitespace()?;
+        write!(decorator, " ")?;
+
+        decorator.start_msg()?;
+        writeln!(decorator, "{}", record.msg())?;
+        decorator.flush()?;
+
+        Ok(())
+    })
 }

--- a/e2e/tests/stablex_test.rs
+++ b/e2e/tests/stablex_test.rs
@@ -207,7 +207,7 @@ fn test_rinkeby() {
         .arg("logs")
         .output()
         .expect("failed to execute process");
-    let logs = String::from_utf8(output.stdout).expect("failed to read logs");
-    // Our logger prints log level with four characters, thus searching for ERRO
-    assert!(!logs.to_lowercase().contains("erro"));
+    // Errors go to stderr while other messages go to stdout.
+    let logs = String::from_utf8(output.stderr).expect("failed to read logs");
+    assert!(logs.is_empty());
 }


### PR DESCRIPTION
This fixes false positives in the e2e test where the test thinks an
error has occurred when it has not.

Test Plan: Add various logs in `main` then run the program while piping stdout and stderr to different destinations. Check that logs arrive at the correct place.

TODO: check that this change doesn't break the kubernetes environment