### PR TITLE
[Trivial] Remove unused env keys

### DIFF
--- a/common-mainnet.env
+++ b/common-mainnet.env
@@ -1,4 +1,3 @@
 ETHEREUM_NODE_URL=https://mainnet.infura.io/v3/9408f47dedf04716a03ef994182cf150
-NETWORK_NAME=mainnet
 NETWORK_ID=1
 SOLVER_TYPE=standard-solver

--- a/common-rinkeby.env
+++ b/common-rinkeby.env
@@ -1,4 +1,3 @@
 ETHEREUM_NODE_URL=https://node.rinkeby.gnosisdev.com/
-NETWORK_NAME=rinkeby
 NETWORK_ID=4
 SOLVER_TYPE=standard-solver

--- a/common.env
+++ b/common.env
@@ -1,9 +1,4 @@
 ETHEREUM_NODE_URL=http://ganache-cli:8545
-NETWORK_NAME=dev
 NETWORK_ID=5777
 PRIVATE_KEY=4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d
-POSTGRES_URL=postgresql://dfusion:let-me-in@postgres/dfusion
-GRAPHQL_PORT=8000
-WS_PORT=8001
-REORG_THRESHOLD=0
 SOLVER_TYPE=naive-solver


### PR DESCRIPTION
Just cleanup the `common*.env` files and remove some old env variables that are no longer used.