### PR TITLE
Use `--help` output to generate readme configuration options section

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,21 +144,72 @@ Afterwards, when you run your environment e.g. with `docker-compose up stablex` 
 
 ## Configuration
 
-The following environment variables can be used to configure the behavior of the services:
+The binary can be configured via command line options and environment variables: `cargo run -- --help`
 
-- *AUCTION_DATA_PAGE_SIZE*: the page size with which to read orders from the smart contract
-- *DFUSION_LOG*: Log-level (e.g. `info,driver=debug`)
-- *ETHEREUM_NODE_URL*: Full-Node to connect to. Make sure the node allows view queries without a gas limit in order to fetch the entire orderbook at once.
-- *NETWORK_ID*: Network ID (e.g. 1 for mainnet, 4 for rinkeby, 5777 for ganache)
-- *OPTIMIZATION_MODEL*: Which style of solver to use (NAIVE for naive, MIP for mixed integer programming and NLP for the  non-linear programming solver)
-- *ORDERBOOK_FILTER*: json encoded object of which tokens/filters to ignore. See below for example filter.
-- *PRIVATE_KEY*: The key with which to sign transactions
-- *WEB3_RPC_TIMEOUT*: The timeout in milliseconds of web3 JSON RPC calls, defaults to 10000ms
-- *TOKEN_DATA*: Allows to set token data - i.e symbol name, decimals, a default external price and a flag for indicating whether updated external prices should be fetched.
-- *TARGET_START_SOLVE_TIME*: The offset from the start of a batch in seconds at which point we should start solving when using the `system` scheduler.
-- *SOLVER_TIME_LIMIT*: The offset from the start of the batch to cap the solver's execution time in seconds.
-- *SCHEDULER*: The scheduling method to use for solving batches. Can be either `system` (default) to use system time to schedule solving batches, or `evm` to use data read from the EVM in order to schedule solving batches.
-- *PRICE_SOURCE_UPDATE_INTERVAL*: Time interval in seconds in which price sources should be updated.
+```
+Gnosis Exchange protocol driver.
+
+USAGE:
+    driver [OPTIONS] --network-id <network-id> --node-url <node-url> --private-key <private-key>
+
+FLAGS:
+    -h, --help
+            Prints help information
+
+    -V, --version
+            Prints version information
+
+
+OPTIONS:
+        --auction-data-page-size <auction-data-page-size>
+            The page size with which to read orders from the smart contract [env: AUCTION_DATA_PAGE_SIZE=]  [default:
+            100]
+        --http-timeout <http-timeout>
+            The default timeout in milliseconds of HTTP requests to remote services such as the Gnosis Safe gas station
+            and exchange REST APIs for fetching price estimates [env: HTTP_TIMEOUT=]  [default: 10000]
+        --log-filter <log-filter>
+            The log fiter to use.
+
+            This follows the `slog-envlogger` syntax (e.g. 'info,driver=debug'). [env: DFUSION_LOG=]  [default: info]
+    -i, --network-id <network-id>
+            The network ID used for signing transactions (e.g. 1 for mainnet, 4 for rinkeby, 5777 for ganache) [env:
+            NETWORK_ID=]
+    -n, --node-url <node-url>
+            The Ethereum node URL to connect to. Make sure that the node allows for queries witout a gas limit to be
+            able to fetch the orderbook [env: ETHEREUM_NODE_URL=]
+        --orderbook-filter <orderbook-filter>
+            JSON encoded object of which tokens/orders to ignore.
+
+            For example: '{ "tokens": [1, 2], "users": { "0x7b60655Ca240AC6c76dD29c13C45BEd969Ee6F0A": { "OrderIds": [0,
+            1] }, "0x7b60655Ca240AC6c76dD29c13C45BEd969Ee6F0B": "All" } }' [env: ORDERBOOK_FILTER=]  [default: {}]
+        --price-source-update-interval <price-source-update-interval>
+            Time interval in seconds in which price sources should be updated [env: PRICE_SOURCE_UPDATE_INTERVAL=]
+            [default: 300]
+    -k, --private-key <private-key>
+            The private key used by the driver to sign transactions [env: PRIVATE_KEY]
+
+        --rpc-timeout <rpc-timeout>
+            The timeout in milliseconds of web3 JSON RPC calls, defaults to 10000ms [env: WEB3_RPC_TIMEOUT=]  [default:
+            10000]
+        --scheduler <scheduler>
+            The kind of scheduler to use [env: SCHEDULER=]  [default: system]
+
+        --solver-time-limit <solver-time-limit>
+            The offset from the start of the batch to cap the solver's execution time [env: SOLVER_TIME_LIMIT=]
+            [default: 210]
+        --solver-type <solver-type>
+            Which style of solver to use. Can be one of: 'NAIVE' for the naive solver; 'MIP' for mixed integer
+            programming solver; 'NLP' for non-linear programming solver [env: SOLVER_TYPE=]  [default: naive-solver]
+        --target-start-solve-time <target-start-solve-time>
+            The offset from the start of a batch in seconds at which point we should start solving [env:
+            TARGET_START_SOLVE_TIME=]  [default: 30]
+        --token-data <token-data>
+            JSON encoded backup token information to provide to the solver.
+
+            For example: '{ "T0001": { "alias": "WETH", "decimals": 18, "externalPrice": 200000000000000000000,
+            "shouldEstimatePrice": false }, "T0004": { "alias": "USDC", "decimals": 6, "externalPrice":
+            1000000000000000000000000000000, "shouldEstimatePrice": true } }' [env: TOKEN_DATA=]  [default: {}]
+```
 
 ### Orderbook Filter Example
 


### PR DESCRIPTION
So that we no longer need to manually repeat documentation.