### PR TITLE
Add pricegraph directory to the docker image build

### DIFF
--- a/docker/rust/Dockerfile
+++ b/docker/rust/Dockerfile
@@ -20,6 +20,7 @@ ONBUILD RUN apt-get update \
 ONBUILD COPY dex-contracts/build ./dex-contracts/build
 ONBUILD COPY driver ./driver
 ONBUILD COPY e2e ./e2e
+ONBUILD COPY pricegraph ./pricegraph
 
 ONBUILD COPY Cargo.* ./
 ONBUILD RUN cargo build


### PR DESCRIPTION
The `pricegraph` crate and directory are now part of the workspace but were not getting copied to the docker build image. This PR addresses that.