### PR TITLE
Don't advance EVM time when waiting for solution

### DIFF
--- a/e2e/src/common.rs
+++ b/e2e/src/common.rs
@@ -106,7 +106,7 @@ fn is_connected_to_ganache(web3: &Web3<Http>) -> bool {
         .version()
         .wait()
         .expect("Failed to determine network ID");
-    network_id == "5777"
+    network_id == GANACHE_NETWORK_ID
 }
 
 pub fn wait_for_condition<C>(

--- a/e2e/src/common.rs
+++ b/e2e/src/common.rs
@@ -99,7 +99,7 @@ pub fn wait_for(web3: &Web3<Http>, seconds: u32) {
 }
 
 fn is_connected_to_ganache(web3: &Web3<Http>) -> bool {
-    const GANACHE_CHAIN_ID: u64 = 5777;
+    const GANACHE_CHAIN_ID: u64 = 1337;
 
     let chain_id = web3
         .eth()

--- a/e2e/src/common.rs
+++ b/e2e/src/common.rs
@@ -99,14 +99,14 @@ pub fn wait_for(web3: &Web3<Http>, seconds: u32) {
 }
 
 fn is_connected_to_ganache(web3: &Web3<Http>) -> bool {
-    const GANACHE_CHAIN_ID: u64 = 1337;
+    const GANACHE_NETWORK_ID: &str = "5777";
 
-    let chain_id = web3
-        .eth()
-        .chain_id()
+    let network_id = web3
+        .net()
+        .version()
         .wait()
-        .expect("Failed to determine chain ID");
-    chain_id.low_u64() == GANACHE_CHAIN_ID
+        .expect("Failed to determine network ID");
+    network_id == "5777"
 }
 
 pub fn wait_for_condition<C>(

--- a/e2e/src/common.rs
+++ b/e2e/src/common.rs
@@ -151,3 +151,11 @@ pub fn approve(tokens: &[IERC20], address: Address, accounts: &[Address], approv
         }
     }
 }
+
+/// Mine a new block so the current EVM timestamp changes.
+pub fn update_evm_time(web3: &Web3<Http>) {
+    web3.transport()
+        .execute("evm_mine", vec![])
+        .wait()
+        .expect("Cannot mine to update current time");
+}

--- a/e2e/tests/stablex_test.rs
+++ b/e2e/tests/stablex_test.rs
@@ -73,7 +73,7 @@ fn test_with_ganache() {
     let batch_id = instance
         .get_current_batch_id()
         .wait_and_expect("Failed to query batch ID");
-    let wait_time = Duration::from_secs(340);
+    let wait_time = Duration::from_secs(640);
     println!(
         "Waiting {}s for the solver to submit a solution for batch {}",
         wait_time.as_secs(),

--- a/e2e/tests/stablex_test.rs
+++ b/e2e/tests/stablex_test.rs
@@ -5,7 +5,7 @@ use ethcontract::{Account, PrivateKey, U256};
 
 use futures::future::join_all;
 
-use e2e::common::{update_evm_time, wait_for_condition, FutureBuilderExt, FutureWaitExt};
+use e2e::common::{wait_for_condition, FutureBuilderExt, FutureWaitExt};
 use e2e::docker_logs;
 use e2e::stablex::{close_auction, setup_stablex};
 use e2e::{BatchExchange, IERC20};
@@ -81,11 +81,8 @@ fn test_with_ganache() {
     );
     // wait for solver to submit solution
     wait_for_condition(
+        &web3,
         || {
-            // NOTE: Make sure that we periodically update the EVM time, as no
-            //   new blocks are being mined to update the EVM timestamp.
-            update_evm_time(&web3);
-
             instance
                 .get_current_objective_value()
                 .wait_and_expect("Cannot get objective value")

--- a/e2e/tests/stablex_test.rs
+++ b/e2e/tests/stablex_test.rs
@@ -70,9 +70,10 @@ fn test_with_ganache() {
         .from(Account::Local(accounts[1], None))
         .wait_and_expect("Cannot place first order");
 
-    let batch_id = instance.get_current_batch_id().call().wait().unwrap();
-    close_auction(&web3, &instance);
-    let wait_time = Duration::from_secs(310);
+    let batch_id = instance
+        .get_current_batch_id()
+        .wait_and_expect("Failed to query batch ID");
+    let wait_time = Duration::from_secs(340);
     println!(
         "Waiting {}s for the solver to submit a solution for batch {}",
         wait_time.as_secs(),

--- a/e2e/tests/stablex_test.rs
+++ b/e2e/tests/stablex_test.rs
@@ -5,7 +5,7 @@ use ethcontract::{Account, PrivateKey, U256};
 
 use futures::future::join_all;
 
-use e2e::common::{wait_for_condition, FutureBuilderExt, FutureWaitExt};
+use e2e::common::{update_evm_time, wait_for_condition, FutureBuilderExt, FutureWaitExt};
 use e2e::docker_logs;
 use e2e::stablex::{close_auction, setup_stablex};
 use e2e::{BatchExchange, IERC20};
@@ -73,7 +73,7 @@ fn test_with_ganache() {
     let batch_id = instance
         .get_current_batch_id()
         .wait_and_expect("Failed to query batch ID");
-    let wait_time = Duration::from_secs(640);
+    let wait_time = Duration::from_secs(340);
     println!(
         "Waiting {}s for the solver to submit a solution for batch {}",
         wait_time.as_secs(),
@@ -82,6 +82,10 @@ fn test_with_ganache() {
     // wait for solver to submit solution
     wait_for_condition(
         || {
+            // NOTE: Make sure that we periodically update the EVM time, as no
+            //   new blocks are being mined to update the EVM timestamp.
+            update_evm_time(&web3);
+
             instance
                 .get_current_objective_value()
                 .wait_and_expect("Cannot get objective value")


### PR DESCRIPTION
We are advancing the time (with `evm_increaseTime`) before waiting for a solution to be submitted. This is racy and causes situations where the orderbook and batch were queried before the `evm_increaseTime` and the solution was submitted for the next batch. This is causing intermittent CI failures with the Ganache test.

Note that this also requires increasing the wait time.

### Test Plan

CI