### PR TITLE
[event based orderbook] Handle orderbook creation from State with regards to batch id better

### DIFF
--- a/driver/src/orderbook/streamed/block_timestamp_reading.rs
+++ b/driver/src/orderbook/streamed/block_timestamp_reading.rs
@@ -1,0 +1,56 @@
+use crate::contracts::Web3;
+use anyhow::{Context as _, Result};
+use ethcontract::{web3::types::BlockId, H256};
+use futures::{compat::Future01CompatExt as _, future::BoxFuture, FutureExt as _};
+
+/// Helper trait to make this functionality mockable for tests.
+pub trait BlockTimestampReading {
+    fn block_timestamp(&mut self, block_hash: H256) -> BoxFuture<Result<u64>>;
+}
+
+/// During normal operation this is implemented by Web3.
+impl BlockTimestampReading for Web3 {
+    fn block_timestamp(&mut self, block_hash: H256) -> BoxFuture<Result<u64>> {
+        async move {
+            let block = self.eth().block(BlockId::Hash(block_hash)).compat().await;
+            let block = block
+                .with_context(|| format!("failed to get block {}", block_hash))?
+                .with_context(|| format!("block {} does not exist", block_hash))?;
+            Ok(block.timestamp.low_u64())
+        }
+        .boxed()
+    }
+}
+
+/// A cache for the block timestamp which avoids having to query the node in the case where we
+/// receive multiple events from the same block in a row.
+#[derive(Debug)]
+pub struct MemoizingBlockTimestampReader<T> {
+    inner: T,
+    hash: H256,
+    timestamp: u64,
+}
+
+impl<T> MemoizingBlockTimestampReader<T> {
+    pub fn new(inner: T) -> Self {
+        Self {
+            inner,
+            hash: H256::zero(),
+            timestamp: 0,
+        }
+    }
+}
+
+impl<T: BlockTimestampReading + Send> BlockTimestampReading for MemoizingBlockTimestampReader<T> {
+    fn block_timestamp(&mut self, block_hash: H256) -> BoxFuture<Result<u64>> {
+        async move {
+            if self.hash != block_hash {
+                let timestamp = self.inner.block_timestamp(block_hash).await?;
+                self.hash = block_hash;
+                self.timestamp = timestamp;
+            }
+            Ok(self.timestamp)
+        }
+        .boxed()
+    }
+}

--- a/driver/src/orderbook/streamed/mod.rs
+++ b/driver/src/orderbook/streamed/mod.rs
@@ -1,8 +1,11 @@
 #![allow(dead_code)]
 
 mod balance;
+mod block_timestamp_reading;
 mod order;
+mod orderbook;
 mod state;
+mod updating_orderbook;
 
 use ethcontract::Address;
 use ethcontract::U256;
@@ -12,3 +15,6 @@ type TokenAddress = Address;
 type OrderId = u16;
 type TokenId = u16;
 type BatchId = u32;
+
+pub use block_timestamp_reading::BlockTimestampReading;
+pub use updating_orderbook::UpdatingOrderbook as Orderbook;

--- a/driver/src/orderbook/streamed/orderbook.rs
+++ b/driver/src/orderbook/streamed/orderbook.rs
@@ -1,0 +1,80 @@
+use super::*;
+use crate::{
+    contracts::stablex_contract::batch_exchange,
+    models::{AccountState, Order},
+    orderbook::StableXOrderBookReading,
+};
+use anyhow::Result;
+use ethcontract::{contract::EventData, H256, U256};
+use state::{Batch, State};
+use std::collections::BTreeMap;
+
+// Ethereum events (logs) can be both created and removed. Removals happen if the chain reorganizes
+// and ends up not including block that was previously thought to be part of the chain.
+// However, the orderbook state (`State`) cannot remove events. To support this, we keep an ordered
+// list of all events based on which the state is built.
+
+#[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct EventSortKey {
+    block_number: u64,
+    /// Is included to differentiate events from the same block number but different blocks which
+    /// can happen during reorgs.
+    block_hash: H256,
+    log_index: usize,
+}
+
+#[derive(Debug)]
+struct Value {
+    event: batch_exchange::Event,
+    /// The batch id is calculated based on the timestamp of the block.
+    batch_id: BatchId,
+}
+
+#[derive(Debug, Default)]
+pub struct Orderbook {
+    events: BTreeMap<EventSortKey, Value>,
+}
+
+impl Orderbook {
+    pub fn handle_event_data(
+        &mut self,
+        event_data: EventData<batch_exchange::Event>,
+        block_number: u64,
+        log_index: usize,
+        block_hash: H256,
+        block_timestamp: u64,
+    ) {
+        let batch_id = block_timestamp as BatchId / 300;
+        let key = EventSortKey {
+            block_number,
+            block_hash,
+            log_index,
+        };
+        match event_data {
+            EventData::Added(event) => self.events.insert(key, Value { event, batch_id }),
+            EventData::Removed(_event) => self.events.remove(&key),
+        };
+    }
+
+    fn create_state(&self) -> Result<State> {
+        self.events
+            .iter()
+            .try_fold(State::default(), |state, (_key, value)| {
+                state.apply_event(&value.event, value.batch_id)
+            })
+    }
+}
+
+impl StableXOrderBookReading for Orderbook {
+    fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
+        // TODO: Handle future batch ids for when we want to do optimistic solving.
+        let state = self.create_state()?;
+        let (account_state, orders) = state.orderbook_for_batch(Batch::Future(index.low_u32()))?;
+        let account_state = account_state
+            // TODO: change AccountState to use U256
+            .map(|(key, value)| (key, value.low_u128()))
+            .collect();
+        let orders = orders.collect();
+        Ok((AccountState(account_state), orders))
+    }
+}

--- a/driver/src/orderbook/streamed/state.rs
+++ b/driver/src/orderbook/streamed/state.rs
@@ -59,7 +59,7 @@ impl State {
         let batch_id = match batch {
             Batch::Current => self.last_batch_id,
             Batch::Future(batch_id) => {
-                // We allow the bach ids being equal to prevent race conditions where the State gets
+                // We allow the batch ids being equal to prevent race conditions where the State gets
                 // a new event right before we want to get the orderbook.
                 ensure!(self.last_batch_id <= batch_id, "batch is in the past");
                 // TODO: in the future we might want to handle the case where
@@ -712,7 +712,6 @@ mod tests {
             .unwrap()
             .1;
         assert_eq!(balance, U256::zero());
-        assert!(state.orderbook_for_batch(Batch::Future(0)).is_err());
         let balance = state
             .orderbook_for_batch(Batch::Future(1))
             .unwrap()
@@ -767,9 +766,6 @@ mod tests {
             .collect::<HashMap<_, _>>();
         assert_eq!(balance.get(&(address(2), 0)), Some(&10.into()));
         assert_eq!(balance.get(&(address(2), 1)), Some(&10.into()));
-
-        // Error because the solution is not complete.
-        assert!(state.orderbook_for_batch(Batch::Future(2)).is_err());
 
         let event = SolutionSubmission {
             submitter: address(4),

--- a/driver/src/orderbook/streamed/state.rs
+++ b/driver/src/orderbook/streamed/state.rs
@@ -23,6 +23,18 @@ pub struct State {
     balances: HashMap<(UserId, TokenAddress), Balance>,
     tokens: Tokens,
     last_solution: LastSolution,
+    /// True when we have received some trades or trade reverts but not yet the final solution
+    /// submission that indiciates all trades have been received.
+    solution_partially_received: bool,
+    last_batch_id: BatchId,
+}
+
+#[derive(Debug)]
+pub enum Batch {
+    /// The current completed batch that can no longer change
+    Current,
+    /// A future potentially still changing batch if a new solution comes in
+    Future(BatchId),
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -33,8 +45,31 @@ struct LastSolution {
 }
 
 impl State {
-    /// Can be used to create a `crate::models::AccountState`.
-    pub fn account_state(
+    /// Errors if State has only received a partial solution which would make the result
+    /// inconsistent.
+    /// Errors if the batch is `Future` but is not actually in the future.
+    /// Account balances that overflow a U256 are skipped.
+    pub fn orderbook(
+        &self,
+        batch: Batch,
+    ) -> Result<(
+        impl Iterator<Item = ((UserId, TokenId), U256)> + '_,
+        impl Iterator<Item = ModelOrder> + '_,
+    )> {
+        let batch_id = match batch {
+            Batch::Current => self.last_batch_id,
+            Batch::Future(batch_id) => {
+                ensure!(self.last_batch_id < batch_id, "batch is not in the future");
+                // This only needs to be ensured for future batches because the current batch cannot
+                // be inconsistent as it does not incorporate pending trades.
+                ensure!(!self.solution_partially_received, "partial solution");
+                batch_id
+            }
+        };
+        Ok((self.account_state(batch_id), self.orders(batch_id)))
+    }
+
+    fn account_state(
         &self,
         batch_id: BatchId,
     ) -> impl Iterator<Item = ((UserId, TokenId), U256)> + '_ {
@@ -46,17 +81,16 @@ impl State {
                 let token_id = self.tokens.get_id_by_address(*token_address)?;
                 Some((
                     (*user_id, token_id),
-                    // TODO: Remove unwrap.
                     // Can fail if user's balance exceeds U256::max.
                     // Can fail while not all trades of a solution have been received and batch_id
                     // is the next batch_id so that we assume that the current solution won't be be
                     // reverted.
-                    balance.get_balance(batch_id).unwrap(),
+                    balance.get_balance(batch_id).ok()?,
                 ))
             })
     }
 
-    pub fn orders(&self, batch_id: BatchId) -> impl Iterator<Item = ModelOrder> + '_ {
+    fn orders(&self, batch_id: BatchId) -> impl Iterator<Item = ModelOrder> + '_ {
         self.orders
             .iter()
             .filter(move |(_, order)| order.is_valid_in_batch(batch_id))
@@ -79,6 +113,8 @@ impl State {
     /// `block_batch_id` is the current batch based on the timestamp of the block that contains the
     ///  event.
     pub fn apply_event(mut self, event: &Event, block_batch_id: BatchId) -> Result<Self> {
+        ensure!(self.last_batch_id <= block_batch_id, "event in the past");
+        self.last_batch_id = block_batch_id;
         match event {
             Event::Deposit(event) => self.deposit(event, block_batch_id)?,
             Event::WithdrawRequest(event) => self.withdraw_request(event, block_batch_id)?,
@@ -198,6 +234,8 @@ impl State {
         sell_balance_fn: impl FnOnce(&mut Balance) -> Result<()>,
         buy_balance_fn: impl FnOnce(&mut Balance) -> Result<()>,
     ) -> Result<()> {
+        self.solution_partially_received = true;
+
         let order = self
             .orders
             .get_mut(&(user_id, order_id))
@@ -232,6 +270,7 @@ impl State {
         self.last_solution.batch_id = block_batch_id;
         self.last_solution.user_id = event.submitter;
         self.last_solution.burnt_fees = event.burnt_fees;
+        self.solution_partially_received = false;
         self.balances
             .entry((event.submitter, fee_token))
             .or_default()
@@ -651,5 +690,94 @@ mod tests {
                 .get_used_amount(2),
             2
         );
+    }
+
+    #[test]
+    fn orderbook_batch_id() {
+        let mut state = state_with_fee();
+        let event = Deposit {
+            user: address(3),
+            token: address(0),
+            amount: 1.into(),
+            batch_id: 0,
+        };
+        state = state.apply_event(&Event::Deposit(event), 0).unwrap();
+        let balance = state.orderbook(Batch::Current).unwrap().0.next().unwrap().1;
+        assert_eq!(balance, U256::zero());
+        assert!(state.orderbook(Batch::Future(0)).is_err());
+        let balance = state
+            .orderbook(Batch::Future(1))
+            .unwrap()
+            .0
+            .next()
+            .unwrap()
+            .1;
+        assert_eq!(balance, U256::one());
+    }
+
+    #[test]
+    fn orderbook_partial_solution() {
+        let mut state = state_with_fee();
+        let event = TokenListing {
+            token: address(1),
+            id: 1,
+        };
+        for token in 0..2 {
+            let event = Deposit {
+                user: address(2),
+                token: address(token),
+                amount: 10.into(),
+                batch_id: 0,
+            };
+            state = state.apply_event(&Event::Deposit(event), 0).unwrap();
+        }
+        state = state.apply_event(&Event::TokenListing(event), 0).unwrap();
+        let event = OrderPlacement {
+            owner: address(2),
+            index: 0,
+            buy_token: 0,
+            sell_token: 1,
+            valid_from: 0,
+            valid_until: 10,
+            price_numerator: 5,
+            price_denominator: 5,
+        };
+        state = state.apply_event(&Event::OrderPlacement(event), 0).unwrap();
+        let event = Trade {
+            owner: address(2),
+            order_id: 0,
+            executed_sell_amount: 1,
+            executed_buy_amount: 2,
+            ..Default::default()
+        };
+        state = state.apply_event(&Event::Trade(event), 1).unwrap();
+
+        let balance = state
+            .orderbook(Batch::Current)
+            .unwrap()
+            .0
+            .collect::<HashMap<_, _>>();
+        assert_eq!(balance.get(&(address(2), 0)), Some(&10.into()));
+        assert_eq!(balance.get(&(address(2), 1)), Some(&10.into()));
+
+        // Error because the solution is not complete.
+        assert!(state.orderbook(Batch::Future(2)).is_err());
+
+        let event = SolutionSubmission {
+            submitter: address(4),
+            burnt_fees: 42.into(),
+            ..Default::default()
+        };
+        state = state
+            .apply_event(&Event::SolutionSubmission(event), 1)
+            .unwrap();
+
+        let balance = state
+            .orderbook(Batch::Future(2))
+            .unwrap()
+            .0
+            .collect::<HashMap<_, _>>();
+        assert_eq!(balance.get(&(address(2), 0)), Some(&12.into()));
+        assert_eq!(balance.get(&(address(2), 1)), Some(&9.into()));
     }
 }

--- a/driver/src/orderbook/streamed/state.rs
+++ b/driver/src/orderbook/streamed/state.rs
@@ -62,9 +62,9 @@ impl State {
                 // We allow the bach ids being equal to prevent race conditions where the State gets
                 // a new event right before we want to get the orderbook.
                 ensure!(self.last_batch_id <= batch_id, "batch is in the past");
-                // This only needs to be ensured for future batches because the current batch cannot
-                // be inconsistent as it does not incorporate pending trades.
-                ensure!(!self.solution_partially_received, "partial solution");
+                // TODO: in the future we might want to handle the case where
+                // solution_partially_received is true and react in some way like erroring or
+                // excluding pending balances.
                 batch_id
             }
         };

--- a/driver/src/orderbook/streamed/state.rs
+++ b/driver/src/orderbook/streamed/state.rs
@@ -59,7 +59,9 @@ impl State {
         let batch_id = match batch {
             Batch::Current => self.last_batch_id,
             Batch::Future(batch_id) => {
-                ensure!(self.last_batch_id < batch_id, "batch is not in the future");
+                // We allow the bach ids being equal to prevent race conditions where the State gets
+                // a new event right before we want to get the orderbook.
+                ensure!(self.last_batch_id <= batch_id, "batch is in the past");
                 // This only needs to be ensured for future batches because the current batch cannot
                 // be inconsistent as it does not incorporate pending trades.
                 ensure!(!self.solution_partially_received, "partial solution");

--- a/driver/src/orderbook/streamed/updating_orderbook.rs
+++ b/driver/src/orderbook/streamed/updating_orderbook.rs
@@ -1,0 +1,157 @@
+use super::*;
+use crate::{
+    contracts::stablex_contract::{batch_exchange, StableXContract},
+    models::{AccountState, Order},
+    orderbook::StableXOrderBookReading,
+};
+use anyhow::{anyhow, bail, ensure, Result};
+use block_timestamp_reading::{BlockTimestampReading, MemoizingBlockTimestampReader};
+use ethcontract::{contract::Event, errors::ExecutionError};
+use futures::{
+    channel::oneshot,
+    future::FutureExt,
+    pin_mut, select_biased,
+    stream::{Stream, StreamExt as _},
+};
+use orderbook::Orderbook;
+use std::future::Future;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
+
+/// An event based orderbook that automatically updates itself with new events from the contract.
+#[derive(Debug)]
+pub struct UpdatingOrderbook {
+    orderbook: Arc<Mutex<Orderbook>>,
+    // Indicates whether the background thread has caught up with past events at which point the
+    // orderbook is ready to be read.
+    orderbook_ready: Arc<AtomicBool>,
+    // When this struct is dropped this sender will be dropped which makes the updater thread stop.
+    _exit_tx: oneshot::Sender<()>,
+}
+
+impl UpdatingOrderbook {
+    pub fn new(
+        _contract: &impl StableXContract,
+        block_timestamp_reader: impl BlockTimestampReading + Send + 'static,
+    ) -> Self {
+        let orderbook = Arc::new(Mutex::new(Orderbook::default()));
+        let orderbook_clone = orderbook.clone();
+        let orderbook_ready = Arc::new(AtomicBool::new(false));
+        let orderbook_ready_clone = orderbook_ready.clone();
+        let (exit_tx, exit_rx) = oneshot::channel();
+        // Create stream first to make sure we do not miss any events between it and past events.
+        // TODO: use the real functions once they are implemented
+        let stream = futures::stream::iter(vec![]).boxed(); // contract.stream_events();
+        let past_events = futures::future::ready(Ok(Vec::new())).boxed(); // contract.past_events();
+
+        std::thread::spawn(move || {
+            let result = futures::executor::block_on(update_with_events_forever(
+                orderbook_clone,
+                orderbook_ready_clone,
+                MemoizingBlockTimestampReader::new(block_timestamp_reader),
+                exit_rx,
+                past_events,
+                stream,
+            ));
+            if let Err(err) = result {
+                log::error!("event based orderbook failed: {}", err);
+                // TODO: implement a retry mechanism
+                // For now we crash the program so force a restart of the whole driver because
+                // without a retry we would be stuck with an outdated orderbook forever.
+                std::process::abort();
+            }
+        });
+
+        Self {
+            orderbook,
+            orderbook_ready,
+            _exit_tx: exit_tx,
+        }
+    }
+}
+
+impl StableXOrderBookReading for UpdatingOrderbook {
+    fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
+        ensure!(
+            self.orderbook_ready.load(Ordering::SeqCst),
+            "orderbook not yet ready"
+        );
+        self.orderbook
+            .lock()
+            .map_err(|err| anyhow!("poison error: {}", err))?
+            .get_auction_data(index)
+    }
+}
+
+/// Update the orderbook with events from the stream forever or until exit_indicator is dropped.
+///
+/// Returns Ok when exit_indicator is dropped.
+/// Returns Err if the stream ends.
+async fn update_with_events_forever(
+    orderbook: Arc<Mutex<Orderbook>>,
+    orderbook_ready: Arc<AtomicBool>,
+    mut block_timestamp_reader: impl BlockTimestampReading,
+    exit_indicator: oneshot::Receiver<()>,
+    past_events: impl Future<Output = Result<Vec<Event<batch_exchange::Event>>, ExecutionError>>,
+    stream: impl Stream<Item = Result<Event<batch_exchange::Event>, ExecutionError>>,
+) -> Result<()> {
+    // `select!` requires the futures to be fused...
+    let exit_indicator = exit_indicator.fuse();
+    let past_events = past_events.fuse();
+    let stream = stream.fuse();
+    // ...and pinned.
+    pin_mut!(exit_indicator);
+    pin_mut!(past_events);
+    pin_mut!(stream);
+
+    loop {
+        // We select over everything together instead of for example the past events first then the
+        // stream to ensure that the stream gets polled at least once which it needs in order to
+        // create the corresponding filter on the node.
+        select_biased! {
+            _ = exit_indicator => return Ok(()),
+            event = stream.next() => {
+                let event = event.ok_or(anyhow!("stream ended"))??;
+                handle_event(&orderbook, &mut block_timestamp_reader, event).await?;
+            },
+            past_events = past_events => {
+                for event in past_events? {
+                    handle_event(&orderbook, &mut block_timestamp_reader, event).await?;
+                }
+                orderbook_ready.store(true, Ordering::SeqCst);
+            },
+        };
+    }
+}
+
+/// Apply a single event to the orderbook.
+async fn handle_event(
+    orderbook: &Mutex<Orderbook>,
+    block_timestamp_reader: &mut impl BlockTimestampReading,
+    event: Event<batch_exchange::Event>,
+) -> Result<()> {
+    match event {
+        Event {
+            data,
+            meta: Some(meta),
+        } => {
+            let block_timestamp = block_timestamp_reader
+                .block_timestamp(meta.block_hash)
+                .await?;
+            orderbook
+                .lock()
+                .map_err(|e| anyhow!("poison error: {}", e))?
+                .handle_event_data(
+                    data,
+                    meta.block_number,
+                    meta.log_index,
+                    meta.block_hash,
+                    block_timestamp,
+                );
+            Ok(())
+        }
+        Event { meta: None, .. } => bail!("event without metadata"),
+    }
+}


### PR DESCRIPTION
fixes #754

This prevents attempting to create the orderbook with a past batch with
is nonsensical as State does not actually support.
This prevents reading the orderbook for a future batch if that
orderbook would be inconsistent due to a partially applied solution.

I notice that the tests feels needlessly long. In the future I want to refactor the tests into more helper functions and macros to make them smaller and easier to read.