### PR TITLE
[Pricegraph] Add WASM bindings to pricegraph crate for price estimation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ target/
 
 # NodeJS
 pricegraph/data/node_modules/
+
+# WASM
+pricegraph/wasm/pkg/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1797,6 +1807,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pricegraph-wasm"
+version = "0.1.0"
+dependencies = [
+ "console_error_panic_hook",
+ "data-encoding",
+ "lazy_static",
+ "pricegraph",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2263,6 +2285,12 @@ name = "scoped-tls"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "scopeguard"
@@ -2788,7 +2816,7 @@ dependencies = [
  "iovec",
  "log 0.4.8",
  "mio",
- "scoped-tls",
+ "scoped-tls 0.1.2",
  "tokio",
  "tokio-executor",
  "tokio-io",
@@ -3171,6 +3199,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7add542ea1ac7fdaa9dc25e031a6af33b7d63376292bd24140c637d00d1c312a"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3198,6 +3238,30 @@ name = "wasm-bindgen-shared"
 version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf76fe7d25ac79748a37538b7daeed1c7a6867c92d3245c12c6222e4a20d639"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648da3460c6d2aa04b715a936329e2e311180efe650b2127d6267f4193ccac14"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls 1.0.0",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2f86cd78a2aa7b1fb4bb6ed854eccb7f9263089c79542dca1576a1518a8467"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,6 +518,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dex-pricegraph"
+version = "0.1.0"
+dependencies = [
+ "console_error_panic_hook",
+ "data-encoding",
+ "lazy_static",
+ "pricegraph",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1804,18 +1816,6 @@ dependencies = [
  "petgraph",
  "primitive-types 0.7.0",
  "thiserror",
-]
-
-[[package]]
-name = "pricegraph-wasm"
-version = "0.1.0"
-dependencies = [
- "console_error_panic_hook",
- "data-encoding",
- "lazy_static",
- "pricegraph",
- "wasm-bindgen",
- "wasm-bindgen-test",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "dex-pricegraph"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "console_error_panic_hook",
  "data-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,12 @@ members = [
     "driver",
     "e2e",
     "pricegraph",
+    "pricegraph/wasm",
 ]
 default-members = [
     "driver",
+    "pricegraph",
 ]
+
+[profile.release]
+opt-level = "s"

--- a/pricegraph/wasm/Cargo.toml
+++ b/pricegraph/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dex-pricegraph"
-version = "0.1.0"
+version = "0.0.1"
 authors = ["Nicholas Rodrigues Lordello <nicholas.lordello@gnosis.pm>"]
 edition = "2018"
 

--- a/pricegraph/wasm/Cargo.toml
+++ b/pricegraph/wasm/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pricegraph-wasm"
+name = "dex-pricegraph"
 version = "0.1.0"
 authors = ["Nicholas Rodrigues Lordello <nicholas.lordello@gnosis.pm>"]
 edition = "2018"

--- a/pricegraph/wasm/Cargo.toml
+++ b/pricegraph/wasm/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "pricegraph-wasm"
+version = "0.1.0"
+authors = ["Nicholas Rodrigues Lordello <nicholas.lordello@gnosis.pm>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+console_error_panic_hook = "0.1"
+pricegraph = { version = "0.1.0", path = ".." }
+wasm-bindgen = "0.2"
+
+[dev-dependencies]
+data-encoding = "2"
+lazy_static = "1"
+wasm-bindgen-test = "0.3"

--- a/pricegraph/wasm/src/lib.rs
+++ b/pricegraph/wasm/src/lib.rs
@@ -1,0 +1,37 @@
+//! This crate provides a thin WASM-compatible wrapper around the `pricegraph`
+//! crate and can be used for estimating prices for a given orderbook.
+
+use pricegraph::{Orderbook, TokenId, TokenPair};
+use wasm_bindgen::prelude::*;
+
+/// A graph representation of a complete orderbook.
+#[wasm_bindgen]
+pub struct PriceEstimator {
+    orderbook: Orderbook,
+}
+
+#[wasm_bindgen]
+impl PriceEstimator {
+    /// Creates a `PriceEstimator` instance by reading an orderbook from encoded
+    /// bytes. Returns an error if the encoded orders are invalid.
+    #[wasm_bindgen(constructor)]
+    pub fn new(bytes: &[u8]) -> Result<PriceEstimator, JsValue> {
+        console_error_panic_hook::set_once();
+
+        let mut orderbook = Orderbook::read(bytes).map_err(|err| err.to_string())?;
+        orderbook.reduce_overlapping_orders();
+
+        Ok(PriceEstimator { orderbook })
+    }
+
+    /// Estimates price for the specified trade. Returns `undefined` if the
+    /// volume cannot be fully filled.
+    #[wasm_bindgen(js_name = "estimatePrice")]
+    pub fn estimate_price(&self, buy: TokenId, sell: TokenId, volume: f64) -> Option<f64> {
+        // NOTE: Make sure to use a copy of the orderbook so that successive
+        // calls to `estimate_price` do not affect eachother.
+        self.orderbook
+            .clone()
+            .fill_market_order(TokenPair { buy, sell }, volume)
+    }
+}

--- a/pricegraph/wasm/tests/nodejs.rs
+++ b/pricegraph/wasm/tests/nodejs.rs
@@ -1,0 +1,32 @@
+extern crate wasm_bindgen_test;
+
+#[path = "../../data/mod.rs"]
+mod data;
+
+use pricegraph_wasm::PriceEstimator;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = Date)]
+    fn now() -> f64;
+}
+
+#[wasm_bindgen_test]
+fn estimate_price() {
+    let start = now();
+
+    let estimator = PriceEstimator::new(&*data::DEFAULT_ORDERBOOK).unwrap();
+    let price = estimator
+        .estimate_price(7, 1, 100.0 * 10.0f64.powi(18))
+        .unwrap();
+
+    let elapsed = now() - start;
+
+    console_log!(
+        "DAI-WETH price for selling 100 WETH: 1 WETH = {} DAI ({}ms)",
+        price,
+        elapsed,
+    );
+}

--- a/pricegraph/wasm/tests/nodejs.rs
+++ b/pricegraph/wasm/tests/nodejs.rs
@@ -3,7 +3,7 @@ extern crate wasm_bindgen_test;
 #[path = "../../data/mod.rs"]
 mod data;
 
-use pricegraph_wasm::PriceEstimator;
+use dex_pricegraph::PriceEstimator;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_test::*;
 


### PR DESCRIPTION
This PR creates WASM bindings for the `pricegraph` crate so that it can be called from the browser and NodeJS :tada: 

### Test Plan

Build the WASM module with `(cd pricegraph/wasm; wasm-pack build --scope gnosis.pm)`. This will build a standalone npm package that can be used in NodeJS and in the browser to estimate prices for a given orderbook.

Additionally, a NodeJS integration test was added that estimates the price of 100 WETH's worth of DAI on an actual orderbook. This can be run with `(cd pricegraph/wasm; wasm-pack test --node)`.