### PR TITLE
[WIP] Initial reliable orderbook retrieval

### DIFF
--- a/driver/build.rs
+++ b/driver/build.rs
@@ -12,6 +12,7 @@ fn generate_contract(name: &str, out: &str) {
     let dest = env::var("OUT_DIR").unwrap();
     println!("cargo:rerun-if-changed={}", artifact);
     Builder::new(artifact)
+        .with_visibility_modifier(Some("pub"))
         .generate()
         .unwrap()
         .write_to_file(Path::new(&dest).join(out))

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -10,6 +10,8 @@ use std::convert::TryInto;
 
 mod filtered_orderbook;
 mod paginated_auction_data_reader;
+mod retrying_retrieval;
+
 pub use filtered_orderbook::{FilteredOrderbookReader, OrderbookFilter};
 
 #[cfg_attr(test, automock)]

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -1,18 +1,16 @@
-use crate::contracts::stablex_contract::StableXContract;
-use crate::models::{AccountState, Order};
-
-use anyhow::Result;
-use ethcontract::U256;
-#[cfg(test)]
-use mockall::automock;
-use paginated_auction_data_reader::PaginatedAuctionDataReader;
-use std::convert::TryInto;
-
 mod filtered_orderbook;
 mod paginated_auction_data_reader;
 mod retrying_retrieval;
 
-pub use filtered_orderbook::{FilteredOrderbookReader, OrderbookFilter};
+pub use self::filtered_orderbook::{FilteredOrderbookReader, OrderbookFilter};
+use self::paginated_auction_data_reader::PaginatedAuctionDataReader;
+use crate::contracts::stablex_contract::StableXContract;
+use crate::models::{AccountState, Order};
+use anyhow::Result;
+use ethcontract::U256;
+#[cfg(test)]
+use mockall::automock;
+use std::convert::TryInto;
 
 #[cfg_attr(test, automock)]
 pub trait StableXOrderBookReading {

--- a/driver/src/orderbook/retrying_retrieval.rs
+++ b/driver/src/orderbook/retrying_retrieval.rs
@@ -1,0 +1,260 @@
+//! This module implements a retrying orderbook reader that accounts for
+//! submitted solutions as well as batches rolling over while the orderbook is
+//! being read.
+
+#![allow(dead_code)]
+
+use crate::contracts::stablex_contract::batch_exchange;
+use crate::contracts::stablex_contract::batch_exchange::event_data::{SolutionSubmission, Trade};
+use crate::models::{AccountState, Order};
+use crate::orderbook::paginated_auction_data_reader::PaginatedAuctionDataReader;
+use anyhow::{anyhow, Result};
+use ethcontract::web3::types::BlockId;
+use ethcontract::{Address, Event, EventData, H256};
+use futures::channel::{mpsc, oneshot};
+use futures::future::{BoxFuture, FutureExt};
+use futures::stream::{BoxStream, StreamExt};
+use futures::{select, try_join};
+use std::collections::HashMap;
+use std::convert::TryInto;
+
+/// Type definition for complete solution data.
+pub type SolutionData = (SolutionSubmission, Vec<Trade>);
+
+/// A trait for querying contract data with futures and streams.
+#[cfg_attr(test, mockall::automock)]
+// NOTE: Clippy complains that the lifetime can be elided with `'_` for the
+//   various streams and futures, but doing so results in a compiler errors.
+#[allow(clippy::needless_lifetimes)]
+pub trait StableXContractAsync: Sync {
+    /// Retrieves the batch for a specific block number.
+    fn batch_id_at_block<'a>(&'a self, block: BlockId) -> BoxFuture<'a, Result<u32>>;
+    /// Retrieves the latest solution for the given batch index.
+    fn latest_solution<'a>(&'a self, batch_id: u32) -> BoxFuture<'a, Result<Option<SolutionData>>>;
+    /// Streams pages of encoded orders.
+    fn encoded_orders_paginated<'a>(
+        &'a self,
+        previous_page_user: Address,
+        previous_page_user_offset: u16,
+        page_size: u16,
+    ) -> BoxFuture<'a, Result<Vec<u8>>>;
+    /// Streams incomming events from the contract that may signal that the
+    /// orderbook retrieval must be retried as the data has become stale.
+    fn all_events<'a>(&'a self) -> BoxStream<'a, Result<Event<batch_exchange::Event>>>;
+}
+
+fn read_orderbook(
+    contract: &dyn StableXContractAsync,
+    batch_id: u32,
+    page_size: u16,
+) -> Result<(AccountState, Vec<Order>)> {
+    futures::executor::block_on(async {
+        // NOTE: Use a bounded channel with a 0 sized buffer so that the sender
+        //   (i.e. the future that is polling the incomming events) can only
+        //   send 1 retry at a time.
+        let (retry_tx, retry_rx) = mpsc::channel::<()>(0);
+        let (done_tx, done_rx) = oneshot::channel::<()>();
+
+        let (solution_event, latest_solution, (account_state, orders)) = try_join!(
+            poll_incoming_events(contract, batch_id, retry_tx, done_rx),
+            contract.latest_solution(batch_id),
+            read_orderbook_async(contract, batch_id, page_size, retry_rx, done_tx),
+        )?;
+
+        if let Some((solution, trades)) = solution_event.or(latest_solution) {
+            todo!("undo {:?} and from {:?} from orderbook", solution, trades);
+        }
+
+        Ok((account_state, orders))
+    })
+}
+
+async fn read_orderbook_async(
+    contract: &dyn StableXContractAsync,
+    batch_id: u32,
+    page_size: u16,
+    mut retry: mpsc::Receiver<()>,
+    _done: oneshot::Sender<()>,
+) -> Result<(AccountState, Vec<Order>)> {
+    let mut reader = PaginatedAuctionDataReader::new(batch_id.into());
+    loop {
+        let mut page_future = contract
+            .encoded_orders_paginated(
+                reader.pagination().previous_page_user,
+                reader
+                    .pagination()
+                    .previous_page_user_offset
+                    .try_into()
+                    .expect("user cannot have more than u16::MAX orders"),
+                page_size,
+            )
+            .fuse();
+
+        let page = select! {
+            page = page_future => page?,
+            _ = retry.next() => {
+                reader = PaginatedAuctionDataReader::new(batch_id.into());
+                continue;
+            },
+            complete => break Err(anyhow!("error processing incoming events")),
+        };
+
+        let number_of_orders: u16 = reader
+            .apply_page(&page)
+            .try_into()
+            .expect("number of orders per page should never overflow a u16");
+
+        if number_of_orders < page_size {
+            return Ok(reader.get_auction_data());
+        }
+    }
+
+    // NOTE: `done` gets dropped automatically when this method returns, making
+    //   its `Receiver` resolve to `Err(Cancelled)` which will cause the event
+    //   loop to break.
+}
+
+async fn poll_incoming_events(
+    contract: &dyn StableXContractAsync,
+    batch_id: u32,
+    mut retry: mpsc::Sender<()>,
+    done: oneshot::Receiver<()>,
+) -> Result<Option<SolutionData>> {
+    use batch_exchange::Event::*;
+    use Batch::*;
+    use EventData::*;
+
+    let mut done = done.fuse();
+    let mut events = contract.all_events().fuse();
+
+    let mut batches = BatchIds::new(contract, batch_id);
+    let mut solutions = SolutionAccumulator::default();
+
+    loop {
+        let event = select! {
+            event = events.select_next_some() => event?,
+            _ = done => break Ok(()),
+            complete => break Err(anyhow!("event stream unexpectedly ended")),
+        };
+
+        let block_hash = match event.meta.as_ref() {
+            Some(meta) => meta.block_hash,
+            _ => return Err(anyhow!("unexpected event on pending block in event stream")),
+        };
+
+        let event_batch = batches.block_batch(block_hash).await?;
+        let (data, added_or_removed) = match event.data {
+            Added(data) => (data, Added(())),
+            Removed(data) => (data, Removed(())),
+        };
+
+        let requires_retry = match (data, event_batch, added_or_removed) {
+            (Deposit(deposit), _, _) if deposit.batch_id <= batch_id => true,
+            (OrderCancellation(_), Past, _) => true,
+            (OrderPlacement(order), _, _)
+                if batch_id >= order.valid_from && batch_id <= order.valid_until =>
+            {
+                true
+            }
+            (SolutionSubmission(solution), Current, Added(_)) => {
+                solutions.add_solution_submission(block_hash, solution);
+                true
+            }
+            (SolutionSubmission(_), Current, Removed(_)) => {
+                solutions.remove_solution_submission(block_hash);
+                true
+            }
+            (Trade(trade), Current, Added(_)) => {
+                solutions.add_trade(block_hash, trade);
+                false
+            }
+            (WithdrawRequest(withdraw), _, _) if withdraw.batch_id <= batch_id => true,
+            _ => false,
+        };
+
+        if requires_retry {
+            match retry.try_send(()) {
+                Ok(()) => {}
+                Err(err) if err.is_full() => {
+                    // This indicates that our buffered channel already has
+                    // another pending retry, so there is no use in adding
+                    // another.
+                }
+                Err(err) => {
+                    return Err(err.into());
+                }
+            }
+        }
+    }?;
+
+    Ok(solutions.latest_solution())
+}
+
+struct BatchIds<'a> {
+    contract: &'a dyn StableXContractAsync,
+    current_batch: u32,
+    block_batch_ids: HashMap<H256, u32>,
+}
+
+enum Batch {
+    Past,
+    Current,
+}
+
+impl<'a> BatchIds<'a> {
+    fn new(contract: &'a dyn StableXContractAsync, current_batch: u32) -> Self {
+        BatchIds {
+            contract,
+            current_batch,
+            block_batch_ids: HashMap::new(),
+        }
+    }
+
+    async fn block_batch(&mut self, block_hash: H256) -> Result<Batch> {
+        use std::cmp::Ordering::*;
+
+        let event_batch_id = match self.block_batch_ids.get(&block_hash) {
+            Some(&id) => id,
+            None => {
+                let id = self.contract.batch_id_at_block(block_hash.into()).await?;
+                self.block_batch_ids.insert(block_hash, id);
+                id
+            }
+        };
+
+        match event_batch_id.cmp(&self.current_batch) {
+            Less => Ok(Batch::Past),
+            Equal => Ok(Batch::Current),
+            Greater => Err(anyhow!("orderbook retrieval took more than a full batch")),
+        }
+    }
+}
+
+#[derive(Default)]
+struct SolutionAccumulator {
+    solutions: HashMap<H256, SolutionData>,
+    blocks: Vec<H256>,
+}
+
+impl SolutionAccumulator {
+    fn add_trade(&mut self, block_hash: H256, trade: Trade) {
+        self.solutions.entry(block_hash).or_default().1.push(trade)
+    }
+
+    fn add_solution_submission(&mut self, block_hash: H256, solution: SolutionSubmission) {
+        self.solutions.entry(block_hash).or_default().0 = solution;
+        self.blocks.push(block_hash);
+    }
+
+    fn remove_solution_submission(&mut self, block_hash: H256) {
+        self.solutions.remove(&block_hash);
+        if let Some(index) = self.blocks.iter().position(|&b| b == block_hash) {
+            self.blocks.remove(index);
+        }
+    }
+
+    fn latest_solution(mut self) -> Option<SolutionData> {
+        let latest = self.blocks.pop()?;
+        self.solutions.remove(&latest)
+    }
+}

--- a/driver/src/orderbook/retrying_retrieval.rs
+++ b/driver/src/orderbook/retrying_retrieval.rs
@@ -1,42 +1,38 @@
-//! This module implements a retrying orderbook reader that accounts for
-//! submitted solutions as well as batches rolling over while the orderbook is
-//! being read.
+//! This module implements a retrying orderbook reader that accounts that allows
+//! the orderbook retrieval to optimistically start before the batch is
+//! finalized and will retry if state invalidating events are emitted.
 
 #![allow(dead_code)]
 
 use crate::contracts::stablex_contract::batch_exchange;
-use crate::contracts::stablex_contract::batch_exchange::event_data::{SolutionSubmission, Trade};
 use crate::models::{AccountState, Order};
 use crate::orderbook::paginated_auction_data_reader::PaginatedAuctionDataReader;
 use anyhow::{anyhow, Result};
 use ethcontract::web3::types::BlockId;
-use ethcontract::{Address, Event, EventData, H256};
+use ethcontract::{Address, BlockNumber, Event, EventData};
 use futures::channel::{mpsc, oneshot};
 use futures::future::{BoxFuture, FutureExt};
 use futures::stream::{BoxStream, StreamExt};
 use futures::{select, try_join};
-use std::collections::HashMap;
 use std::convert::TryInto;
-
-/// Type definition for complete solution data.
-pub type SolutionData = (SolutionSubmission, Vec<Trade>);
 
 /// A trait for querying contract data with futures and streams.
 #[cfg_attr(test, mockall::automock)]
-// NOTE: Clippy complains that the lifetime can be elided with `'_` for the
-//   various streams and futures, but doing so results in a compiler errors.
 #[allow(clippy::needless_lifetimes)]
 pub trait StableXContractAsync: Sync {
     /// Retrieves the batch for a specific block number.
     fn batch_id_at_block<'a>(&'a self, block: BlockId) -> BoxFuture<'a, Result<u32>>;
+    /// Searches for the block number of the last block of the given batch. If
+    /// the batch has not yet been finalized, then the current block number is
+    /// returned.
+    fn last_block_for_batch<'a>(&'a self, batch_id: u32) -> BoxFuture<'a, Result<u64>>;
     /// Retrieves the latest solution for the given batch index.
-    fn latest_solution<'a>(&'a self, batch_id: u32) -> BoxFuture<'a, Result<Option<SolutionData>>>;
-    /// Streams pages of encoded orders.
     fn encoded_orders_paginated<'a>(
         &'a self,
         previous_page_user: Address,
         previous_page_user_offset: u16,
         page_size: u16,
+        block_number: BlockNumber,
     ) -> BoxFuture<'a, Result<Vec<u8>>>;
     /// Streams incomming events from the contract that may signal that the
     /// orderbook retrieval must be retried as the data has become stale.
@@ -52,30 +48,48 @@ fn read_orderbook(
         // NOTE: Use a bounded channel with a 0 sized buffer so that the sender
         //   (i.e. the future that is polling the incomming events) can only
         //   send 1 retry at a time.
-        let (retry_tx, retry_rx) = mpsc::channel::<()>(0);
+        let (retry_tx, retry_rx) = mpsc::channel::<u64>(0);
+        // NOTE: Use a one shot channel to signal when the orderbook retrieval
+        //   is complete so that the event watcher future can end.
         let (done_tx, done_rx) = oneshot::channel::<()>();
 
-        let (solution_event, latest_solution, (account_state, orders)) = try_join!(
-            poll_incoming_events(contract, batch_id, retry_tx, done_rx),
-            contract.latest_solution(batch_id),
-            read_orderbook_async(contract, batch_id, page_size, retry_rx, done_tx),
+        let (_, (account_state, orders)) = try_join!(
+            watch_contract_events(contract, batch_id, retry_tx, done_rx),
+            async move {
+                let result = read_orderbook_at_block(contract, batch_id, page_size, retry_rx).await;
+                // NOTE: drop `done` sender so that the event watcher future
+                // exits gracefully.
+                drop(done_tx);
+                result
+            }
         )?;
-
-        if let Some((solution, trades)) = solution_event.or(latest_solution) {
-            todo!("undo {:?} and from {:?} from orderbook", solution, trades);
-        }
 
         Ok((account_state, orders))
     })
 }
 
-async fn read_orderbook_async(
+/// Read an orderbook at a given block. This method takes an additional `retry`
+/// channel that is used to signal when the orderbook retrieval needs to be
+/// restarted on a new block number because new events have arrived indicating
+/// that the retrieved orderbook may be stale and produce invalid solutions.
+///
+/// Note this method is asynchronous so that it can simultaneously poll both
+/// incomming retry signals and the oderbook pages and restart querying the
+/// orderbook as soon as possible.
+async fn read_orderbook_at_block(
     contract: &dyn StableXContractAsync,
     batch_id: u32,
     page_size: u16,
-    mut retry: mpsc::Receiver<()>,
-    _done: oneshot::Sender<()>,
+    mut retry: mpsc::Receiver<u64>,
 ) -> Result<(AccountState, Vec<Order>)> {
+    // NOTE: First get the block used to query the orderbook. This is either
+    //   the last block of the batch, or a new block number
+    let mut last_block_future = contract.last_block_for_batch(batch_id).fuse();
+    let mut block_number = select! {
+        block = last_block_future => block?,
+        block = retry.select_next_some() => block,
+    };
+
     let mut reader = PaginatedAuctionDataReader::new(batch_id.into());
     loop {
         let mut page_future = contract
@@ -87,16 +101,22 @@ async fn read_orderbook_async(
                     .try_into()
                     .expect("user cannot have more than u16::MAX orders"),
                 page_size,
+                block_number.into(),
             )
             .fuse();
 
         let page = select! {
             page = page_future => page?,
-            _ = retry.next() => {
+            block = retry.next() => {
+                block_number = match block {
+                    Some(block) => block,
+                    None => {
+                        return Err(anyhow!("retry channel unexpectedly closed"));
+                    }
+                };
                 reader = PaginatedAuctionDataReader::new(batch_id.into());
                 continue;
             },
-            complete => break Err(anyhow!("error processing incoming events")),
         };
 
         let number_of_orders: u16 = reader
@@ -108,72 +128,83 @@ async fn read_orderbook_async(
             return Ok(reader.get_auction_data());
         }
     }
-
-    // NOTE: `done` gets dropped automatically when this method returns, making
-    //   its `Receiver` resolve to `Err(Cancelled)` which will cause the event
-    //   loop to break.
 }
 
-async fn poll_incoming_events(
+/// Watches exchange contract events for events that would invalidate an
+/// orderbook.
+///
+/// This event uses a `retry` channel to signal the most accurate block number
+/// to use to re-query the orderbook in case an event is encoutered that would
+/// otherwise invalidate the orderbook
+///
+/// Note this takes an additional `done` channel that can be used to request
+/// this future to end. If the done channel is never signaled, then the future
+/// returned by this method will not resolve unless it encounters an error.
+async fn watch_contract_events(
     contract: &dyn StableXContractAsync,
     batch_id: u32,
-    mut retry: mpsc::Sender<()>,
+    mut retry: mpsc::Sender<u64>,
     done: oneshot::Receiver<()>,
-) -> Result<Option<SolutionData>> {
+) -> Result<()> {
     use batch_exchange::Event::*;
-    use Batch::*;
     use EventData::*;
 
     let mut done = done.fuse();
     let mut events = contract.all_events().fuse();
 
-    let mut batches = BatchIds::new(contract, batch_id);
-    let mut solutions = SolutionAccumulator::default();
-
     loop {
+        // NOTE: Wait for the next event. Simultaneously poll the done channel
+        //   to check to see if the caller requested us to exit.
         let event = select! {
-            event = events.select_next_some() => event?,
+            event = events.next() => match event.transpose()? {
+                Some(event) => event,
+                None => break Err(anyhow!("event stream unexpectedly ended")),
+            },
             _ = done => break Ok(()),
-            complete => break Err(anyhow!("event stream unexpectedly ended")),
         };
 
-        let block_hash = match event.meta.as_ref() {
-            Some(meta) => meta.block_hash,
+        let block_number = match event.meta.as_ref() {
+            Some(meta) => meta.block_number,
             _ => return Err(anyhow!("unexpected event on pending block in event stream")),
         };
 
-        let event_batch = batches.block_batch(block_hash).await?;
-        let (data, added_or_removed) = match event.data {
-            Added(data) => (data, Added(())),
-            Removed(data) => (data, Removed(())),
-        };
-
-        let requires_retry = match (data, event_batch, added_or_removed) {
-            (Deposit(deposit), _, _) if deposit.batch_id <= batch_id => true,
-            (OrderCancellation(_), Past, _) => true,
-            (OrderPlacement(order), _, _)
-                if batch_id >= order.valid_from && batch_id <= order.valid_until =>
-            {
-                true
+        let requires_retry = match &event.data {
+            // NOTE: A deposit or withdrawal was either added or removed as a
+            //   result of a reorg. That means that a user balance may have been
+            //   retrieved with an incorrect value and may cause an invalid
+            //   solution either by generating more negative utility or using a
+            //   larger amount than is permitted.
+            Added(Deposit(deposit)) | Removed(Deposit(deposit)) => deposit.batch_id <= batch_id,
+            Added(WithdrawRequest(withdraw)) | Removed(WithdrawRequest(withdraw)) => {
+                withdraw.batch_id <= batch_id
             }
-            (SolutionSubmission(solution), Current, Added(_)) => {
-                solutions.add_solution_submission(block_hash, solution);
-                true
+            // NOTE: A new order cancellation event was emitted, this means that
+            //   a potentially invalid event was included in the account state
+            //   that can lead to invalid solutions. Note that if the event was
+            //   removed, then we are missing a valid order which means the
+            //   solution may be suboptimal but it is not worth retrying.
+            Added(OrderCancellation(_)) => {
+                let event_batch_id = contract
+                    .batch_id_at_block(BlockId::Number(block_number.into()))
+                    .await?;
+                event_batch_id <= batch_id
             }
-            (SolutionSubmission(_), Current, Removed(_)) => {
-                solutions.remove_solution_submission(block_hash);
-                true
+            // NOTE: The reciprocal of an order cancellation. Note that new
+            //   orders are ignored, as they cannot cause invalid solutions.
+            Removed(OrderPlacement(order)) => {
+                batch_id >= order.valid_from && batch_id <= order.valid_until
             }
-            (Trade(trade), Current, Added(_)) => {
-                solutions.add_trade(block_hash, trade);
-                false
-            }
-            (WithdrawRequest(withdraw), _, _) if withdraw.batch_id <= batch_id => true,
             _ => false,
         };
 
         if requires_retry {
-            match retry.try_send(()) {
+            // NOTE: For removed events, this means that the previous block is
+            //   now the most accurate block to use for querying the orderbook.
+            let retry_block_number = match &event.data {
+                Added(_) => block_number,
+                Removed(_) => block_number - 1,
+            };
+            match retry.try_send(retry_block_number) {
                 Ok(()) => {}
                 Err(err) if err.is_full() => {
                     // This indicates that our buffered channel already has
@@ -187,74 +218,5 @@ async fn poll_incoming_events(
         }
     }?;
 
-    Ok(solutions.latest_solution())
-}
-
-struct BatchIds<'a> {
-    contract: &'a dyn StableXContractAsync,
-    current_batch: u32,
-    block_batch_ids: HashMap<H256, u32>,
-}
-
-enum Batch {
-    Past,
-    Current,
-}
-
-impl<'a> BatchIds<'a> {
-    fn new(contract: &'a dyn StableXContractAsync, current_batch: u32) -> Self {
-        BatchIds {
-            contract,
-            current_batch,
-            block_batch_ids: HashMap::new(),
-        }
-    }
-
-    async fn block_batch(&mut self, block_hash: H256) -> Result<Batch> {
-        use std::cmp::Ordering::*;
-
-        let event_batch_id = match self.block_batch_ids.get(&block_hash) {
-            Some(&id) => id,
-            None => {
-                let id = self.contract.batch_id_at_block(block_hash.into()).await?;
-                self.block_batch_ids.insert(block_hash, id);
-                id
-            }
-        };
-
-        match event_batch_id.cmp(&self.current_batch) {
-            Less => Ok(Batch::Past),
-            Equal => Ok(Batch::Current),
-            Greater => Err(anyhow!("orderbook retrieval took more than a full batch")),
-        }
-    }
-}
-
-#[derive(Default)]
-struct SolutionAccumulator {
-    solutions: HashMap<H256, SolutionData>,
-    blocks: Vec<H256>,
-}
-
-impl SolutionAccumulator {
-    fn add_trade(&mut self, block_hash: H256, trade: Trade) {
-        self.solutions.entry(block_hash).or_default().1.push(trade)
-    }
-
-    fn add_solution_submission(&mut self, block_hash: H256, solution: SolutionSubmission) {
-        self.solutions.entry(block_hash).or_default().0 = solution;
-        self.blocks.push(block_hash);
-    }
-
-    fn remove_solution_submission(&mut self, block_hash: H256) {
-        self.solutions.remove(&block_hash);
-        if let Some(index) = self.blocks.iter().position(|&b| b == block_hash) {
-            self.blocks.remove(index);
-        }
-    }
-
-    fn latest_solution(mut self) -> Option<SolutionData> {
-        let latest = self.blocks.pop()?;
-        self.solutions.remove(&latest)
-    }
+    Ok(())
 }


### PR DESCRIPTION
This PR starts implementing a reliable orderbook retrieval mechanism where it concurrently:
- scans for the last block in the solving batch and uses it to query the orderbook.
- listens for incoming events (in case of reorgs or the orderbook is being fetched optimistically assuming that no meaningful changes to the orderbook will happen) and signals along a channel to the orderbook querying thread to restart in case a meaningful change to the orderbook was detected.

This PR assumes the existence of an unimplemented `StableXContractAsync` trait that abstracts the contract and EVM interactions required for this implementation.

It has been modified from the original PR to no longer track solution submissions (in order to "unapply" trades) by ensuring that the orderbook gets queried at the latest on the last block of the current batch, making it impossible for solutions have been submitted.

This would solve #684 

Note that the current paginated orderbook collection abstraction fit in perfectly and didn't require any changes, which is super awesome!

### Test Plan

Unit tests to be implemented in order to validate the event and querying logic. If this works, put it on staging early in the week to see if it performs well or not. We can use Graphana metrics to measure if by starting the system scheduler a littler earlier, which is now safe since a change to the orderbook would be detected and cause the orderbook retrieval to restart, the solvers would have additional time to produce solutions.