### PR TITLE
[Pricegraph] Remove overlapping ring trades

### DIFF
--- a/pricegraph/benches/main.rs
+++ b/pricegraph/benches/main.rs
@@ -16,11 +16,11 @@ pub fn orderbook_is_overlapping(c: &mut Criterion) {
     });
 }
 
-pub fn orderbook_update_projection_graph(c: &mut Criterion) {
-    c.bench_function("Orderbook::update_projection_graph", |b| {
+pub fn orderbook_reduce_overlapping_ring_trades(c: &mut Criterion) {
+    c.bench_function("Orderbook::reduce_overlapping_ring_trades", |b| {
         b.iter_batched(
             data::read_default_orderbook,
-            |mut orderbook| orderbook.update_projection_graph(),
+            |mut orderbook| orderbook.reduce_overlapping_ring_trades(),
             BatchSize::SmallInput,
         )
     });
@@ -30,6 +30,6 @@ criterion_group!(
     benches,
     orderbook_read,
     orderbook_is_overlapping,
-    orderbook_update_projection_graph,
+    orderbook_reduce_overlapping_ring_trades,
 );
 criterion_main!(benches);

--- a/pricegraph/benches/main.rs
+++ b/pricegraph/benches/main.rs
@@ -16,11 +16,11 @@ pub fn orderbook_is_overlapping(c: &mut Criterion) {
     });
 }
 
-pub fn orderbook_reduce_overlapping_ring_trades(c: &mut Criterion) {
-    c.bench_function("Orderbook::reduce_overlapping_ring_trades", |b| {
+pub fn orderbook_reduce_overlapping_orders(c: &mut Criterion) {
+    c.bench_function("Orderbook::reduce_overlapping_orders", |b| {
         b.iter_batched(
             data::read_default_orderbook,
-            |mut orderbook| orderbook.reduce_overlapping_ring_trades(),
+            |mut orderbook| orderbook.reduce_overlapping_orders(),
             BatchSize::SmallInput,
         )
     });
@@ -30,6 +30,6 @@ criterion_group!(
     benches,
     orderbook_read,
     orderbook_is_overlapping,
-    orderbook_reduce_overlapping_ring_trades,
+    orderbook_reduce_overlapping_orders,
 );
 criterion_main!(benches);

--- a/pricegraph/src/graph.rs
+++ b/pricegraph/src/graph.rs
@@ -3,3 +3,5 @@
 //! implementation.
 
 pub mod bellman_ford;
+pub mod path;
+pub mod subgraph;

--- a/pricegraph/src/graph/path.rs
+++ b/pricegraph/src/graph/path.rs
@@ -1,0 +1,66 @@
+//! Utilities for finding paths from predecessor vectors.
+
+use petgraph::graph::NodeIndex;
+
+/// Finds a cycle and returns a vector representing a path along the cycle,
+/// ending that is the predecessor of the starting node.
+///
+/// Returns `None` if no such cycle can be found.
+pub fn find_cycle(predecessor: &[Option<NodeIndex>], start: NodeIndex) -> Option<Vec<NodeIndex>> {
+    // NOTE: First find a node that is actually on the cycle, this is done
+    // because a negative cycle can be detected on any node connected to the
+    // cycle and not just nodes on the cycle itself.
+    let mut visited = vec![false; predecessor.len()];
+    let mut current = start;
+    visited[current.index()] = true;
+    loop {
+        current = predecessor[current.index()]?;
+        if visited[current.index()] {
+            break;
+        }
+        visited[current.index()] = true;
+    }
+
+    // NOTE: `current` is now guaranteed to be on the cycle, so just walk
+    // backwards until we reach `current` again.
+    let start = current;
+    let mut path = Vec::with_capacity(predecessor.len());
+    loop {
+        current = predecessor[current.index()]?;
+        path.push(current);
+        if current == start {
+            break;
+        }
+    }
+
+    // NOTE: `path` is in reverse order, since it was built by walking the cycle
+    // backwards, so reverse it and done!
+    path.reverse();
+    Some(path)
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::graph::bellman_ford::{self, NegativeCycle};
+    use petgraph::Graph;
+
+    #[test]
+    fn search_finds_negative_cycle() {
+        // NOTE: There is a negative cycle from 1 -> 2 -> 3 -> 1 with a
+        // transient weight of -1.
+        let graph = Graph::<(), f64>::from_edges(&[
+            (0, 1, 1.0),
+            (1, 2, 2.0),
+            (1, 4, -100.0),
+            (2, 3, 3.0),
+            (3, 1, -6.0),
+            (4, 3, 200.0),
+        ]);
+
+        let NegativeCycle(predecessor, node) = bellman_ford::search(&graph, 0.into()).unwrap_err();
+        let cycle = find_cycle(&predecessor, node).unwrap();
+
+        assert_eq!(cycle, &[1.into(), 2.into(), 3.into()]);
+    }
+}

--- a/pricegraph/src/graph/path.rs
+++ b/pricegraph/src/graph/path.rs
@@ -6,15 +6,15 @@ use petgraph::graph::NodeIndex;
 /// ending that is the predecessor of the starting node.
 ///
 /// Returns `None` if no such cycle can be found.
-pub fn find_cycle(predecessor: &[Option<NodeIndex>], start: NodeIndex) -> Option<Vec<NodeIndex>> {
+pub fn find_cycle(predecessors: &[Option<NodeIndex>], start: NodeIndex) -> Option<Vec<NodeIndex>> {
     // NOTE: First find a node that is actually on the cycle, this is done
     // because a negative cycle can be detected on any node connected to the
     // cycle and not just nodes on the cycle itself.
-    let mut visited = vec![false; predecessor.len()];
+    let mut visited = vec![false; predecessors.len()];
     let mut current = start;
     visited[current.index()] = true;
     loop {
-        current = predecessor[current.index()]?;
+        current = predecessors[current.index()]?;
         if visited[current.index()] {
             break;
         }
@@ -24,9 +24,9 @@ pub fn find_cycle(predecessor: &[Option<NodeIndex>], start: NodeIndex) -> Option
     // NOTE: `current` is now guaranteed to be on the cycle, so just walk
     // backwards until we reach `current` again.
     let start = current;
-    let mut path = Vec::with_capacity(predecessor.len());
+    let mut path = Vec::with_capacity(predecessors.len());
     loop {
-        current = predecessor[current.index()]?;
+        current = predecessors[current.index()]?;
         path.push(current);
         if current == start {
             break;
@@ -58,8 +58,8 @@ pub mod tests {
             (4, 3, 200.0),
         ]);
 
-        let NegativeCycle(predecessor, node) = bellman_ford::search(&graph, 0.into()).unwrap_err();
-        let cycle = find_cycle(&predecessor, node).unwrap();
+        let NegativeCycle(predecessors, node) = bellman_ford::search(&graph, 0.into()).unwrap_err();
+        let cycle = find_cycle(&predecessors, node).unwrap();
 
         assert_eq!(cycle, &[1.into(), 2.into(), 3.into()]);
     }

--- a/pricegraph/src/graph/subgraph.rs
+++ b/pricegraph/src/graph/subgraph.rs
@@ -29,15 +29,15 @@ impl Subgraphs {
         let Self(mut remaining_tokens) = self;
         while let Some(&token) = remaining_tokens.iter().next() {
             remaining_tokens.remove(&token);
-            let predecessor = match f(token) {
-                ControlFlow::Continue(predecessor) => predecessor,
+            let predecessors = match f(token) {
+                ControlFlow::Continue(predecessors) => predecessors,
                 ControlFlow::Break(result) => return Some(result),
             };
 
-            for connected in predecessor
-                .iter()
+            for connected in predecessors
+                .into_iter()
                 .enumerate()
-                .filter_map(|(i, &pre)| pre.map(|_| NodeIndex::new(i)))
+                .filter_map(|(i, pre)| pre.map(|_| NodeIndex::new(i)))
             {
                 remaining_tokens.remove(&connected);
             }

--- a/pricegraph/src/graph/subgraph.rs
+++ b/pricegraph/src/graph/subgraph.rs
@@ -1,0 +1,58 @@
+//! Module implementing tools for iterating over disconnected subgraphs.
+
+use petgraph::graph::NodeIndex;
+use std::collections::BTreeSet;
+
+/// A struct used for iterating over disconnected subgraphs in the orderbook for
+/// detecting orderbook overlaps and reducing the orderbook.
+///
+/// Note that this pseudo-iterator uses a `BTreeSet` to ensure that subgraphs
+/// are visited in a predictable order starting the from the first node.
+pub struct Subgraphs(BTreeSet<NodeIndex>);
+
+impl Subgraphs {
+    /// Create a new subgraphs iterator from an iterator of node indices.
+    pub fn new(nodes: impl Iterator<Item = NodeIndex>) -> Self {
+        Subgraphs(nodes.collect())
+    }
+
+    /// Iterate through each subgraph with the provided closure returning the
+    /// predecessor vector for the current node indicating which nodes are
+    /// connected to it.
+    pub fn for_each(self, mut f: impl FnMut(NodeIndex) -> Vec<Option<NodeIndex>>) {
+        self.for_each_until(|node| <ControlFlow<()>>::Continue(f(node)));
+    }
+
+    /// Iterate through each subgraph with the provided closure, returning the
+    /// control flow `Break` value if there was an early return.
+    pub fn for_each_until<T>(self, mut f: impl FnMut(NodeIndex) -> ControlFlow<T>) -> Option<T> {
+        let Self(mut remaining_tokens) = self;
+        while let Some(&token) = remaining_tokens.iter().next() {
+            remaining_tokens.remove(&token);
+            let predecessor = match f(token) {
+                ControlFlow::Continue(predecessor) => predecessor,
+                ControlFlow::Break(result) => return Some(result),
+            };
+
+            for connected in predecessor
+                .iter()
+                .enumerate()
+                .filter_map(|(i, &pre)| pre.map(|_| NodeIndex::new(i)))
+            {
+                remaining_tokens.remove(&connected);
+            }
+        }
+
+        None
+    }
+}
+
+/// An enum for representing control flow when iterating subgraphs.
+pub enum ControlFlow<T> {
+    /// Continue the iterating through the subgraphs with the provided
+    /// predecessor vector indicating which nodes are connected to the current
+    /// subgraph.
+    Continue(Vec<Option<NodeIndex>>),
+    /// Stop iterating through the subgraphs and return a result.
+    Break(T),
+}


### PR DESCRIPTION
This PR implements removing negative cycles (which are overlapping ring trades) from an orderbook graph.

### Test Plan

New unit test and benchmark reducing mainnet orderbook with ~900 orders:
```
Orderbook::reduce_overlapping_ring_trades                                                                            
                        time:   [511.12 us 512.32 us 513.70 us]
```