### PR TITLE
[Easy] fix shadow flag

### DIFF
--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -171,7 +171,12 @@ struct Options {
     /// Use a shadowed orderbook reader along side a primary reader so that the
     /// queried data can be compared and produce log errors in case they
     /// disagree.
-    #[structopt(long, env = "USE_SHADOWED_ORDERBOOK")]
+    #[structopt(
+        long,
+        env = "USE_SHADOWED_ORDERBOOK",
+        default_value = "false",
+        parse(try_from_str)
+    )]
     use_shadowed_orderbook: bool,
 }
 


### PR DESCRIPTION
Our kubernetes setup is configured to set the value of the `USE_SHADOWED_ORDERBOOK` env var to "true" or "false" depending on the solver type we are running.

However, the default behaviour of boolean structops flags is that it evaluates to true, whenever the flag is present (regardless of value): https://docs.rs/structopt/0.3.14/structopt/#type-magic

This PR makes it so that we use a from_str parser to turn "true" into true and "false" into false

### Test Plan

```
export USE_SHADOWED_ORDERBOOK=false
cargo run # see shadowed orderbook is false

export USE_SHADOWED_ORDERBOOK=true
cargo run # see shadowed orderbook is true
```