### PR TITLE
Sleep longer to make sure solver gets started

### DIFF
--- a/e2e/tests/stablex_test.rs
+++ b/e2e/tests/stablex_test.rs
@@ -200,7 +200,7 @@ fn test_rinkeby() {
         .get_seconds_remaining_in_batch()
         .wait_and_expect("Cannot get seconds remaining in batch")
         .low_u64()
-        + 30;
+        + 60;
 
     println!("Sleeping {} seconds...", sleep_time);
     std::thread::sleep(Duration::from_secs(sleep_time));


### PR DESCRIPTION
Since moving to the system time scheduler for Rinkeby tests, it is likely that the solver never gets started as we only wait until the target start time (30s) of the next batch, and don't wait for the solver to actually get started.

Here is an example run where the solver was never even ran: https://travis-ci.com/github/gnosis/dex-services/builds/154083477#L1974

### Test Plan

CI and verify that the solver gets run.