### PR TITLE
[getOpenOrderbook 1] Split PaginatedAuctionDataReader

### DIFF
--- a/driver/src/orderbook/auction_data_reader.rs
+++ b/driver/src/orderbook/auction_data_reader.rs
@@ -95,7 +95,7 @@ impl AuctionDataReader {
         packed_auction_bytes
             .chunks(AUCTION_ELEMENT_WIDTH)
             .map(|chunk| {
-                let mut result = auction_element_from_chunk(chunk);
+                let mut result = auction_element_from_slice(chunk);
                 let order_counter = self
                     .user_order_counts
                     .entry(result.order.account_id)
@@ -158,7 +158,7 @@ impl PaginatedAuctionDataReader {
             return;
         }
 
-        let previous_page_user = auction_element_from_chunk(
+        let previous_page_user = auction_element_from_slice(
             &packed_auction_bytes
                 [packed_auction_bytes.len() - AUCTION_ELEMENT_WIDTH..packed_auction_bytes.len()],
         )
@@ -183,7 +183,7 @@ impl PaginatedAuctionDataReader {
     }
 }
 
-fn auction_element_from_chunk(chunk: &[u8]) -> StableXAuctionElement {
+fn auction_element_from_slice(chunk: &[u8]) -> StableXAuctionElement {
     let mut chunk_array = [0u8; AUCTION_ELEMENT_WIDTH];
     chunk_array.copy_from_slice(chunk);
     StableXAuctionElement::from_bytes(&chunk_array)

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -2,14 +2,14 @@ use crate::contracts::stablex_contract::StableXContract;
 use crate::models::{AccountState, Order};
 
 use anyhow::Result;
+use auction_data_reader::PaginatedAuctionDataReader;
 use ethcontract::U256;
 #[cfg(test)]
 use mockall::automock;
-use paginated_auction_data_reader::PaginatedAuctionDataReader;
 use std::convert::TryInto;
 
+mod auction_data_reader;
 mod filtered_orderbook;
-mod paginated_auction_data_reader;
 pub use filtered_orderbook::{FilteredOrderbookReader, OrderbookFilter};
 
 #[cfg_attr(test, automock)]
@@ -41,25 +41,18 @@ impl<'a> PaginatedStableXOrderBookReader<'a> {
 
 impl<'a> StableXOrderBookReading for PaginatedStableXOrderBookReader<'a> {
     fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
-        let mut reader = PaginatedAuctionDataReader::new(index);
-        loop {
-            let number_of_orders: u16 = reader
-                .apply_page(
-                    &self.contract.get_auction_data_paginated(
-                        self.page_size,
-                        reader.pagination().previous_page_user,
-                        reader
-                            .pagination()
-                            .previous_page_user_offset
-                            .try_into()
-                            .expect("user cannot have more than u16::MAX orders"),
-                    )?,
-                )
-                .try_into()
-                .expect("number of orders per page should never overflow a u16");
-            if number_of_orders < self.page_size {
-                return Ok(reader.get_auction_data());
-            }
+        let mut reader = PaginatedAuctionDataReader::new(index, self.page_size as usize);
+        while let Some(pagination) = reader.pagination() {
+            let page = &self.contract.get_auction_data_paginated(
+                self.page_size,
+                pagination.previous_page_user,
+                pagination
+                    .previous_page_user_offset
+                    .try_into()
+                    .expect("user cannot have more than u16::MAX orders"),
+            )?;
+            reader.apply_page(page);
         }
+        Ok(reader.get_auction_data())
     }
 }

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -42,11 +42,11 @@ impl<'a> PaginatedStableXOrderBookReader<'a> {
 impl<'a> StableXOrderBookReading for PaginatedStableXOrderBookReader<'a> {
     fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
         let mut reader = PaginatedAuctionDataReader::new(index, self.page_size as usize);
-        while let Some(pagination) = reader.pagination() {
+        while let Some(page_info) = reader.next_page() {
             let page = &self.contract.get_auction_data_paginated(
                 self.page_size,
-                pagination.previous_page_user,
-                pagination
+                page_info.previous_page_user,
+                page_info
                     .previous_page_user_offset
                     .try_into()
                     .expect("user cannot have more than u16::MAX orders"),


### PR DESCRIPTION
We are using the `PaginatedAuctionDataReader` abstraction to process pages that we fetch via `getEncodedOrdersPaginated`. I would like to reuse that abstraction for the open orderbook fetching which filters valid orders on-chain.

The pagination logic for this way of fetching is done differently (also on-chain). This PR therefore splits the functionality of PaginatedAuctionDataReader into two parts

1) AuctionDataReader which just applies pages and knows nothing about pagination
2) PaginatedAuctionDataReader which uses 1) for page application and on top of that keeps track of page info

This way we will be able to reuse component 1) in the next PR

I slightly changed the semantics of the component in so far as that instead of returning the elements inside the unfiltered page (which would not be available in the open orderbook fetching) we know make the pagination field optional. None will indicate that there is no next page.

### Test Plan

Adjusted unit tests and made sure they are still passing.