### PR TITLE
Retrieve orderbook on last block of solving batch.

### DIFF
--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -174,10 +174,14 @@ impl StableXContract for StableXContractImpl {
                 .ok_or_else(|| anyhow!("block {:?} is missing", block_number))
         };
 
-        let mut block_number = None;
         let mut current_block = get_block(BlockNumber::Latest)?;
-        while (batch_id as u64) < current_block.timestamp.as_u64() / BATCH_DURATION {
-            let previous_block_number = current_block.number.ok_or_else(|| anyhow!(""))? - 1;
+        let mut block_number = None;
+        while (batch_id as u64) < current_block.timestamp.as_u64() / BATCH_DURATION
+            && current_block.number != Some(0.into())
+        {
+            let previous_block_number = current_block.number.ok_or_else(|| {
+                anyhow!("block {:?} has a missing block number", current_block.hash)
+            })? - 1;
             current_block = get_block(previous_block_number.into())?;
             block_number = Some(previous_block_number.as_u64());
         }

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -173,7 +173,7 @@ impl StableXContract for StableXContractImpl {
                 .ok_or_else(|| anyhow!("block {:?} is missing", block_number))
         };
 
-        let mut current_block = get_block(BlockNumber::Latest)?;
+        let mut current_block = get_block(BlockNumber::Pending)?;
         let mut block_number = None;
         while batch_id < get_block_batch_id(&current_block) {
             if current_block.number == Some(0.into()) {

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -209,7 +209,7 @@ impl StableXContract for StableXContractImpl {
             previous_page_user_offset,
             U256::from(page_size),
         );
-        orders_builder.block = block_number.or(Some(BlockNumber::Pending));
+        orders_builder.block = block_number;
         orders_builder.m.tx.gas = None;
         orders_builder.call().wait().map_err(From::from)
     }

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -146,7 +146,7 @@ impl StableXContract for StableXContractImpl {
                 .ok_or_else(|| anyhow!("block {:?} is missing", block_number))
         };
 
-        let mut current_block = get_block(BlockNumber::Pending)?;
+        let mut current_block = get_block(BlockNumber::Latest)?;
         let mut block_number = None;
         while batch_id < get_block_batch_id(&current_block) {
             if current_block.number == Some(0.into()) {

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -10,7 +10,7 @@ pub use self::shadow_orderbook::ShadowedOrderbookReader;
 use crate::contracts::stablex_contract::StableXContract;
 use crate::models::{AccountState, Order};
 use anyhow::Result;
-use ethcontract::U256;
+use ethcontract::{BlockNumber, U256};
 #[cfg(test)]
 use mockall::automock;
 use std::convert::TryInto;

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -10,7 +10,7 @@ pub use self::shadow_orderbook::ShadowedOrderbookReader;
 use crate::contracts::stablex_contract::StableXContract;
 use crate::models::{AccountState, Order};
 use anyhow::Result;
-use ethcontract::U256;
+use ethcontract::{BlockNumber, U256};
 #[cfg(test)]
 use mockall::automock;
 use std::convert::TryInto;
@@ -54,7 +54,7 @@ impl StableXOrderBookReading for PaginatedStableXOrderBookReader {
                     .previous_page_user_offset
                     .try_into()
                     .expect("user cannot have more than u16::MAX orders"),
-                None,
+                Some(BlockNumber::Pending),
             )?;
             reader.apply_page(page);
         }

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -10,7 +10,7 @@ pub use self::shadow_orderbook::ShadowedOrderbookReader;
 use crate::contracts::stablex_contract::StableXContract;
 use crate::models::{AccountState, Order};
 use anyhow::Result;
-use ethcontract::{BlockNumber, U256};
+use ethcontract::U256;
 #[cfg(test)]
 use mockall::automock;
 use std::convert::TryInto;
@@ -54,6 +54,7 @@ impl StableXOrderBookReading for PaginatedStableXOrderBookReader {
                     .previous_page_user_offset
                     .try_into()
                     .expect("user cannot have more than u16::MAX orders"),
+                None,
             )?;
             reader.apply_page(page);
         }


### PR DESCRIPTION
This PR introduces code to search for the last block of the solving batch and retrieve the orderbook on that batch. This makes so the open solver and EVM-scheduler solvers that start later than system time solvers don't potentially retrieve an invalid orderbook that contains solution trades.

### Test Plan

CI and let it run in staging for a bit to see what happens. We have tried this before, but ran into issues where we were not able to query state at a specific block. The theory is that the load balancer was connecting different requests to different nodes that had not yet seen the block.

If we run into this, we can try enforcing a keep-alive policy to ensure that these queries get done to the same node.