### PR TITLE
Simplify AccountState

### DIFF
--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -316,7 +316,7 @@ pub mod tests {
     use crate::models::order::test_util::order_to_executed_order;
     use crate::models::AccountState;
 
-    use ethcontract::{Address, H256, U256};
+    use ethcontract::{Address, U256};
     use std::collections::HashMap;
 
     #[test]
@@ -512,12 +512,7 @@ pub mod tests {
     #[test]
     fn test_insufficient_balance() {
         const NUM_TOKENS: u16 = 10;
-        let state = AccountState::new(
-            H256::zero(),
-            U256::zero(),
-            vec![0; (NUM_TOKENS * 2) as usize],
-            NUM_TOKENS,
-        );
+        let state = AccountState::new(vec![0; (NUM_TOKENS * 2) as usize], NUM_TOKENS);
         let orders = vec![
             Order {
                 id: 0,
@@ -622,9 +617,8 @@ pub mod tests {
         let users = [Address::from_low_u64_be(0), Address::from_low_u64_be(1)];
         let state = {
             let mut state = AccountState::default();
-            state.num_tokens = u16::max_value();
-            state.increment_balance(0, users[0], 3000 * BASE_UNIT);
-            state.increment_balance(1, users[1], 3000 * BASE_UNIT);
+            state.increase_balance(users[0], 0, 3000 * BASE_UNIT);
+            state.increase_balance(users[1], 1, 3000 * BASE_UNIT);
             state
         };
         let orders = vec![

--- a/driver/src/price_finding/optimization_price_finder.rs
+++ b/driver/src/price_finding/optimization_price_finder.rs
@@ -316,7 +316,7 @@ pub mod tests {
     use crate::models::AccountState;
     use crate::price_estimation::MockPriceEstimating;
     use crate::util::test_util::map_from_slice;
-    use ethcontract::{Address, H256, U256};
+    use ethcontract::Address;
     use serde_json::json;
     use std::collections::BTreeMap;
 
@@ -521,12 +521,7 @@ pub mod tests {
 
     #[test]
     fn test_serialize_balances() {
-        let state = models::AccountState::new(
-            H256::zero(),
-            U256::zero(),
-            vec![100, 200, 300, 400, 500, 600],
-            3,
-        );
+        let state = models::AccountState::new(vec![100, 200, 300, 400, 500, 600], 3);
         let orders = [
             models::Order {
                 id: 0,


### PR DESCRIPTION
Removed unused fields.

Turned hash map of hash map into a single hash map. This is simpler and
more efficient.

Exposed undlerying hash map directly.
AccountState wraps the hash map with convenience methods but there is no
reason to not allow direct access to other code.

Test Plan: existing unit tests