### PR TITLE
Use event based orderbook as primary orderbook

### DIFF
--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -230,6 +230,7 @@ fn main() {
         contract.clone(),
         options.auction_data_page_size,
         &options.orderbook_filter,
+        web3,
     );
 
     // NOTE: Keep the shadowed orderbook around so it doesn't get dropped and we

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -9,9 +9,11 @@ pub use self::filtered_orderbook::{FilteredOrderbookReader, OrderbookFilter};
 pub use self::onchain_filtered_orderbook::OnchainFilteredOrderBookReader;
 pub use self::paginated_orderbook::PaginatedStableXOrderBookReader;
 pub use self::shadow_orderbook::ShadowedOrderbookReader;
+pub use self::streamed::Orderbook as EventBasedOrderbook;
 
 use crate::contracts::stablex_contract::StableXContractImpl;
 use crate::models::{AccountState, Order};
+use crate::orderbook::streamed::BlockTimestampReading;
 use anyhow::{anyhow, Error, Result};
 use ethcontract::U256;
 #[cfg(test)]
@@ -34,8 +36,11 @@ pub trait StableXOrderBookReading {
 pub enum OrderbookReaderKind {
     /// An unfiltered paginated orderbook read directly from the EVM
     Paginated,
-    /// A paginated orderbook reader read from and filtered by EVM
+    /// A paginated orderbook read from and filtered by EVM
     OnchainFiltered,
+    /// An orderbook reader that is built from subscribing to
+    /// relevant ethereum events emitted by the exchange contract
+    EventBased,
 }
 
 impl OrderbookReaderKind {
@@ -45,6 +50,7 @@ impl OrderbookReaderKind {
         contract: Arc<StableXContractImpl>,
         auction_data_page_size: u16,
         orderbook_filter: &OrderbookFilter,
+        block_timestamp_reader: impl BlockTimestampReading + Send + 'static,
     ) -> Box<dyn StableXOrderBookReading + Sync> {
         match self {
             OrderbookReaderKind::Paginated => Box::new(PaginatedStableXOrderBookReader::new(
@@ -56,6 +62,10 @@ impl OrderbookReaderKind {
                 auction_data_page_size,
                 orderbook_filter,
             )),
+            OrderbookReaderKind::EventBased => Box::new(EventBasedOrderbook::new(
+                contract.as_ref(),
+                block_timestamp_reader,
+            )),
         }
     }
 }
@@ -66,6 +76,7 @@ impl FromStr for OrderbookReaderKind {
         match value.to_lowercase().as_str() {
             "paginated" => Ok(OrderbookReaderKind::Paginated),
             "onchainfiltered" => Ok(OrderbookReaderKind::OnchainFiltered),
+            "eventbased" => Ok(OrderbookReaderKind::EventBased),
             _ => Err(anyhow!("unknown orderbook reader kind '{}'", value)),
         }
     }

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -1,19 +1,21 @@
 mod auction_data_reader;
 mod filtered_orderbook;
 mod onchain_filtered_orderbook;
+mod paginated_orderbook;
 mod shadow_orderbook;
 
-use self::auction_data_reader::PaginatedAuctionDataReader;
 pub use self::filtered_orderbook::{FilteredOrderbookReader, OrderbookFilter};
 pub use self::onchain_filtered_orderbook::OnchainFilteredOrderBookReader;
+pub use self::paginated_orderbook::PaginatedStableXOrderBookReader;
 pub use self::shadow_orderbook::ShadowedOrderbookReader;
-use crate::contracts::stablex_contract::StableXContract;
+
+use crate::contracts::stablex_contract::StableXContractImpl;
 use crate::models::{AccountState, Order};
-use anyhow::Result;
-use ethcontract::{BlockNumber, U256};
+use anyhow::{anyhow, Error, Result};
+use ethcontract::U256;
 #[cfg(test)]
 use mockall::automock;
-use std::convert::TryInto;
+use std::str::FromStr;
 use std::sync::Arc;
 
 #[cfg_attr(test, automock)]
@@ -26,38 +28,44 @@ pub trait StableXOrderBookReading {
     fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)>;
 }
 
-/// Implements the StableXOrderBookReading trait by using the underlying
-/// contract in a paginated way.
-/// This avoid hitting gas limits when the total amount of orders is large.
-pub struct PaginatedStableXOrderBookReader {
-    contract: Arc<dyn StableXContract + Send + Sync>,
-    page_size: u16,
+/// The different kinds of orderbook readers.
+#[derive(Debug)]
+pub enum OrderbookReaderKind {
+    /// An unfiltered paginated orderbook read directly from the EVM
+    Paginated,
+    /// A paginated orderbook reader read from and filtered by EVM
+    OnchainFiltered,
 }
 
-impl PaginatedStableXOrderBookReader {
-    pub fn new(contract: Arc<dyn StableXContract + Send + Sync>, page_size: u16) -> Self {
-        Self {
-            contract,
-            page_size,
+impl OrderbookReaderKind {
+    /// Creates a new Orderbook reader based on the parameters.
+    pub fn create(
+        &self,
+        contract: Arc<StableXContractImpl>,
+        auction_data_page_size: u16,
+        orderbook_filter: &OrderbookFilter,
+    ) -> Box<dyn StableXOrderBookReading + Sync> {
+        match self {
+            OrderbookReaderKind::Paginated => Box::new(PaginatedStableXOrderBookReader::new(
+                contract,
+                auction_data_page_size,
+            )),
+            OrderbookReaderKind::OnchainFiltered => Box::new(OnchainFilteredOrderBookReader::new(
+                contract,
+                auction_data_page_size,
+                orderbook_filter,
+            )),
         }
     }
 }
 
-impl StableXOrderBookReading for PaginatedStableXOrderBookReader {
-    fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
-        let mut reader = PaginatedAuctionDataReader::new(index, self.page_size as usize);
-        while let Some(page_info) = reader.next_page() {
-            let page = &self.contract.get_auction_data_paginated(
-                self.page_size,
-                page_info.previous_page_user,
-                page_info
-                    .previous_page_user_offset
-                    .try_into()
-                    .expect("user cannot have more than u16::MAX orders"),
-                Some(BlockNumber::Pending),
-            )?;
-            reader.apply_page(page);
+impl FromStr for OrderbookReaderKind {
+    type Err = Error;
+    fn from_str(value: &str) -> Result<Self> {
+        match value.to_lowercase().as_str() {
+            "paginated" => Ok(OrderbookReaderKind::Paginated),
+            "onchainfiltered" => Ok(OrderbookReaderKind::OnchainFiltered),
+            _ => Err(anyhow!("unknown orderbook reader kind '{}'", value)),
         }
-        Ok(reader.get_auction_data())
     }
 }

--- a/driver/src/orderbook/paginated_orderbook.rs
+++ b/driver/src/orderbook/paginated_orderbook.rs
@@ -1,0 +1,45 @@
+use crate::contracts::stablex_contract::StableXContract;
+use crate::models::{AccountState, Order};
+
+use super::auction_data_reader::PaginatedAuctionDataReader;
+use super::StableXOrderBookReading;
+use anyhow::Result;
+use ethcontract::{BlockNumber, U256};
+use std::convert::TryInto;
+use std::sync::Arc;
+
+/// Implements the StableXOrderBookReading trait by using the underlying
+/// contract in a paginated way.
+/// This avoid hitting gas limits when the total amount of orders is large.
+pub struct PaginatedStableXOrderBookReader {
+    contract: Arc<dyn StableXContract + Send + Sync>,
+    page_size: u16,
+}
+
+impl PaginatedStableXOrderBookReader {
+    pub fn new(contract: Arc<dyn StableXContract + Send + Sync>, page_size: u16) -> Self {
+        Self {
+            contract,
+            page_size,
+        }
+    }
+}
+
+impl StableXOrderBookReading for PaginatedStableXOrderBookReader {
+    fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
+        let mut reader = PaginatedAuctionDataReader::new(index, self.page_size as usize);
+        while let Some(page_info) = reader.next_page() {
+            let page = &self.contract.get_auction_data_paginated(
+                self.page_size,
+                page_info.previous_page_user,
+                page_info
+                    .previous_page_user_offset
+                    .try_into()
+                    .expect("user cannot have more than u16::MAX orders"),
+                Some(BlockNumber::Pending),
+            )?;
+            reader.apply_page(page);
+        }
+        Ok(reader.get_auction_data())
+    }
+}


### PR DESCRIPTION
This big exciting new PR takes all the challenging accomplishments from #678 and puts them to work by making the tremendous new Event Based Orderbook our driver's primary orderbook!

In brief, this PR simply set aside the existing primary order book `PaginatedOrderbook` to make room for the cool new `EventOrderbook`. 

Depends on a version bump of ethcontracts!

Test Plan: I would say that end to end tests should give us a pretty good idea of whether or not this is working. Note that acquiring all the past events could eventually become very slow... Not sure how this will affect the e2e testing.
