### PR TITLE
[Streamed Orderbook] Read block timestamps in batches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
         - cargo clippy --all --all-targets -- -D warnings
         - cargo fmt --all -- --check
         # Build and publish compact image with compiled binary
-        - docker build --tag stablex-binary-public --build-arg SOLVER_BASE=gnosispm/dex-open-solver:v0.0.7 --build-arg RUST_BASE=rust-binary -f docker/rust/Dockerfile .
+        - docker build --tag stablex-binary-public --build-arg SOLVER_BASE=gnosispm/dex-open-solver:v0.0.8 --build-arg RUST_BASE=rust-binary -f docker/rust/Dockerfile .
         # StableX e2e Tests (Ganache) - open solver
         - docker-compose -f docker-compose.yml -f docker-compose.open-solver.yml  up -d stablex
         - cargo test -p e2e ganache -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc755679c12bda8e5523a71e4d654b6bf2e14bd838dfc48cde6559a05caf7d1"
+checksum = "63f696897c88b57f4ffe3c69d8e1a0613c7d0e6c4833363c8560fbde9c47b966"
 dependencies = [
  "atty",
  "cast",
@@ -349,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01e15e0ea58e8234f96146b1f91fa9d0e4dd7a38da93ff7a75d42c0b9d3a545"
+checksum = "ddeaf7989f00f2e1d871a26a110f3ed713632feac17f65f03ca938c542618b60"
 dependencies = [
  "cast",
  "itertools",
@@ -1272,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 #[macro_use]
 mod macros;
 

--- a/driver/src/metrics/http_metrics.rs
+++ b/driver/src/metrics/http_metrics.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use ethcontract::jsonrpc::types::{Call, Request};
 use prometheus::{HistogramOpts, HistogramVec, Registry, DEFAULT_BUCKETS};
 use std::sync::Arc;
 use std::time::Duration;
@@ -104,8 +105,24 @@ labels! {
         EthCall => "eth_call",
         EthEstimateGas => "eth_estimate_gas",
         EthRpc => "eth_rpc",
+        EthBatchRPC => "eth_batch_rpc",
         Kraken => "kraken",
         Dexag => "dexag",
         GasStation => "gas_station",
+    }
+}
+
+impl From<&Request> for HttpLabel {
+    fn from(request: &Request) -> Self {
+        match request {
+            Request::Single(call) => match &call {
+                Call::MethodCall(call) if call.method == "eth_call" => HttpLabel::EthCall,
+                Call::MethodCall(call) if call.method == "eth_estimateGas" => {
+                    HttpLabel::EthEstimateGas
+                }
+                _ => HttpLabel::EthRpc,
+            },
+            Request::Batch(_) => HttpLabel::EthBatchRPC,
+        }
     }
 }

--- a/driver/src/orderbook/filtered_orderbook.rs
+++ b/driver/src/orderbook/filtered_orderbook.rs
@@ -69,8 +69,8 @@ impl<'a> FilteredOrderbookReader<'a> {
 }
 
 impl<'a> StableXOrderBookReading for FilteredOrderbookReader<'a> {
-    fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
-        let (state, orders) = self.orderbook.get_auction_data(index)?;
+    fn get_auction_data(&self, batch_id_to_solve: U256) -> Result<(AccountState, Vec<Order>)> {
+        let (state, orders) = self.orderbook.get_auction_data(batch_id_to_solve)?;
         let token_filtered_orders: Vec<Order> = match &self.filter.tokens {
             TokenFilter::Whitelist(token_list) => orders
                 .into_iter()

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -28,8 +28,8 @@ pub trait StableXOrderBookReading {
     /// and open orders or an error in case it cannot get this information.
     ///
     /// # Arguments
-    /// * `index` - the auction index for which returned orders should be valid
-    fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)>;
+    /// * `batch_id_to_solve` - the index for which returned orders should be valid
+    fn get_auction_data(&self, batch_id_to_solve: U256) -> Result<(AccountState, Vec<Order>)>;
 }
 
 /// The different kinds of orderbook readers.

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -11,9 +11,8 @@ pub use self::paginated_orderbook::PaginatedStableXOrderBookReader;
 pub use self::shadow_orderbook::ShadowedOrderbookReader;
 pub use self::streamed::Orderbook as EventBasedOrderbook;
 
-use crate::contracts::stablex_contract::StableXContractImpl;
+use crate::contracts::{stablex_contract::StableXContractImpl, Web3};
 use crate::models::{AccountState, Order};
-use crate::orderbook::streamed::BlockTimestampReading;
 
 use anyhow::{anyhow, Error, Result};
 use ethcontract::U256;
@@ -51,7 +50,7 @@ impl OrderbookReaderKind {
         contract: Arc<StableXContractImpl>,
         auction_data_page_size: u16,
         orderbook_filter: &OrderbookFilter,
-        block_timestamp_reader: impl BlockTimestampReading + Send + 'static,
+        web3: Web3,
     ) -> Box<dyn StableXOrderBookReading + Sync> {
         match self {
             OrderbookReaderKind::Paginated => Box::new(PaginatedStableXOrderBookReader::new(
@@ -63,10 +62,9 @@ impl OrderbookReaderKind {
                 auction_data_page_size,
                 orderbook_filter,
             )),
-            OrderbookReaderKind::EventBased => Box::new(EventBasedOrderbook::new(
-                contract.as_ref(),
-                block_timestamp_reader,
-            )),
+            OrderbookReaderKind::EventBased => {
+                Box::new(EventBasedOrderbook::new(contract.as_ref(), web3))
+            }
         }
     }
 }

--- a/driver/src/orderbook/onchain_filtered_orderbook.rs
+++ b/driver/src/orderbook/onchain_filtered_orderbook.rs
@@ -33,9 +33,11 @@ impl OnchainFilteredOrderBookReader {
 }
 
 impl StableXOrderBookReading for OnchainFilteredOrderBookReader {
-    fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
-        let last_block = self.contract.get_last_block_for_batch(index.as_u32())?;
-        let mut reader = IndexedAuctionDataReader::new(index);
+    fn get_auction_data(&self, batch_id_to_solve: U256) -> Result<(AccountState, Vec<Order>)> {
+        let last_block = self
+            .contract
+            .get_last_block_for_batch(batch_id_to_solve.as_u32())?;
+        let mut reader = IndexedAuctionDataReader::new(batch_id_to_solve);
         let mut auction_data = FilteredOrderPage {
             indexed_elements: vec![],
             has_next_page: true,
@@ -44,7 +46,7 @@ impl StableXOrderBookReading for OnchainFilteredOrderBookReader {
         };
         while auction_data.has_next_page {
             auction_data = self.contract.get_filtered_auction_data_paginated(
-                index,
+                batch_id_to_solve,
                 self.filter.clone(),
                 self.page_size,
                 auction_data.next_page_user,

--- a/driver/src/orderbook/paginated_orderbook.rs
+++ b/driver/src/orderbook/paginated_orderbook.rs
@@ -26,8 +26,9 @@ impl PaginatedStableXOrderBookReader {
 }
 
 impl StableXOrderBookReading for PaginatedStableXOrderBookReader {
-    fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
-        let mut reader = PaginatedAuctionDataReader::new(index, self.page_size as usize);
+    fn get_auction_data(&self, batch_id_to_solve: U256) -> Result<(AccountState, Vec<Order>)> {
+        let mut reader =
+            PaginatedAuctionDataReader::new(batch_id_to_solve, self.page_size as usize);
         while let Some(page_info) = reader.next_page() {
             let page = &self.contract.get_auction_data_paginated(
                 self.page_size,

--- a/driver/src/orderbook/shadow_orderbook.rs
+++ b/driver/src/orderbook/shadow_orderbook.rs
@@ -48,14 +48,14 @@ impl<'a> ShadowedOrderbookReader<'a> {
 }
 
 impl<'a> StableXOrderBookReading for ShadowedOrderbookReader<'a> {
-    fn get_auction_data(&self, batch_id: U256) -> Result<Orderbook> {
-        let orderbook = self.primary.get_auction_data(batch_id)?;
+    fn get_auction_data(&self, batch_id_to_solve: U256) -> Result<Orderbook> {
+        let orderbook = self.primary.get_auction_data(batch_id_to_solve)?;
 
         // NOTE: Ignore errors here as they indicate that the shadow reader is
         //   already reading an orderbook.
         let _ = self
             .shadow_channel
-            .try_send((batch_id.low_u32(), orderbook.clone()));
+            .try_send((batch_id_to_solve.low_u32(), orderbook.clone()));
 
         Ok(orderbook)
     }

--- a/driver/src/orderbook/streamed/block_timestamp_reading.rs
+++ b/driver/src/orderbook/streamed/block_timestamp_reading.rs
@@ -80,12 +80,12 @@ async fn query_block_timestamps_batched(
 
 /// A cache for the block timestamp.
 #[derive(Debug)]
-pub struct MemoizingBlockTimestampReader<T> {
+pub struct CachedBlockTimestampReader<T> {
     inner: T,
     cache: HashMap<H256, u64>,
 }
 
-impl<T: BlockTimestampBatchReading + Send> MemoizingBlockTimestampReader<T> {
+impl<T: BlockTimestampBatchReading + Send> CachedBlockTimestampReader<T> {
     pub fn new(inner: T) -> Self {
         Self {
             inner,
@@ -107,7 +107,7 @@ impl<T: BlockTimestampBatchReading + Send> MemoizingBlockTimestampReader<T> {
     }
 }
 
-impl<T: BlockTimestampReading + Send> BlockTimestampReading for MemoizingBlockTimestampReader<T> {
+impl<T: BlockTimestampReading + Send> BlockTimestampReading for CachedBlockTimestampReader<T> {
     fn block_timestamp(&mut self, block_hash: H256) -> BoxFuture<Result<u64>> {
         async move {
             if let Some(timestamp) = self.cache.get(&block_hash) {

--- a/driver/src/orderbook/streamed/block_timestamp_reading.rs
+++ b/driver/src/orderbook/streamed/block_timestamp_reading.rs
@@ -94,9 +94,13 @@ impl<T: BlockTimestampBatchReading + Send> MemoizingBlockTimestampReader<T> {
     }
 
     pub fn prepare_cache(&mut self, block_hashes: HashSet<H256>) -> BoxFuture<Result<()>> {
+        let missing_hashes = block_hashes
+            .into_iter()
+            .filter(|hash| self.cache.contains_key(&hash))
+            .collect();
         async move {
             self.cache
-                .extend(self.inner.block_timestamps(block_hashes).await?);
+                .extend(self.inner.block_timestamps(missing_hashes).await?);
             Ok(())
         }
         .boxed()

--- a/driver/src/orderbook/streamed/updating_orderbook.rs
+++ b/driver/src/orderbook/streamed/updating_orderbook.rs
@@ -75,7 +75,7 @@ impl UpdatingOrderbook {
 }
 
 impl StableXOrderBookReading for UpdatingOrderbook {
-    fn get_auction_data(&self, index: U256) -> Result<(AccountState, Vec<Order>)> {
+    fn get_auction_data(&self, batch_id_to_solve: U256) -> Result<(AccountState, Vec<Order>)> {
         ensure!(
             self.orderbook_ready.load(Ordering::SeqCst),
             "orderbook not yet ready"
@@ -83,7 +83,7 @@ impl StableXOrderBookReading for UpdatingOrderbook {
         self.orderbook
             .lock()
             .map_err(|err| anyhow!("poison error: {}", err))?
-            .get_auction_data(index)
+            .get_auction_data(batch_id_to_solve)
     }
 }
 

--- a/driver/src/orderbook/streamed/updating_orderbook.rs
+++ b/driver/src/orderbook/streamed/updating_orderbook.rs
@@ -8,7 +8,7 @@ use crate::{
     orderbook::StableXOrderBookReading,
 };
 use anyhow::{anyhow, bail, ensure, Result};
-use block_timestamp_reading::{BlockTimestampReading, MemoizingBlockTimestampReader};
+use block_timestamp_reading::{BlockTimestampReading, CachedBlockTimestampReader};
 use ethcontract::{contract::Event, errors::ExecutionError, H256};
 use futures::{
     channel::oneshot,
@@ -51,7 +51,7 @@ impl UpdatingOrderbook {
             let result = futures::executor::block_on(update_with_events_forever(
                 orderbook_clone,
                 orderbook_ready_clone,
-                MemoizingBlockTimestampReader::new(web3),
+                CachedBlockTimestampReader::new(web3),
                 exit_rx,
                 past_events,
                 stream,
@@ -95,7 +95,7 @@ impl StableXOrderBookReading for UpdatingOrderbook {
 async fn update_with_events_forever(
     orderbook: Arc<Mutex<Orderbook>>,
     orderbook_ready: Arc<AtomicBool>,
-    mut block_timestamp_reader: MemoizingBlockTimestampReader<Web3>,
+    mut block_timestamp_reader: CachedBlockTimestampReader<Web3>,
     exit_indicator: oneshot::Receiver<()>,
     past_events: impl Future<Output = Result<Vec<Event<batch_exchange::Event>>, ExecutionError>>,
     stream: impl Stream<Item = Result<Event<batch_exchange::Event>, ExecutionError>>,

--- a/driver/src/orderbook/streamed/updating_orderbook.rs
+++ b/driver/src/orderbook/streamed/updating_orderbook.rs
@@ -19,6 +19,7 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc, Mutex,
 };
+use std::{process, thread, time::Duration};
 
 /// An event based orderbook that automatically updates itself with new events from the contract.
 #[derive(Debug)]
@@ -55,11 +56,13 @@ impl UpdatingOrderbook {
                 stream,
             ));
             if let Err(err) = result {
-                log::error!("event based orderbook failed: {}", err);
+                log::error!("event based orderbook failed: {:?}", err);
                 // TODO: implement a retry mechanism
-                // For now we crash the program so force a restart of the whole driver because
+                // For now we error the program so force a restart of the whole driver because
                 // without a retry we would be stuck with an outdated orderbook forever.
-                std::process::abort();
+                // Sleep for one second, so that we have time to flush the logs.
+                thread::sleep(Duration::from_secs(1));
+                process::exit(1);
             }
         });
 

--- a/driver/src/orderbook/streamed/updating_orderbook.rs
+++ b/driver/src/orderbook/streamed/updating_orderbook.rs
@@ -1,12 +1,15 @@
 use super::*;
 use crate::{
-    contracts::stablex_contract::{batch_exchange, StableXContract},
+    contracts::{
+        stablex_contract::{batch_exchange, StableXContract},
+        Web3,
+    },
     models::{AccountState, Order},
     orderbook::StableXOrderBookReading,
 };
 use anyhow::{anyhow, bail, ensure, Result};
 use block_timestamp_reading::{BlockTimestampReading, MemoizingBlockTimestampReader};
-use ethcontract::{contract::Event, errors::ExecutionError};
+use ethcontract::{contract::Event, errors::ExecutionError, H256};
 use futures::{
     channel::oneshot,
     future::FutureExt,
@@ -14,6 +17,7 @@ use futures::{
     stream::{Stream, StreamExt as _},
 };
 use orderbook::Orderbook;
+use std::collections::HashSet;
 use std::future::Future;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -33,10 +37,7 @@ pub struct UpdatingOrderbook {
 }
 
 impl UpdatingOrderbook {
-    pub fn new(
-        contract: &dyn StableXContract,
-        block_timestamp_reader: impl BlockTimestampReading + Send + 'static,
-    ) -> Self {
+    pub fn new(contract: &dyn StableXContract, web3: Web3) -> Self {
         let orderbook = Arc::new(Mutex::new(Orderbook::default()));
         let orderbook_clone = orderbook.clone();
         let orderbook_ready = Arc::new(AtomicBool::new(false));
@@ -50,7 +51,7 @@ impl UpdatingOrderbook {
             let result = futures::executor::block_on(update_with_events_forever(
                 orderbook_clone,
                 orderbook_ready_clone,
-                MemoizingBlockTimestampReader::new(block_timestamp_reader),
+                MemoizingBlockTimestampReader::new(web3),
                 exit_rx,
                 past_events,
                 stream,
@@ -94,7 +95,7 @@ impl StableXOrderBookReading for UpdatingOrderbook {
 async fn update_with_events_forever(
     orderbook: Arc<Mutex<Orderbook>>,
     orderbook_ready: Arc<AtomicBool>,
-    mut block_timestamp_reader: impl BlockTimestampReading,
+    mut block_timestamp_reader: MemoizingBlockTimestampReader<Web3>,
     exit_indicator: oneshot::Receiver<()>,
     past_events: impl Future<Output = Result<Vec<Event<batch_exchange::Event>>, ExecutionError>>,
     stream: impl Stream<Item = Result<Event<batch_exchange::Event>, ExecutionError>>,
@@ -124,6 +125,11 @@ async fn update_with_events_forever(
             past_events = past_events => {
                 let past_events = past_events?;
                 log::info!("Received {} past events.", past_events.len());
+                let block_hashes = past_events.iter().map(|event| {
+                    let metadata = event.meta.as_ref().ok_or(anyhow!("event without metadata: {:?}", event))?;
+                    Ok(metadata.block_hash)
+                }).collect::<Result<HashSet<H256>>>()?;
+                block_timestamp_reader.prepare_cache(block_hashes).await?;
                 for event in past_events {
                     handle_event(&orderbook, &mut block_timestamp_reader, event).await?;
                 }

--- a/driver/src/transport.rs
+++ b/driver/src/transport.rs
@@ -1,8 +1,8 @@
 use crate::http::{HttpClient, HttpFactory, HttpLabel};
 use anyhow::Error;
-use ethcontract::jsonrpc::types::{Call, Output};
+use ethcontract::jsonrpc::types::{Call, Output, Request};
 use ethcontract::web3::helpers;
-use ethcontract::web3::{Error as Web3Error, RequestId, Transport};
+use ethcontract::web3::{BatchTransport, Error as Web3Error, RequestId, Transport};
 use futures::compat::Compat;
 use futures::future::{BoxFuture, FutureExt, TryFutureExt};
 use isahc::config::{Configurable, VersionNegotiation};
@@ -48,18 +48,12 @@ impl HttpTransport {
     }
 }
 
+type RpcResult = Result<Value, Web3Error>;
+
 impl HttpTransportInner {
     /// Execute an HTTP JSON RPC request.
-    async fn execute_rpc(
-        self: Arc<Self>,
-        id: RequestId,
-        request: Call,
-    ) -> Result<Value, Web3Error> {
-        let label = match &request {
-            Call::MethodCall(call) if call.method == "eth_call" => HttpLabel::EthCall,
-            Call::MethodCall(call) if call.method == "eth_estimateGas" => HttpLabel::EthEstimateGas,
-            _ => HttpLabel::EthRpc,
-        };
+    async fn execute_rpc(self: Arc<Self>, id: RequestId, request: Request) -> RpcResult {
+        let label: HttpLabel = (&request).into();
 
         let request = serde_json::to_string(&request)?;
         debug!("[id:{}] sending request: '{}'", id, &request);
@@ -85,10 +79,38 @@ impl HttpTransportInner {
             }
         }
 
+        Ok(json)
+    }
+
+    async fn execute_single_rpc(self: Arc<Self>, id: RequestId, call: Call) -> RpcResult {
+        let json = self.execute_rpc(id, Request::Single(call)).await?;
         let output = Output::deserialize(json)?;
         let result = helpers::to_result_from_output(output)?;
-
         Ok(result)
+    }
+
+    async fn execute_batch_rpc(
+        self: Arc<Self>,
+        id: RequestId,
+        request: Vec<Call>,
+    ) -> Result<Vec<RpcResult>, Web3Error> {
+        let result = self.execute_rpc(id, Request::Batch(request)).await?;
+        let sub_results = result.as_array().ok_or_else(|| {
+            warn!(
+                "[id:{}] Batch request did not return a list of responses: '{}'",
+                id,
+                result.to_string()
+            );
+            Web3Error::InvalidResponse(result.to_string())
+        })?;
+        Ok(sub_results
+            .iter()
+            .map(|result| {
+                let output = Output::deserialize(result)?;
+                let result = helpers::to_result_from_output(output)?;
+                Ok(result)
+            })
+            .collect())
     }
 }
 
@@ -99,7 +121,7 @@ impl Debug for HttpTransport {
 }
 
 impl Transport for HttpTransport {
-    type Out = Compat<BoxFuture<'static, Result<Value, Web3Error>>>;
+    type Out = Compat<BoxFuture<'static, RpcResult>>;
 
     fn prepare(&self, method: &str, params: Vec<Value>) -> (RequestId, Call) {
         let id = self.0.id.fetch_add(1, Ordering::SeqCst);
@@ -109,6 +131,27 @@ impl Transport for HttpTransport {
     }
 
     fn send(&self, id: RequestId, request: Call) -> Self::Out {
-        self.0.clone().execute_rpc(id, request).boxed().compat()
+        self.0
+            .clone()
+            .execute_single_rpc(id, request)
+            .boxed()
+            .compat()
+    }
+}
+
+impl BatchTransport for HttpTransport {
+    type Batch = Compat<BoxFuture<'static, Result<Vec<RpcResult>, Web3Error>>>;
+
+    fn send_batch<T>(&self, requests: T) -> Self::Batch
+    where
+        T: IntoIterator<Item = (RequestId, Call)>,
+    {
+        let id = self.0.id.fetch_add(1, Ordering::SeqCst);
+        let requests = requests.into_iter().map(|r| r.1).collect();
+        self.0
+            .clone()
+            .execute_batch_rpc(id, requests)
+            .boxed()
+            .compat()
     }
 }


### PR DESCRIPTION
This PR improves the long cold start time when using the event based orderbook, by batching the requests for block timestamps. 
With the current business logic, we need to get the timestamp for each block that emitted a relevant event. On rinkeby alone this results in a few thousand requests that we send to the FullNode. By batching these calls into a few single requests we can significantly decrease roundtrip time and network overhead.

On my local machine (4G speed) I can now sync the event based orderbook on rinkeby in less than a minute (before it would take more than 20 miuntes) - **a speedup of 20x.**

Future changes to the business logic might make it so we don't have to fetch historic timestamps anymore (cf. discussion in #760), however even for our incremental fetching it can be beneficial to batch the timestamp requests.

My approach is to change the `MemoizingBlockTimestampReader` to contain a full map instead of just the last block's timestamp and furthermore make it "pre-heatable" by querying a bunch of block timestamps in advance. This way, it will instantly return the queried block hashes from memory (at least for now for the past events).

### Test Plan

run it using:

`cargo run -- --network-id=4 --node-url=https://blue-parity.rinkeby.gnosisdev.com --use-shadowed-orderbook true --primary_orderbook EventBased`

and see that we have "Finished applying past events" much earlier than before.