### PR TITLE
[Trivial] Remove unused orderbook API methods

### DIFF
--- a/driver/src/orderbook/filtered_orderbook.rs
+++ b/driver/src/orderbook/filtered_orderbook.rs
@@ -45,10 +45,6 @@ impl<'a> FilteredOrderbookReader<'a> {
 }
 
 impl<'a> StableXOrderBookReading for FilteredOrderbookReader<'a> {
-    fn get_auction_index(&self) -> Result<U256> {
-        self.orderbook.get_auction_index()
-    }
-
     fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
         let (state, orders) = self.orderbook.get_auction_data(index)?;
         let filtered = orders

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -15,10 +15,6 @@ pub use filtered_orderbook::OrderbookFilter;
 
 #[cfg_attr(test, automock)]
 pub trait StableXOrderBookReading {
-    /// Returns the index of the auction that is currently being solved
-    /// or an error in case it cannot get this information.
-    fn get_auction_index(&self) -> Result<U256>;
-
     /// Returns the current state of the order book, including account balances
     /// and open orders or an error in case it cannot get this information.
     ///
@@ -45,12 +41,6 @@ impl<'a> PaginatedStableXOrderBookReader<'a> {
 }
 
 impl<'a> StableXOrderBookReading for PaginatedStableXOrderBookReader<'a> {
-    fn get_auction_index(&self) -> Result<U256> {
-        self.contract
-            .get_current_auction_index()
-            .map(|batch_collecting_orders| batch_collecting_orders - 1)
-    }
-
     fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
         let mut reader = PaginatedAuctionDataReader::new(index);
         loop {


### PR DESCRIPTION
Since the orderbook is no longer responsible for determining the batch ID, remove the call from the the orderbook reading trait.

### Test Plan

It should build.