### PR TITLE
Retry with increased gas price

### DIFF
--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -86,7 +86,7 @@ pub trait StableXContract {
         solution: Solution,
         claimed_objective_value: U256,
         gas_price: U256,
-        timeout: Option<usize>,
+        block_timeout: Option<usize>,
     ) -> Result<(), MethodError>;
 }
 
@@ -150,7 +150,7 @@ impl StableXContract for StableXContractImpl {
         solution: Solution,
         claimed_objective_value: U256,
         gas_price: U256,
-        timeout: Option<usize>,
+        block_timeout: Option<usize>,
     ) -> Result<(), MethodError> {
         let (prices, token_ids_for_price) = encode_prices_for_contract(&solution.prices);
         let (owners, order_ids, volumes) = encode_execution_for_contract(&solution.executed_orders);
@@ -172,7 +172,7 @@ impl StableXContract for StableXContractImpl {
             .gas(5_500_000.into());
 
         method.tx.resolve = Some(ResolveCondition::Confirmed(ConfirmParams {
-            block_timeout: timeout,
+            block_timeout,
             ..Default::default()
         }));
         method.send().wait()?;

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -5,16 +5,17 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use anyhow::Result;
-use ethcontract::transaction::GasPrice;
+use ethcontract::transaction::{GasPrice, ResolveCondition};
 use ethcontract::{Address, BlockNumber, PrivateKey, U256};
 use lazy_static::lazy_static;
 #[cfg(test)]
 use mockall::automock;
 
 use crate::contracts;
-use crate::gas_station::GasPriceEstimating;
 use crate::models::{ExecutedOrder, Solution};
 use crate::util::FutureWaitExt;
+use ethcontract::errors::MethodError;
+use ethcontract::transaction::confirm::ConfirmParams;
 
 lazy_static! {
     // In the BatchExchange smart contract, the objective value will be multiplied by
@@ -24,27 +25,18 @@ lazy_static! {
 
 include!(concat!(env!("OUT_DIR"), "/batch_exchange.rs"));
 
-pub struct StableXContractImpl<'a> {
+pub struct StableXContractImpl {
     instance: BatchExchange,
-    gas_price_estimating: &'a (dyn GasPriceEstimating + Sync),
 }
 
-impl<'a> StableXContractImpl<'a> {
-    pub fn new(
-        web3: &contracts::Web3,
-        key: PrivateKey,
-        network_id: u64,
-        gas_price_estimating: &'a (dyn GasPriceEstimating + Sync),
-    ) -> Result<Self> {
+impl StableXContractImpl {
+    pub fn new(web3: &contracts::Web3, key: PrivateKey, network_id: u64) -> Result<Self> {
         let defaults = contracts::method_defaults(key, network_id)?;
 
         let mut instance = BatchExchange::deployed(&web3).wait()?;
         *instance.defaults_mut() = defaults;
 
-        Ok(StableXContractImpl {
-            instance,
-            gas_price_estimating,
-        })
+        Ok(StableXContractImpl { instance })
     }
 
     pub fn account(&self) -> Address {
@@ -93,10 +85,12 @@ pub trait StableXContract {
         batch_index: U256,
         solution: Solution,
         claimed_objective_value: U256,
-    ) -> Result<()>;
+        gas_price: U256,
+        timeout: Option<usize>,
+    ) -> Result<(), MethodError>;
 }
 
-impl<'a> StableXContract for StableXContractImpl<'a> {
+impl StableXContract for StableXContractImpl {
     fn get_current_auction_index(&self) -> Result<u32> {
         let auction_index = self.instance.get_current_batch_id().call().wait()?;
         Ok(auction_index)
@@ -155,17 +149,13 @@ impl<'a> StableXContract for StableXContractImpl<'a> {
         batch_index: U256,
         solution: Solution,
         claimed_objective_value: U256,
-    ) -> Result<()> {
+        gas_price: U256,
+        timeout: Option<usize>,
+    ) -> Result<(), MethodError> {
         let (prices, token_ids_for_price) = encode_prices_for_contract(&solution.prices);
         let (owners, order_ids, volumes) = encode_execution_for_contract(&solution.executed_orders);
-        let gas_price = self.gas_price_estimating.estimate_gas_price();
-        if let Err(ref err) = gas_price {
-            log::warn!(
-                "failed to get gas price from gnosis safe gas station: {}",
-                err
-            );
-        }
-        self.instance
+        let mut method = self
+            .instance
             .submit_solution(
                 batch_index.low_u32(),
                 claimed_objective_value,
@@ -175,17 +165,17 @@ impl<'a> StableXContract for StableXContractImpl<'a> {
                 prices,
                 token_ids_for_price,
             )
-            .gas_price(
-                gas_price
-                    .map(|gas_price| GasPrice::Value(gas_price.fast))
-                    .unwrap_or(GasPrice::Scaled(3.0)),
-            )
+            .gas_price(GasPrice::Value(gas_price))
             // NOTE: Gas estimate might be off, as we race with other solution
             //   submissions and thus might have to revert trades which costs
             //   more gas than expected.
-            .gas(5_500_000.into())
-            .send()
-            .wait()?;
+            .gas(5_500_000.into());
+
+        method.tx.resolve = Some(ResolveCondition::Confirmed(ConfirmParams {
+            block_timeout: timeout,
+            ..Default::default()
+        }));
+        method.send().wait()?;
 
         Ok(())
     }

--- a/driver/src/gas_station.rs
+++ b/driver/src/gas_station.rs
@@ -9,7 +9,7 @@ use uint::FromDecStrErr;
 pub const DEFAULT_URI: &str = "https://safe-relay.gnosis.io/api/v1/gas-station/";
 
 /// Result of the api call. Prices are in wei.
-#[derive(Deserialize, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Debug, Default, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct GasPrice {
     pub last_update: String,

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -192,13 +192,8 @@ fn main() {
     .unwrap();
 
     // Set up web3 and contract connection.
-    let contract = StableXContractImpl::new(
-        &web3,
-        options.private_key.clone(),
-        options.network_id,
-        &gas_station,
-    )
-    .unwrap();
+    let contract =
+        StableXContractImpl::new(&web3, options.private_key.clone(), options.network_id).unwrap();
     info!("Using contract at {:?}", contract.address());
     info!("Using account {:?}", contract.account());
 
@@ -213,7 +208,7 @@ fn main() {
     let filtered_orderbook = FilteredOrderbookReader::new(&orderbook, options.orderbook_filter);
 
     // Set up solution submitter.
-    let solution_submitter = StableXSolutionSubmitter::new(&contract);
+    let solution_submitter = StableXSolutionSubmitter::new(&contract, &gas_station);
 
     // Set up the driver and start the run-loop.
     let driver = StableXDriverImpl::new(

--- a/driver/src/solution_submission/mod.rs
+++ b/driver/src/solution_submission/mod.rs
@@ -207,6 +207,10 @@ fn retry_with_gas_price_increase(
     } {
         // Increase gas
         gas_price = std::cmp::min(gas_price * INCREASE_FACTOR, gas_cap);
+        info!(
+            "retrying solution submission with increased gas price {}",
+            gas_price,
+        );
     }
 
     result

--- a/driver/src/solution_submission/mod.rs
+++ b/driver/src/solution_submission/mod.rs
@@ -164,7 +164,7 @@ fn retry_with_gas_price_increase(
     gas_cap: U256,
 ) -> Result<(), MethodError> {
     const INCREASE_FACTOR: u32 = 2;
-    const BLOCK_TIMEOUT: usize = 1;
+    const BLOCK_TIMEOUT: usize = 2;
     const DEFAULT_GAS_PRICE: u64 = 15_000_000_000;
 
     let mut gas_price = match gas_price_estimating.estimate_gas_price() {

--- a/driver/src/solution_submission/mod.rs
+++ b/driver/src/solution_submission/mod.rs
@@ -3,6 +3,7 @@
 use crate::contracts::stablex_contract::StableXContract;
 use crate::models::Solution;
 
+use crate::gas_station::GasPriceEstimating;
 use anyhow::{Error, Result};
 use ethcontract::errors::{ExecutionError, MethodError};
 use ethcontract::web3::types::TransactionReceipt;
@@ -88,11 +89,18 @@ impl From<Error> for SolutionSubmissionError {
 
 pub struct StableXSolutionSubmitter<'a> {
     contract: &'a (dyn StableXContract + Sync),
+    gas_price_estimating: &'a (dyn GasPriceEstimating + Sync),
 }
 
 impl<'a> StableXSolutionSubmitter<'a> {
-    pub fn new(contract: &'a (dyn StableXContract + Sync)) -> Self {
-        Self { contract }
+    pub fn new(
+        contract: &'a (dyn StableXContract + Sync),
+        gas_price_estimating: &'a (dyn GasPriceEstimating + Sync),
+    ) -> Self {
+        Self {
+            contract,
+            gas_price_estimating,
+        }
     }
 }
 
@@ -120,42 +128,102 @@ impl<'a> StableXSolutionSubmitting for StableXSolutionSubmitter<'a> {
         solution: Solution,
         claimed_objective_value: U256,
     ) -> Result<(), SolutionSubmissionError> {
-        self.contract
-            .submit_solution(
-                batch_index.clone(),
-                solution.clone(),
-                claimed_objective_value,
-            )
-            .map_err(|err| {
-                extract_transaction_receipt(&err)
-                    .and_then(|tx| {
-                        let block_number = tx.block_number?;
-                        match self.contract.get_solution_objective_value(
-                            batch_index,
-                            solution,
-                            Some(block_number.into()),
-                        ) {
-                            Ok(_) => None,
-                            Err(e) => Some(SolutionSubmissionError::from(e)),
-                        }
-                    })
-                    .unwrap_or_else(|| SolutionSubmissionError::Unexpected(err))
-            })
+        retry_with_gas_price_increase(
+            self.contract,
+            batch_index,
+            solution.clone(),
+            claimed_objective_value,
+            self.gas_price_estimating,
+            60_000_000_000u64.into(),
+        )
+        .map_err(|err| {
+            extract_transaction_receipt(&err)
+                .and_then(|tx| {
+                    let block_number = tx.block_number?;
+                    match self.contract.get_solution_objective_value(
+                        batch_index,
+                        solution,
+                        Some(block_number.into()),
+                    ) {
+                        Ok(_) => None,
+                        Err(e) => Some(SolutionSubmissionError::from(e)),
+                    }
+                })
+                .unwrap_or_else(|| SolutionSubmissionError::Unexpected(err.into()))
+        })
+        .map(|_| ())
     }
 }
 
-fn extract_transaction_receipt(err: &Error) -> Option<&TransactionReceipt> {
-    err.downcast_ref::<MethodError>()
-        .and_then(|method_error| match &method_error.inner {
-            ExecutionError::Failure(tx) => Some(tx.as_ref()),
-            _ => None,
-        })
+fn retry_with_gas_price_increase(
+    contract: &dyn StableXContract,
+    batch_index: U256,
+    solution: Solution,
+    claimed_objective_value: U256,
+    gas_price_estimating: &dyn GasPriceEstimating,
+    gas_cap: U256,
+) -> Result<(), MethodError> {
+    const INCREASE_FACTOR: u32 = 2;
+    const BLOCK_TIMEOUT: usize = 1;
+    const DEFAULT_GAS_PRICE: u64 = 15_000_000_000;
+
+    let mut gas_price = match gas_price_estimating.estimate_gas_price() {
+        Ok(gas_estimate) => gas_estimate.fast,
+        Err(ref err) => {
+            log::warn!(
+                "failed to get gas price from gnosis safe gas station: {}",
+                err
+            );
+            U256::from(DEFAULT_GAS_PRICE)
+        }
+    };
+    // Never exceed the gas cap.
+    gas_price = std::cmp::min(gas_price, gas_cap);
+
+    let mut result;
+    // the following block emulates a do-while loop
+    while {
+        // Submit solution at estimated gas price (not exceeding the cap)
+        result = contract.submit_solution(
+            batch_index,
+            solution.clone(),
+            claimed_objective_value,
+            gas_price,
+            if gas_price == gas_cap {
+                None
+            } else {
+                Some(BLOCK_TIMEOUT)
+            },
+        );
+        // Breaking condition for our loop
+        gas_price < gas_cap
+            && matches!(
+                result,
+                Err(MethodError {
+                    inner: ExecutionError::ConfirmTimeout,
+                    ..
+                })
+            )
+    } {
+        // Increase gas
+        gas_price = std::cmp::min(gas_price * INCREASE_FACTOR, gas_cap);
+    }
+
+    result
+}
+
+fn extract_transaction_receipt(err: &MethodError) -> Option<&TransactionReceipt> {
+    match &err.inner {
+        ExecutionError::Failure(tx) => Some(tx.as_ref()),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::contracts::stablex_contract::MockStableXContract;
+    use crate::gas_station::{GasPrice, MockGasPriceEstimating};
 
     use anyhow::anyhow;
     use ethcontract::web3::types::H2048;
@@ -179,11 +247,94 @@ mod tests {
             .expect_get_solution_objective_value()
             .return_once(move |_, _, _| Ok(U256::from(42)));
 
-        let submitter = StableXSolutionSubmitter::new(&contract);
+        let gas_station = MockGasPriceEstimating::new();
+
+        let submitter = StableXSolutionSubmitter::new(&contract, &gas_station);
         let result = submitter.get_solution_objective_value(U256::zero(), Solution::trivial());
 
         contract.checkpoint();
         assert_eq!(result.unwrap(), U256::from(42));
+    }
+
+    #[test]
+    fn test_retry_with_gas_price_increase_once() {
+        let mut contract = MockStableXContract::new();
+        contract
+            .expect_submit_solution()
+            .times(1)
+            .with(always(), always(), always(), eq(U256::from(5)), eq(Some(1)))
+            .return_once(|_, _, _, _, _| {
+                Err(MethodError::from_parts(
+                    "submitSolution(uint32,uint256,address[],uint16[],uint128[],uint128[],uint16[])"
+                        .to_owned(),
+                    ExecutionError::ConfirmTimeout,
+                ))
+            });
+        contract
+            .expect_submit_solution()
+            .with(always(), always(), always(), eq(U256::from(9)), eq(None))
+            .return_once(|_, _, _, _, _| Ok(()));
+
+        let mut gas_station = MockGasPriceEstimating::new();
+        gas_station.expect_estimate_gas_price().return_once(|| {
+            Ok(GasPrice {
+                fast: 5.into(),
+                ..Default::default()
+            })
+        });
+
+        retry_with_gas_price_increase(
+            &contract,
+            1.into(),
+            Solution::trivial(),
+            1.into(),
+            &gas_station,
+            9.into(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_retry_with_gas_price_increase_timeout() {
+        let mut contract = MockStableXContract::new();
+        contract
+            .expect_submit_solution()
+            .times(1)
+            .with(always(), always(), always(), eq(U256::from(5)), eq(Some(1)))
+            .return_once(|_, _, _, _, _| {
+                Err(MethodError::from_parts(
+                    "submitSolution(uint32,uint256,address[],uint16[],uint128[],uint128[],uint16[])"
+                        .to_owned(),
+                    ExecutionError::ConfirmTimeout,
+                ))
+            });
+        contract
+            .expect_submit_solution()
+            .with(always(), always(), always(), eq(U256::from(9)), eq(None))
+            .return_once(|_, _, _, _, _| {
+                Err(MethodError::from_parts(
+                    "submitSolution(uint32,uint256,address[],uint16[],uint128[],uint128[],uint16[])"
+                        .to_owned(),
+                    ExecutionError::ConfirmTimeout,
+                ))
+            });
+
+        let mut gas_station = MockGasPriceEstimating::new();
+        gas_station.expect_estimate_gas_price().return_once(|| {
+            Ok(GasPrice {
+                fast: 5.into(),
+                ..Default::default()
+            })
+        });
+        assert!(retry_with_gas_price_increase(
+            &contract,
+            1.into(),
+            Solution::trivial(),
+            1.into(),
+            &gas_station,
+            9.into(),
+        )
+        .is_err())
     }
 
     #[test]
@@ -202,8 +353,9 @@ mod tests {
                     ExecutionError::Revert(Some("SafeMath: subtraction overflow".to_owned())),
                 )))
             });
+        let gas_station = MockGasPriceEstimating::new();
 
-        let submitter = StableXSolutionSubmitter::new(&contract);
+        let submitter = StableXSolutionSubmitter::new(&contract, &gas_station);
         let result = submitter.get_solution_objective_value(U256::zero(), Solution::trivial());
 
         match result.expect_err("Should have errored") {
@@ -236,12 +388,12 @@ mod tests {
         // Submit Solution returns failed tx
         contract
             .expect_submit_solution()
-            .return_once(move |_, _, _| {
-                Err(anyhow!(MethodError::from_parts(
+            .return_once(move |_, _, _, _, _| {
+                Err(MethodError::from_parts(
                     "submitSolution(uint32,uint256,address[],uint16[],uint128[],uint128[],uint16[])"
                         .to_owned(),
                     ExecutionError::Failure(Box::new(receipt)),
-                )))
+                ))
             });
         // Get objective value on old block number returns revert reason
         contract
@@ -254,8 +406,15 @@ mod tests {
                     ExecutionError::Revert(Some("Claimed objective doesn't sufficiently improve current solution".to_owned())),
                 )))
             });
+        let mut gas_station = MockGasPriceEstimating::new();
+        gas_station.expect_estimate_gas_price().return_once(|| {
+            Ok(GasPrice {
+                fast: 5.into(),
+                ..Default::default()
+            })
+        });
 
-        let submitter = StableXSolutionSubmitter::new(&contract);
+        let submitter = StableXSolutionSubmitter::new(&contract, &gas_station);
         let result = submitter.submit_solution(U256::zero(), Solution::trivial(), U256::zero());
 
         match result.expect_err("Should have errored") {


### PR DESCRIPTION
This PR introduces a few fundamental changes to `StableXContract.submit_solution` so to have a natural implementation of `retry_with_increased_gas_price` that is easily testable.

- `GasStation` is moved into the `SolutionSubmitter` instead of `StableXContract`
- Introduce a new function `retry_with_gas_price_increase` which doubles the gas price if solution is not mined within one block (to a maximum cap of 60 GWei).
- This functionality is tested with one test showing the gas price incremented (to the cap) and another which persists in not being mined. 

Note that the initial gas estimate cannot exceed the cap and that the the block timeout is reset to default on the last submitted transaction.

Closes #677


**TestPlan** Unit tests.