### PR TITLE
[Pricegraph] Build orderbook from encoded orders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,6 +775,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
 name = "float-cmp"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,6 +1650,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "petgraph"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c127eea4a29ec6c85d153c59dc1213f33ec74cead30fe4730aecc88cc1fd92"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "phf"
 version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1767,6 +1783,8 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "data-encoding",
+ "lazy_static",
+ "petgraph",
  "primitive-types 0.7.0",
 ]
 

--- a/pricegraph/Cargo.toml
+++ b/pricegraph/Cargo.toml
@@ -9,8 +9,10 @@ name = "main"
 harness = false
 
 [dependencies]
+petgraph = "0.5"
 primitive-types = "0.7"
 
 [dev-dependencies]
 criterion = "0.3"
 data-encoding = "2"
+lazy_static = "1"

--- a/pricegraph/benches/main.rs
+++ b/pricegraph/benches/main.rs
@@ -1,7 +1,6 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use pricegraph::Orderbook;
 
-/// Module containing test orderbook data.
 #[path = "../data/mod.rs"]
 pub mod data;
 
@@ -15,7 +14,7 @@ pub fn orderbook_is_overlapping(c: &mut Criterion) {
     let orderbook = Orderbook::read(&data::ORDERBOOKS[0]).expect("error reading orderbook");
 
     c.bench_function("Orderbook::is_overlapping", |b| {
-        b.iter(|| black_box(&orderbook).is_overlapping())
+        b.iter(|| orderbook.is_overlapping())
     });
 }
 

--- a/pricegraph/benches/main.rs
+++ b/pricegraph/benches/main.rs
@@ -1,22 +1,23 @@
-use criterion::{criterion_group, criterion_main, Criterion};
-use data_encoding::Specification;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use pricegraph::Orderbook;
 
-pub fn orderbook_read(c: &mut Criterion) {
-    let hex = {
-        let mut spec = Specification::new();
-        spec.symbols.push_str("0123456789abcdef");
-        spec.ignore.push_str(" \n");
-        spec.encoding().unwrap()
-    };
-    let encoded_orderbook = hex
-        .decode(include_bytes!("../data/orderbook-5287195.hex"))
-        .expect("orderbook contains invalid hex");
+/// Module containing test orderbook data.
+#[path = "../data/mod.rs"]
+pub mod data;
 
+pub fn orderbook_read(c: &mut Criterion) {
     c.bench_function("Orderbook::read", |b| {
-        b.iter(|| Orderbook::read(&encoded_orderbook).expect("error reading orderbook"))
+        b.iter(|| Orderbook::read(&data::ORDERBOOKS[0]).expect("error reading orderbook"))
     });
 }
 
-criterion_group!(benches, orderbook_read);
+pub fn orderbook_is_overlapping(c: &mut Criterion) {
+    let orderbook = Orderbook::read(&data::ORDERBOOKS[0]).expect("error reading orderbook");
+
+    c.bench_function("Orderbook::is_overlapping", |b| {
+        b.iter(|| black_box(&orderbook).is_overlapping())
+    });
+}
+
+criterion_group!(benches, orderbook_read, orderbook_is_overlapping);
 criterion_main!(benches);

--- a/pricegraph/data/mod.rs
+++ b/pricegraph/data/mod.rs
@@ -1,0 +1,20 @@
+//! Module containing test orderbook data.
+
+use data_encoding::{Encoding, Specification};
+use lazy_static::lazy_static;
+
+lazy_static! {
+    /// A permissive hex encoding that allows for whitespace.
+    pub static ref HEX: Encoding = {
+        let mut spec = Specification::new();
+        spec.symbols.push_str("0123456789abcdef");
+        spec.ignore.push_str(" \n");
+        spec.encoding().unwrap()
+    };
+
+    /// The raw encoded test orderbooks that were retrieved from the mainnet
+    /// smart contract for testing.
+    pub static ref ORDERBOOKS: Vec<Vec<u8>> = vec![
+        HEX.decode(include_bytes!("orderbook-5287195.hex")).unwrap(),
+    ];
+}

--- a/pricegraph/src/encoding.rs
+++ b/pricegraph/src/encoding.rs
@@ -1,21 +1,65 @@
 //! This module implements decoding for the standard `BatchExchange` contract
 //! encoded orders.
 
-use crate::{TokenId, UserId};
-use primitive_types::U256;
+use primitive_types::{H160, U256};
 
+/// The stride of an orderbook element in bytes.
 pub const ELEMENT_STRIDE: usize = 112;
 
+/// A type alias for a batch ID.
 pub type BatchId = u32;
 
+/// A type alias for a token ID.
+pub type TokenId = u16;
+
+/// A type alias for a user ID.
+pub type UserId = H160;
+
+/// A struct representing a buy/sell token pair.
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub struct TokenPair {
+    /// The buy token.
+    pub buy: TokenId,
+    /// The sell token.
+    pub sell: TokenId,
+}
+
+/// A struct representing the validity of an order.
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub struct Validity {
+    /// The batch starting from which the order is valid.
+    pub from: BatchId,
+    /// The last batch the order is valid for.
+    pub to: BatchId,
+}
+
+/// A price expressed as a fraction of buy and sell amounts.
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub struct Price {
+    /// The price numerator, or the buy amount.
+    pub numerator: u128,
+    /// The price denominator, or the sell amount.
+    pub denominator: u128,
+}
+
+/// An orderbook element that is retrieved from the smart contract.
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct Element {
+    /// The user that placed the order.
     pub user: UserId,
+    /// The user's sell token balance.
     pub balance: U256,
-    pub pair: (TokenId, TokenId),
-    pub valid: (BatchId, BatchId),
-    pub price: (u128, u128),
-    pub amount: u128,
+    /// The token pair for which this order was placed.
+    pub pair: TokenPair,
+    /// The validity of the order.
+    pub valid: Validity,
+    /// The price fraction for the order.
+    ///
+    /// Note that if one of the prices is `UNBOUNDED_AMOUNT` then that signals
+    /// that the order is an unbounded order and has no amount limit.
+    pub price: Price,
+    /// The remaining sell amount available to this order.
+    pub remaining_sell_amount: u128,
 }
 
 impl Element {
@@ -38,6 +82,9 @@ impl Element {
                 (U256) => {
                     U256::from_big_endian(&read!(32))
                 };
+                (H160) => {
+                    H160(read!(20))
+                };
                 ($n:expr) => {{
                     let mut buf = [0u8; $n];
                     buf.copy_from_slice(&chunk[..$n]);
@@ -48,12 +95,21 @@ impl Element {
 
             #[allow(unused_assignments, clippy::eval_order_dependence)]
             Element {
-                user: read!(20),
+                user: read!(H160),
                 balance: read!(U256),
-                pair: (read!(u16), read!(u16)),
-                valid: (read!(u32), read!(u32)),
-                price: (read!(u128), read!(u128)),
-                amount: read!(u128),
+                pair: TokenPair {
+                    buy: read!(u16),
+                    sell: read!(u16),
+                },
+                valid: Validity {
+                    from: read!(u32),
+                    to: read!(u32),
+                },
+                price: Price {
+                    numerator: read!(u128),
+                    denominator: read!(u128),
+                },
+                remaining_sell_amount: read!(u128),
             }
         }))
     }
@@ -73,21 +129,29 @@ mod tests {
         assert_eq!(
             Element::read_all(&bytes).unwrap().next(),
             Some(Element {
-                user: *b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\
-                         \x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13",
+                user: H160(
+                    *b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\
+                       \x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13"
+                ),
                 balance: U256([
                     0x2c2d2e2f30313233,
                     0x2425262728292a2b,
                     0x1c1d1e1f20212223,
                     0x1415161718191a1b,
                 ]),
-                pair: (0x3435, 0x3637),
-                valid: (0x38393a3b, 0x3c3d3e3f),
-                price: (
-                    0x404142434445464748494a4b4c4d4e4f,
-                    0x505152535455565758595a5b5c5d5e5f,
-                ),
-                amount: 0x606162636465666768696a6b6c6d6e6f,
+                pair: TokenPair {
+                    buy: 0x3435,
+                    sell: 0x3637,
+                },
+                valid: Validity {
+                    from: 0x38393a3b,
+                    to: 0x3c3d3e3f,
+                },
+                price: Price {
+                    numerator: 0x404142434445464748494a4b4c4d4e4f,
+                    denominator: 0x505152535455565758595a5b5c5d5e5f,
+                },
+                remaining_sell_amount: 0x606162636465666768696a6b6c6d6e6f,
             })
         );
     }

--- a/pricegraph/src/encoding.rs
+++ b/pricegraph/src/encoding.rs
@@ -54,9 +54,6 @@ pub struct Element {
     /// The validity of the order.
     pub valid: Validity,
     /// The price fraction for the order.
-    ///
-    /// Note that if one of the prices is `UNBOUNDED_AMOUNT` then that signals
-    /// that the order is an unbounded order and has no amount limit.
     pub price: Price,
     /// The remaining sell amount available to this order.
     pub remaining_sell_amount: u128,

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -1,31 +1,8 @@
 mod encoding;
+mod orderbook;
 
-use crate::encoding::{Element, InvalidLength};
-use std::collections::HashSet;
-
-pub type TokenId = u16;
-pub type UserId = [u8; 20];
-
-pub struct Orderbook {
-    _tokens: HashSet<TokenId>,
-}
-
-impl Orderbook {
-    pub fn read(orders: impl AsRef<[u8]>) -> Result<Orderbook, InvalidLength> {
-        let mut tokens = HashSet::new();
-        for element in Element::read_all(orders.as_ref())? {
-            tokens.insert(element.pair.0);
-            tokens.insert(element.pair.1);
-        }
-
-        Ok(Orderbook { _tokens: tokens })
-    }
-}
+pub use orderbook::Orderbook;
 
 #[cfg(test)]
-mod tests {
-    #[test]
-    fn assert() {
-        assert_eq!(1, 1);
-    }
-}
+#[path = "../data/mod.rs"]
+pub mod data;

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -1,0 +1,207 @@
+//! Implementation of a graph representation of an orderbook where tokens are
+//! vertices and orders are edges (with users and balances as auxiliary data
+//! to these edges).
+//!
+//! Storage is optimized for graph-related operations such as listing the edges
+//! (i.e. orders) connecting a token pair.
+
+use crate::encoding::{Element, InvalidLength, Price, TokenId, TokenPair, UserId};
+use petgraph::graph::DiGraph;
+use std::cmp;
+use std::collections::HashMap;
+use std::f64;
+
+/// A graph representation of a complete orderbook.
+#[cfg_attr(test, derive(Debug))]
+pub struct Orderbook {
+    /// A map of sell tokens to a mapping of buy tokens to orders such that
+    /// `orders[sell][buy]` is a vector of orders selling token `sell` and
+    /// buying token `buy`.
+    orders: OrderMap,
+    /// A projection of the order book onto a graph of lowest priced orders
+    /// between tokens.
+    projection: DiGraph<TokenId, f64>,
+}
+
+impl Orderbook {
+    /// Reads an orderbook from encoded bytes returning an error if the encoded
+    /// orders are invalid.
+    pub fn read(bytes: impl AsRef<[u8]>) -> Result<Orderbook, InvalidLength> {
+        let mut max_token = 0;
+        let mut orders = OrderMap::new();
+
+        for element in Element::read_all(bytes.as_ref())? {
+            let TokenPair { buy, sell } = element.pair;
+            max_token = cmp::max(max_token, cmp::max(buy, sell));
+            orders
+                .entry(sell)
+                .or_default()
+                .entry(buy)
+                .or_default()
+                .push(element.into());
+        }
+
+        // NOTE: Sort the orders per token pair in descending order, this makes
+        // it so the last order is the cheapest one and can be determined given
+        // a token pair in `O(1)`, and it can simply be `pop`-ed once its amount
+        // is used up and removed from the graph in `O(1)` as well.
+        for pair_orders in orders.values_mut().flat_map(|o| o.values_mut()) {
+            pair_orders.sort_unstable_by(Order::cmp_decending_prices);
+        }
+
+        let mut projection = DiGraph::new();
+        let token_nodes = (0..=max_token)
+            .map(|token_id| projection.add_node(token_id))
+            .collect::<Vec<_>>();
+        projection.extend_with_edges(orders.iter().flat_map(|(sell, orders)| {
+            let sell_node = token_nodes[*sell as usize];
+            orders.iter().map({
+                let token_nodes = &token_nodes;
+                move |(buy, orders)| {
+                    let buy_node = token_nodes[*buy as usize];
+                    let weight = orders
+                        .last()
+                        .expect("unexpected empty pair orders collection in map")
+                        .weight;
+                    (sell_node, buy_node, weight)
+                }
+            })
+        }));
+
+        Ok(Orderbook { orders, projection })
+    }
+
+    /// Returns the number of orders in the orderbook.
+    pub fn num_orders(&self) -> usize {
+        self.orders
+            .values()
+            .flat_map(|o| o.values())
+            .map(Vec::len)
+            .sum()
+    }
+
+    /// Detects whether or not a solution can be found by finding negative
+    /// cycles in the projection graph starting from the fee token.
+    ///
+    /// Conceptually, a negative cycle is a trading path starting and ending at
+    /// a token (going through an arbitrary number of other distinct tokens)
+    /// where the total weight is less than `0`, i.e. the effective sell price
+    /// is less than `1`. This means that there is a price overlap along this
+    /// ring trade and it is connected to the fee token.
+    pub fn is_overlapping(&self) -> bool {
+        let fee_token = match self
+            .projection
+            .node_indices()
+            .find(|i| self.projection[*i] == 0)
+        {
+            Some(token) => token,
+            None => {
+                // NOTE: The fee token is not in the graph, this means there are
+                // no orders buying or selling the fee token and therefore it
+                // cannot be overlapping.
+                return false;
+            }
+        };
+
+        petgraph::algo::bellman_ford(&self.projection, fee_token).is_err()
+    }
+}
+
+/// Type definition for a mapping of orders between buy and sell tokens.
+type OrderMap = HashMap<TokenId, HashMap<TokenId, Vec<Order>>>;
+
+/// A single order with a reference to the user.
+///
+/// Note that we approximate amounts and prices with floating point numbers.
+/// While this can lead to rounding errors it greatly simplifies the graph
+/// computations and still leads to acceptable estimates.
+#[cfg_attr(test, derive(Debug, PartialEq))]
+struct Order {
+    /// The user owning the order.
+    pub user: UserId,
+    /// The maximum capacity for this order, this is equivalent to the order's
+    /// sell amount (or price denominator). Note that orders are also limited by
+    /// their user's balance.
+    pub amount: f64,
+    /// The effective sell price for this order, that is price for this order
+    /// including fees of the sell token expressed in the buy token.
+    ///
+    /// Specifically, this is the sell amount over the buy amount or price
+    /// denominator over price numerator, which is the inverse price as
+    /// expressed by the exchange.
+    pub price: f64,
+    /// The weight of the order in the graph. This is the base-2 logarithm of
+    /// the price including fees. This enables transitive prices to be computed
+    /// using addition.
+    pub weight: f64,
+}
+
+impl Order {
+    /// Compare two orders by descending price order.
+    ///
+    /// This method is used for sorting orders, instead of just sorting by key
+    /// on `price` field because `f64`s don't implement `Ord` and as such cannot
+    /// be used for sorting. This be because there is no real ordering for
+    /// `NaN`s and `NaN < 0 == false` and `NaN >= 0 == false` (cf. IEEE 754-2008
+    /// section 5.11), which can cause serious problems with sorting.
+    fn cmp_decending_prices(a: &Order, b: &Order) -> cmp::Ordering {
+        b.price
+            .partial_cmp(&a.price)
+            .expect("orders cannot have NaN prices")
+    }
+}
+
+impl From<Element> for Order {
+    fn from(element: Element) -> Self {
+        let amount = if is_unbounded(&element) {
+            f64::INFINITY
+        } else {
+            element.price.denominator as _
+        };
+        let price = as_effective_sell_price(&element.price);
+        let weight = price.log2();
+
+        Order {
+            user: element.user,
+            amount,
+            price,
+            weight,
+        }
+    }
+}
+
+/// Returns `true` if the order is unbounded, that is it has an unlimited sell
+/// amount.
+fn is_unbounded(element: &Element) -> bool {
+    const UNBOUNDED_AMOUNT: u128 = u128::max_value();
+    element.price.numerator == UNBOUNDED_AMOUNT || element.price.denominator == UNBOUNDED_AMOUNT
+}
+
+/// Calculates an effective price as a `f64` from a price fraction.
+fn as_effective_sell_price(price: &Price) -> f64 {
+    const FEE_FACTOR: f64 = 1.0 / 0.999;
+    FEE_FACTOR * (price.denominator as f64) / (price.numerator as f64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use data_encoding::Specification;
+
+    #[test]
+    fn reads_real_orderbook() {
+        let hex = {
+            let mut spec = Specification::new();
+            spec.symbols.push_str("0123456789abcdef");
+            spec.ignore.push_str(" \n");
+            spec.encoding().unwrap()
+        };
+        let encoded_orderbook = hex
+            .decode(include_bytes!("../data/orderbook-5287195.hex"))
+            .expect("orderbook contains invalid hex");
+
+        let orderbook = Orderbook::read(&encoded_orderbook).expect("error reading orderbook");
+        assert_eq!(orderbook.num_orders(), 896);
+        assert!(orderbook.is_overlapping());
+    }
+}


### PR DESCRIPTION
This PR implements building a graph representation of an orderbook from encoded orders and computing whether or not the orderbook is overlapping by looking for negative cycles in the graph.

### Test Plan

Unit tests and new benchmark for `is_overlapping()`, which competes in:
```
Orderbook::is_overlapping
                        time:   [4.1024 us 4.1123 us 4.1230 us]
```