### PR TITLE
[Streamed Orderbook] Fix batchId off-by-one error

### DIFF
--- a/driver/src/orderbook/filtered_orderbook.rs
+++ b/driver/src/orderbook/filtered_orderbook.rs
@@ -69,8 +69,8 @@ impl<'a> FilteredOrderbookReader<'a> {
 }
 
 impl<'a> StableXOrderBookReading for FilteredOrderbookReader<'a> {
-    fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
-        let (state, orders) = self.orderbook.get_auction_data(index)?;
+    fn get_auction_data(&self, batch_id_to_solve: U256) -> Result<(AccountState, Vec<Order>)> {
+        let (state, orders) = self.orderbook.get_auction_data(batch_id_to_solve)?;
         let token_filtered_orders: Vec<Order> = match &self.filter.tokens {
             TokenFilter::Whitelist(token_list) => orders
                 .into_iter()

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -28,8 +28,8 @@ pub trait StableXOrderBookReading {
     /// and open orders or an error in case it cannot get this information.
     ///
     /// # Arguments
-    /// * `index` - the auction index for which returned orders should be valid
-    fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)>;
+    /// * `batch_id_to_solve` - the index for which returned orders should be valid
+    fn get_auction_data(&self, batch_id_to_solve: U256) -> Result<(AccountState, Vec<Order>)>;
 }
 
 /// The different kinds of orderbook readers.

--- a/driver/src/orderbook/onchain_filtered_orderbook.rs
+++ b/driver/src/orderbook/onchain_filtered_orderbook.rs
@@ -33,9 +33,11 @@ impl OnchainFilteredOrderBookReader {
 }
 
 impl StableXOrderBookReading for OnchainFilteredOrderBookReader {
-    fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
-        let last_block = self.contract.get_last_block_for_batch(index.as_u32())?;
-        let mut reader = IndexedAuctionDataReader::new(index);
+    fn get_auction_data(&self, batch_id_to_solve: U256) -> Result<(AccountState, Vec<Order>)> {
+        let last_block = self
+            .contract
+            .get_last_block_for_batch(batch_id_to_solve.as_u32())?;
+        let mut reader = IndexedAuctionDataReader::new(batch_id_to_solve);
         let mut auction_data = FilteredOrderPage {
             indexed_elements: vec![],
             has_next_page: true,
@@ -44,7 +46,7 @@ impl StableXOrderBookReading for OnchainFilteredOrderBookReader {
         };
         while auction_data.has_next_page {
             auction_data = self.contract.get_filtered_auction_data_paginated(
-                index,
+                batch_id_to_solve,
                 self.filter.clone(),
                 self.page_size,
                 auction_data.next_page_user,

--- a/driver/src/orderbook/paginated_orderbook.rs
+++ b/driver/src/orderbook/paginated_orderbook.rs
@@ -26,8 +26,9 @@ impl PaginatedStableXOrderBookReader {
 }
 
 impl StableXOrderBookReading for PaginatedStableXOrderBookReader {
-    fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
-        let mut reader = PaginatedAuctionDataReader::new(index, self.page_size as usize);
+    fn get_auction_data(&self, batch_id_to_solve: U256) -> Result<(AccountState, Vec<Order>)> {
+        let mut reader =
+            PaginatedAuctionDataReader::new(batch_id_to_solve, self.page_size as usize);
         while let Some(page_info) = reader.next_page() {
             let page = &self.contract.get_auction_data_paginated(
                 self.page_size,

--- a/driver/src/orderbook/shadow_orderbook.rs
+++ b/driver/src/orderbook/shadow_orderbook.rs
@@ -48,14 +48,14 @@ impl<'a> ShadowedOrderbookReader<'a> {
 }
 
 impl<'a> StableXOrderBookReading for ShadowedOrderbookReader<'a> {
-    fn get_auction_data(&self, batch_id: U256) -> Result<Orderbook> {
-        let orderbook = self.primary.get_auction_data(batch_id)?;
+    fn get_auction_data(&self, batch_id_to_solve: U256) -> Result<Orderbook> {
+        let orderbook = self.primary.get_auction_data(batch_id_to_solve)?;
 
         // NOTE: Ignore errors here as they indicate that the shadow reader is
         //   already reading an orderbook.
         let _ = self
             .shadow_channel
-            .try_send((batch_id.low_u32(), orderbook.clone()));
+            .try_send((batch_id_to_solve.low_u32(), orderbook.clone()));
 
         Ok(orderbook)
     }

--- a/driver/src/orderbook/streamed/state.rs
+++ b/driver/src/orderbook/streamed/state.rs
@@ -547,7 +547,7 @@ mod tests {
         };
         state = state.apply_event(&Event::OrderPlacement(event), 0).unwrap();
 
-        assert_eq!(state.orders(0).next(), None);
+        assert_eq!(state.orders(1).next(), None);
         let expected_orders = vec![ModelOrder {
             id: 0,
             account_id: address(2),
@@ -556,9 +556,9 @@ mod tests {
             buy_amount: 3,
             sell_amount: 4,
         }];
-        assert_eq!(state.orders(1).collect::<Vec<_>>(), expected_orders);
         assert_eq!(state.orders(2).collect::<Vec<_>>(), expected_orders);
-        assert_eq!(state.orders(3).next(), None);
+        assert_eq!(state.orders(3).collect::<Vec<_>>(), expected_orders);
+        assert_eq!(state.orders(4).next(), None);
 
         let event = OrderCancellation {
             owner: address(2),
@@ -568,10 +568,10 @@ mod tests {
             .apply_event(&Event::OrderCancellation(event), 2)
             .unwrap();
 
-        assert_eq!(state.orders(0).next(), None);
-        assert_eq!(state.orders(1).collect::<Vec<_>>(), expected_orders);
-        assert_eq!(state.orders(2).next(), None);
+        assert_eq!(state.orders(1).next(), None);
+        assert_eq!(state.orders(2).collect::<Vec<_>>(), expected_orders);
         assert_eq!(state.orders(3).next(), None);
+        assert_eq!(state.orders(4).next(), None);
 
         let event = Event::OrderDeletion(OrderDeletion {
             owner: address(2),
@@ -579,10 +579,10 @@ mod tests {
         });
         assert!(state.clone().apply_event(&event, 2).is_err());
         state = state.apply_event(&event, 3).unwrap();
-        assert_eq!(state.orders(0).next(), None);
         assert_eq!(state.orders(1).next(), None);
         assert_eq!(state.orders(2).next(), None);
         assert_eq!(state.orders(3).next(), None);
+        assert_eq!(state.orders(4).next(), None);
     }
 
     #[test]

--- a/driver/src/orderbook/streamed/state.rs
+++ b/driver/src/orderbook/streamed/state.rs
@@ -68,7 +68,7 @@ impl State {
                 batch_id
             }
         };
-        Ok((self.account_state(batch_id), self.orders(batch_id - 1)))
+        Ok((self.account_state(batch_id), self.orders(batch_id)))
     }
 
     fn account_state(
@@ -95,7 +95,9 @@ impl State {
     fn orders(&self, batch_id: BatchId) -> impl Iterator<Item = ModelOrder> + '_ {
         self.orders
             .iter()
-            .filter(move |(_, order)| order.is_valid_in_batch(batch_id))
+            // State is returned **excluding** the given `batch_id` however order validity is internally stored
+            // **including** `batch_id`. Thus we need subtract 1 here to get all orders valid for batch_id -1.
+            .filter(move |(_, order)| order.is_valid_in_batch(batch_id - 1))
             .map(move |((user_id, order_id), order)| {
                 order.as_model_order(batch_id, *user_id, *order_id)
             })

--- a/driver/src/orderbook/streamed/state.rs
+++ b/driver/src/orderbook/streamed/state.rs
@@ -68,7 +68,7 @@ impl State {
                 batch_id
             }
         };
-        Ok((self.account_state(batch_id), self.orders(batch_id)))
+        Ok((self.account_state(batch_id), self.orders(batch_id - 1)))
     }
 
     fn account_state(
@@ -701,9 +701,9 @@ mod tests {
             user: address(3),
             token: address(0),
             amount: 1.into(),
-            batch_id: 0,
+            batch_id: 1,
         };
-        state = state.apply_event(&Event::Deposit(event), 0).unwrap();
+        state = state.apply_event(&Event::Deposit(event), 1).unwrap();
         let balance = state
             .orderbook_for_batch(Batch::Current)
             .unwrap()
@@ -713,7 +713,7 @@ mod tests {
             .1;
         assert_eq!(balance, U256::zero());
         let balance = state
-            .orderbook_for_batch(Batch::Future(1))
+            .orderbook_for_batch(Batch::Future(2))
             .unwrap()
             .0
             .next()

--- a/driver/src/orderbook/streamed/updating_orderbook.rs
+++ b/driver/src/orderbook/streamed/updating_orderbook.rs
@@ -72,7 +72,7 @@ impl UpdatingOrderbook {
 }
 
 impl StableXOrderBookReading for UpdatingOrderbook {
-    fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
+    fn get_auction_data(&self, batch_id_to_solve: U256) -> Result<(AccountState, Vec<Order>)> {
         ensure!(
             self.orderbook_ready.load(Ordering::SeqCst),
             "orderbook not yet ready"
@@ -80,7 +80,7 @@ impl StableXOrderBookReading for UpdatingOrderbook {
         self.orderbook
             .lock()
             .map_err(|err| anyhow!("poison error: {}", err))?
-            .get_auction_data(index)
+            .get_auction_data(batch_id_to_solve)
     }
 }
 


### PR DESCRIPTION
This is a ~pretty~ extremely hacky short-term fix for #785 with the goal to keep on getting more consistency results and elminate known issues.

To summarize, `orderbook_for_batch` currently returns the balances that are valid in `batch - 1` and the orders that are valid in `batch`. This PR changes it to also return the orders that are valid in `batch-1`. Then, we need to increment the batchID we get passed in from `OrderbookReading` as this is already the index of the batch we are trying to solve (and for which we want the orderbook).

I also renamed the variable in the OrderbookReading trait to make it more explicit which batch this ID is for.

I'm happy to make/accept a cleaner fix if you guys have an idea.

### Test Plan

1. The first bug was that we would get errors if an event is received in the first 30s of a batch (since this would advance last_batch_id and then result assertion errors that we are querying on a past batch id). I tested locally that this is no longer the case (https://rinkeby.etherscan.io/tx/0x7556fe7b1ddfcb51d1b72cbc67c3060bad9dc5cae3639cd540f74c363e8c4942)
2. When creating an order and a deposit in the same batch the order would get correctly included by the streamed orderbook, but the deposit would be ignored. I tested locally that this is no longer the case (tx from above + deposit in the same batch https://rinkeby.etherscan.io/tx/0x63f94ce7cd43aaf2295da66315fffc2dffd43612f1308ec5dd3725717bf6707c)