### PR TITLE
Do not use a stream for event based orderbook

### DIFF
--- a/driver/src/contracts/stablex_contract.rs
+++ b/driver/src/contracts/stablex_contract.rs
@@ -128,6 +128,8 @@ pub trait StableXContract {
 
     fn past_events(
         &self,
+        from_block: BlockNumber,
+        to_block: BlockNumber,
     ) -> BoxFuture<'static, Result<Vec<Event<batch_exchange::Event>>, ExecutionError>>;
 
     fn stream_events(
@@ -290,11 +292,13 @@ impl StableXContract for StableXContractImpl {
 
     fn past_events(
         &self,
+        from_block: BlockNumber,
+        to_block: BlockNumber,
     ) -> BoxFuture<'static, Result<Vec<Event<batch_exchange::Event>>, ExecutionError>> {
         self.instance
             .all_events()
-            .from_block(ethcontract::BlockNumber::Earliest)
-            .to_block(ethcontract::BlockNumber::Latest)
+            .from_block(from_block)
+            .to_block(to_block)
             .query_past_events_paginated()
             .boxed()
     }

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -62,9 +62,7 @@ impl OrderbookReaderKind {
                 auction_data_page_size,
                 orderbook_filter,
             )),
-            OrderbookReaderKind::EventBased => {
-                Box::new(EventBasedOrderbook::new(contract.as_ref(), web3))
-            }
+            OrderbookReaderKind::EventBased => Box::new(EventBasedOrderbook::new(contract, web3)),
         }
     }
 }

--- a/driver/src/orderbook/streamed/orderbook.rs
+++ b/driver/src/orderbook/streamed/orderbook.rs
@@ -56,6 +56,14 @@ impl Orderbook {
         };
     }
 
+    pub fn delete_events_starting_at_block(&mut self, block_number: u64) {
+        self.events.split_off(&EventSortKey {
+            block_number,
+            block_hash: H256::zero(),
+            log_index: 0,
+        });
+    }
+
     fn create_state(&self) -> Result<State> {
         self.events
             .iter()


### PR DESCRIPTION
Using a error stream prevents use from using load balanced nodes because
if the node changes under us the new node will not have the log filter
that was set up by the stream.
Instead we always query all past logs of the last X blocks, delete the
previous events from this range and then apply the one.
This works even when the node switches and makes it easier to implement
retries on errors in the futures.