### PR TITLE
[Easy] Log error chain or streamed orderbook exit

### DIFF
--- a/driver/src/orderbook/streamed/updating_orderbook.rs
+++ b/driver/src/orderbook/streamed/updating_orderbook.rs
@@ -19,6 +19,7 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc, Mutex,
 };
+use std::{process, thread, time::Duration};
 
 /// An event based orderbook that automatically updates itself with new events from the contract.
 #[derive(Debug)]
@@ -55,11 +56,13 @@ impl UpdatingOrderbook {
                 stream,
             ));
             if let Err(err) = result {
-                log::error!("event based orderbook failed: {}", err);
+                log::error!("event based orderbook failed: {:?}", err);
                 // TODO: implement a retry mechanism
-                // For now we crash the program so force a restart of the whole driver because
+                // For now we error the program so force a restart of the whole driver because
                 // without a retry we would be stuck with an outdated orderbook forever.
-                std::process::abort();
+                // Sleep for one second, so that we have time to flush the logs.
+                thread::sleep(Duration::from_secs(1));
+                process::exit(1);
             }
         });
 


### PR DESCRIPTION
Three small changes to the way we exit the updating orderbook in case of an error:

1. Print the entire error stack trace not just the top level (by using the Debug print of anyhow)
2. Sleep for 1s before exiting to allow the logs to be flushed (I tried synchronously flushing them but that did not work)
3. Use process::exit instead of abort, as suggested by @nlordell (not feeling strongly about this)

### Test Plan

When working with the streamed orderbook and runnig into an error, make sure we can read the error reason and error chain.