### PR TITLE
[Pricegraph] Implemented updating projection graph edges by removing filled orders

### DIFF
--- a/pricegraph/benches/main.rs
+++ b/pricegraph/benches/main.rs
@@ -1,22 +1,35 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use pricegraph::Orderbook;
 
 #[path = "../data/mod.rs"]
 pub mod data;
 
 pub fn orderbook_read(c: &mut Criterion) {
-    c.bench_function("Orderbook::read", |b| {
-        b.iter(|| Orderbook::read(&data::ORDERBOOKS[0]).expect("error reading orderbook"))
-    });
+    c.bench_function("Orderbook::read", |b| b.iter(data::read_default_orderbook));
 }
 
 pub fn orderbook_is_overlapping(c: &mut Criterion) {
-    let orderbook = Orderbook::read(&data::ORDERBOOKS[0]).expect("error reading orderbook");
+    let orderbook = data::read_default_orderbook();
 
     c.bench_function("Orderbook::is_overlapping", |b| {
         b.iter(|| orderbook.is_overlapping())
     });
 }
 
-criterion_group!(benches, orderbook_read, orderbook_is_overlapping);
+pub fn orderbook_update_projection_graph(c: &mut Criterion) {
+    c.bench_function("Orderbook::update_projection_graph", |b| {
+        b.iter_batched(
+            data::read_default_orderbook,
+            |mut orderbook| orderbook.update_projection_graph(),
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+criterion_group!(
+    benches,
+    orderbook_read,
+    orderbook_is_overlapping,
+    orderbook_update_projection_graph,
+);
 criterion_main!(benches);

--- a/pricegraph/data/mod.rs
+++ b/pricegraph/data/mod.rs
@@ -1,7 +1,9 @@
 //! Module containing test orderbook data.
 
+use super::Orderbook;
 use data_encoding::{Encoding, Specification};
 use lazy_static::lazy_static;
+use std::collections::BTreeMap;
 
 lazy_static! {
     /// A permissive hex encoding that allows for whitespace.
@@ -14,7 +16,30 @@ lazy_static! {
 
     /// The raw encoded test orderbooks that were retrieved from the mainnet
     /// smart contract for testing.
-    pub static ref ORDERBOOKS: Vec<Vec<u8>> = vec![
-        HEX.decode(include_bytes!("orderbook-5287195.hex")).unwrap(),
-    ];
+    pub static ref ORDERBOOKS: BTreeMap<usize, Vec<u8>> = {
+        let mut orderbooks = BTreeMap::new();
+
+        macro_rules! add_orderbook {
+            ($batch:tt) => {
+                #[allow(clippy::unreadable_literal)]
+                orderbooks.insert($batch, HEX.decode(include_bytes!(
+                    concat!("orderbook-", stringify!($batch), ".hex"),
+                )).unwrap());
+            }
+        };
+
+        add_orderbook!(5287195);
+
+        orderbooks
+    };
+}
+
+/// Reads a test orderbook by batch ID.
+pub fn read_orderbook(batch_id: usize) -> Orderbook {
+    Orderbook::read(&ORDERBOOKS[&batch_id]).expect("error reading orderbook")
+}
+
+/// Reads the default test orderbook.
+pub fn read_default_orderbook() -> Orderbook {
+    read_orderbook(5_287_195)
 }

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -1,5 +1,6 @@
 mod encoding;
 mod graph;
+mod num;
 mod orderbook;
 
 pub use orderbook::Orderbook;

--- a/pricegraph/src/num.rs
+++ b/pricegraph/src/num.rs
@@ -1,0 +1,43 @@
+//! Module implementing floating point arithmetic for the price graph.
+
+use primitive_types::U256;
+use std::cmp;
+use std::f64;
+
+/// Convert an unsigned 256-bit integer into a `f64`.
+pub fn u256_to_f64(u: U256) -> f64 {
+    let (u, factor) = match u {
+        U256([_, _, 0, 0]) => (u, 1.0),
+        U256([_, _, _, 0]) => (u >> 64, 2.0f64.powi(64)),
+        U256([_, _, _, _]) => (u >> 128, 2.0f64.powi(128)),
+    };
+    (u.low_u128() as f64) * factor
+}
+
+/// Calculates the minimum of two floats. Note that we cannot use the standard
+/// library `std::cmp::min` here since `f64` does not implement `Ord`. This be
+/// because there is no real ordering for `NaN`s and `NaN < 0 == false` and
+/// `NaN >= 0 == false` (cf. IEEE 754-2008 section 5.11).
+///
+/// # Panics
+///
+/// If any of the two floats are NaN.
+pub fn min(a: f64, b: f64) -> f64 {
+    match a
+        .partial_cmp(&b)
+        .expect("orderbooks cannot have NaN quantities")
+    {
+        cmp::Ordering::Less => a,
+        _ => b,
+    }
+}
+
+/// Checks for equality comparison between floats allowing for an `EPSILON`
+/// margin of error.
+///
+/// For more information, see the clippy lint:
+/// https://rust-lang.github.io/rust-clippy/master/index.html#float_cmp
+#[cfg(test)]
+pub fn eq(a: f64, b: f64) -> bool {
+    (a - b).abs() <= f64::EPSILON
+}

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -8,11 +8,11 @@
 mod order;
 mod user;
 
-use self::order::{Order, OrderMap};
+use self::order::{Order, OrderCollector, OrderMap};
 use self::user::UserMap;
 use crate::encoding::{Element, InvalidLength, TokenId, TokenPair};
 use crate::graph::bellman_ford;
-use petgraph::graph::{DiGraph, NodeIndex};
+use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
 use std::cmp;
 use std::f64;
 
@@ -42,7 +42,7 @@ impl Orderbook {
     /// Creates an orderbook from an iterator over decoded auction elements.
     fn from_elements(elements: impl IntoIterator<Item = Element>) -> Orderbook {
         let mut max_token = 0;
-        let mut orders = OrderMap::default();
+        let mut orders = OrderCollector::default();
         let mut users = UserMap::default();
 
         for element in elements {
@@ -56,14 +56,7 @@ impl Orderbook {
             orders.insert_order(Order::new(element, order_id));
         }
 
-        // NOTE: Sort the orders per token pair in descending order, this makes
-        // it so the last order is the cheapest one and can be determined given
-        // a token pair in `O(1)`, and it can simply be `pop`-ed once its amount
-        // is used up and removed from the graph in `O(1)` as well.
-        for (_, pair_orders) in orders.all_pairs_mut() {
-            pair_orders.sort_unstable_by(Order::cmp_descending_prices);
-        }
-
+        let orders = orders.collect();
         let mut projection = DiGraph::new();
         for token_id in 0..=max_token {
             let token_node = projection.add_node(token_id);
@@ -79,8 +72,8 @@ impl Orderbook {
                     .last()
                     .expect("unexpected token pair in orders map without any orders");
                 (
-                    node_index(pair.sell),
                     node_index(pair.buy),
+                    node_index(pair.sell),
                     cheapest_order.weight(),
                 )
             }
@@ -110,6 +103,59 @@ impl Orderbook {
         let fee_token = node_index(0);
         bellman_ford::search(&self.projection, fee_token).is_err()
     }
+
+    /// Updates the projection graph for every token pair.
+    pub fn update_projection_graph(&mut self) {
+        let pairs = self
+            .orders
+            .all_pairs()
+            .map(|(pair, _)| pair)
+            .collect::<Vec<_>>();
+        for pair in pairs {
+            self.update_projection_graph_edge(pair);
+        }
+    }
+
+    /// Updates the projection graph edge between a token pair.
+    ///
+    /// This is done by removing all "dust" orders, i.e. orders whose remaining
+    /// amount or whose users remaining balance is zero, and then either
+    /// updating the projection graph edge with the weight of the new cheapest
+    /// order or removing the edge entirely if no orders remain for the given
+    /// token pair.
+    fn update_projection_graph_edge(&mut self, pair: TokenPair) {
+        while let Some(true) = self
+            .orders
+            .pair_order(pair)
+            .map(|order| order.get_effective_amount(&self.users) <= 0.0)
+        {
+            self.orders.remove_pair_order(pair);
+        }
+
+        let edge = self
+            .get_pair_edge(pair)
+            .expect("missing edge between token pair with orders");
+        if let Some(order) = self.orders.pair_order(pair) {
+            self.projection[edge] = order.weight();
+        } else {
+            self.projection.remove_edge(edge);
+        }
+    }
+
+    /// Retrieve the edge index in the projection graph for a token pair,
+    /// returning `None` when the edge does not exist.
+    fn get_pair_edge(&self, pair: TokenPair) -> Option<EdgeIndex> {
+        let (buy, sell) = (node_index(pair.buy), node_index(pair.sell));
+        self.projection.find_edge(buy, sell)
+    }
+
+    /// Retrieve the weight of an edge in the projection graph. This is used for
+    /// testing that the projection graph is in sync with the order map.
+    #[cfg(test)]
+    fn get_projected_pair_weight(&self, pair: TokenPair) -> f64 {
+        let edge = self.get_pair_edge(pair).unwrap();
+        self.projection[edge]
+    }
 }
 
 /// Create a node index from a token ID.
@@ -120,22 +166,107 @@ fn node_index(token: TokenId) -> NodeIndex {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use data_encoding::Specification;
+    use crate::data;
+    use crate::encoding::UserId;
+    use crate::num;
+
+    /// Returns a `UserId` for a test user index.
+    ///
+    /// This method is meant to be used in conjunction with orderbooks created
+    /// with the `orderbook` macro.
+    fn user_id(id: u8) -> UserId {
+        UserId::repeat_byte(id)
+    }
+
+    /// Macro for constructing an orderbook using a DSL for testing purposes.
+    macro_rules! orderbook {
+        (
+            users {$(
+                @ $user:tt {$(
+                    token $token:tt => $balance:expr,
+                )*}
+            )*}
+            orders {$(
+                owner @ $owner:tt
+                buying $buy:tt [ $buy_amount:expr ]
+                selling $sell:tt [ $sell_amount:expr ] $( ($remaining:expr) )?
+            ,)*}
+        ) => {{
+            let mut balances = std::collections::HashMap::new();
+            $($(
+                balances.insert(($user, $token), primitive_types::U256::from($balance));
+            )*)*
+            let elements = vec![$(
+                $crate::encoding::Element {
+                    user: user_id($owner),
+                    balance: balances[&($owner, $sell)],
+                    pair: $crate::encoding::TokenPair {
+                        buy: $buy,
+                        sell: $sell,
+                    },
+                    valid: $crate::encoding::Validity {
+                        from: 0,
+                        to: u32::max_value(),
+                    },
+                    price: $crate::encoding::Price {
+                        numerator: $buy_amount,
+                        denominator: $sell_amount,
+                    },
+                    remaining_sell_amount: match &[$sell_amount, $($remaining)?][..] {
+                        [_, remaining] => *remaining,
+                        _ => $sell_amount,
+                    },
+                },
+            )*];
+            Orderbook::from_elements(elements)
+        }};
+    }
 
     #[test]
     fn reads_real_orderbook() {
-        let hex = {
-            let mut spec = Specification::new();
-            spec.symbols.push_str("0123456789abcdef");
-            spec.ignore.push_str(" \n");
-            spec.encoding().unwrap()
-        };
-        let encoded_orderbook = hex
-            .decode(include_bytes!("../data/orderbook-5287195.hex"))
-            .expect("orderbook contains invalid hex");
-
-        let orderbook = Orderbook::read(&encoded_orderbook).expect("error reading orderbook");
+        let orderbook = data::read_default_orderbook();
         assert_eq!(orderbook.num_orders(), 896);
         assert!(orderbook.is_overlapping());
+    }
+
+    #[test]
+    fn removes_drained_and_balanceless_orders() {
+        let mut orderbook = orderbook! {
+            users {
+                @1 {
+                    token 0 => 5_000_000,
+                }
+                @2 {
+                    token 0 => 1_000_000_000,
+                }
+                @3 {
+                    token 0 => 0,
+                }
+            }
+            orders {
+                owner @1 buying 1 [1_000_000_000] selling 0 [1_000_000_000],
+                owner @2 buying 1 [1_000_000_000] selling 0 [2_000_000_000] (0),
+                owner @3 buying 1 [1_000_000_000] selling 0 [3_000_000_000],
+            }
+        };
+
+        let pair = TokenPair { buy: 1, sell: 0 };
+
+        let order = orderbook.orders.pair_order(pair).unwrap();
+        assert_eq!(orderbook.num_orders(), 3);
+        assert_eq!(order.user, user_id(3));
+        assert!(num::eq(
+            order.weight(),
+            orderbook.get_projected_pair_weight(pair),
+        ));
+
+        orderbook.update_projection_graph();
+        let order = orderbook.orders.pair_order(pair).unwrap();
+        assert_eq!(orderbook.num_orders(), 1);
+        assert_eq!(order.user, user_id(1));
+        assert!(num::eq(
+            order.weight(),
+            orderbook.get_projected_pair_weight(pair),
+        ));
     }
 }

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -126,7 +126,7 @@ impl Orderbook {
     fn update_projection_graph_edge(&mut self, pair: TokenPair) {
         while let Some(true) = self
             .orders
-            .pair_order(pair)
+            .best_order_for_pair(pair)
             .map(|order| order.get_effective_amount(&self.users) <= 0.0)
         {
             self.orders.remove_pair_order(pair);
@@ -135,7 +135,7 @@ impl Orderbook {
         let edge = self
             .get_pair_edge(pair)
             .expect("missing edge between token pair with orders");
-        if let Some(order) = self.orders.pair_order(pair) {
+        if let Some(order) = self.orders.best_order_for_pair(pair) {
             self.projection[edge] = order.weight();
         } else {
             self.projection.remove_edge(edge);
@@ -252,7 +252,7 @@ mod tests {
 
         let pair = TokenPair { buy: 1, sell: 0 };
 
-        let order = orderbook.orders.pair_order(pair).unwrap();
+        let order = orderbook.orders.best_order_for_pair(pair).unwrap();
         assert_eq!(orderbook.num_orders(), 3);
         assert_eq!(order.user, user_id(3));
         assert!(num::eq(
@@ -261,7 +261,7 @@ mod tests {
         ));
 
         orderbook.update_projection_graph();
-        let order = orderbook.orders.pair_order(pair).unwrap();
+        let order = orderbook.orders.best_order_for_pair(pair).unwrap();
         assert_eq!(orderbook.num_orders(), 1);
         assert_eq!(order.user, user_id(1));
         assert!(num::eq(

--- a/pricegraph/src/orderbook/order.rs
+++ b/pricegraph/src/orderbook/order.rs
@@ -65,24 +65,24 @@ impl OrderMap {
 
     /// Returns the orders for an order pair. Returns `None` if that pair has
     /// no orders.
-    fn pair_orders(&self, pair: TokenPair) -> Option<&[Order]> {
+    fn orders_for_pair(&self, pair: TokenPair) -> Option<&[Order]> {
         Some(self.0.get(&pair.sell)?.get(&pair.buy)?.as_slice())
     }
 
     /// Returns a mutable reference to orders for an order pair. Returns `None`
     /// if that pair has no orders.
-    fn pair_orders_mut(&mut self, pair: TokenPair) -> Option<&mut Vec<Order>> {
+    fn orders_for_pair_mut(&mut self, pair: TokenPair) -> Option<&mut Vec<Order>> {
         self.0.get_mut(&pair.sell)?.get_mut(&pair.buy)
     }
 
     /// Returns a reference to the cheapest order given an order pair.
-    pub fn pair_order(&self, pair: TokenPair) -> Option<&Order> {
-        self.pair_orders(pair)?.last()
+    pub fn best_order_for_pair(&self, pair: TokenPair) -> Option<&Order> {
+        self.orders_for_pair(pair)?.last()
     }
 
     /// Returns a mutable reference to the cheapest order given an order pair.
-    pub fn pair_order_mut(&mut self, pair: TokenPair) -> Option<&mut Order> {
-        self.pair_orders_mut(pair)?.last_mut()
+    pub fn best_order_for_pair_mut(&mut self, pair: TokenPair) -> Option<&mut Order> {
+        self.orders_for_pair_mut(pair)?.last_mut()
     }
 
     /// Removes the current cheapest order pair from the mapping.

--- a/pricegraph/src/orderbook/order.rs
+++ b/pricegraph/src/orderbook/order.rs
@@ -1,15 +1,20 @@
 //! Data and logic related to token pair order management.
 
+#![allow(dead_code)]
+
+use super::UserMap;
 use crate::encoding::{Element, Price, TokenId, TokenPair, UserId};
+use crate::num;
 use std::cmp;
 use std::collections::HashMap;
 use std::f64;
 
-/// Type definition for a mapping of orders between buy and sell tokens.
+/// A type for collecting orders and building an order map that garantees that
+/// per-pair orders are sorted for optimal access.
 #[derive(Debug, Default)]
-pub struct OrderMap(HashMap<TokenId, HashMap<TokenId, Vec<Order>>>);
+pub struct OrderCollector(HashMap<TokenId, HashMap<TokenId, Vec<Order>>>);
 
-impl OrderMap {
+impl OrderCollector {
     /// Adds a new order to the order map.
     pub fn insert_order(&mut self, order: Order) {
         self.0
@@ -20,6 +25,28 @@ impl OrderMap {
             .push(order);
     }
 
+    /// Builds an order map from the inserted orders, ensuring that the orders
+    /// are sorted the orders per token pair in descending order, this makes it
+    /// so the last order is the cheapest one and can be determined given a
+    /// token pair in `O(1)`, and it can simply be `pop`-ed once its amount is
+    /// used up and removed from the graph in `O(1)` as well.
+    pub fn collect(self) -> OrderMap {
+        let mut orders = OrderMap(self.0);
+        for (_, pair_orders) in orders.all_pairs_mut() {
+            pair_orders.sort_unstable_by(Order::cmp_descending_prices);
+        }
+
+        orders
+    }
+}
+
+/// Type definition for a mapping of orders between buy and sell tokens. Token
+/// pair orders are garanteed to be in order, so that the cheapest order is
+/// always at the end of the token pair order vector.
+#[derive(Debug)]
+pub struct OrderMap(HashMap<TokenId, HashMap<TokenId, Vec<Order>>>);
+
+impl OrderMap {
     /// Returns an iterator over the collection of orders for each token pair.
     pub fn all_pairs(&self) -> impl Iterator<Item = (TokenPair, &'_ [Order])> + '_ {
         self.0.iter().flat_map(|(&sell, o)| {
@@ -29,11 +56,50 @@ impl OrderMap {
     }
 
     /// Returns an iterator over the collection of orders for each token pair.
-    pub fn all_pairs_mut(&mut self) -> impl Iterator<Item = (TokenPair, &'_ mut Vec<Order>)> + '_ {
+    fn all_pairs_mut(&mut self) -> impl Iterator<Item = (TokenPair, &'_ mut Vec<Order>)> + '_ {
         self.0.iter_mut().flat_map(|(&sell, o)| {
             o.iter_mut()
                 .map(move |(&buy, o)| (TokenPair { sell, buy }, o))
         })
+    }
+
+    /// Returns the orders for an order pair. Returns `None` if that pair has
+    /// no orders.
+    fn pair_orders(&self, pair: TokenPair) -> Option<&[Order]> {
+        Some(self.0.get(&pair.sell)?.get(&pair.buy)?.as_slice())
+    }
+
+    /// Returns a mutable reference to orders for an order pair. Returns `None`
+    /// if that pair has no orders.
+    fn pair_orders_mut(&mut self, pair: TokenPair) -> Option<&mut Vec<Order>> {
+        self.0.get_mut(&pair.sell)?.get_mut(&pair.buy)
+    }
+
+    /// Returns a reference to the cheapest order given an order pair.
+    pub fn pair_order(&self, pair: TokenPair) -> Option<&Order> {
+        self.pair_orders(pair)?.last()
+    }
+
+    /// Returns a mutable reference to the cheapest order given an order pair.
+    pub fn pair_order_mut(&mut self, pair: TokenPair) -> Option<&mut Order> {
+        self.pair_orders_mut(pair)?.last_mut()
+    }
+
+    /// Removes the current cheapest order pair from the mapping.
+    pub fn remove_pair_order(&mut self, pair: TokenPair) -> Option<Order> {
+        let sell_orders = self.0.get_mut(&pair.sell)?;
+        let pair_orders = sell_orders.get_mut(&pair.buy)?;
+
+        let removed = pair_orders.pop();
+
+        if pair_orders.is_empty() {
+            sell_orders.remove(&pair.buy)?;
+        }
+        if sell_orders.is_empty() {
+            self.0.remove(&pair.sell);
+        }
+
+        removed
     }
 }
 
@@ -51,8 +117,8 @@ pub struct Order {
     /// The token pair.
     pub pair: TokenPair,
     /// The maximum capacity for this order, this is equivalent to the order's
-    /// sell amount (or price denominator). Note that orders are also limited by
-    /// their user's balance.
+    /// remaining sell amount. Note that orders are also limited by their user's
+    /// balance.
     pub amount: f64,
     /// The effective sell price for this order, that is price for this order
     /// including fees of the sell token expressed in the buy token.
@@ -69,7 +135,7 @@ impl Order {
         let amount = if is_unbounded(&element) {
             f64::INFINITY
         } else {
-            element.price.denominator as _
+            element.remaining_sell_amount as _
         };
         let price = as_effective_sell_price(&element.price);
 
@@ -89,7 +155,7 @@ impl Order {
     /// be used for sorting. This be because there is no real ordering for
     /// `NaN`s and `NaN < 0 == false` and `NaN >= 0 == false` (cf. IEEE 754-2008
     /// section 5.11), which can cause serious problems with sorting.
-    pub fn cmp_descending_prices(a: &Order, b: &Order) -> cmp::Ordering {
+    fn cmp_descending_prices(a: &Order, b: &Order) -> cmp::Ordering {
         b.price
             .partial_cmp(&a.price)
             .expect("orders cannot have NaN prices")
@@ -100,6 +166,14 @@ impl Order {
     /// using addition.
     pub fn weight(&self) -> f64 {
         self.price.log2()
+    }
+
+    /// Retrieves the effective remaining amount for this order based on user
+    /// balances. This is the minimum between the remaining order amount and
+    /// the user's sell token balance.
+    pub fn get_effective_amount(&self, users: &UserMap) -> f64 {
+        let balance = users[&self.user].balance_of(self.pair.sell);
+        num::min(self.amount, balance)
     }
 }
 
@@ -113,5 +187,5 @@ fn is_unbounded(element: &Element) -> bool {
 /// Calculates an effective price as a `f64` from a price fraction.
 fn as_effective_sell_price(price: &Price) -> f64 {
     const FEE_FACTOR: f64 = 1.0 / 0.999;
-    FEE_FACTOR * (price.denominator as f64) / (price.numerator as f64)
+    FEE_FACTOR * (price.numerator as f64) / (price.denominator as f64)
 }

--- a/pricegraph/src/orderbook/user.rs
+++ b/pricegraph/src/orderbook/user.rs
@@ -1,7 +1,7 @@
 //! Module implementing user and user token balance management.
 
 use crate::encoding::{Element, TokenId, UserId};
-use primitive_types::U256;
+use crate::num;
 use std::collections::HashMap;
 
 /// A type definiton for a mapping between user IDs to user data.
@@ -24,19 +24,14 @@ impl User {
 
         self.balances
             .entry(element.pair.sell)
-            .or_insert_with(|| u256_to_f64(element.balance));
+            .or_insert_with(|| num::u256_to_f64(element.balance));
         self.num_orders += 1;
 
         order_id
     }
-}
 
-/// Convert an unsigned 256-bit integer into a `f64`.
-fn u256_to_f64(u: U256) -> f64 {
-    let (u, factor) = match u {
-        U256([_, _, 0, 0]) => (u, 1.0),
-        U256([_, _, _, 0]) => (u >> 64, 2.0f64.powi(64)),
-        U256([_, _, _, _]) => (u >> 128, 2.0f64.powi(128)),
-    };
-    (u.low_u128() as f64) * factor
+    /// Retrieves the user's balance for a token
+    pub fn balance_of(&self, token: TokenId) -> f64 {
+        self.balances.get(&token).copied().unwrap_or(0.0)
+    }
 }


### PR DESCRIPTION
This implements an important sub-step in the algorithm that updates the projection graph's edges to reflect the updated weights once orders get used up.

### Test Plan

New unit test and benchmark.