### PR TITLE
Initialize orderbook early

### DIFF
--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -281,6 +281,9 @@ fn main() {
     let mut scheduler = options
         .scheduler
         .create(&*contract, &driver, scheduler_config);
+    orderbook
+        .initialize()
+        .expect("primary orderbook initialization failed");
     scheduler.start();
 }
 

--- a/driver/src/orderbook/filtered_orderbook.rs
+++ b/driver/src/orderbook/filtered_orderbook.rs
@@ -95,6 +95,9 @@ impl<'a> StableXOrderBookReading for FilteredOrderbookReader<'a> {
         });
         Ok(util::normalize_auction_data(state, user_filtered_orders))
     }
+    fn initialize(&self) -> Result<()> {
+        self.orderbook.initialize()
+    }
 }
 
 #[cfg(test)]

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -31,6 +31,11 @@ pub trait StableXOrderBookReading {
     /// # Arguments
     /// * `batch_id_to_solve` - the index for which returned orders should be valid
     fn get_auction_data(&self, batch_id_to_solve: U256) -> Result<(AccountState, Vec<Order>)>;
+    /// Perform potential heavy initialization of the orderbook. If this fails or wasn't called
+    // the orderbook will initialize on first use of `get_auction_data`.
+    fn initialize(&self) -> Result<()> {
+        Ok(())
+    }
 }
 
 /// The different kinds of orderbook readers.

--- a/driver/src/orderbook/shadow_orderbook.rs
+++ b/driver/src/orderbook/shadow_orderbook.rs
@@ -59,9 +59,6 @@ impl<'a> StableXOrderBookReading for ShadowedOrderbookReader<'a> {
 
         Ok(orderbook)
     }
-    fn initialize(&self) -> Result<()> {
-        self.primary.initialize()
-    }
 }
 
 /// Background shadow thread that receives orders from the order channel,
@@ -74,9 +71,6 @@ fn background_shadow_reader(
     reader: &dyn StableXOrderBookReading,
     channel: Receiver<(u32, Orderbook)>,
 ) {
-    if let Err(err) = reader.initialize() {
-        log::error!("failed to initialize shadowed orderbook: {:?}", err);
-    }
     while let Ok((batch_id, primary_orderbook)) = channel.recv() {
         let shadow_orderbook = match reader.get_auction_data(batch_id.into()) {
             Ok(orderbook) => orderbook,

--- a/driver/src/orderbook/shadow_orderbook.rs
+++ b/driver/src/orderbook/shadow_orderbook.rs
@@ -59,6 +59,9 @@ impl<'a> StableXOrderBookReading for ShadowedOrderbookReader<'a> {
 
         Ok(orderbook)
     }
+    fn initialize(&self) -> Result<()> {
+        self.primary.initialize()
+    }
 }
 
 /// Background shadow thread that receives orders from the order channel,
@@ -71,6 +74,9 @@ fn background_shadow_reader(
     reader: &dyn StableXOrderBookReading,
     channel: Receiver<(u32, Orderbook)>,
 ) {
+    if let Err(err) = reader.initialize() {
+        log::error!("failed to initialize shadowed orderbook: {:?}", err);
+    }
     while let Ok((batch_id, primary_orderbook)) = channel.recv() {
         let shadow_orderbook = match reader.get_auction_data(batch_id.into()) {
             Ok(orderbook) => orderbook,

--- a/driver/src/orderbook/streamed/updating_orderbook.rs
+++ b/driver/src/orderbook/streamed/updating_orderbook.rs
@@ -192,6 +192,9 @@ impl StableXOrderBookReading for UpdatingOrderbook {
     /// Blocks on updating the orderbook. This can be expensive if `initialize` hasn't been called before.
     fn get_auction_data(&self, batch_id_to_solve: U256) -> Result<(AccountState, Vec<Order>)> {
         self.do_with_context(|context| {
+            // In the case where initialize has not yet been called we update the orderbook again.
+            // This is useful because the initial update can take a long time so it is possible that
+            // the current block has changed since then.
             self.update_with_events(context).wait()?;
             context.orderbook.get_auction_data(batch_id_to_solve)
         })


### PR DESCRIPTION
The event based orderbook can take minutes to initialize. Instead of
implicitly doing this the first time the orderbook is requested we do it
on start up. This helps when we would be waiting to solve the next batch
anyway.

closes #800 