### PR TITLE
Remove latest_solve_attempt config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,7 @@ The following environment variables can be used to configure the behavior of the
 - *WEB3_RPC_TIMEOUT*: The timeout in milliseconds of web3 JSON RPC calls, defaults to 10000ms
 - *TOKEN_DATA*: Allows to set token data - i.e symbol name, decimals, a default external price and a flag for indicating whether updated external prices should be fetched.
 - *TARGET_START_SOLVE_TIME*: The offset from the start of a batch in seconds at which point we should start solving.
-- *LATEST_SOLVE_ATTEMPT_TIME*: The offset from the start of the batch in seconds at which point there is not enough time left to attempt to solve.
-- *SOLVER_TIME_LIMIT*: The offset from the start of the batch to cap the solver's execution time. Note that this is slightly different from *LATEST_SOLVE_ATTEMPT_TIME*, the latter is that absolute latest in which solving a solution will be attempted, while the former determines how much time the solver actually has to run. Another way to look at it is that the solver will be started with a time limit that is at least `SOLVER_TIME_LIMIT - LATEST_SOLVE_ATTEMPT_TIME` and at most `SOLVER_TIME_LIMIT - TARGET_START_SOLVE_TIME`.
+- *SOLVER_TIME_LIMIT*: The offset from the start of the batch to cap the solver's execution time in seconds.
 - *PRICE_SOURCE_UPDATE_INTERVAL*: Time interval in seconds in which price sources should be updated.
 
 ### Orderbook Filter Example

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -138,16 +138,6 @@ struct Options {
     )]
     target_start_solve_time: Duration,
 
-    /// The offset from the start of the batch in seconds at which point there
-    /// is not enough time left to attempt to solve.
-    #[structopt(
-        long,
-        env = "LATEST_SOLVE_ATTEMPT_TIME",
-        default_value = "180",
-        parse(try_from_str = duration_secs),
-    )]
-    latest_solve_attempt_time: Duration,
-
     /// The offset from the start of the batch to cap the solver's execution
     /// time.
     #[structopt(
@@ -232,7 +222,6 @@ fn main() {
         &driver,
         AuctionTimingConfiguration {
             target_start_solve_time: options.target_start_solve_time,
-            latest_solve_attempt_time: options.latest_solve_attempt_time,
             solver_time_limit: options.solver_time_limit,
         },
     );


### PR DESCRIPTION
If there is still time left in solver_time_limit then we should run the
solver regardless of how little time that is. Worst case is it doesn't
find a solution quickly enough which is the same result as if we hadn't
attempted to run it at all.