### PR TITLE
Solve each batch in its own thread

### DIFF
--- a/driver/src/driver/scheduler.rs
+++ b/driver/src/driver/scheduler.rs
@@ -21,7 +21,7 @@ pub trait Scheduler {
     fn start(&mut self) -> !;
 }
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct AuctionTimingConfiguration {
     /// The offset from the start of a batch at which point we should start
     /// solving.

--- a/driver/src/driver/scheduler/system.rs
+++ b/driver/src/driver/scheduler/system.rs
@@ -84,7 +84,12 @@ impl<'a> SystemScheduler<'a> {
                 batch_id,
                 &driver_result,
             ) {
-                SolveAgain::Yes { time_limit } => solver_time_limit = time_limit,
+                SolveAgain::Yes { time_limit } => {
+                    if time_limit > RETRY_SLEEP_DURATION {
+                        thread::sleep(RETRY_SLEEP_DURATION);
+                    }
+                    solver_time_limit = time_limit - RETRY_SLEEP_DURATION;
+                }
                 SolveAgain::No => break,
             }
         });

--- a/driver/src/driver/scheduler/system.rs
+++ b/driver/src/driver/scheduler/system.rs
@@ -435,10 +435,10 @@ mod tests {
             );
             counter += 1;
             match counter % 3 {
-                //0 => DriverResult::Ok,
-                _ => DriverResult::Retry(anyhow!("")),
-                //2 => DriverResult::Skip(anyhow!("")),
-                //_ => unreachable!(),
+                0 => DriverResult::Ok,
+                1 => DriverResult::Retry(anyhow!("")),
+                2 => DriverResult::Skip(anyhow!("")),
+                _ => unreachable!(),
             }
         });
 

--- a/driver/src/driver/scheduler/system.rs
+++ b/driver/src/driver/scheduler/system.rs
@@ -136,10 +136,9 @@ fn should_attempt_to_solve_again(
 ) -> bool {
     match driver_result {
         DriverResult::Ok => false,
-        DriverResult::Retry(_) => match determine_action(auction_timing_configuration, None, now) {
-            Ok(Action::Solve(batch_id_, _)) if batch_id_ == batch_id => true,
-            _ => false,
-        },
+        DriverResult::Retry(_) => {
+            now < (batch_id.solve_start_time() + auction_timing_configuration.solver_time_limit)
+        }
         DriverResult::Skip(_) => false,
     }
 }

--- a/driver/src/driver/scheduler/system.rs
+++ b/driver/src/driver/scheduler/system.rs
@@ -7,7 +7,7 @@ use log::info;
 use std::thread;
 use std::time::{Duration, SystemTime, SystemTimeError};
 
-const RETRY_SLEEP_DURATION: Duration = Duration::from_secs(10);
+const RETRY_SLEEP_DURATION: Duration = Duration::from_secs(1);
 
 /// Wraps a batch id as in the smart contract to add functionality related to
 /// the current time.


### PR DESCRIPTION
We want to solve each batch in its own thread so that one batch cannot make another start late. In the future this allows us to potentially start a solver optimistically even before its auction is up.

Test Plan: New unit tests, CI, manual test with the `ignored` test.