### PR TITLE
[easy] Revert bump of open-solver version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
         - cargo clippy --all --all-targets -- -D warnings
         - cargo fmt --all -- --check
         # Build and publish compact image with compiled binary
-        - docker build --tag stablex-binary-public --build-arg SOLVER_BASE=gnosispm/dex-open-solver:v0.0.6 --build-arg RUST_BASE=rust-binary -f docker/rust/Dockerfile .
+        - docker build --tag stablex-binary-public --build-arg SOLVER_BASE=gnosispm/dex-open-solver:v0.0.5 --build-arg RUST_BASE=rust-binary -f docker/rust/Dockerfile .
         # StableX e2e Tests (Ganache) - open solver
         - docker-compose -f docker-compose.yml -f docker-compose.open-solver.yml  up -d stablex
         - cargo test -p e2e ganache -- --nocapture

--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -74,7 +74,7 @@ impl SolverType {
 pub fn execute_open_solver(
     result_folder: &str,
     input_file: &str,
-    min_avg_fee_per_order: u128,
+    _min_avg_fee_per_order: u128,
 ) -> Result<Output> {
     let mut command = Command::new("python");
     let open_solver_command = command
@@ -87,7 +87,8 @@ pub fn execute_open_solver(
             result_folder.to_owned(),
             "06_solution_int_valid.json",
         ))
-        .arg(format!("--min-avg-fee-per-order={}", min_avg_fee_per_order))
+        // Uncomment when we bump the solver version back to 0.0.6.
+        // .arg(format!("--min-avg-fee-per-order={}", min_avg_fee_per_order))
         .arg(String::from("best-token-pair"));
     debug!("Using open-solver command `{:?}`", open_solver_command);
     Ok(open_solver_command.output()?)


### PR DESCRIPTION
The open solver on rinkeby is outputting invalid solutions which spams
the alert channel. Let's see if reverting the version bump fixes it.