### PR TITLE
[Easy] Ignore balances for orders that we filter out

### DIFF
--- a/driver/src/orderbook/shadow_orderbook.rs
+++ b/driver/src/orderbook/shadow_orderbook.rs
@@ -92,6 +92,8 @@ fn background_shadow_reader(
             for order_change in order_changes {
                 log::error!("{}", order_change);
             }
+        } else {
+            log::info!("Primary and shadow orderbook are consistent");
         }
     }
 }


### PR DESCRIPTION
When testing the shadow orderbook locally I'm getting a lot of difference of the form:

> ERRO [driver::orderbook::shadow_orderbook] user 0xaec3c8ed9516a206a4fd47ec77f026edd533cf17 token 4 primary balance of 1061889845 but shadow balance 0

Reason for this is that the onchain filtering orderbook does not serialize balances for sell tokens for which there are no valid orders, whereas the current implementation of AuctionDataReader takes all balances into account (regardless of whether they are filtered later).

The fix is simply to filter auction elements before serializing their balance.

I also added a print statement for us to know when a consistency check was successful.

### Test Plan

Adjusted unit test, running the shadowed orderbook and seeing them being consistent.