### PR TITLE
Read/Write Orderbook to File

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,15 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
@@ -588,6 +597,7 @@ dependencies = [
  "log 0.4.8",
  "mockall",
  "prometheus",
+ "ron",
  "rouille",
  "rustc-hex",
  "serde",
@@ -2223,6 +2233,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a7d3f9bed94764eac15b8f14af59fac420c236adaff743b7bcc88e265cb4345"
 dependencies = [
  "rustc-hex",
+]
+
+[[package]]
+name = "ron"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ece421e0c4129b90e4a35b6f625e472e96c552136f5093a2f4fa2bbb75a62d5"
+dependencies = [
+ "base64 0.10.1",
+ "bitflags 1.2.1",
+ "serde",
 ]
 
 [[package]]

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -15,6 +15,7 @@ isahc = { version = "0.9.1", features = ["json"] }
 lazy_static = "1.4.0"
 log = "0.4.8"
 prometheus = "0.8.0"
+ron = "0.5.1"
 rouille = "3.0.0"
 rustc-hex = "2.1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/driver/src/orderbook/streamed/orderbook.rs
+++ b/driver/src/orderbook/streamed/orderbook.rs
@@ -10,7 +10,6 @@ use crate::{
 use anyhow::{Context, Result};
 use ethcontract::{contract::EventData, H256, U256};
 use log::info;
-use ron;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::convert::TryFrom;


### PR DESCRIPTION
For improved performance on driver restart, it would be nice if the Orderbook could be recovered from file rather than restreaming the entire ethereum event logs. In order to achieve this, we first require a a way to read and write orderbook to disk.

This PR implements exactly this, 

- `Orderbook::write_to_file(path)`
- `impl TryFrom<&Path> for Orderbook`
- `impl TryFrom<File> for Orderbook`
- `impl TryFrom<&[u8]> for Orderbook`

Along with a full cycle unit test!


