### PR TITLE
[Shadow Orderbook] Integrate the shadowed orderbook with the driver

### DIFF
--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -26,6 +26,7 @@ lazy_static! {
 include!(concat!(env!("OUT_DIR"), "/batch_exchange.rs"));
 include!(concat!(env!("OUT_DIR"), "/batch_exchange_viewer.rs"));
 
+#[derive(Clone)]
 pub struct StableXContractImpl {
     instance: BatchExchange,
     viewer: BatchExchangeViewer,

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -12,6 +12,7 @@ use ethcontract::U256;
 #[cfg(test)]
 use mockall::automock;
 use std::convert::TryInto;
+use std::sync::Arc;
 
 #[cfg_attr(test, automock)]
 pub trait StableXOrderBookReading {
@@ -27,14 +28,14 @@ pub trait StableXOrderBookReading {
 /// contract in a paginated way.
 /// This avoid hitting gas limits when the total amount of orders is large.
 pub struct PaginatedStableXOrderBookReader {
-    contract: Box<dyn StableXContract + Send + Sync>,
+    contract: Arc<dyn StableXContract + Send + Sync>,
     page_size: u16,
 }
 
 impl PaginatedStableXOrderBookReader {
-    pub fn new(contract: impl StableXContract + Send + Sync + 'static, page_size: u16) -> Self {
+    pub fn new(contract: Arc<dyn StableXContract + Send + Sync>, page_size: u16) -> Self {
         Self {
-            contract: Box::new(contract),
+            contract,
             page_size,
         }
     }

--- a/driver/src/orderbook/shadow_orderbook.rs
+++ b/driver/src/orderbook/shadow_orderbook.rs
@@ -5,8 +5,6 @@
 //! This is useful for validating alternate account retrieval methods during
 //! development.
 
-#![allow(dead_code)]
-
 use super::StableXOrderBookReading;
 use crate::models::{AccountState, Order, TokenId};
 use anyhow::Result;
@@ -23,7 +21,7 @@ type Orderbook = (AccountState, Vec<Order>);
 /// compare results.
 pub struct ShadowedOrderbookReader<'a> {
     primary: &'a (dyn StableXOrderBookReading + Sync),
-    shadow_thread: JoinHandle<()>,
+    _shadow_thread: JoinHandle<()>,
     shadow_channel: SyncSender<(u32, Orderbook)>,
 }
 
@@ -43,27 +41,9 @@ impl<'a> ShadowedOrderbookReader<'a> {
 
         ShadowedOrderbookReader {
             primary,
-            shadow_thread,
+            _shadow_thread: shadow_thread,
             shadow_channel: shadow_channel_tx,
         }
-    }
-
-    /// Explicitely stop the shadowed orderbook reader returning an error if the
-    /// inner shadow reader thread panicked.
-    ///
-    /// Note this method does not need to be called as the shadow thread will
-    /// automatically get cleaned up once the reader is dropped.
-    pub fn stop(self) -> thread::Result<()> {
-        let Self {
-            shadow_thread,
-            shadow_channel,
-            ..
-        } = self;
-
-        drop(shadow_channel);
-        shadow_thread.join()?;
-
-        Ok(())
     }
 }
 

--- a/driver/src/orderbook/shadow_orderbook.rs
+++ b/driver/src/orderbook/shadow_orderbook.rs
@@ -48,7 +48,7 @@ impl<'a> ShadowedOrderbookReader<'a> {
         }
     }
 
-    /// Eplicitely stop the shadowed orderbook reader returning an error if the
+    /// Explicitely stop the shadowed orderbook reader returning an error if the
     /// inner shadow reader thread panicked.
     ///
     /// Note this method does not need to be called as the shadow thread will


### PR DESCRIPTION
This PR makes the driver actually use the shadow orderbook. This means that for each batch, the orderbook will be queried twice and compared to one another.

This PR also changes the paginated orderbook to take ownership of its contract instance. This was to simplify the code around the lifetimes of the shadowed orderbook which must live in its own thread.

I had originally planed to use `crossbeam` scoped threads but that required the scope to be created in the `main` method which complicated things a bit and leaked some of the implementation details out of the shadowed orderbook.

### Test Plan

CI - this will make sure (at least on Rinkeby) that the orderbook being retrieved is the same at the beginning of the batch as it is in the middle of the batch. If this runs in staging it will also check this for mainnet. While, right now, this is not true in general (#684) it will be a useful test to see if #736 indeed fixes #684 once it is implemented.