### PR TITLE
Use BatchExchangeViewer contract for order fetching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,8 +554,8 @@ dependencies = [
  "byteorder",
  "chrono",
  "crossbeam-utils",
- "ethcontract",
- "ethcontract-generate",
+ "ethcontract 0.6.0 (git+https://github.com/gnosis/ethcontract-rs.git?rev=01346aacc88771ad5c592af1f531cca92c452ef2)",
+ "ethcontract-generate 0.6.0 (git+https://github.com/gnosis/ethcontract-rs.git?rev=01346aacc88771ad5c592af1f531cca92c452ef2)",
  "futures 0.3.4",
  "isahc",
  "lazy_static",
@@ -584,7 +584,7 @@ name = "e2e"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "ethcontract",
+ "ethcontract 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4",
 ]
 
@@ -657,12 +657,11 @@ dependencies = [
 [[package]]
 name = "ethcontract"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11117f7cfeb0a38abe518ec123493d86f9545375ba5f2b48e947ef97c585a982"
+source = "git+https://github.com/gnosis/ethcontract-rs.git?rev=01346aacc88771ad5c592af1f531cca92c452ef2#01346aacc88771ad5c592af1f531cca92c452ef2"
 dependencies = [
  "ethabi 9.0.1",
- "ethcontract-common",
- "ethcontract-derive",
+ "ethcontract-common 0.6.0 (git+https://github.com/gnosis/ethcontract-rs.git?rev=01346aacc88771ad5c592af1f531cca92c452ef2)",
+ "ethcontract-derive 0.6.0 (git+https://github.com/gnosis/ethcontract-rs.git?rev=01346aacc88771ad5c592af1f531cca92c452ef2)",
  "futures 0.3.4",
  "futures-timer",
  "hex",
@@ -677,6 +676,46 @@ dependencies = [
  "uint",
  "web3",
  "zeroize",
+]
+
+[[package]]
+name = "ethcontract"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11117f7cfeb0a38abe518ec123493d86f9545375ba5f2b48e947ef97c585a982"
+dependencies = [
+ "ethabi 9.0.1",
+ "ethcontract-common 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethcontract-derive 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4",
+ "futures-timer",
+ "hex",
+ "jsonrpc-core",
+ "lazy_static",
+ "pin-project",
+ "rlp",
+ "secp256k1",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "uint",
+ "web3",
+ "zeroize",
+]
+
+[[package]]
+name = "ethcontract-common"
+version = "0.6.0"
+source = "git+https://github.com/gnosis/ethcontract-rs.git?rev=01346aacc88771ad5c592af1f531cca92c452ef2#01346aacc88771ad5c592af1f531cca92c452ef2"
+dependencies = [
+ "ethabi 11.0.0",
+ "hex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror",
+ "tiny-keccak 2.0.1",
+ "web3",
 ]
 
 [[package]]
@@ -698,14 +737,41 @@ dependencies = [
 [[package]]
 name = "ethcontract-derive"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11606e5683b2abf83f0077791ff4a8a426eb0723ff5a4cdc160574eabd1d2c53"
+source = "git+https://github.com/gnosis/ethcontract-rs.git?rev=01346aacc88771ad5c592af1f531cca92c452ef2#01346aacc88771ad5c592af1f531cca92c452ef2"
 dependencies = [
- "ethcontract-common",
- "ethcontract-generate",
+ "ethcontract-common 0.6.0 (git+https://github.com/gnosis/ethcontract-rs.git?rev=01346aacc88771ad5c592af1f531cca92c452ef2)",
+ "ethcontract-generate 0.6.0 (git+https://github.com/gnosis/ethcontract-rs.git?rev=01346aacc88771ad5c592af1f531cca92c452ef2)",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ethcontract-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11606e5683b2abf83f0077791ff4a8a426eb0723ff5a4cdc160574eabd1d2c53"
+dependencies = [
+ "ethcontract-common 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethcontract-generate 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ethcontract-generate"
+version = "0.6.0"
+source = "git+https://github.com/gnosis/ethcontract-rs.git?rev=01346aacc88771ad5c592af1f531cca92c452ef2#01346aacc88771ad5c592af1f531cca92c452ef2"
+dependencies = [
+ "Inflector",
+ "anyhow",
+ "curl",
+ "ethcontract-common 0.6.0 (git+https://github.com/gnosis/ethcontract-rs.git?rev=01346aacc88771ad5c592af1f531cca92c452ef2)",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "url 2.1.1",
 ]
 
 [[package]]
@@ -717,7 +783,7 @@ dependencies = [
  "Inflector",
  "anyhow",
  "curl",
- "ethcontract-common",
+ "ethcontract-common 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,8 +554,8 @@ dependencies = [
  "byteorder",
  "chrono",
  "crossbeam-utils",
- "ethcontract 0.6.0 (git+https://github.com/gnosis/ethcontract-rs.git?rev=01346aacc88771ad5c592af1f531cca92c452ef2)",
- "ethcontract-generate 0.6.0 (git+https://github.com/gnosis/ethcontract-rs.git?rev=01346aacc88771ad5c592af1f531cca92c452ef2)",
+ "ethcontract",
+ "ethcontract-generate",
  "futures 0.3.4",
  "isahc",
  "lazy_static",
@@ -584,7 +584,7 @@ name = "e2e"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "ethcontract 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethcontract",
  "futures 0.3.4",
 ]
 
@@ -656,37 +656,13 @@ dependencies = [
 
 [[package]]
 name = "ethcontract"
-version = "0.6.0"
-source = "git+https://github.com/gnosis/ethcontract-rs.git?rev=01346aacc88771ad5c592af1f531cca92c452ef2#01346aacc88771ad5c592af1f531cca92c452ef2"
-dependencies = [
- "ethabi 9.0.1",
- "ethcontract-common 0.6.0 (git+https://github.com/gnosis/ethcontract-rs.git?rev=01346aacc88771ad5c592af1f531cca92c452ef2)",
- "ethcontract-derive 0.6.0 (git+https://github.com/gnosis/ethcontract-rs.git?rev=01346aacc88771ad5c592af1f531cca92c452ef2)",
- "futures 0.3.4",
- "futures-timer",
- "hex",
- "jsonrpc-core",
- "lazy_static",
- "pin-project",
- "rlp",
- "secp256k1",
- "serde",
- "serde_json",
- "thiserror",
- "uint",
- "web3",
- "zeroize",
-]
-
-[[package]]
-name = "ethcontract"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11117f7cfeb0a38abe518ec123493d86f9545375ba5f2b48e947ef97c585a982"
+checksum = "1f019278e3a866019e999edc2e17c4aa6806316cf869413f35ee2f2948fec9f9"
 dependencies = [
  "ethabi 9.0.1",
- "ethcontract-common 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethcontract-derive 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethcontract-common",
+ "ethcontract-derive",
  "futures 0.3.4",
  "futures-timer",
  "hex",
@@ -705,24 +681,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-common"
-version = "0.6.0"
-source = "git+https://github.com/gnosis/ethcontract-rs.git?rev=01346aacc88771ad5c592af1f531cca92c452ef2#01346aacc88771ad5c592af1f531cca92c452ef2"
-dependencies = [
- "ethabi 11.0.0",
- "hex",
- "serde",
- "serde_derive",
- "serde_json",
- "thiserror",
- "tiny-keccak 2.0.1",
- "web3",
-]
-
-[[package]]
-name = "ethcontract-common"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110d2632d8719942769856be7d862cef74b42dbb3a060da75f322b73d09c2bad"
+checksum = "664e1fc08b1aaea6159787742db14c0f33e8c4d3572e1826c2336cd14fa27525"
 dependencies = [
  "ethabi 11.0.0",
  "hex",
@@ -736,24 +697,12 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-derive"
-version = "0.6.0"
-source = "git+https://github.com/gnosis/ethcontract-rs.git?rev=01346aacc88771ad5c592af1f531cca92c452ef2#01346aacc88771ad5c592af1f531cca92c452ef2"
-dependencies = [
- "ethcontract-common 0.6.0 (git+https://github.com/gnosis/ethcontract-rs.git?rev=01346aacc88771ad5c592af1f531cca92c452ef2)",
- "ethcontract-generate 0.6.0 (git+https://github.com/gnosis/ethcontract-rs.git?rev=01346aacc88771ad5c592af1f531cca92c452ef2)",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "ethcontract-derive"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11606e5683b2abf83f0077791ff4a8a426eb0723ff5a4cdc160574eabd1d2c53"
+checksum = "80be0591248a374fc4e1683636579f5d56b1c3af673fa54c0abc23b390c57b32"
 dependencies = [
- "ethcontract-common 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethcontract-generate 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethcontract-common",
+ "ethcontract-generate",
  "proc-macro2",
  "quote",
  "syn",
@@ -761,29 +710,14 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-generate"
-version = "0.6.0"
-source = "git+https://github.com/gnosis/ethcontract-rs.git?rev=01346aacc88771ad5c592af1f531cca92c452ef2#01346aacc88771ad5c592af1f531cca92c452ef2"
-dependencies = [
- "Inflector",
- "anyhow",
- "curl",
- "ethcontract-common 0.6.0 (git+https://github.com/gnosis/ethcontract-rs.git?rev=01346aacc88771ad5c592af1f531cca92c452ef2)",
- "proc-macro2",
- "quote",
- "syn",
- "url 2.1.1",
-]
-
-[[package]]
-name = "ethcontract-generate"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28041a9ae3c21166a1033e493ec53ee735ccd0d50123f62bedbf663aaf7374dc"
+checksum = "9bd5f639bb0490656a9d61a5e049b4767efa74eb9e843d750f7db437130d46e9"
 dependencies = [
  "Inflector",
  "anyhow",
  "curl",
- "ethcontract-common 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethcontract-common",
  "proc-macro2",
  "quote",
  "syn",

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1"
 byteorder = "1.3.4"
 chrono = "0.4.11"
 crossbeam-utils = "0.7"
-ethcontract = { git = "https://github.com/gnosis/ethcontract-rs.git", rev = "01346aacc88771ad5c592af1f531cca92c452ef2" }
+ethcontract = "0.6.1"
 futures = { version = "0.3.4", features = ["compat"] }
 isahc = { version = "0.9.1", features = ["json"] }
 lazy_static = "1.4.0"
@@ -35,4 +35,4 @@ url = "2.1.1"
 mockall = "0.7.0"
 
 [build-dependencies]
-ethcontract-generate = { git = "https://github.com/gnosis/ethcontract-rs.git", rev = "01346aacc88771ad5c592af1f531cca92c452ef2" }
+ethcontract-generate = "0.6.1"

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1"
 byteorder = "1.3.4"
 chrono = "0.4.11"
 crossbeam-utils = "0.7"
-ethcontract = "0.6.0"
+ethcontract = { git = "https://github.com/gnosis/ethcontract-rs.git", rev = "01346aacc88771ad5c592af1f531cca92c452ef2" }
 futures = { version = "0.3.4", features = ["compat"] }
 isahc = { version = "0.9.1", features = ["json"] }
 lazy_static = "1.4.0"
@@ -35,4 +35,4 @@ url = "2.1.1"
 mockall = "0.7.0"
 
 [build-dependencies]
-ethcontract-generate = "0.6.0"
+ethcontract-generate = { git = "https://github.com/gnosis/ethcontract-rs.git", rev = "01346aacc88771ad5c592af1f531cca92c452ef2" }

--- a/driver/build.rs
+++ b/driver/build.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 fn main() {
     generate_contract("BatchExchange", "batch_exchange.rs");
+    generate_contract("BatchExchangeViewer", "batch_exchange_viewer.rs");
 }
 
 fn generate_contract(name: &str, out: &str) {

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
-ethcontract = "0.6.0"
+ethcontract = "0.6.1"
 futures = { version = "0.3.4", features = ["compat"] }

--- a/e2e/src/common.rs
+++ b/e2e/src/common.rs
@@ -1,11 +1,10 @@
 use crate::*;
 
 use ethcontract::contract::{
-    CallFuture, Deploy, DeployBuilder, DeployFuture, MethodBuilder, MethodSendFuture,
-    ViewMethodBuilder,
+    CallFuture, Deploy, DeployBuilder, DeployFuture, Detokenizable, MethodBuilder,
+    MethodSendFuture, ViewMethodBuilder,
 };
 use ethcontract::web3::api::Web3;
-use ethcontract::web3::contract::tokens::Detokenize;
 use ethcontract::web3::futures::Future as F;
 use ethcontract::web3::transports::Http;
 use ethcontract::web3::Transport;
@@ -55,6 +54,7 @@ pub trait FutureBuilderExt: Sized {
 impl<T, R> FutureBuilderExt for MethodBuilder<T, R>
 where
     T: Transport,
+    R: Detokenizable,
 {
     type Future = MethodSendFuture<T>;
 
@@ -66,7 +66,7 @@ where
 impl<T, R> FutureBuilderExt for ViewMethodBuilder<T, R>
 where
     T: Transport,
-    R: Detokenize,
+    R: Detokenizable,
 {
     type Future = CallFuture<T, R>;
 


### PR DESCRIPTION
This PR changes the contract that we use to fetch the on-chain orderbook from BatchExchange to BatchExchangeViewer. We made a few gas optimizations inside the viewer contract, which should allow for a larger page size and thus fast orderbook fetching.

We needed to update the dex-contracts submodule to get the latest deployments of the BatchExchangeViewer and need to wait on a hotfix in ethcontracts which will allow functions with void return types in the ABI.

### Test Plan

Run driver locally and see orderbook fetching on 4G in ~30s.