### PR TITLE
[Shadow Orderbook] Orderbook reading implementation

### DIFF
--- a/driver/src/orderbook/shadow_orderbook.rs
+++ b/driver/src/orderbook/shadow_orderbook.rs
@@ -12,6 +12,7 @@ use crate::models::{AccountState, Order, TokenId};
 use anyhow::Result;
 use ethcontract::{Address, U256};
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::thread::{self, JoinHandle};
 
@@ -90,10 +91,9 @@ fn background_shadow_reader(
     reader: &dyn StableXOrderBookReading,
     channel: Receiver<(u32, Orderbook)>,
 ) {
-    while let Ok((batch_id, orderbook)) = channel.recv() {
-        let diff = match Diff::compare_to_reader(&orderbook, reader, batch_id) {
-            Ok(diff) if diff.is_empty() => continue,
-            Ok(diff) => diff,
+    while let Ok((batch_id, primary_orderbook)) = channel.recv() {
+        let shadow_orderbook = match reader.get_auction_data(batch_id.into()) {
+            Ok(orderbook) => orderbook,
             Err(err) => {
                 log::error!(
                     "encountered an error reading the orderbook with the shadow reader: {:?}",
@@ -103,42 +103,14 @@ fn background_shadow_reader(
             }
         };
 
-        let Diff(balance_changes, order_changes) = diff;
-        for balance_change in balance_changes {
-            log::error!(
-                "user {:?} token {} primary balance of {} different than shadow {}",
-                balance_change.user,
-                balance_change.token.0,
-                balance_change.primary,
-                balance_change.shadow,
-            );
-        }
-        for order_change in order_changes {
-            match order_change {
-                OrderChange::Added(order) => log::error!(
-                    "user {:?} order {} in primary but missing from shadow",
-                    order.account_id,
-                    order.id,
-                ),
-                OrderChange::Removed(order) => log::error!(
-                    "user {:?} order {} missing from primary but in shadow",
-                    order.account_id,
-                    order.id,
-                ),
-                OrderChange::Modified {
-                    user,
-                    id,
-                    primary,
-                    shadow,
-                } => {
-                    log::error!(
-                        "user {:?} order {} with primary values {:?} but shadow values {:?}",
-                        user,
-                        id,
-                        primary,
-                        shadow,
-                    );
-                }
+        let diff = Diff::compare(&primary_orderbook, &shadow_orderbook);
+        if !diff.is_empty() {
+            let Diff(balance_changes, order_changes) = diff;
+            for balance_change in balance_changes {
+                log::error!("{}", balance_change);
+            }
+            for order_change in order_changes {
+                log::error!("{}", order_change);
             }
         }
     }
@@ -215,6 +187,16 @@ impl BalanceChange {
     }
 }
 
+impl fmt::Display for BalanceChange {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "user {:?} token {} primary balance of {} but shadow balance {}",
+            self.user, self.token.0, self.primary, self.shadow,
+        )
+    }
+}
+
 /// Represents a change in order data between a primary and shadow orderbook.
 #[derive(Debug, PartialEq)]
 enum OrderChange {
@@ -272,6 +254,33 @@ impl OrderChange {
         match self {
             OrderChange::Added(order) | OrderChange::Removed(order) => (order.account_id, order.id),
             OrderChange::Modified { user, id, .. } => (*user, *id),
+        }
+    }
+}
+
+impl fmt::Display for OrderChange {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            OrderChange::Added(order) => write!(
+                f,
+                "user {:?} order {} in primary but missing from shadow",
+                order.account_id, order.id,
+            ),
+            OrderChange::Removed(order) => write!(
+                f,
+                "user {:?} order {} missing from primary but in shadow",
+                order.account_id, order.id,
+            ),
+            OrderChange::Modified {
+                user,
+                id,
+                primary,
+                shadow,
+            } => write!(
+                f,
+                "user {:?} order {} with primary values {:?} but shadow values {:?}",
+                user, id, primary, shadow,
+            ),
         }
     }
 }

--- a/driver/src/orderbook/shadow_orderbook.rs
+++ b/driver/src/orderbook/shadow_orderbook.rs
@@ -10,11 +10,139 @@
 use super::StableXOrderBookReading;
 use crate::models::{AccountState, Order, TokenId};
 use anyhow::Result;
-use ethcontract::Address;
+use ethcontract::{Address, U256};
 use std::collections::{HashMap, HashSet};
+use std::sync::mpsc::{self, Receiver, SyncSender};
+use std::thread::{self, JoinHandle};
 
 /// A type definition representing a complete orderbook.
 type Orderbook = (AccountState, Vec<Order>);
+
+/// A shadowed orderbook reader where two orderbook reading implementations
+/// compare results.
+pub struct ShadowedOrderbookReader<'a> {
+    primary: &'a dyn StableXOrderBookReading,
+    shadow_thread: JoinHandle<()>,
+    shadow_channel: SyncSender<(u32, Orderbook)>,
+}
+
+impl<'a> ShadowedOrderbookReader<'a> {
+    /// Create a new instance of a shadowed orderbook reader that starts a
+    /// background thread
+    pub fn new(
+        primary: &'a dyn StableXOrderBookReading,
+        shadow: Box<dyn StableXOrderBookReading + Send + 'static>,
+    ) -> Self {
+        // NOTE: Create a bounded channel with a 0-sized buffer, this makes it
+        //   if the primary orderbook is read and the shadow is still reading,
+        //   the diff for that specific orderbook is skipped.
+        let (shadow_channel_tx, shadow_channel_rx) = mpsc::sync_channel(0);
+        let shadow_thread =
+            thread::spawn(move || background_shadow_reader(&*shadow, shadow_channel_rx));
+
+        ShadowedOrderbookReader {
+            primary,
+            shadow_thread,
+            shadow_channel: shadow_channel_tx,
+        }
+    }
+
+    /// Eplicitely stop the shadowed orderbook reader returning an error if the
+    /// inner shadow reader thread panicked.
+    ///
+    /// Note this method does not need to be called as the shadow thread will
+    /// automatically get cleaned up once the reader is dropped.
+    pub fn stop(self) -> thread::Result<()> {
+        let Self {
+            shadow_thread,
+            shadow_channel,
+            ..
+        } = self;
+
+        drop(shadow_channel);
+        shadow_thread.join()?;
+
+        Ok(())
+    }
+}
+
+impl<'a> StableXOrderBookReading for ShadowedOrderbookReader<'a> {
+    fn get_auction_data(&self, batch_id: U256) -> Result<Orderbook> {
+        let orderbook = self.primary.get_auction_data(batch_id)?;
+
+        // NOTE: Ignore errors here as they indicate that the shadow reader is
+        //   already reading an orderbook.
+        let _ = self
+            .shadow_channel
+            .try_send((batch_id.low_u32(), orderbook.clone()));
+
+        Ok(orderbook)
+    }
+}
+
+/// Background shadow thread that receives orders from the order channel,
+/// queries the exact same account state with the shadow reader, and then
+/// compares its results the ones from the primary reader.
+///
+/// Exits once the channel has been closed indicating that the shadow
+/// thread should exit.
+fn background_shadow_reader(
+    reader: &dyn StableXOrderBookReading,
+    channel: Receiver<(u32, Orderbook)>,
+) {
+    while let Ok((batch_id, orderbook)) = channel.recv() {
+        let diff = match Diff::compare_to_reader(&orderbook, reader, batch_id) {
+            Ok(diff) if diff.is_empty() => continue,
+            Ok(diff) => diff,
+            Err(err) => {
+                log::error!(
+                    "encountered an error reading the orderbook with the shadow reader: {:?}",
+                    err
+                );
+                continue;
+            }
+        };
+
+        let Diff(balance_changes, order_changes) = diff;
+        for balance_change in balance_changes {
+            log::error!(
+                "user {:?} token {} primary balance of {} different than shadow {}",
+                balance_change.user,
+                balance_change.token.0,
+                balance_change.primary,
+                balance_change.shadow,
+            );
+        }
+        for order_change in order_changes {
+            match order_change {
+                OrderChange::Added(order) => log::error!(
+                    "user {:?} order {} in primary but missing from shadow",
+                    order.account_id,
+                    order.id,
+                ),
+                OrderChange::Removed(order) => log::error!(
+                    "user {:?} order {} missing from primary but in shadow",
+                    order.account_id,
+                    order.id,
+                ),
+                OrderChange::Modified {
+                    user,
+                    id,
+                    primary,
+                    shadow,
+                } => {
+                    log::error!(
+                        "user {:?} order {} with primary values {:?} but shadow values {:?}",
+                        user,
+                        id,
+                        primary,
+                        shadow,
+                    );
+                }
+            }
+        }
+    }
+}
 
 /// A struct representing a diffs in two queried orderbooks.
 #[derive(Debug, PartialEq)]

--- a/driver/src/orderbook/shadow_orderbook.rs
+++ b/driver/src/orderbook/shadow_orderbook.rs
@@ -47,7 +47,7 @@ impl<'a> ShadowedOrderbookReader<'a> {
         }
     }
 
-    /// Eplicitely stop the shadowed orderbook reader returning an error if the
+    /// Explicitely stop the shadowed orderbook reader returning an error if the
     /// inner shadow reader thread panicked.
     ///
     /// Note this method does not need to be called as the shadow thread will


### PR DESCRIPTION
This PR implements `StableXOrderbookReading` for the "shadow" orderbook which works by sending a clone of the orderbook computed by the primary orderbook reader to a background thread that reads the orderbook at the same batch with the shadow orderbook and then comparing the two orderbooks and producing a reduced diff that is logged to the error console (for slack events :rotating_light:).

Note that this implementation is not yet integrated with the rest of the driver.

### Test Plan

 Not sure what the best way to test the threading code is... The diffing of orderbooks is already tested :smile: 