### PR TITLE
Add Sync bounds to allow usage of driver from multiple threads

### DIFF
--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -24,7 +24,7 @@ include!(concat!(env!("OUT_DIR"), "/batch_exchange.rs"));
 
 pub struct StableXContractImpl<'a> {
     instance: BatchExchange,
-    gas_price_estimating: &'a dyn GasPriceEstimating,
+    gas_price_estimating: &'a (dyn GasPriceEstimating + Sync),
 }
 
 impl<'a> StableXContractImpl<'a> {
@@ -32,7 +32,7 @@ impl<'a> StableXContractImpl<'a> {
         web3: &contracts::Web3,
         key: PrivateKey,
         network_id: u64,
-        gas_price_estimating: &'a dyn GasPriceEstimating,
+        gas_price_estimating: &'a (dyn GasPriceEstimating + Sync),
     ) -> Result<Self> {
         let defaults = contracts::method_defaults(key, network_id)?;
 

--- a/driver/src/driver/scheduler.rs
+++ b/driver/src/driver/scheduler.rs
@@ -56,7 +56,7 @@ pub struct AuctionTimingConfiguration {
 }
 
 pub struct Scheduler<'a> {
-    driver: &'a mut dyn StableXDriver,
+    driver: &'a (dyn StableXDriver + Sync),
     auction_timing_configuration: AuctionTimingConfiguration,
     last_solved_batch: Option<BatchId>,
 }
@@ -69,7 +69,7 @@ enum Action {
 
 impl<'a> Scheduler<'a> {
     pub fn new(
-        driver: &'a mut dyn StableXDriver,
+        driver: &'a (dyn StableXDriver + Sync),
         auction_timing_configuration: AuctionTimingConfiguration,
     ) -> Self {
         assert!(
@@ -204,13 +204,13 @@ mod tests {
 
     #[test]
     fn determine_action_without_matching_last_solved_batch() {
-        let mut driver = MockStableXDriver::new();
+        let driver = MockStableXDriver::new();
         let auction_timing_configuration = AuctionTimingConfiguration {
             target_start_solve_time: Duration::from_secs(10),
             latest_solve_attempt_time: Duration::from_secs(20),
             solver_time_limit: Duration::from_secs(30),
         };
-        let scheduler = Scheduler::new(&mut driver, auction_timing_configuration);
+        let scheduler = Scheduler::new(&driver, auction_timing_configuration);
 
         let base_time = SystemTime::UNIX_EPOCH + Duration::from_secs(300);
 
@@ -259,13 +259,13 @@ mod tests {
 
     #[test]
     fn determine_action_with_matching_last_solved_batch() {
-        let mut driver = MockStableXDriver::new();
+        let driver = MockStableXDriver::new();
         let auction_timing_configuration = AuctionTimingConfiguration {
             target_start_solve_time: Duration::from_secs(10),
             latest_solve_attempt_time: Duration::from_secs(20),
             solver_time_limit: Duration::from_secs(30),
         };
-        let mut scheduler = Scheduler::new(&mut driver, auction_timing_configuration);
+        let mut scheduler = Scheduler::new(&driver, auction_timing_configuration);
         scheduler.last_solved_batch = Some(BatchId(0));
 
         let base_time = SystemTime::UNIX_EPOCH + Duration::from_secs(300);
@@ -332,7 +332,7 @@ mod tests {
             latest_solve_attempt_time: Duration::from_secs(20),
             solver_time_limit: Duration::from_secs(30),
         };
-        let mut scheduler = Scheduler::new(&mut driver, auction_timing_configuration);
+        let mut scheduler = Scheduler::new(&driver, auction_timing_configuration);
 
         let base_time = SystemTime::UNIX_EPOCH + Duration::from_secs(300);
 

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -210,8 +210,7 @@ fn main() {
 
     // Set up solver.
     let fee = Some(Fee::default());
-    let mut price_finder =
-        price_finding::create_price_finder(fee, options.solver_type, price_oracle);
+    let price_finder = price_finding::create_price_finder(fee, options.solver_type, price_oracle);
 
     // Create the orderbook reader.
     let orderbook = PaginatedStableXOrderBookReader::new(&contract, options.auction_data_page_size);
@@ -223,14 +222,14 @@ fn main() {
     let solution_submitter = StableXSolutionSubmitter::new(&contract, &eth_rpc);
 
     // Set up the driver and start the run-loop.
-    let mut driver = StableXDriverImpl::new(
-        &mut *price_finder,
+    let driver = StableXDriverImpl::new(
+        &*price_finder,
         &filtered_orderbook,
         &solution_submitter,
         &stablex_metrics,
     );
     let mut scheduler = Scheduler::new(
-        &mut driver,
+        &driver,
         AuctionTimingConfiguration {
             target_start_solve_time: options.target_start_solve_time,
             latest_solve_attempt_time: options.latest_solve_attempt_time,

--- a/driver/src/orderbook/filtered_orderbook.rs
+++ b/driver/src/orderbook/filtered_orderbook.rs
@@ -34,12 +34,15 @@ impl FromStr for OrderbookFilter {
 }
 
 pub struct FilteredOrderbookReader<'a> {
-    orderbook: &'a dyn StableXOrderBookReading,
+    orderbook: &'a (dyn StableXOrderBookReading + Sync),
     filter: OrderbookFilter,
 }
 
 impl<'a> FilteredOrderbookReader<'a> {
-    pub fn new(orderbook: &'a dyn StableXOrderBookReading, filter: OrderbookFilter) -> Self {
+    pub fn new(
+        orderbook: &'a (dyn StableXOrderBookReading + Sync),
+        filter: OrderbookFilter,
+    ) -> Self {
         Self { orderbook, filter }
     }
 }
@@ -80,7 +83,7 @@ mod test {
     #[test]
     fn test_filter_deserialization() {
         let json = r#"{
-            "tokens": [1,2], 
+            "tokens": [1,2],
             "users": {
                 "0x7b60655Ca240AC6c76dD29c13C45BEd969Ee6F0A": {"OrderIds": [0,1]},
                 "0x7b60655Ca240AC6c76dD29c13C45BEd969Ee6F0B": "All"

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -31,12 +31,12 @@ pub trait StableXOrderBookReading {
 /// contract in a paginated way.
 /// This avoid hitting gas limits when the total amount of orders is large.
 pub struct PaginatedStableXOrderBookReader<'a> {
-    contract: &'a dyn StableXContract,
+    contract: &'a (dyn StableXContract + Sync),
     page_size: u16,
 }
 
 impl<'a> PaginatedStableXOrderBookReader<'a> {
-    pub fn new(contract: &'a dyn StableXContract, page_size: u16) -> Self {
+    pub fn new(contract: &'a (dyn StableXContract + Sync), page_size: u16) -> Self {
         Self {
             contract,
             page_size,

--- a/driver/src/price_estimation/mod.rs
+++ b/driver/src/price_estimation/mod.rs
@@ -37,7 +37,7 @@ pub struct PriceOracle {
     /// whitelisted tokens get their prices estimated.
     tokens: TokenData,
     /// The price source to use.
-    source: Box<dyn PriceSource>,
+    source: Box<dyn PriceSource + Sync>,
 }
 
 impl PriceOracle {
@@ -47,7 +47,7 @@ impl PriceOracle {
         tokens: TokenData,
         update_interval: Duration,
     ) -> Result<Self> {
-        let source: Box<dyn PriceSource> = if tokens.is_empty() {
+        let source: Box<dyn PriceSource + Sync> = if tokens.is_empty() {
             Box::new(NoopPriceSource)
         } else {
             let source = AveragePriceSource::new(
@@ -66,7 +66,7 @@ impl PriceOracle {
     }
 
     #[cfg(test)]
-    fn with_source(tokens: TokenData, source: impl PriceSource + 'static) -> Self {
+    fn with_source(tokens: TokenData, source: impl PriceSource + Sync + 'static) -> Self {
         PriceOracle {
             tokens,
             source: Box::new(source),

--- a/driver/src/price_finding/mod.rs
+++ b/driver/src/price_finding/mod.rs
@@ -11,8 +11,8 @@ use log::info;
 pub fn create_price_finder(
     fee: Option<Fee>,
     solver_type: SolverType,
-    price_oracle: impl PriceEstimating + 'static,
-) -> Box<dyn PriceFinding> {
+    price_oracle: impl PriceEstimating + Sync + 'static,
+) -> Box<dyn PriceFinding + Sync> {
     if solver_type == SolverType::NaiveSolver {
         info!("Using naive price finder");
         Box::new(NaiveSolver::new(fee))

--- a/driver/src/price_finding/optimization_price_finder.rs
+++ b/driver/src/price_finding/optimization_price_finder.rs
@@ -168,14 +168,14 @@ pub struct OptimisationPriceFinder {
     read_output: fn(&str) -> std::io::Result<String>,
     fee: Option<Fee>,
     solver_type: SolverType,
-    price_oracle: Box<dyn PriceEstimating>,
+    price_oracle: Box<dyn PriceEstimating + Sync>,
 }
 
 impl OptimisationPriceFinder {
     pub fn new(
         fee: Option<Fee>,
         solver_type: SolverType,
-        price_oracle: impl PriceEstimating + 'static,
+        price_oracle: impl PriceEstimating + Sync + 'static,
     ) -> Self {
         OptimisationPriceFinder {
             write_input,

--- a/driver/src/solution_submission/mod.rs
+++ b/driver/src/solution_submission/mod.rs
@@ -76,12 +76,12 @@ impl From<Error> for SolutionSubmissionError {
 }
 
 pub struct StableXSolutionSubmitter<'a> {
-    contract: &'a dyn StableXContract,
-    rpc: &'a dyn EthRpc,
+    contract: &'a (dyn StableXContract + Sync),
+    rpc: &'a (dyn EthRpc + Sync),
 }
 
 impl<'a> StableXSolutionSubmitter<'a> {
-    pub fn new(contract: &'a dyn StableXContract, rpc: &'a dyn EthRpc) -> Self {
+    pub fn new(contract: &'a (dyn StableXContract + Sync), rpc: &'a (dyn EthRpc + Sync)) -> Self {
         Self { contract, rpc }
     }
 }


### PR DESCRIPTION
(and turn one mutable reference into immutable)

The Sync bounds are needed for a future PR that will solve each batch in
its own thread.

An alternative approach to adding Sync to all the trait bounds is to use generics instead of dyn traits. This would make each part more composable as it would still be individually usable even if it is not Sync which could help in tests. On the other hand it would mean more generics on every struct. I stuck with dyn traits because that is what already had but I don't mind either approach.