### PR TITLE
[Pricegraph] Estimate price by filling market order in the orderbook graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,6 +1793,7 @@ dependencies = [
  "lazy_static",
  "petgraph",
  "primitive-types 0.7.0",
+ "thiserror",
 ]
 
 [[package]]

--- a/pricegraph/Cargo.toml
+++ b/pricegraph/Cargo.toml
@@ -11,6 +11,7 @@ harness = false
 [dependencies]
 petgraph = "0.5"
 primitive-types = "0.7"
+thiserror = "1"
 
 [dev-dependencies]
 assert_approx_eq = "1"

--- a/pricegraph/benches/main.rs
+++ b/pricegraph/benches/main.rs
@@ -16,11 +16,11 @@ pub fn orderbook_is_overlapping(c: &mut Criterion) {
     });
 }
 
-pub fn orderbook_update_projection_graph(c: &mut Criterion) {
-    c.bench_function("Orderbook::update_projection_graph", |b| {
+pub fn orderbook_reduce_overlapping_ring_trades(c: &mut Criterion) {
+    c.bench_function("Orderbook::reduce_overlapping_ring_trades", |b| {
         b.iter_batched(
             data::read_default_orderbook,
-            |mut orderbook| orderbook.update_projection_graph(),
+            |mut orderbook| orderbook.reduce_overlapping_ring_trades(),
             BatchSize::SmallInput,
         )
     });
@@ -30,6 +30,6 @@ criterion_group!(
     benches,
     orderbook_read,
     orderbook_is_overlapping,
-    orderbook_update_projection_graph,
+    orderbook_reduce_overlapping_ring_trades,
 );
 criterion_main!(benches);

--- a/pricegraph/benches/main.rs
+++ b/pricegraph/benches/main.rs
@@ -30,15 +30,7 @@ pub fn orderbook_reduce_overlapping_orders(c: &mut Criterion) {
 pub fn orderbook_fill_market_order(c: &mut Criterion) {
     let dai_weth = TokenPair { buy: 7, sell: 1 };
     let eth = 10.0f64.powi(18);
-    let volumes = &[
-        0.1 * eth,
-        0.2 * eth,
-        0.5 * eth,
-        eth,
-        2.0 * eth,
-        5.0 * eth,
-        10.0 * eth,
-    ];
+    let volumes = &[0.1 * eth, eth, 10.0 * eth, 100.0 * eth, 1000.0 * eth];
 
     let mut group = c.benchmark_group("Orderbook::fill_market_order");
     for volume in volumes {

--- a/pricegraph/benches/main.rs
+++ b/pricegraph/benches/main.rs
@@ -1,5 +1,5 @@
-use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use pricegraph::Orderbook;
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use pricegraph::{Orderbook, TokenPair};
 
 #[path = "../data/mod.rs"]
 pub mod data;
@@ -18,12 +18,57 @@ pub fn orderbook_is_overlapping(c: &mut Criterion) {
 
 pub fn orderbook_reduce_overlapping_orders(c: &mut Criterion) {
     c.bench_function("Orderbook::reduce_overlapping_orders", |b| {
+        let orderbook = data::read_default_orderbook();
         b.iter_batched(
-            data::read_default_orderbook,
+            || orderbook.clone(),
             |mut orderbook| orderbook.reduce_overlapping_orders(),
             BatchSize::SmallInput,
         )
     });
+}
+
+pub fn orderbook_fill_market_order(c: &mut Criterion) {
+    let dai_weth = TokenPair { buy: 7, sell: 1 };
+    let eth = 10.0f64.powi(18);
+    let volumes = &[
+        0.1 * eth,
+        0.2 * eth,
+        0.5 * eth,
+        eth,
+        2.0 * eth,
+        5.0 * eth,
+        10.0 * eth,
+    ];
+
+    let mut group = c.benchmark_group("Orderbook::fill_market_order");
+    for volume in volumes {
+        group.bench_with_input(BenchmarkId::from_parameter(volume), volume, |b, &volume| {
+            let orderbook = data::read_default_orderbook();
+            b.iter_batched(
+                || orderbook.clone(),
+                |mut orderbook| orderbook.fill_market_order(black_box(dai_weth), volume),
+                BatchSize::SmallInput,
+            )
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("Orderbook::fill_market_order(reduced)");
+    for volume in volumes {
+        group.bench_with_input(BenchmarkId::from_parameter(volume), volume, |b, &volume| {
+            let reduced_orderbook = {
+                let mut orderbook = data::read_default_orderbook();
+                orderbook.reduce_overlapping_orders();
+                orderbook
+            };
+            b.iter_batched(
+                || reduced_orderbook.clone(),
+                |mut orderbook| orderbook.fill_market_order(black_box(dai_weth), volume),
+                BatchSize::SmallInput,
+            )
+        });
+    }
+    group.finish();
 }
 
 criterion_group!(
@@ -31,5 +76,6 @@ criterion_group!(
     orderbook_read,
     orderbook_is_overlapping,
     orderbook_reduce_overlapping_orders,
+    orderbook_fill_market_order,
 );
 criterion_main!(benches);

--- a/pricegraph/benches/main.rs
+++ b/pricegraph/benches/main.rs
@@ -16,11 +16,11 @@ pub fn orderbook_is_overlapping(c: &mut Criterion) {
     });
 }
 
-pub fn orderbook_reduce_overlapping_ring_trades(c: &mut Criterion) {
-    c.bench_function("Orderbook::reduce_overlapping_ring_trades", |b| {
+pub fn orderbook_reduce_overlapping_orders(c: &mut Criterion) {
+    c.bench_function("Orderbook::reduce_overlapping_orders", |b| {
         b.iter_batched(
             data::read_default_orderbook,
-            |mut orderbook| orderbook.reduce_overlapping_ring_trades(),
+            |mut orderbook| orderbook.reduce_overlapping_orders(),
             BatchSize::SmallInput,
         )
     });
@@ -30,6 +30,6 @@ criterion_group!(
     benches,
     orderbook_read,
     orderbook_is_overlapping,
-    orderbook_reduce_overlapping_ring_trades,
+    orderbook_reduce_overlapping_orders,
 );
 criterion_main!(benches);

--- a/pricegraph/src/graph.rs
+++ b/pricegraph/src/graph.rs
@@ -3,3 +3,5 @@
 //! implementation.
 
 pub mod bellman_ford;
+pub mod path;
+pub mod subgraph;

--- a/pricegraph/src/graph/path.rs
+++ b/pricegraph/src/graph/path.rs
@@ -1,0 +1,66 @@
+//! Utilities for finding paths from predecessor vectors.
+
+use petgraph::graph::NodeIndex;
+
+/// Finds a cycle and returns a vector representing a path along the cycle,
+/// ending that is the predecessor of the starting node.
+///
+/// Returns `None` if no such cycle can be found.
+pub fn find_cycle(predecessor: &[Option<NodeIndex>], start: NodeIndex) -> Option<Vec<NodeIndex>> {
+    // NOTE: First find a node that is actually on the cycle, this is done
+    // because a negative cycle can be detected on any node connected to the
+    // cycle and not just nodes on the cycle itself.
+    let mut visited = vec![false; predecessor.len()];
+    let mut current = start;
+    visited[current.index()] = true;
+    loop {
+        current = predecessor[current.index()]?;
+        if visited[current.index()] {
+            break;
+        }
+        visited[current.index()] = true;
+    }
+
+    // NOTE: `current` is now guaranteed to be on the cycle, so just walk
+    // backwards until we reach `current` again.
+    let start = current;
+    let mut path = Vec::with_capacity(predecessor.len());
+    loop {
+        current = predecessor[current.index()]?;
+        path.push(current);
+        if current == start {
+            break;
+        }
+    }
+
+    // NOTE: `path` is in reverse order, since it was built by walking the cycle
+    // backwards, so reverse it and done!
+    path.reverse();
+    Some(path)
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::graph::bellman_ford::{self, NegativeCycle};
+    use petgraph::Graph;
+
+    #[test]
+    fn search_finds_negative_cycle() {
+        // NOTE: There is a negative cycle from 1 -> 2 -> 3 -> 1 with a
+        // transient weight of -1.
+        let graph = Graph::<(), f64>::from_edges(&[
+            (0, 1, 1.0),
+            (1, 2, 2.0),
+            (1, 4, -100.0),
+            (2, 3, 3.0),
+            (3, 1, -6.0),
+            (4, 3, 200.0),
+        ]);
+
+        let NegativeCycle(predecessor, node) = bellman_ford::search(&graph, 0.into()).unwrap_err();
+        let cycle = find_cycle(&predecessor, node).unwrap();
+
+        assert_eq!(cycle, &[1.into(), 2.into(), 3.into()]);
+    }
+}

--- a/pricegraph/src/graph/path.rs
+++ b/pricegraph/src/graph/path.rs
@@ -39,6 +39,27 @@ pub fn find_cycle(predecessor: &[Option<NodeIndex>], start: NodeIndex) -> Option
     Some(path)
 }
 
+/// Finds a path between two tokens. Returns `None` if no such path exists.
+pub fn find_path(
+    predecessor: &[Option<NodeIndex>],
+    start: NodeIndex,
+    end: NodeIndex,
+) -> Option<Vec<NodeIndex>> {
+    let mut path = Vec::with_capacity(predecessor.len());
+
+    let mut current = end;
+    while current != start {
+        path.push(current);
+        current = predecessor[current.index()]?;
+    }
+    path.push(start);
+
+    // NOTE: `path` is in reverse order, since it was built by walking the path
+    // backwards, so reverse it and done!
+    path.reverse();
+    Some(path)
+}
+
 #[cfg(test)]
 pub mod tests {
     use super::*;

--- a/pricegraph/src/graph/path.rs
+++ b/pricegraph/src/graph/path.rs
@@ -84,4 +84,31 @@ pub mod tests {
 
         assert_eq!(cycle, &[1.into(), 2.into(), 3.into()]);
     }
+
+    #[test]
+    fn search_finds_shortest_path() {
+        //  0 --2.0-> 1 --1.0-> 2
+        //  |         |         |
+        // 4.0       7.0        |
+        //  v         v         |
+        //  3         5        5.0
+        //  |         ^         |
+        // 1.0       1.0        |
+        //  |         |         |
+        //  \-------> 4 <-------/
+        let graph = Graph::<(), f64>::from_edges(&[
+            (0, 1, 2.0),
+            (0, 3, 4.0),
+            (1, 2, 1.0),
+            (1, 5, 7.0),
+            (2, 4, 5.0),
+            (4, 5, 1.0),
+            (3, 4, 1.0),
+        ]);
+
+        let (_, predecessor) = bellman_ford::search(&graph, 0.into()).unwrap();
+        let path = find_path(&predecessor, 0.into(), 5.into()).unwrap();
+
+        assert_eq!(path, &[0.into(), 3.into(), 4.into(), 5.into()]);
+    }
 }

--- a/pricegraph/src/graph/subgraph.rs
+++ b/pricegraph/src/graph/subgraph.rs
@@ -1,0 +1,58 @@
+//! Module implementing tools for iterating over disconnected subgraphs.
+
+use petgraph::graph::NodeIndex;
+use std::collections::BTreeSet;
+
+/// A struct used for iterating over disconnected subgraphs in the orderbook for
+/// detecting orderbook overlaps and reducing the orderbook.
+///
+/// Note that this pseudo-iterator uses a `BTreeSet` to ensure that subgraphs
+/// are visited in a predictable order starting the from the first node.
+pub struct Subgraphs(BTreeSet<NodeIndex>);
+
+impl Subgraphs {
+    /// Create a new subgraphs iterator from an iterator of node indices.
+    pub fn new(nodes: impl Iterator<Item = NodeIndex>) -> Self {
+        Subgraphs(nodes.collect())
+    }
+
+    /// Iterate through each subgraph with the provided closure returning the
+    /// predecessor vector for the current node indicating which nodes are
+    /// connected to it.
+    pub fn for_each(self, mut f: impl FnMut(NodeIndex) -> Vec<Option<NodeIndex>>) {
+        self.for_each_until(|node| <ControlFlow<()>>::Continue(f(node)));
+    }
+
+    /// Iterate through each subgraph with the provided closure, returning the
+    /// control flow `Break` value if there was an early return.
+    pub fn for_each_until<T>(self, mut f: impl FnMut(NodeIndex) -> ControlFlow<T>) -> Option<T> {
+        let Self(mut remaining_tokens) = self;
+        while let Some(&token) = remaining_tokens.iter().next() {
+            remaining_tokens.remove(&token);
+            let predecessor = match f(token) {
+                ControlFlow::Continue(predecessor) => predecessor,
+                ControlFlow::Break(result) => return Some(result),
+            };
+
+            for connected in predecessor
+                .iter()
+                .enumerate()
+                .filter_map(|(i, &pre)| pre.map(|_| NodeIndex::new(i)))
+            {
+                remaining_tokens.remove(&connected);
+            }
+        }
+
+        None
+    }
+}
+
+/// An enum for representing control flow when iterating subgraphs.
+pub enum ControlFlow<T> {
+    /// Continue the iterating through the subgraphs with the provided
+    /// predecessor vector indicating which nodes are connected to the current
+    /// subgraph.
+    Continue(Vec<Option<NodeIndex>>),
+    /// Stop iterating through the subgraphs and return a result.
+    Break(T),
+}

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -3,6 +3,7 @@ mod graph;
 mod num;
 mod orderbook;
 
+pub use encoding::{TokenId, TokenPair};
 pub use orderbook::Orderbook;
 
 #[cfg(test)]

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -185,7 +185,7 @@ impl Orderbook {
 
         // NOTE: The transient price is the price of the sell token in terms of
         // the buy token. Since we are trying to find an order that would create
-        // a cycle of weight 0 that starts at the sell token and ends at the buy
+        // a cycle of weight 0 that starts at the buy token and ends at the sell
         // token, we want the inverse price with fees removed.
         Some(1.0 / (last_transient_price * FEE_FACTOR))
     }
@@ -542,6 +542,51 @@ mod tests {
         // as user 2's 5->3 order and user 4's 6->7 order.
         assert_eq!(orderbook.num_orders(), 6);
         assert!(!orderbook.is_overlapping());
+    }
+
+    #[test]
+    fn fills_market_order_with_correct_price() {
+/*
+ *     const orderbook = new Orderbook("ETH", "DAI", new Fraction(0, 1));
+
+    orderbook.addBid(new Offer(new Fraction(90, 1), 3));
+    orderbook.addBid(new Offer(new Fraction(95, 1), 2));
+    orderbook.addBid(new Offer(new Fraction(99, 1), 1));
+
+    orderbook.addAsk(new Offer(new Fraction(101, 1), 2));
+    orderbook.addAsk(new Offer(new Fraction(105, 1), 1));
+    orderbook.addAsk(new Offer(new Fraction(110, 1), 3));
+    */
+        //  /---0.5---v
+        // 1          2
+        // ^---1.0---/
+        let mut orderbook = orderbook! {
+            users {
+                @1 {
+                    token 1 => 20_000_000,
+                    token 2 => 10_000_000,
+                    token 3 => 10_000_000,
+                    token 4 => 10_000_000,
+                    token 5 => 20_000_000,
+                }
+                @2 {
+                    token 2 => 1_000_000_000,
+                    token 3 => 1_000_000_000,
+                }
+            }
+            orders {
+                owner @1 buying 0 [10_000_000] selling 1 [10_000_000],
+                owner @1 buying 2 [10_000_000] selling 1 [10_000_000] (1_000_000),
+                owner @1 buying 2 [10_000_000] selling 3 [10_000_000],
+                owner @1 buying 3 [10_000_000] selling 4 [10_000_000],
+                owner @1 buying 4 [10_000_000] selling 5 [10_000_000],
+
+                owner @2 buying 1 [5_000_000] selling 2 [10_000_000],
+                owner @2 buying 5 [5_000_000] selling 3 [10_000_000],
+            }
+        };
+
+        assert!(orderbook.is_overlapping());
     }
 
     #[test]

--- a/pricegraph/src/orderbook/order.rs
+++ b/pricegraph/src/orderbook/order.rs
@@ -41,7 +41,7 @@ impl OrderCollector {
 /// Type definition for a mapping of orders between buy and sell tokens. Token
 /// pair orders are garanteed to be in order, so that the cheapest order is
 /// always at the end of the token pair order vector.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct OrderMap(HashMap<TokenId, HashMap<TokenId, Vec<Order>>>);
 
 impl OrderMap {
@@ -117,7 +117,7 @@ impl OrderMap {
 /// Note that we approximate amounts and prices with floating point numbers.
 /// While this can lead to rounding errors it greatly simplifies the graph
 /// computations and still leads to acceptable estimates.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct Order {
     /// The user owning the order.
     pub user: UserId,

--- a/pricegraph/src/orderbook/user.rs
+++ b/pricegraph/src/orderbook/user.rs
@@ -8,7 +8,7 @@ use std::collections::{hash_map, HashMap};
 pub type UserMap = HashMap<UserId, User>;
 
 /// User data containing balances and number of orders.
-#[derive(Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default)]
 pub struct User {
     /// User balances per token.
     balances: HashMap<TokenId, f64>,


### PR DESCRIPTION
This PR implements filling a market order in the orderbook graph using the successive shortest path algorithm. It allows for price estimation as it returns the price of the final shortest path used to fill the remaining volume.

### Test Plan

Unit tests (run with `--nocapture` to see price estimates for DAI/WETH on a real orderbook) and very promising benchmarks:
```
Orderbook::fill_market_order/100000000000000000                                                                            
                        time:   [488.01 us 492.00 us 496.36 us]
Orderbook::fill_market_order/1000000000000000000                                                                            
                        time:   [489.00 us 492.21 us 495.73 us]
Orderbook::fill_market_order/10000000000000000000                                                                            
                        time:   [491.00 us 495.20 us 499.58 us]
Orderbook::fill_market_order/100000000000000000000                                                                            
                        time:   [519.72 us 522.40 us 525.17 us]
Orderbook::fill_market_order/1000000000000000000000                                                                            
                        time:   [552.44 us 556.99 us 561.93 us]

Orderbook::fill_market_order(reduced)/100000000000000000                                                                            
                        time:   [22.840 us 23.260 us 23.614 us]
Orderbook::fill_market_order(reduced)/1000000000000000000                                                                            
                        time:   [23.277 us 23.766 us 24.182 us]
Orderbook::fill_market_order(reduced)/10000000000000000000                                                                            
                        time:   [23.047 us 23.449 us 23.784 us]
Orderbook::fill_market_order(reduced)/100000000000000000000                                                                            
                        time:   [37.304 us 38.050 us 38.645 us]
Orderbook::fill_market_order(reduced)/1000000000000000000000                                                                            
                        time:   [83.246 us 85.535 us 87.633 us]
```

WIth a reduced orderbook (so if the orderbook gets reused for multiple estimates) it takes 20-90 microsecond to perform a price estimate (depending on how much slippage there is) :rocket:. 
Even when using a non-reduced orderbook where the cycles need to be removed beforehand, the computation takes less than a millisecond.