### PR TITLE
Implement contract deployment in Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "contracts"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "env_logger",
+ "ethcontract",
+ "ethcontract-generate",
+ "futures 0.3.5",
+ "log 0.4.11",
+ "serde",
+]
+
+[[package]]
 name = "core"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "contracts",
     "core",
     "driver",
     "e2e",
@@ -9,6 +10,7 @@ members = [
     "pricegraph/wasm",
 ]
 default-members = [
+    "contracts",
     "core",
     "driver",
     "price-estimator",

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "contracts"
+version = "0.1.0"
+authors = ["Nicholas Rodrigues Lordello <nicholas.lordello@gnosis.pm>"]
+edition = "2018"
+
+[[bin]]
+name = "deploy"
+required-features = ["bin"]
+
+[features]
+default = []
+bin = [
+    "anyhow",
+    "env_logger",
+    "futures",
+    "log",
+]
+
+[dependencies]
+ethcontract = "0.7.2"
+serde = "1.0.114"
+
+# [bin-dependencies]
+anyhow = { version = "1.0.32", optional = true }
+env_logger = { version = "", optional = true }
+futures = { version = "0.3.5", features = ["compat"], optional = true }
+log = { version = "0.4.11", optional = true }
+
+[build-dependencies]
+ethcontract-generate = "0.7.2"
+

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -23,7 +23,7 @@ serde = "1.0.114"
 
 # [bin-dependencies]
 anyhow = { version = "1.0.32", optional = true }
-env_logger = { version = "", optional = true }
+env_logger = { version = "0.7.1", optional = true }
 futures = { version = "0.3.5", features = ["compat"], optional = true }
 log = { version = "0.4.11", optional = true }
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,38 @@
+# Gnosis Protocol Contracts
+
+This crate contains `ethcontract` generated bindings to the Gnosis Protocol
+contracts. Additionally it includes a `deploy` script for deploying contracts
+to a test-net for E2E testing.
+
+## `deploy` Script
+
+A `[[bin]]` script for deploying Gnosis Protocol contracts to a test network.
+This script requires a test node such as Ganache listening on `127.0.0.1:8545`.
+It can be run from the repository root:
+
+```
+$ (cd contracts; cargo run -p contracts --bin deploy --features bin)
+   Compiling contracts v0.1.0 (/var/home/nlordell/Developer/dex-services/contracts)
+    Finished dev [unoptimized + debuginfo] target(s) in 4.87s
+     Running `/var/home/nlordell/Developer/dex-services/target/debug/deploy`
+[2020-08-05T12:43:07Z INFO  deploy] checking connection to local test node http://localhost:8545
+[2020-08-05T12:43:07Z INFO  deploy] deploying library contracts
+[2020-08-05T12:43:07Z INFO  deploy] deployed IdToAddressBiMap to 0x65dbc7c034b644401ad2a1f1ed8b284ae41e56bc
+[2020-08-05T12:43:07Z INFO  deploy] deployed IterableAppendOnlySet to 0xc27e5a197f7f1c794bcd348f673d80687eff83a6
+[2020-08-05T12:43:07Z INFO  deploy] deploying fee token contracts
+[2020-08-05T12:43:07Z INFO  deploy] deployed TokenOWL to 0x8f534a8084d9306527ff15c919f7fa691c0ca856
+[2020-08-05T12:43:07Z INFO  deploy] deployed TokenOWLProxy to 0x445d64d63f42401c8c7ff846d2a92edd2b31417b
+[2020-08-05T12:43:07Z INFO  deploy] deploying exchange and viewer contracts
+[2020-08-05T12:43:07Z INFO  deploy] deployed BatchExchange to 0x4fab5591ff63d133854e937ad4568afef5264e6a
+[2020-08-05T12:43:07Z INFO  deploy] deployed BatchExchangeViewer to 0x63f7170efe984d40d1a435a917b99c71ad645901
+```
+
+This will generate `$CONTRACT_NAME.addr` files in the `target/deploy` directory.
+The `build.rs` script uses these files to inject test network deployed addresses
+into the generated bindings so `Contract::deployed()` methods work as expected
+for E2E tests when connected to a local network.
+
+Note that the `contracts` crate needs to be re-built after running the `deploy`
+script to generate bindings with the injected test network addresses. This is
+done automatically on `cargo build` by leveraging the `cargo:rerun-if-changed`
+build script feature.

--- a/contracts/build.rs
+++ b/contracts/build.rs
@@ -1,0 +1,40 @@
+use ethcontract_generate::Builder;
+use std::{env, fs, path::Path};
+
+#[path = "src/paths.rs"]
+mod paths;
+
+fn main() {
+    generate_contract("BatchExchange");
+    generate_contract("BatchExchangeViewer");
+    generate_contract("IdToAddressBiMap");
+    generate_contract("IterableAppendOnlySet");
+    generate_contract("TokenOWL");
+    generate_contract("TokenOWLProxy");
+}
+
+fn generate_contract(name: &str) {
+    let artifact = format!("../dex-contracts/build/contracts/{}.json", name);
+    let dest = env::var("OUT_DIR").unwrap();
+
+    let mut builder = Builder::new(artifact)
+        .with_visibility_modifier(Some("pub"))
+        .add_event_derive("serde::Deserialize")
+        .add_event_derive("serde::Serialize");
+
+    if let Some(address) = contract_address(name) {
+        builder = builder.add_deployment_str(5777, address.trim());
+    }
+
+    builder
+        .generate()
+        .unwrap()
+        .write_to_file(Path::new(&dest).join(format!("{}.rs", name)))
+        .unwrap();
+}
+
+fn contract_address(name: &str) -> Option<String> {
+    let path = paths::contract_address_file(name);
+    println!("cargo:rerun-if-changed={}", path.display());
+    Some(fs::read_to_string(path).ok()?)
+}

--- a/contracts/src/bin/deploy.rs
+++ b/contracts/src/bin/deploy.rs
@@ -1,0 +1,116 @@
+//! Script to deploy Gnosis Protocol contracts to a local test network.
+//! Additionally writes the deployed addresses to the `target` directory so that
+//! they can be used by the build script.
+
+use anyhow::{anyhow, bail, Context as _, Result};
+use contracts::*;
+use env_logger::Env;
+use ethcontract::{Address, Http, Web3};
+use futures::compat::Future01CompatExt as _;
+use std::{
+    fs, thread,
+    time::{Duration, Instant},
+};
+
+fn main() {
+    env_logger::init_from_env(Env::default().default_filter_or("warn,deploy=debug"));
+
+    if let Err(err) = futures::executor::block_on(run()) {
+        log::error!("Error deploying contracts: {:?}", err);
+        std::process::exit(-1);
+    }
+}
+
+async fn run() -> Result<()> {
+    const NODE_URL: &str = "http://localhost:8545";
+
+    let (eloop, http) = Http::new(NODE_URL)?;
+    let web3 = Web3::new(http);
+    eloop.into_remote();
+
+    log::info!("checking connection to local test node {}", NODE_URL);
+    wait_for_node(&web3).await?;
+
+    macro_rules! deploy {
+            ($contract:ident) => { deploy!($contract ()) };
+            ($contract:ident ( $($param:expr),* $(,)? )) => {{
+                log::debug!(concat!("deploying ", stringify!($contract), "..."));
+                let instance = $contract::builder(&web3 $(, $param)*)
+                    .gas(8_000_000.into())
+                    .deploy()
+                    .await
+                    .context(concat!("failed to deploy ", stringify!($contract)))?;
+                log::debug!("deployed to {:?}", instance.address());
+                write_contract_address(stringify!($contract), instance.address())
+                    .context(concat!(
+                        "failed to write contract address for ",
+                        stringify!($contract),
+                    ))?;
+
+                instance
+            }};
+        }
+
+    log::info!("deploying library contracts");
+    let bi_map = deploy!(IdToAddressBiMap);
+    let iterable_set = deploy!(IterableAppendOnlySet);
+
+    log::info!("deploying fee token contracts");
+    let owl = deploy!(TokenOWL);
+    let owl_proxy = deploy!(TokenOWLProxy(owl.address()));
+
+    log::info!("deploying exchange and viewer contracts");
+    let exchange = deploy!(BatchExchange(
+        batch_exchange::Libraries {
+            id_to_address_bi_map: bi_map.address(),
+            iterable_append_only_set: iterable_set.address(),
+        },
+        u16::max_value().into(),
+        owl_proxy.address(),
+    ));
+    deploy!(BatchExchangeViewer(exchange.address()));
+
+    Ok(())
+}
+
+/// Writes the deployed contract address to the workspace `target` directory.
+fn write_contract_address(name: &str, address: Address) -> Result<()> {
+    let path = paths::contract_address_file(name);
+    let dir = path
+        .parent()
+        .ok_or_else(|| anyhow!("contract address path does not have a parent directory"))?;
+
+    fs::create_dir_all(dir)?;
+    fs::write(path, format!("{:?}", address))?;
+
+    Ok(())
+}
+
+/// Waits for the local development node to become available. Returns an error
+/// if the node does not become available after a certain amount of time.
+async fn wait_for_node(web3: &Web3<Http>) -> Result<()> {
+    const NODE_READY_TIMEOUT: Duration = Duration::from_secs(30);
+    const NODE_READY_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+    let start = Instant::now();
+    while start.elapsed() < NODE_READY_TIMEOUT {
+        if web3.eth().accounts().compat().await.is_ok() {
+            return Ok(());
+        }
+
+        log::warn!(
+            "node not responding, retrying in {}s",
+            NODE_READY_POLL_INTERVAL.as_secs_f64(),
+        );
+
+        // NOTE: Usually a blocking call in a future is bad, but since we block
+        // on this future right at the beginning and have no concurrent fibers,
+        // it should be OK for this simple script.
+        thread::sleep(NODE_READY_POLL_INTERVAL);
+    }
+
+    bail!(
+        "Timed out waiting for node after {}s",
+        NODE_READY_TIMEOUT.as_secs(),
+    )
+}

--- a/contracts/src/bin/deploy.rs
+++ b/contracts/src/bin/deploy.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 fn main() {
-    env_logger::init_from_env(Env::default().default_filter_or("warn,deploy=debug"));
+    env_logger::init_from_env(Env::default().default_filter_or("warn,deploy=info"));
 
     if let Err(err) = futures::executor::block_on(run()) {
         log::error!("Error deploying contracts: {:?}", err);
@@ -50,7 +50,7 @@ async fn run() -> Result<()> {
                 write_contract_address(stringify!($contract), instance.address())
                     .with_context(|| format!("failed to write contract address for {}", NAME))?;
 
-                log::info!("deployed to {:?}", instance.address());
+                log::info!("deployed {} to {:?}", NAME, instance.address());
                 instance
             }};
         }

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -1,0 +1,9 @@
+#[cfg(feature = "bin")]
+pub mod paths;
+
+include!(concat!(env!("OUT_DIR"), "/BatchExchange.rs"));
+include!(concat!(env!("OUT_DIR"), "/BatchExchangeViewer.rs"));
+include!(concat!(env!("OUT_DIR"), "/IdToAddressBiMap.rs"));
+include!(concat!(env!("OUT_DIR"), "/IterableAppendOnlySet.rs"));
+include!(concat!(env!("OUT_DIR"), "/TokenOWL.rs"));
+include!(concat!(env!("OUT_DIR"), "/TokenOWLProxy.rs"));

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -1,3 +1,7 @@
+// TODO(nlordell): Remove this lint once we release a new `ethcontract` version
+// that does not trigger this lint.
+#![allow(unused_braces)]
+
 #[cfg(feature = "bin")]
 pub mod paths;
 

--- a/contracts/src/paths.rs
+++ b/contracts/src/paths.rs
@@ -1,0 +1,12 @@
+//! Module for common paths used for generated contract bindings.
+
+use std::path::{Path, PathBuf};
+
+/// Path to file containing address of a contract deployed to a test network.
+pub fn contract_address_file(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("target")
+        .join("deploy")
+        .join(format!("{}.addr", name))
+}


### PR DESCRIPTION
This PR adds a new `contract` crate with a `deploy` script to deploy exchange contracts to a development network.

This an initial step towards #846 where we need an alternative to `scripts/setup_contracts.sh` which uses Truffle. The next steps in order to no longer require NodeJS are:
- Update `core` and `e2e` to use the new `contracts` crate.
- Update the Travis build file to use `cargo run -p contracts --bin deploy` instead of performing a Truffle migration.
- Use the `@gnosis.pm/dex-contracts` npm package for retrieving the contract artifact instead of building `dex-contracts` with Truffle.
- Update the README with new build instructions.

### Test Plan

Run the deploy script:
```
$ (cd contracts; cargo run -p contracts --bin deploy --features bin)
   Compiling contracts v0.1.0 (/var/home/nlordell/Developer/dex-services/contracts)
    Finished dev [unoptimized + debuginfo] target(s) in 12.14s
     Running `/var/home/nlordell/Developer/dex-services/target/debug/deploy`
[2020-08-05T12:43:07Z INFO  deploy] checking connection to local test node http://localhost:8545
[2020-08-05T12:43:07Z INFO  deploy] deploying library contracts
[2020-08-05T12:43:07Z INFO  deploy] deployed IdToAddressBiMap to 0x65dbc7c034b644401ad2a1f1ed8b284ae41e56bc
[2020-08-05T12:43:07Z INFO  deploy] deployed IterableAppendOnlySet to 0xc27e5a197f7f1c794bcd348f673d80687eff83a6
[2020-08-05T12:43:07Z INFO  deploy] deploying fee token contracts
[2020-08-05T12:43:07Z INFO  deploy] deployed TokenOWL to 0x8f534a8084d9306527ff15c919f7fa691c0ca856
[2020-08-05T12:43:07Z INFO  deploy] deployed TokenOWLProxy to 0x445d64d63f42401c8c7ff846d2a92edd2b31417b
[2020-08-05T12:43:07Z INFO  deploy] deploying exchange and viewer contracts
[2020-08-05T12:43:07Z INFO  deploy] deployed BatchExchange to 0x5355d6d088ddc1a99b29114976a6ca0321d71fa6
[2020-08-05T12:43:07Z INFO  deploy] deployed BatchExchangeViewer to 0x63f7170efe984d40d1a435a917b99c71ad645901
```

Then check that the `BatchExchange` contract address matches in the generated code:
```
$ for byte in $(echo '5355d6d088ddc1a99b29114976a6ca0321d71fa6' | grep -o ..); do printf "%d\n" "0x$byte"; done | xargs
83 85 214 208 136 221 193 169 155 41 17 73 118 166 202 3 33 215 31 166
$ cargo build && cat target/debug/build/contracts-*/out/BatchExchange.rs | grep -C 3 Address::from
   Compiling contracts v0.1.0 (/var/home/nlordell/Developer/dex-services/contracts)
    Finished dev [unoptimized + debuginfo] target(s) in 4.01s
            let artifact = Self::artifact();
            let network = match network_id {
                "5777" => self::ethcontract::common::truffle::Network {
                    address: self::ethcontract::Address::from([
                        83, 85, 214, 208, 136, 221, 193, 169, 155, 41, 17, 73, 118, 166, 202, 3,
                        33, 215, 31, 166,
                    ]),
```