### PR TITLE
Bumped ethcontract to v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0beb0833dea2e98c76212214ed1b3b313c4654b093557a1db4d9846bb13ffd4"
+checksum = "11117f7cfeb0a38abe518ec123493d86f9545375ba5f2b48e947ef97c585a982"
 dependencies = [
  "ethabi 9.0.1",
  "ethcontract-common",
@@ -674,15 +674,16 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "uint",
  "web3",
  "zeroize",
 ]
 
 [[package]]
 name = "ethcontract-common"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7c86ec634abf31651f2c9f88c6c97a08eba59db085f74fb135756615764aaa"
+checksum = "110d2632d8719942769856be7d862cef74b42dbb3a060da75f322b73d09c2bad"
 dependencies = [
  "ethabi 11.0.0",
  "hex",
@@ -696,20 +697,22 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-derive"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c082df9c592925fd9bd4a6a0ef4156741da0a400e20c3ad1b5efbc132f8f90"
+checksum = "11606e5683b2abf83f0077791ff4a8a426eb0723ff5a4cdc160574eabd1d2c53"
 dependencies = [
+ "ethcontract-common",
  "ethcontract-generate",
  "proc-macro2",
+ "quote",
  "syn",
 ]
 
 [[package]]
 name = "ethcontract-generate"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e6bf510ff3f62c8a0e2421ddaa8578dfb565af267bfaa3a22ddedde027779f5"
+checksum = "28041a9ae3c21166a1033e493ec53ee735ccd0d50123f62bedbf663aaf7374dc"
 dependencies = [
  "Inflector",
  "anyhow",

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1"
 byteorder = "1.3.4"
 chrono = "0.4.11"
 crossbeam-utils = "0.7"
-ethcontract = "0.5.0"
+ethcontract = "0.6.0"
 futures = { version = "0.3.4", features = ["compat"] }
 isahc = { version = "0.9.1", features = ["json"] }
 lazy_static = "1.4.0"
@@ -35,4 +35,4 @@ url = "2.1.1"
 mockall = "0.7.0"
 
 [build-dependencies]
-ethcontract-generate = "0.5.0"
+ethcontract-generate = "0.6.0"

--- a/driver/src/solution_submission/mod.rs
+++ b/driver/src/solution_submission/mod.rs
@@ -131,7 +131,7 @@ impl<'a> StableXSolutionSubmitting for StableXSolutionSubmitter<'a> {
 fn extract_transaction_hash(err: &Error) -> Option<H256> {
     err.downcast_ref::<MethodError>()
         .and_then(|method_error| match &method_error.inner {
-            ExecutionError::Failure(tx_hash) => Some(*tx_hash),
+            ExecutionError::Failure(tx) => Some(tx.transaction_hash),
             _ => None,
         })
 }
@@ -202,10 +202,13 @@ mod tests {
             .expect_submit_solution()
             .return_once(move |_, _, _| {
                 Err(anyhow!(MethodError::from_parts(
-                "submitSolution(uint32,uint256,address[],uint16[],uint128[],uint128[],uint16[])"
-                    .to_owned(),
-                ExecutionError::Failure(tx_hash),
-            )))
+                    "submitSolution(uint32,uint256,address[],uint16[],uint128[],uint128[],uint16[])"
+                        .to_owned(),
+                    ExecutionError::Failure(Box::new(TransactionReceipt {
+                        transaction_hash: tx_hash,
+                        ..Default::default()
+                    })),
+                )))
             });
         // Get objective value on old block number returns revert reason
         contract

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
-ethcontract = "0.5.0"
+ethcontract = "0.6.0"
 futures = { version = "0.3.4", features = ["compat"] }

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -1,10 +1,10 @@
 // Stable X contracts artifacts
-ethcontract::contract!("dex-contracts/build/contracts/BatchExchange.json");
-ethcontract::contract!("dex-contracts/build/contracts/IERC20.json");
-ethcontract::contract!("dex-contracts/build/contracts/IdToAddressBiMap.json");
-ethcontract::contract!("dex-contracts/build/contracts/IterableAppendOnlySet.json");
-ethcontract::contract!("dex-contracts/build/contracts/TokenOWL.json");
-ethcontract::contract!("dex-contracts/build/contracts/ERC20Mintable.json");
+ethcontract::contract!(pub "dex-contracts/build/contracts/BatchExchange.json");
+ethcontract::contract!(pub "dex-contracts/build/contracts/IERC20.json");
+ethcontract::contract!(pub "dex-contracts/build/contracts/IdToAddressBiMap.json");
+ethcontract::contract!(pub "dex-contracts/build/contracts/IterableAppendOnlySet.json");
+ethcontract::contract!(pub "dex-contracts/build/contracts/TokenOWL.json");
+ethcontract::contract!(pub "dex-contracts/build/contracts/ERC20Mintable.json");
 
 pub mod common;
 pub mod docker_logs;


### PR DESCRIPTION
Bumped ethcontract to latest version which includes event streams and some other goodies. Added required changes to make the driver and e2e crate compile.

### Test Plan

CI!