### PR TITLE
[Easy] New solver config: standard solver should also use external prices

### DIFF
--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -54,55 +54,55 @@ impl SolverType {
         time_limit: String,
     ) -> Result<Output> {
         match self {
-            SolverType::OpenSolver => self.execute_open_solver(result_folder, input_file),
+            SolverType::OpenSolver => execute_open_solver(result_folder, input_file),
             SolverType::StandardSolver => {
-                self.execute_private_solver(result_folder, input_file, time_limit)
+                execute_private_solver(result_folder, input_file, time_limit)
             }
             SolverType::FallbackSolver => {
-                self.execute_private_solver(result_folder, input_file, time_limit)
+                execute_private_solver(result_folder, input_file, time_limit)
             }
             SolverType::NaiveSolver => {
                 panic!("fn execute should not be called by the naive solver")
             }
         }
     }
-    pub fn execute_open_solver(self, result_folder: &str, input_file: &str) -> Result<Output> {
-        let mut command = Command::new("python");
-        let open_solver_command = command
-            .current_dir("/app/open_solver")
-            .args(&["-m", "src.match"])
-            .arg(format!("{}{}", "/app/", input_file.to_owned()))
-            .arg(format!(
-                "--solution={}{}{}",
-                "/app/",
-                result_folder.to_owned(),
-                "06_solution_int_valid.json",
-            ))
-            .arg(String::from("best-token-pair"));
-        debug!("Using open-solver command `{:?}`", open_solver_command);
-        Ok(open_solver_command.output()?)
-    }
+}
 
-    pub fn execute_private_solver(
-        self,
-        result_folder: &str,
-        input_file: &str,
-        time_limit: String,
-    ) -> Result<Output> {
-        let mut command = Command::new("python");
-        let private_solver_command = command
-            .current_dir("/app/batchauctions")
-            .args(&["-m", "scripts.e2e._run"])
-            .arg(format!("{}{}", "/app/", input_file.to_owned()))
-            .arg(format!("--outputDir={}{}", "/app/", result_folder))
-            .args(&["--solverTimeLimit", &time_limit])
-            .arg(String::from("--useExternalPrices"));
-        debug!(
-            "Using private-solver command `{:?}`",
-            private_solver_command
-        );
-        Ok(private_solver_command.output()?)
-    }
+pub fn execute_open_solver(result_folder: &str, input_file: &str) -> Result<Output> {
+    let mut command = Command::new("python");
+    let open_solver_command = command
+        .current_dir("/app/open_solver")
+        .args(&["-m", "src.match"])
+        .arg(format!("{}{}", "/app/", input_file.to_owned()))
+        .arg(format!(
+            "--solution={}{}{}",
+            "/app/",
+            result_folder.to_owned(),
+            "06_solution_int_valid.json",
+        ))
+        .arg(String::from("best-token-pair"));
+    debug!("Using open-solver command `{:?}`", open_solver_command);
+    Ok(open_solver_command.output()?)
+}
+
+pub fn execute_private_solver(
+    result_folder: &str,
+    input_file: &str,
+    time_limit: String,
+) -> Result<Output> {
+    let mut command = Command::new("python");
+    let private_solver_command = command
+        .current_dir("/app/batchauctions")
+        .args(&["-m", "scripts.e2e._run"])
+        .arg(format!("{}{}", "/app/", input_file.to_owned()))
+        .arg(format!("--outputDir={}{}", "/app/", result_folder))
+        .args(&["--solverTimeLimit", &time_limit])
+        .arg(String::from("--useExternalPrices"));
+    debug!(
+        "Using private-solver command `{:?}`",
+        private_solver_command
+    );
+    Ok(private_solver_command.output()?)
 }
 
 #[cfg_attr(test, automock)]

--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -95,13 +95,11 @@ impl SolverType {
             .args(&["-m", "scripts.e2e._run"])
             .arg(format!("{}{}", "/app/", input_file.to_owned()))
             .arg(format!("--outputDir={}{}", "/app/", result_folder))
-            .args(&["--solverTimeLimit", &time_limit]);
+            .args(&["--solverTimeLimit", &time_limit])
+            .arg(String::from("--useExternalPrices"));
         let private_solver_command = match self {
             SolverType::StandardSolver => standard_solver_command,
-            SolverType::FallbackSolver => {
-                standard_solver_command.arg(String::from("--useExternalPrices"));
-                standard_solver_command
-            }
+            SolverType::FallbackSolver => standard_solver_command,
             _ => panic!("{:?} is not a private solver", self),
         };
         debug!(

--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -90,18 +90,13 @@ impl SolverType {
         time_limit: String,
     ) -> Result<Output> {
         let mut command = Command::new("python");
-        let standard_solver_command = command
+        let private_solver_command = command
             .current_dir("/app/batchauctions")
             .args(&["-m", "scripts.e2e._run"])
             .arg(format!("{}{}", "/app/", input_file.to_owned()))
             .arg(format!("--outputDir={}{}", "/app/", result_folder))
             .args(&["--solverTimeLimit", &time_limit])
             .arg(String::from("--useExternalPrices"));
-        let private_solver_command = match self {
-            SolverType::StandardSolver => standard_solver_command,
-            SolverType::FallbackSolver => standard_solver_command,
-            _ => panic!("{:?} is not a private solver", self),
-        };
         debug!(
             "Using private-solver command `{:?}`",
             private_solver_command


### PR DESCRIPTION
In the solver-team, we realized that the solutions found under consideration of the external prices are almost always better than the other solutions.

Hence, we decided to use external price feeds always. (cp: https://gnosisinc.slack.com/archives/CS6NV17HP/p1585220425012100)

The main difference between the standard and the fallback solver will be the whitelist of tokens, which I will configure in gnosis-staging.