### PR TITLE
Removing docker-compose.binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
         # Build and publish compact image with compiled binary
         - docker build --tag stablex-binary-public --build-arg SOLVER_BASE=gnosispm/dex-open-solver:v0.0.9-dev --build-arg RUST_BASE=rust-binary -f docker/rust/Dockerfile .
         # StableX e2e Tests (Ganache) - open solver
-        - docker-compose -f docker-compose.yml -f docker-compose.binary.yml -f docker-compose.open-solver.yml  up -d stablex
+        - docker-compose -f docker-compose.yml -f docker-compose.open-solver.yml  up -d stablex
         - cargo test -p e2e ganache -- --nocapture
         - docker-compose logs
         # Build and publish compact image with compiled binary
@@ -44,11 +44,11 @@ matrix:
         # StableX e2e Tests (Ganache) - naive solver
         - docker-compose down
         - ./scripts/setup_contracts.sh
-        - docker-compose -f docker-compose.yml -f docker-compose.binary.yml -f docker-compose.private-solver.yml up -d stablex
+        - docker-compose -f docker-compose.yml -f docker-compose.private-solver.yml up -d stablex
         - cargo test -p e2e ganache -- --nocapture
         - docker-compose logs
         # StableX e2e Tests (Rinkeby)
-        - docker-compose down && docker-compose -f docker-compose.yml -f docker-compose.rinkeby.yml -f docker-compose.binary.yml -f docker-compose.private-solver.yml up -d stablex
+        - docker-compose down && docker-compose -f docker-compose.yml -f docker-compose.rinkeby.yml -f docker-compose.private-solver.yml up -d stablex
         - cargo test -p e2e rinkeby -- --nocapture
         - docker-compose logs
       deploy:

--- a/docker-compose.binary.yml
+++ b/docker-compose.binary.yml
@@ -1,7 +1,0 @@
-version: "3.6"
-services:
-  stablex:
-    command: ./stablex
-    build:
-      args:
-        - RUST_BASE=rust-binary

--- a/docker-compose.open-solver.yml
+++ b/docker-compose.open-solver.yml
@@ -1,6 +1,7 @@
 version: "3.6"
 services:
   stablex:
+    command: ./stablex
     image: stablex-binary-public
     environment:
       - SOLVER_TYPE=open-solver

--- a/docker-compose.private-solver.yml
+++ b/docker-compose.private-solver.yml
@@ -1,4 +1,5 @@
 version: "3.6"
 services:
   stablex:
+    command: ./stablex
     image: stablex-binary-private


### PR DESCRIPTION
I just realized that https://github.com/gnosis/dex-services/pull/680 kept the unnecessary `docker-compose.binary` file. 

Since we are introducing the `docker-compose.private-solver.yml` and `docker-compose.open-solver.yml`, which store the images `stablex-binary-private` and `stablex-binary-public`, there was no need to keep `docker-compose.binary.yml`. I forgot to remove it.

Sorry, for the late clean up