### PR TITLE
Implement BatchTransport via Http

### DIFF
--- a/driver/src/metrics/http_metrics.rs
+++ b/driver/src/metrics/http_metrics.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use ethcontract::jsonrpc::types::{Call, Request};
 use prometheus::{HistogramOpts, HistogramVec, Registry, DEFAULT_BUCKETS};
 use std::sync::Arc;
 use std::time::Duration;
@@ -104,8 +105,24 @@ labels! {
         EthCall => "eth_call",
         EthEstimateGas => "eth_estimate_gas",
         EthRpc => "eth_rpc",
+        EthBatchRPC => "eth_batch_rpc",
         Kraken => "kraken",
         Dexag => "dexag",
         GasStation => "gas_station",
+    }
+}
+
+impl From<&Request> for HttpLabel {
+    fn from(request: &Request) -> Self {
+        match request {
+            Request::Single(call) => match &call {
+                Call::MethodCall(call) if call.method == "eth_call" => HttpLabel::EthCall,
+                Call::MethodCall(call) if call.method == "eth_estimateGas" => {
+                    HttpLabel::EthEstimateGas
+                }
+                _ => HttpLabel::EthRpc,
+            },
+            Request::Batch(_) => HttpLabel::EthBatchRPC,
+        }
     }
 }


### PR DESCRIPTION
This PR implements the BatchTransport trait for our own HttpTransport implementation. Instead of sending a single JSON object containing the method, parms, id, etc, we send a list of multiple objects (potentially for different methods).

In the success case the result is a list of response objects one for each request.

### Test Plan

Using the new transport for fetching multiple block timestamps in a single request in the next PR.