### PR TITLE
New benign error for not accepted solution due to fetching the orderbook after a solution has been applied

### DIFF
--- a/driver/src/solution_submission/mod.rs
+++ b/driver/src/solution_submission/mod.rs
@@ -78,6 +78,9 @@ impl From<Error> for SolutionSubmissionError {
                         "SafeMath: subtraction overflow" => {
                             Some(SolutionSubmissionError::Benign(reason.clone()))
                         }
+                        "Amount exceeds user\'s balance." => {
+                            Some(SolutionSubmissionError::Benign(reason.clone()))
+                        }
                         _ => None,
                     }
                 }

--- a/driver/src/solution_submission/mod.rs
+++ b/driver/src/solution_submission/mod.rs
@@ -78,6 +78,7 @@ impl From<Error> for SolutionSubmissionError {
                         "SafeMath: subtraction overflow" => {
                             Some(SolutionSubmissionError::Benign(reason.clone()))
                         }
+                        // TODO: Should only be a benign error until https://github.com/gnosis/dex-services/issues/684 is solved
                         "Amount exceeds user\'s balance." => {
                             Some(SolutionSubmissionError::Benign(reason.clone()))
                         }


### PR DESCRIPTION
This PR is controversial.

Since we don't have a solution for this issue: https://github.com/gnosis/dex-services/issues/684 until we get the event-based order book fetching and it keeps popping up in our alerts, this PR will silence the notifications for this error.

The obvious risk is that this PR silences other errors with the same error message as well.