### PR TITLE
[Easy] Don't log batches that ran out of time as successful

### DIFF
--- a/driver/src/driver/stablex_driver.rs
+++ b/driver/src/driver/stablex_driver.rs
@@ -138,7 +138,7 @@ impl<'a> StableXDriverImpl<'a> {
 
         if !submitted {
             self.metrics
-                .autcion_processed_but_not_submitted(batch_to_solve);
+                .auction_processed_but_not_submitted(batch_to_solve);
         };
 
         Ok(())

--- a/driver/src/driver/stablex_driver.rs
+++ b/driver/src/driver/stablex_driver.rs
@@ -137,7 +137,8 @@ impl<'a> StableXDriverImpl<'a> {
         };
 
         if !submitted {
-            self.metrics.autcion_processed_but_not_submitted(batch_to_solve);
+            self.metrics
+                .autcion_processed_but_not_submitted(batch_to_solve);
         };
 
         Ok(())

--- a/driver/src/driver/stablex_driver.rs
+++ b/driver/src/driver/stablex_driver.rs
@@ -137,7 +137,7 @@ impl<'a> StableXDriverImpl<'a> {
         };
 
         if !submitted {
-            self.metrics.auction_skipped(batch_to_solve);
+            self.metrics.autcion_processed_but_not_submitted(batch_to_solve);
         };
 
         Ok(())
@@ -160,7 +160,6 @@ impl<'a> StableXDriver for StableXDriverImpl<'a> {
         let price_finding_time_limit = match deadline.checked_duration_since(Instant::now()) {
             Some(time_limit) if time_limit > Duration::from_secs(1) => time_limit,
             _ => {
-                self.metrics.auction_skipped(batch_to_solve);
                 warn!("orderbook retrieval exceeded time limit");
                 return DriverResult::Ok;
             }

--- a/driver/src/metrics/stablex_metrics.rs
+++ b/driver/src/metrics/stablex_metrics.rs
@@ -179,8 +179,8 @@ impl StableXMetrics {
         }
     }
 
-    pub fn auction_skipped(&self, batch: U256) {
-        let stage_label = &[ProcessingStage::Skipped.as_ref()];
+    pub fn autcion_processed_but_not_submitted(&self, batch: U256) {
+        let stage_label = &[ProcessingStage::SolutionNotSubmitted.as_ref()];
         self.processing_times
             .with_label_values(stage_label)
             .set(time_elapsed_since_batch_start(batch));
@@ -258,12 +258,19 @@ trait InitializeableMetric: 'static + Sized + AsRef<str> {
 }
 
 enum ProcessingStage {
+    /// The processing of a new batch has started
     Started,
+    /// The orderbook and account state has been fetched
     OrdersFetched,
+    /// A solution for the batch has been produced
     Solved,
+    /// The auction solution has been verified
     Verified,
+    /// The auction solution has been submitted
     Submitted,
-    Skipped,
+    /// Processing was successful, but solution was not submitted
+    /// (e.g. solution did not improve objective value)
+    SolutionNotSubmitted,
 }
 
 impl AsRef<str> for ProcessingStage {
@@ -274,7 +281,7 @@ impl AsRef<str> for ProcessingStage {
             Self::Solved => "solved",
             Self::Verified => "verified",
             Self::Submitted => "submitted",
-            Self::Skipped => "skipped",
+            Self::SolutionNotSubmitted => "skipped",
         }
     }
 }
@@ -287,7 +294,7 @@ impl InitializeableMetric for ProcessingStage {
         Self::Solved,
         Self::Verified,
         Self::Submitted,
-        Self::Skipped,
+        Self::SolutionNotSubmitted,
     ];
 }
 

--- a/driver/src/metrics/stablex_metrics.rs
+++ b/driver/src/metrics/stablex_metrics.rs
@@ -179,7 +179,7 @@ impl StableXMetrics {
         }
     }
 
-    pub fn autcion_processed_but_not_submitted(&self, batch: U256) {
+    pub fn auction_processed_but_not_submitted(&self, batch: U256) {
         let stage_label = &[ProcessingStage::SolutionNotSubmitted.as_ref()];
         self.processing_times
             .with_label_values(stage_label)


### PR DESCRIPTION
https://github.com/gnosis/dex-services/pull/656#discussion_r395529456 identified and explained the issue. 

We are currently already seeing a bunch of auctions in which we run out of time fetching the orderbook (cf. [kibana](https://logs.gnosisdev.com/goto/75c991c4167005acff9e14a8b72db20a)).

However this is not at all reflected in our top-level grafana metrics or alerts. Reason is that such batches are still recorded as being successfully processed.

This PR makes it so that we don't log a successful processing event in this case and adds some more docs to make the expectation of each event stage more explicit for future maintainers.

### Test Plan

Once merged, expect to see more "downtime" in the staging Grafana dashboard.