### PR TITLE
Simple solution for the new parameter min-avg-fee-per-order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
         - cargo clippy --all --all-targets -- -D warnings
         - cargo fmt --all -- --check
         # Build and publish compact image with compiled binary
-        - docker build --tag stablex-binary-public --build-arg SOLVER_BASE=gnosispm/dex-open-solver:v0.0.5 --build-arg RUST_BASE=rust-binary -f docker/rust/Dockerfile .
+        - docker build --tag stablex-binary-public --build-arg SOLVER_BASE=gnosispm/dex-open-solver:v0.0.6 --build-arg RUST_BASE=rust-binary -f docker/rust/Dockerfile .
         # StableX e2e Tests (Ganache) - open solver
         - docker-compose -f docker-compose.yml -f docker-compose.open-solver.yml  up -d stablex
         - cargo test -p e2e ganache -- --nocapture

--- a/README.md
+++ b/README.md
@@ -197,6 +197,9 @@ OPTIONS:
         --solver-time-limit <solver-time-limit>
             The offset from the start of the batch to cap the solver's execution time [env: SOLVER_TIME_LIMIT=]
             [default: 210]
+        --min-avg-fee-per-order <min-avg-fee-per-order>
+            Solver parameter: The minimum avg fee per order that allows the solver to run economically viable.
+            [default: 0]
         --solver-type <solver-type>
             Which style of solver to use. Can be one of: 'NAIVE' for the naive solver; 'MIP' for mixed integer
             programming solver; 'NLP' for non-linear programming solver [env: SOLVER_TYPE=]  [default: naive-solver]

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -150,6 +150,11 @@ struct Options {
     )]
     solver_time_limit: Duration,
 
+    /// Solver parameter: minimal average fee per order
+    /// Its unit is [OWL]
+    #[structopt(long, env = "MIN_AVG_FEE_PER_ORDER", default_value = "0")]
+    min_avg_fee_per_order: u128,
+
     /// The kind of scheduler to use.
     #[structopt(long, env = "SCHEDULER", default_value = "system")]
     scheduler: SchedulerKind,
@@ -209,7 +214,12 @@ fn main() {
 
     // Set up solver.
     let fee = Some(Fee::default());
-    let price_finder = price_finding::create_price_finder(fee, options.solver_type, price_oracle);
+    let price_finder = price_finding::create_price_finder(
+        fee,
+        options.solver_type,
+        price_oracle,
+        options.min_avg_fee_per_order,
+    );
 
     // Create the orderbook reader.
     let primary_orderbook =

--- a/driver/src/price_finding/mod.rs
+++ b/driver/src/price_finding/mod.rs
@@ -12,12 +12,18 @@ pub fn create_price_finder(
     fee: Option<Fee>,
     solver_type: SolverType,
     price_oracle: impl PriceEstimating + Sync + 'static,
+    min_avg_fee_per_order: u128,
 ) -> Box<dyn PriceFinding + Sync> {
     if solver_type == SolverType::NaiveSolver {
         info!("Using naive price finder");
         Box::new(NaiveSolver::new(fee))
     } else {
         info!("Using {:?} optimization price finder", solver_type);
-        Box::new(OptimisationPriceFinder::new(fee, solver_type, price_oracle))
+        Box::new(OptimisationPriceFinder::new(
+            fee,
+            solver_type,
+            price_oracle,
+            min_avg_fee_per_order,
+        ))
     }
 }

--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -52,14 +52,17 @@ impl SolverType {
         result_folder: &str,
         input_file: &str,
         time_limit: String,
+        min_avg_fee_per_order: u128,
     ) -> Result<Output> {
         match self {
-            SolverType::OpenSolver => execute_open_solver(result_folder, input_file),
+            SolverType::OpenSolver => {
+                execute_open_solver(result_folder, input_file, min_avg_fee_per_order)
+            }
             SolverType::StandardSolver => {
-                execute_private_solver(result_folder, input_file, time_limit)
+                execute_private_solver(result_folder, input_file, time_limit, min_avg_fee_per_order)
             }
             SolverType::FallbackSolver => {
-                execute_private_solver(result_folder, input_file, time_limit)
+                execute_private_solver(result_folder, input_file, time_limit, min_avg_fee_per_order)
             }
             SolverType::NaiveSolver => {
                 panic!("fn execute should not be called by the naive solver")
@@ -68,7 +71,11 @@ impl SolverType {
     }
 }
 
-pub fn execute_open_solver(result_folder: &str, input_file: &str) -> Result<Output> {
+pub fn execute_open_solver(
+    result_folder: &str,
+    input_file: &str,
+    min_avg_fee_per_order: u128,
+) -> Result<Output> {
     let mut command = Command::new("python");
     let open_solver_command = command
         .current_dir("/app/open_solver")
@@ -80,6 +87,7 @@ pub fn execute_open_solver(result_folder: &str, input_file: &str) -> Result<Outp
             result_folder.to_owned(),
             "06_solution_int_valid.json",
         ))
+        .arg(format!("--min-avg-fee-per-order={}", min_avg_fee_per_order))
         .arg(String::from("best-token-pair"));
     debug!("Using open-solver command `{:?}`", open_solver_command);
     Ok(open_solver_command.output()?)
@@ -89,6 +97,7 @@ pub fn execute_private_solver(
     result_folder: &str,
     input_file: &str,
     time_limit: String,
+    min_avg_fee_per_order: u128,
 ) -> Result<Output> {
     let mut command = Command::new("python");
     let private_solver_command = command
@@ -97,6 +106,7 @@ pub fn execute_private_solver(
         .arg(format!("{}{}", "/app/", input_file.to_owned()))
         .arg(format!("--outputDir={}{}", "/app/", result_folder))
         .args(&["--solverTimeLimit", &time_limit])
+        .arg(format!("--minAvgFeePerOrder={}", min_avg_fee_per_order))
         .arg(String::from("--useExternalPrices"));
     debug!(
         "Using private-solver command `{:?}`",


### PR DESCRIPTION
Replaces the "solver_config" solution from here:
https://github.com/gnosis/dex-services/pull/762

Just reads the single parameter MIN_AVG_FEE_PER_ORDER and stores it in the OptimisationFinder struct, in parallel to the solver_type


---
testplan: e2e tests