### PR TITLE
[getOpenOrderbook 2] Use onchain filter to fetch orders

### DIFF
--- a/driver/src/contracts/stablex_auction_element.rs
+++ b/driver/src/contracts/stablex_auction_element.rs
@@ -27,7 +27,9 @@ impl StableXAuctionElement {
     /// serialized information.
     pub fn from_bytes(bytes: &[u8; AUCTION_ELEMENT_WIDTH]) -> Self {
         let mut indexed_bytes = [0u8; INDEXED_AUCTION_ELEMENT_WIDTH];
-        indexed_bytes.copy_from_slice(bytes);
+        for (index, bit) in bytes.iter().enumerate() {
+            indexed_bytes[index] = *bit;
+        }
         Self::from_indexed_bytes(&indexed_bytes)
     }
 

--- a/driver/src/contracts/stablex_auction_element.rs
+++ b/driver/src/contracts/stablex_auction_element.rs
@@ -159,6 +159,38 @@ pub mod tests {
     }
 
     #[test]
+    fn test_index_auction_element() {
+        let bytes: [u8; 114] = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, // user: 20 elements
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 3, // sellTokenBalance: 3, 32 elements
+            1, 2, // buyToken: 256+2,
+            1, 1, // sellToken: 256+1,
+            0, 0, 0, 2, // validFrom: 2
+            0, 0, 1, 5, // validUntil: 256+5
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, // priceNumerator: 258
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3, // priceDenominator: 259
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, // remainingAmount: 2**8 + 1 = 257
+            0, 1, // order index
+        ];
+        let res = StableXAuctionElement::from_indexed_bytes(&bytes);
+        let auction_element = StableXAuctionElement {
+            valid_from: U256::from(2),
+            valid_until: U256::from(261),
+            sell_token_balance: 3,
+            order: Order {
+                id: 1,
+                account_id: Address::from_low_u64_be(1),
+                buy_token: 258,
+                sell_token: 257,
+                buy_amount: (258 * 257 + 258) / 259,
+                sell_amount: 257,
+            },
+        };
+        assert_eq!(res, auction_element);
+    }
+
+    #[test]
     #[should_panic]
     fn test_from_bytes_fails_on_hopefully_null() {
         StableXAuctionElement::from_bytes(&[1u8; 112]);

--- a/driver/src/contracts/stablex_auction_element.rs
+++ b/driver/src/contracts/stablex_auction_element.rs
@@ -55,7 +55,7 @@ impl StableXAuctionElement {
         let numerator = BigEndian::read_u128(&bytes[64..80]);
         let denominator = BigEndian::read_u128(&bytes[80..96]);
         let remaining = BigEndian::read_u128(&bytes[96..112]);
-        let id = u16::from_le_bytes([bytes[112], bytes[113]]);
+        let id = u16::from_le_bytes([bytes[113], bytes[112]]);
         let (buy_amount, sell_amount) = compute_buy_sell_amounts(numerator, denominator, remaining);
         StableXAuctionElement {
             valid_from,

--- a/driver/src/contracts/stablex_auction_element.rs
+++ b/driver/src/contracts/stablex_auction_element.rs
@@ -5,7 +5,7 @@ use ethcontract::{Address, U256};
 use crate::util::CeiledDiv;
 
 pub const AUCTION_ELEMENT_WIDTH: usize = 112;
-// Indexed auction elements have the orderId appened at the end
+/// Indexed auction elements have the orderId appended at the end
 pub const INDEXED_AUCTION_ELEMENT_WIDTH: usize = AUCTION_ELEMENT_WIDTH + 2;
 
 #[derive(Debug, PartialEq)]

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -135,7 +135,8 @@ impl StableXContract for StableXContractImpl {
     ) -> Result<FilteredAuctionData> {
         let target_batch = batch_index.low_u32();
         let mut builder = self.viewer.get_filtered_orders_paginated(
-            [target_batch, target_batch, target_batch],
+            // Balances should be valid for the batch at which we are submitting (target batch + 1)
+            [target_batch, target_batch, target_batch + 1],
             vec![],
             previous_page_user,
             previous_page_user_offset,

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -57,6 +57,13 @@ impl StableXContractImpl {
     }
 }
 
+pub struct FilteredAuctionData {
+    pub indexed_elements: Vec<u8>,
+    pub has_next_page: bool,
+    pub next_page_user: Address,
+    pub next_page_user_offset: u16,
+}
+
 #[cfg_attr(test, automock)]
 pub trait StableXContract {
     /// Retrieve the current batch ID that is accepting orders. Note that this
@@ -65,6 +72,16 @@ pub trait StableXContract {
 
     /// Retrieve the time remaining in the batch.
     fn get_current_auction_remaining_time(&self) -> Result<Duration>;
+
+    /// Retrieve one page of indexed auction data that is filtered on chain
+    /// to only include orders valid at the given batchId.
+    fn get_filtered_auction_data_paginated(
+        &self,
+        batch_index: U256,
+        page_size: u16,
+        previous_page_user: Address,
+        previous_page_user_offset: u16,
+    ) -> Result<FilteredAuctionData>;
 
     /// Retrieve one page of auction data.
     /// `block` is needed because the state of the smart contract could change
@@ -107,6 +124,38 @@ impl StableXContract for StableXContractImpl {
             .call()
             .wait()?;
         Ok(Duration::from_secs(remaining_seconds.as_u64()))
+    }
+
+    fn get_filtered_auction_data_paginated(
+        &self,
+        batch_index: U256,
+        page_size: u16,
+        previous_page_user: Address,
+        previous_page_user_offset: u16,
+    ) -> Result<FilteredAuctionData> {
+        let target_batch = batch_index.low_u32();
+        let mut builder = self.viewer.get_filtered_orders_paginated(
+            [target_batch, target_batch, target_batch],
+            vec![],
+            previous_page_user,
+            previous_page_user_offset,
+            page_size,
+        );
+        builder.m.tx.gas = None;
+        builder
+            .call()
+            .wait()
+            .map(
+                |(indexed_elements, has_next_page, next_page_user, next_page_user_offset)| {
+                    FilteredAuctionData {
+                        indexed_elements,
+                        has_next_page,
+                        next_page_user,
+                        next_page_user_offset,
+                    }
+                },
+            )
+            .map_err(From::from)
     }
 
     fn get_auction_data_paginated(

--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -78,6 +78,7 @@ pub trait StableXContract {
     fn get_filtered_auction_data_paginated(
         &self,
         batch_index: U256,
+        token_whitelist: Vec<u16>,
         page_size: u16,
         previous_page_user: Address,
         previous_page_user_offset: u16,
@@ -129,6 +130,7 @@ impl StableXContract for StableXContractImpl {
     fn get_filtered_auction_data_paginated(
         &self,
         batch_index: U256,
+        token_whitelist: Vec<u16>,
         page_size: u16,
         previous_page_user: Address,
         previous_page_user_offset: u16,
@@ -137,7 +139,7 @@ impl StableXContract for StableXContractImpl {
         let mut builder = self.viewer.get_filtered_orders_paginated(
             // Balances should be valid for the batch at which we are submitting (target batch + 1)
             [target_batch, target_batch, target_batch + 1],
-            vec![],
+            token_whitelist,
             previous_page_user,
             previous_page_user_offset,
             page_size,

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -24,8 +24,8 @@ use crate::gas_station::GnosisSafeGasStation;
 use crate::http::HttpFactory;
 use crate::metrics::{HttpMetrics, MetricsServer, StableXMetrics};
 use crate::orderbook::{
-    FilteredOrderbookReader, OrderbookFilter, PaginatedStableXOrderBookReader,
-    ShadowedOrderbookReader, StableXOrderBookReading,
+    FilteredOrderbookReader, OnchainFilteredOrderBookReader, OrderbookFilter,
+    PaginatedStableXOrderBookReader, ShadowedOrderbookReader, StableXOrderBookReading,
 };
 use crate::price_estimation::{PriceOracle, TokenData};
 use crate::price_finding::{Fee, SolverType};
@@ -221,7 +221,7 @@ fn main() {
         .use_shadowed_orderbook
     {
         let shadow_orderbook =
-            PaginatedStableXOrderBookReader::new(contract.clone(), options.auction_data_page_size);
+            OnchainFilteredOrderBookReader::new(contract.clone(), options.auction_data_page_size);
         let shadowed_orderbook = ShadowedOrderbookReader::new(&primary_orderbook, shadow_orderbook);
         Box::new(shadowed_orderbook)
     } else {

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -220,8 +220,11 @@ fn main() {
     let unfiltered_orderbook: Box<dyn StableXOrderBookReading + Sync> = if options
         .use_shadowed_orderbook
     {
-        let shadow_orderbook =
-            OnchainFilteredOrderBookReader::new(contract.clone(), options.auction_data_page_size);
+        let shadow_orderbook = OnchainFilteredOrderBookReader::new(
+            contract.clone(),
+            options.auction_data_page_size,
+            &options.orderbook_filter,
+        );
         let shadowed_orderbook = ShadowedOrderbookReader::new(&primary_orderbook, shadow_orderbook);
         Box::new(shadowed_orderbook)
     } else {

--- a/driver/src/orderbook/filtered_orderbook.rs
+++ b/driver/src/orderbook/filtered_orderbook.rs
@@ -31,6 +31,15 @@ pub struct OrderbookFilter {
     users: HashMap<Address, UserOrderFilter>,
 }
 
+impl OrderbookFilter {
+    pub fn whitelist(&self) -> Option<&HashSet<u16>> {
+        match &self.tokens {
+            TokenFilter::Whitelist(whitelist) => Some(whitelist),
+            TokenFilter::Blacklist(_) => None,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 enum UserOrderFilter {
     All,

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -1,9 +1,11 @@
 mod auction_data_reader;
 mod filtered_orderbook;
+mod onchain_filtered_orderbook;
 mod shadow_orderbook;
 
 use self::auction_data_reader::PaginatedAuctionDataReader;
 pub use self::filtered_orderbook::{FilteredOrderbookReader, OrderbookFilter};
+pub use self::onchain_filtered_orderbook::OnchainFilteredOrderBookReader;
 pub use self::shadow_orderbook::ShadowedOrderbookReader;
 use crate::contracts::stablex_contract::StableXContract;
 use crate::models::{AccountState, Order};

--- a/driver/src/orderbook/onchain_filtered_orderbook.rs
+++ b/driver/src/orderbook/onchain_filtered_orderbook.rs
@@ -1,4 +1,4 @@
-use crate::contracts::stablex_contract::{FilteredAuctionData, StableXContract};
+use crate::contracts::stablex_contract::{FilteredOrderPage, StableXContract};
 use crate::models::{AccountState, Order};
 
 use super::auction_data_reader::IndexedAuctionDataReader;
@@ -25,7 +25,7 @@ impl OnchainFilteredOrderBookReader {
 impl StableXOrderBookReading for OnchainFilteredOrderBookReader {
     fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
         let mut reader = IndexedAuctionDataReader::new(index);
-        let mut auction_data = FilteredAuctionData {
+        let mut auction_data = FilteredOrderPage {
             indexed_elements: vec![],
             has_next_page: true,
             next_page_user: Address::zero(),

--- a/driver/src/orderbook/onchain_filtered_orderbook.rs
+++ b/driver/src/orderbook/onchain_filtered_orderbook.rs
@@ -27,7 +27,7 @@ impl OnchainFilteredOrderBookReader {
             filter: filter
                 .whitelist()
                 .map(|set| set.iter().cloned().collect())
-                .unwrap_or(vec![]),
+                .unwrap_or_else(|| vec![]),
         }
     }
 }
@@ -51,7 +51,7 @@ impl StableXOrderBookReading for OnchainFilteredOrderBookReader {
             )?;
             reader.apply_page(&auction_data.indexed_elements);
         }
-        return Ok(reader.get_auction_data());
+        Ok(reader.get_auction_data())
     }
 }
 

--- a/driver/src/orderbook/onchain_filtered_orderbook.rs
+++ b/driver/src/orderbook/onchain_filtered_orderbook.rs
@@ -54,3 +54,169 @@ impl StableXOrderBookReading for OnchainFilteredOrderBookReader {
         return Ok(reader.get_auction_data());
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contracts::stablex_contract::MockStableXContract;
+    use mockall::Sequence;
+
+    const FIRST_ORDER: &[u8] = &[
+        // order 1
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, // user: 20 elements
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 4, // sellTokenBalance: 4, 32 elements
+        1, 2, // buyToken: 256+2,
+        1, 1, // sellToken: 256+1, 56
+        0, 0, 0, 2, // validFrom: 2
+        0, 0, 1, 5, // validUntil: 256+5 64
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, // priceNumerator: 258
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3, // priceDenominator: 259
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, // remainingAmount: 2**8 + 1 = 257
+        0, 0, // order index
+    ];
+    const SECOND_ORDER: &[u8] = &[
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, // user:
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 5, // sellTokenBalance: 5
+        1, 1, // buyToken: 256+1
+        1, 2, // sellToken: 256+2
+        0, 0, 0, 2, // validFrom: 2
+        0, 0, 1, 5, // validUntil: 256+5
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, // priceNumerator: 258;
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3, // priceDenominator: 259
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, // remainingAmount: 2**8 = 256
+        0, 1, // order index
+    ];
+
+    #[test]
+    fn test_no_data() {
+        let mut contract = MockStableXContract::new();
+
+        contract
+            .expect_get_filtered_auction_data_paginated()
+            .times(1)
+            .returning(|_, _, _, _, _| {
+                Ok(FilteredOrderPage {
+                    indexed_elements: vec![],
+                    has_next_page: false,
+                    next_page_user: Address::zero(),
+                    next_page_user_offset: 1,
+                })
+            });
+
+        let reader = OnchainFilteredOrderBookReader::new(
+            Arc::new(contract),
+            10,
+            &OrderbookFilter::default(),
+        );
+        assert_eq!(
+            reader.get_auction_data(U256::from(42)).unwrap(),
+            (AccountState::default(), vec![])
+        )
+    }
+
+    #[test]
+    fn test_single_page() {
+        let mut contract = MockStableXContract::new();
+
+        contract
+            .expect_get_filtered_auction_data_paginated()
+            .times(1)
+            .returning(|_, _, _, _, _| {
+                Ok(FilteredOrderPage {
+                    indexed_elements: FIRST_ORDER.to_vec(),
+                    has_next_page: false,
+                    next_page_user: Address::from_low_u64_be(1),
+                    next_page_user_offset: 0,
+                })
+            });
+
+        let reader = OnchainFilteredOrderBookReader::new(
+            Arc::new(contract),
+            10,
+            &OrderbookFilter::default(),
+        );
+
+        let mut state = AccountState::default();
+        state.increase_balance(Address::from_low_u64_be(1), 257, 4);
+        let order = Order {
+            id: 0,
+            account_id: Address::from_low_u64_be(1),
+            buy_token: 258,
+            sell_token: 257,
+            buy_amount: 257,
+            sell_amount: 257,
+        };
+
+        assert_eq!(
+            reader.get_auction_data(U256::from(42)).unwrap(),
+            (state, vec![order])
+        )
+    }
+
+    #[test]
+    fn test_two_pages() {
+        let mut contract = MockStableXContract::new();
+        let mut seq = Sequence::new();
+
+        contract
+            .expect_get_filtered_auction_data_paginated()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_, _, _, _, _| {
+                Ok(FilteredOrderPage {
+                    indexed_elements: FIRST_ORDER.to_vec(),
+                    has_next_page: true,
+                    next_page_user: Address::from_low_u64_be(1),
+                    next_page_user_offset: 0,
+                })
+            });
+
+        contract
+            .expect_get_filtered_auction_data_paginated()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_, _, _, _, _| {
+                Ok(FilteredOrderPage {
+                    indexed_elements: SECOND_ORDER.to_vec(),
+                    has_next_page: false,
+                    next_page_user: Address::from_low_u64_be(1),
+                    next_page_user_offset: 1,
+                })
+            });
+
+        let reader = OnchainFilteredOrderBookReader::new(
+            Arc::new(contract),
+            10,
+            &OrderbookFilter::default(),
+        );
+
+        let mut state = AccountState::default();
+        state.increase_balance(Address::from_low_u64_be(1), 257, 4);
+        state.increase_balance(Address::from_low_u64_be(1), 258, 5);
+        let orders = vec![
+            Order {
+                id: 0,
+                account_id: Address::from_low_u64_be(1),
+                buy_token: 258,
+                sell_token: 257,
+                buy_amount: 257,
+                sell_amount: 257,
+            },
+            Order {
+                id: 1,
+                account_id: Address::from_low_u64_be(1),
+                buy_token: 257,
+                sell_token: 258,
+                buy_amount: 256,
+                sell_amount: 256,
+            },
+        ];
+
+        assert_eq!(
+            reader.get_auction_data(U256::from(42)).unwrap(),
+            (state, orders)
+        )
+    }
+}

--- a/driver/src/orderbook/onchain_filtered_orderbook.rs
+++ b/driver/src/orderbook/onchain_filtered_orderbook.rs
@@ -1,0 +1,45 @@
+use crate::contracts::stablex_contract::{FilteredAuctionData, StableXContract};
+use crate::models::{AccountState, Order};
+
+use super::auction_data_reader::IndexedAuctionDataReader;
+use super::StableXOrderBookReading;
+
+use anyhow::Result;
+use ethcontract::{Address, U256};
+use std::sync::Arc;
+
+pub struct OnchainFilteredOrderBookReader {
+    contract: Arc<dyn StableXContract + Send + Sync>,
+    page_size: u16,
+}
+
+impl OnchainFilteredOrderBookReader {
+    pub fn new(contract: Arc<dyn StableXContract + Send + Sync>, page_size: u16) -> Self {
+        Self {
+            contract,
+            page_size,
+        }
+    }
+}
+
+impl StableXOrderBookReading for OnchainFilteredOrderBookReader {
+    fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
+        let mut reader = IndexedAuctionDataReader::new(index);
+        let mut auction_data = FilteredAuctionData {
+            indexed_elements: vec![],
+            has_next_page: true,
+            next_page_user: Address::zero(),
+            next_page_user_offset: 0,
+        };
+        while auction_data.has_next_page {
+            auction_data = self.contract.get_filtered_auction_data_paginated(
+                index,
+                self.page_size,
+                auction_data.next_page_user,
+                auction_data.next_page_user_offset,
+            )?;
+            reader.apply_page(&auction_data.indexed_elements);
+        }
+        return Ok(reader.get_auction_data());
+    }
+}

--- a/driver/src/orderbook/onchain_filtered_orderbook.rs
+++ b/driver/src/orderbook/onchain_filtered_orderbook.rs
@@ -2,6 +2,7 @@ use crate::contracts::stablex_contract::{FilteredOrderPage, StableXContract};
 use crate::models::{AccountState, Order};
 
 use super::auction_data_reader::IndexedAuctionDataReader;
+use super::filtered_orderbook::OrderbookFilter;
 use super::StableXOrderBookReading;
 
 use anyhow::Result;
@@ -11,13 +12,22 @@ use std::sync::Arc;
 pub struct OnchainFilteredOrderBookReader {
     contract: Arc<dyn StableXContract + Send + Sync>,
     page_size: u16,
+    filter: Vec<u16>,
 }
 
 impl OnchainFilteredOrderBookReader {
-    pub fn new(contract: Arc<dyn StableXContract + Send + Sync>, page_size: u16) -> Self {
+    pub fn new(
+        contract: Arc<dyn StableXContract + Send + Sync>,
+        page_size: u16,
+        filter: &OrderbookFilter,
+    ) -> Self {
         Self {
             contract,
             page_size,
+            filter: filter
+                .whitelist()
+                .map(|set| set.iter().cloned().collect())
+                .unwrap_or(vec![]),
         }
     }
 }
@@ -34,6 +44,7 @@ impl StableXOrderBookReading for OnchainFilteredOrderBookReader {
         while auction_data.has_next_page {
             auction_data = self.contract.get_filtered_auction_data_paginated(
                 index,
+                self.filter.clone(),
                 self.page_size,
                 auction_data.next_page_user,
                 auction_data.next_page_user_offset,


### PR DESCRIPTION
Draft to get some early feedback. Still missing unit tests and proper wiring (not sure if I should make it configurable of if we want to get rid of the existing Orderbook reader, which is probably safer).

This PR introduces a new Reader implementation that uses the BatchExchangeViewer and in particular its methods that filter order on0chain (instead of on the client). The main benefit is that this methods allows to query balance for a future batch (e.g. the one that starts in the next block) and will thus allow us to fetch the orderbook from the last block of the previous batch rather than on the first block of the batch we are actually trying to solve

### Test Plan

Will add a unit test to the AuctionDataReader. Also running this locally and making sure that at least number of orders/users/tokens are correct. Would probably be cool to already use this in combination with the Diff tool and see that it runs smooth locally.