### PR TITLE
Fix e2e test log error check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,6 +512,7 @@ dependencies = [
 name = "e2e"
 version = "1.0.0"
 dependencies = [
+ "anyhow",
  "ethcontract",
  "futures 0.3.4",
 ]

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -4,5 +4,6 @@ version = "1.0.0"
 edition = "2018"
 
 [dependencies]
+anyhow = "1"
 ethcontract = "0.4.2"
 futures = { version = "0.3.4", features = ["compat"] }

--- a/e2e/src/docker_logs.rs
+++ b/e2e/src/docker_logs.rs
@@ -1,52 +1,35 @@
 use anyhow::{anyhow, Context, Result};
 use std::process::Command;
 
-fn find_stablex_container_in_output(output: &str) -> Option<&str> {
-    output
-        .split('\n')
-        .skip(2)
-        .filter_map(|line| line.split(' ').next())
-        .find(|container_name| container_name.starts_with("dex-services_stablex_1"))
-}
-
-fn find_stablex_container() -> Result<String> {
-    let output = Command::new("docker-compose")
+fn find_container_id(container_name: &str) -> Result<String> {
+    let output = Command::new("docker")
         .arg("ps")
+        .arg("--quiet")
+        .arg("--filter")
+        .arg(format!("name={}", container_name))
         .output()
-        .context("failed to execute `docker-compose ps`")?;
+        .context("failed to execute `docker ps`")?;
     if !output.status.success() {
         return Err(anyhow!("status code is not success"));
     }
     let output = std::str::from_utf8(&output.stdout).context("output is not utf8")?;
-    find_stablex_container_in_output(&output)
-        .map(|name| name.to_string())
-        .ok_or_else(|| anyhow!("failed to find stablex container"))
+    output
+        .split('\n')
+        .next()
+        .map(|string| string.to_string())
+        .ok_or_else(|| anyhow!("did not find container in output: {}", output))
 }
 
-pub fn assert_no_errors_logged() {
-    let container_name = find_stablex_container()
+pub fn assert_no_errors_logged(container_name: &str) {
+    let container_id = find_container_id(container_name)
         .context("failed to find stablex container name")
         .unwrap();
     let output = Command::new("docker")
         .arg("logs")
-        .arg(&container_name)
+        .arg(container_id)
         .output()
         .expect("failed to execute process");
     assert!(output.status.success());
     // Errors go to stderr while other messages go to stdout.
     assert!(output.stderr.is_empty());
-}
-
-#[test]
-fn find_stablex_container_in_output_() {
-    let output = r#"
-               Name                         Command               State           Ports
---------------------------------------------------------------------------------------------
-dex-services_ganache-cli_1   node /app/ganache-core.doc ...   Up      0.0.0.0:8545->8545/tcp
-dex-services_stablex_1_f31cbd690fe3       /tini -- cargo run               Up      0.0.0.0:9586->9586/tcp
-"#;
-    assert_eq!(
-        find_stablex_container_in_output(output).unwrap(),
-        "dex-services_stablex_1_f31cbd690fe3"
-    );
 }

--- a/e2e/src/docker_logs.rs
+++ b/e2e/src/docker_logs.rs
@@ -1,0 +1,52 @@
+use anyhow::{anyhow, Context, Result};
+use std::process::Command;
+
+fn find_stablex_container_in_output(output: &str) -> Option<&str> {
+    output
+        .split('\n')
+        .skip(2)
+        .filter_map(|line| line.split(' ').next())
+        .find(|container_name| container_name.starts_with("dex-services_stablex_1"))
+}
+
+fn find_stablex_container() -> Result<String> {
+    let output = Command::new("docker-compose")
+        .arg("ps")
+        .output()
+        .context("failed to execute `docker-compose ps`")?;
+    if !output.status.success() {
+        return Err(anyhow!("status code is not success"));
+    }
+    let output = std::str::from_utf8(&output.stdout).context("output is not utf8")?;
+    find_stablex_container_in_output(&output)
+        .map(|name| name.to_string())
+        .ok_or_else(|| anyhow!("failed to find stablex container"))
+}
+
+pub fn assert_no_errors_logged() {
+    let container_name = find_stablex_container()
+        .context("failed to find stablex container name")
+        .unwrap();
+    let output = Command::new("docker")
+        .arg("logs")
+        .arg(&container_name)
+        .output()
+        .expect("failed to execute process");
+    assert!(output.status.success());
+    // Errors go to stderr while other messages go to stdout.
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn find_stablex_container_in_output_() {
+    let output = r#"
+               Name                         Command               State           Ports
+--------------------------------------------------------------------------------------------
+dex-services_ganache-cli_1   node /app/ganache-core.doc ...   Up      0.0.0.0:8545->8545/tcp
+dex-services_stablex_1_f31cbd690fe3       /tini -- cargo run               Up      0.0.0.0:9586->9586/tcp
+"#;
+    assert_eq!(
+        find_stablex_container_in_output(output).unwrap(),
+        "dex-services_stablex_1_f31cbd690fe3"
+    );
+}

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -7,4 +7,5 @@ ethcontract::contract!("dex-contracts/build/contracts/TokenOWL.json");
 ethcontract::contract!("dex-contracts/build/contracts/ERC20Mintable.json");
 
 pub mod common;
+pub mod docker_logs;
 pub mod stablex;

--- a/e2e/tests/stablex_test.rs
+++ b/e2e/tests/stablex_test.rs
@@ -202,5 +202,5 @@ fn test_rinkeby() {
     println!("Sleeping {} seconds...", sleep_time);
     std::thread::sleep(Duration::from_secs(sleep_time));
 
-    docker_logs::assert_no_errors_logged();
+    docker_logs::assert_no_errors_logged("dex-services_stablex_1");
 }

--- a/e2e/tests/stablex_test.rs
+++ b/e2e/tests/stablex_test.rs
@@ -6,11 +6,11 @@ use ethcontract::{Account, PrivateKey, U256};
 use futures::future::join_all;
 
 use e2e::common::{wait_for_condition, FutureBuilderExt, FutureWaitExt};
+use e2e::docker_logs;
 use e2e::stablex::{close_auction, setup_stablex};
 use e2e::{BatchExchange, IERC20};
 
 use std::env;
-use std::process::Command;
 use std::time::Duration;
 
 #[test]
@@ -202,12 +202,5 @@ fn test_rinkeby() {
     println!("Sleeping {} seconds...", sleep_time);
     std::thread::sleep(Duration::from_secs(sleep_time));
 
-    // Make sure there was no error
-    let output = Command::new("docker-compose")
-        .arg("logs")
-        .output()
-        .expect("failed to execute process");
-    // Errors go to stderr while other messages go to stdout.
-    let logs = String::from_utf8(output.stderr).expect("failed to read logs");
-    assert!(logs.is_empty());
+    docker_logs::assert_no_errors_logged();
 }


### PR DESCRIPTION
`docker-compose logs` outputs both stdout and stderr logs to its own
stdout. This makes us unable to differentiate between the two and
introduced a bug where we would never detect errors.
`docker logs` on the other hand is aware of this functionality.