### PR TITLE
[Easy] Bump ethcontract 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,7 @@ dependencies = [
  "chrono",
  "crossbeam-utils",
  "ethcontract",
- "ethcontract-generate 0.6.1",
+ "ethcontract-generate",
  "futures 0.3.4",
  "isahc",
  "lazy_static",
@@ -655,20 +655,6 @@ dependencies = [
 
 [[package]]
 name = "ethabi"
-version = "11.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97652a7d1f2504d6c885c87e242a06ccef5bd3054093d3fb742d8fb64806231a"
-dependencies = [
- "ethereum-types 0.8.0",
- "rustc-hex",
- "serde",
- "serde_json",
- "tiny-keccak 1.5.0",
- "uint",
-]
-
-[[package]]
-name = "ethabi"
 version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052a565e3de82944527d6d10a465697e6bb92476b772ca7141080c901f6a63c6"
@@ -714,7 +700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d70cbd3e78c774c344a92be8ac4652e41349b3aee8be02d7196ce7cbe39ac74"
 dependencies = [
  "ethabi 9.0.1",
- "ethcontract-common 0.7.0",
+ "ethcontract-common",
  "ethcontract-derive",
  "futures 0.3.4",
  "futures-timer",
@@ -730,22 +716,6 @@ dependencies = [
  "uint",
  "web3",
  "zeroize",
-]
-
-[[package]]
-name = "ethcontract-common"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664e1fc08b1aaea6159787742db14c0f33e8c4d3572e1826c2336cd14fa27525"
-dependencies = [
- "ethabi 11.0.0",
- "hex",
- "serde",
- "serde_derive",
- "serde_json",
- "thiserror",
- "tiny-keccak 2.0.2",
- "web3",
 ]
 
 [[package]]
@@ -770,27 +740,11 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d565443e4c359ef7db4957435af3b5171a30ce517620c921a1470eb2104ee45d"
 dependencies = [
- "ethcontract-common 0.7.0",
- "ethcontract-generate 0.7.0",
+ "ethcontract-common",
+ "ethcontract-generate",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "ethcontract-generate"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd5f639bb0490656a9d61a5e049b4767efa74eb9e843d750f7db437130d46e9"
-dependencies = [
- "Inflector",
- "anyhow",
- "curl",
- "ethcontract-common 0.6.1",
- "proc-macro2",
- "quote",
- "syn",
- "url 2.1.1",
 ]
 
 [[package]]
@@ -802,7 +756,7 @@ dependencies = [
  "Inflector",
  "anyhow",
  "curl",
- "ethcontract-common 0.7.0",
+ "ethcontract-common",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d70cbd3e78c774c344a92be8ac4652e41349b3aee8be02d7196ce7cbe39ac74"
+checksum = "5f2a203f1daee89dc2d9f71c89a5571f615e556ec803ac1d55e0620ab28f1bee"
 dependencies = [
  "ethabi 9.0.1",
  "ethcontract-common",
@@ -720,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-common"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f165fcbd50afa40da9ade1bbc81818031ba5c3f60a6f4aa14c8a55bd9104c5"
+checksum = "7898f63c78b866bc55d62df1a7598b9da9a54e323a3ac056929ec2947b1914aa"
 dependencies = [
  "ethabi 12.0.0",
  "hex",
@@ -736,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-derive"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d565443e4c359ef7db4957435af3b5171a30ce517620c921a1470eb2104ee45d"
+checksum = "037f6f651ff95c8865e7261a35c3c372ade05aef33ede586ade2e7d51642cdb9"
 dependencies = [
  "ethcontract-common",
  "ethcontract-generate",
@@ -749,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-generate"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6c02365b0835970c2d9be59eb14fa90baa5aeed4c174a3e46c532ce965a0dc"
+checksum = "fe0e22f4249553b97125610821634fa193da4a301da5100072e238823a247411"
 dependencies = [
  "Inflector",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,7 @@ dependencies = [
  "chrono",
  "crossbeam-utils",
  "ethcontract",
- "ethcontract-generate",
+ "ethcontract-generate 0.6.1",
  "futures 0.3.4",
  "isahc",
  "lazy_static",
@@ -645,7 +645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "965126c64662832991f5a748893577630b558e47fa94e7f35aefcd20d737cef7"
 dependencies = [
  "error-chain",
- "ethereum-types",
+ "ethereum-types 0.8.0",
  "rustc-hex",
  "serde",
  "serde_derive",
@@ -659,7 +659,21 @@ version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97652a7d1f2504d6c885c87e242a06ccef5bd3054093d3fb742d8fb64806231a"
 dependencies = [
- "ethereum-types",
+ "ethereum-types 0.8.0",
+ "rustc-hex",
+ "serde",
+ "serde_json",
+ "tiny-keccak 1.5.0",
+ "uint",
+]
+
+[[package]]
+name = "ethabi"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052a565e3de82944527d6d10a465697e6bb92476b772ca7141080c901f6a63c6"
+dependencies = [
+ "ethereum-types 0.9.0",
  "rustc-hex",
  "serde",
  "serde_json",
@@ -681,13 +695,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethcontract"
-version = "0.6.1"
+name = "ethbloom"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f019278e3a866019e999edc2e17c4aa6806316cf869413f35ee2f2948fec9f9"
+checksum = "9e7abcddbdd5db30aeed4deb586adc4824e6c247e2f7238d1187f752893f096b"
+dependencies = [
+ "crunchy",
+ "fixed-hash 0.6.0",
+ "impl-rlp",
+ "impl-serde 0.3.0",
+ "tiny-keccak 2.0.2",
+]
+
+[[package]]
+name = "ethcontract"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d70cbd3e78c774c344a92be8ac4652e41349b3aee8be02d7196ce7cbe39ac74"
 dependencies = [
  "ethabi 9.0.1",
- "ethcontract-common",
+ "ethcontract-common 0.7.0",
  "ethcontract-derive",
  "futures 0.3.4",
  "futures-timer",
@@ -722,13 +749,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethcontract-derive"
-version = "0.6.1"
+name = "ethcontract-common"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80be0591248a374fc4e1683636579f5d56b1c3af673fa54c0abc23b390c57b32"
+checksum = "31f165fcbd50afa40da9ade1bbc81818031ba5c3f60a6f4aa14c8a55bd9104c5"
 dependencies = [
- "ethcontract-common",
- "ethcontract-generate",
+ "ethabi 12.0.0",
+ "hex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror",
+ "tiny-keccak 2.0.2",
+ "web3",
+]
+
+[[package]]
+name = "ethcontract-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d565443e4c359ef7db4957435af3b5171a30ce517620c921a1470eb2104ee45d"
+dependencies = [
+ "ethcontract-common 0.7.0",
+ "ethcontract-generate 0.7.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -743,7 +786,23 @@ dependencies = [
  "Inflector",
  "anyhow",
  "curl",
- "ethcontract-common",
+ "ethcontract-common 0.6.1",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "url 2.1.1",
+]
+
+[[package]]
+name = "ethcontract-generate"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6c02365b0835970c2d9be59eb14fa90baa5aeed4c174a3e46c532ce965a0dc"
+dependencies = [
+ "Inflector",
+ "anyhow",
+ "curl",
+ "ethcontract-common 0.7.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -756,11 +815,25 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba744248e3553a393143d5ebb68939fc3a4ec0c22a269682535f5ffe7fed728c"
 dependencies = [
- "ethbloom",
+ "ethbloom 0.8.1",
  "fixed-hash 0.5.2",
  "impl-rlp",
  "impl-serde 0.2.3",
  "primitive-types 0.6.2",
+ "uint",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964c23cdee0ca07d5be2a628b46d5c11a2134ce554a8c16d8dbc2db647e4fd4d"
+dependencies = [
+ "ethbloom 0.9.0",
+ "fixed-hash 0.6.0",
+ "impl-rlp",
+ "impl-serde 0.3.0",
+ "primitive-types 0.7.0",
  "uint",
 ]
 
@@ -1837,6 +1910,8 @@ checksum = "e5e4b9943a2da369aec5e96f7c10ebc74fcf434d39590d974b0a3460e6f67fbb"
 dependencies = [
  "fixed-hash 0.6.0",
  "impl-codec",
+ "impl-rlp",
+ "impl-serde 0.3.0",
  "uint",
 ]
 
@@ -3284,7 +3359,7 @@ dependencies = [
  "base64 0.11.0",
  "derive_more",
  "ethabi 9.0.1",
- "ethereum-types",
+ "ethereum-types 0.8.0",
  "futures 0.1.29",
  "hyper 0.12.35",
  "hyper-tls",

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -35,4 +35,4 @@ url = "2.1.1"
 mockall = "0.7.0"
 
 [build-dependencies]
-ethcontract-generate = "0.6.1"
+ethcontract-generate = "0.7.0"

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1"
 byteorder = "1.3.4"
 chrono = "0.4.11"
 crossbeam-utils = "0.7"
-ethcontract = "0.6.1"
+ethcontract = "0.7.0"
 futures = { version = "0.3.4", features = ["compat"] }
 isahc = { version = "0.9.1", features = ["json"] }
 lazy_static = "1.4.0"

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1"
 byteorder = "1.3.4"
 chrono = "0.4.11"
 crossbeam-utils = "0.7"
-ethcontract = "0.7.0"
+ethcontract = "0.7.1"
 futures = { version = "0.3.4", features = ["compat"] }
 isahc = { version = "0.9.1", features = ["json"] }
 lazy_static = "1.4.0"
@@ -35,4 +35,4 @@ url = "2.1.1"
 mockall = "0.7.0"
 
 [build-dependencies]
-ethcontract-generate = "0.7.0"
+ethcontract-generate = "0.7.1"

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
-ethcontract = "0.7.0"
+ethcontract = "0.7.1"
 futures = { version = "0.3.4", features = ["compat"] }

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
-ethcontract = "0.6.1"
+ethcontract = "0.7.0"
 futures = { version = "0.3.4", features = ["compat"] }


### PR DESCRIPTION
:point_up: 

This includes the new paginated event query which is needed for the event based orderbook. Note that 0.7.0 was skipped because of clippy lint errors in the generated code because of the newly released Rust 1.43.

### Test Plan

CI, only new stuff so existing code shouldn't be affected.