### PR TITLE
Sync Event Based Orderbook from Disk.

### DIFF
--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -184,6 +184,13 @@ struct Options {
         parse(try_from_str)
     )]
     use_shadowed_orderbook: bool,
+
+    #[structopt(
+        long,
+        env = "ORDERBOOK_FILEPATH",
+        default_value = "/var/db/stablex_orderbook.ron"
+    )]
+    orderbook_filepath: String,
 }
 
 fn main() {
@@ -238,6 +245,7 @@ fn main() {
         options.auction_data_page_size,
         &options.orderbook_filter,
         web3,
+        options.orderbook_filepath,
     );
 
     // NOTE: Keep the shadowed orderbook around so it doesn't get dropped and we

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -37,6 +37,7 @@ use ethcontract::PrivateKey;
 use log::info;
 use prometheus::Registry;
 use std::num::ParseIntError;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
@@ -185,12 +186,8 @@ struct Options {
     )]
     use_shadowed_orderbook: bool,
 
-    #[structopt(
-        long,
-        env = "ORDERBOOK_FILEPATH",
-        default_value = "/var/db/stablex_orderbook.ron"
-    )]
-    orderbook_filepath: String,
+    #[structopt(long, env = "ORDERBOOK_FILE", parse(from_os_str))]
+    orderbook_file: Option<PathBuf>,
 }
 
 fn main() {
@@ -245,7 +242,7 @@ fn main() {
         options.auction_data_page_size,
         &options.orderbook_filter,
         web3,
-        options.orderbook_filepath,
+        options.orderbook_file,
     );
 
     // NOTE: Keep the shadowed orderbook around so it doesn't get dropped and we

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -18,6 +18,7 @@ use anyhow::{anyhow, Error, Result};
 use ethcontract::U256;
 #[cfg(test)]
 use mockall::automock;
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -51,7 +52,7 @@ impl OrderbookReaderKind {
         auction_data_page_size: u16,
         orderbook_filter: &OrderbookFilter,
         web3: Web3,
-        file_path: String,
+        file_path: Option<PathBuf>,
     ) -> Box<dyn StableXOrderBookReading + Sync> {
         match self {
             OrderbookReaderKind::Paginated => Box::new(PaginatedStableXOrderBookReader::new(

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -51,6 +51,7 @@ impl OrderbookReaderKind {
         auction_data_page_size: u16,
         orderbook_filter: &OrderbookFilter,
         web3: Web3,
+        file_path: String,
     ) -> Box<dyn StableXOrderBookReading + Sync> {
         match self {
             OrderbookReaderKind::Paginated => Box::new(PaginatedStableXOrderBookReader::new(
@@ -62,7 +63,9 @@ impl OrderbookReaderKind {
                 auction_data_page_size,
                 orderbook_filter,
             )),
-            OrderbookReaderKind::EventBased => Box::new(EventBasedOrderbook::new(contract, web3)),
+            OrderbookReaderKind::EventBased => {
+                Box::new(EventBasedOrderbook::new(contract, web3, file_path))
+            }
         }
     }
 }

--- a/driver/src/orderbook/streamed/orderbook.rs
+++ b/driver/src/orderbook/streamed/orderbook.rs
@@ -88,6 +88,10 @@ impl Orderbook {
         Ok(())
     }
 
+    pub fn last_handled_block(&self) -> Option<u64> {
+        Some(self.events.iter().next_back()?.0.block_number)
+    }
+
     fn create_state(&self) -> Result<State> {
         self.events
             .iter()

--- a/driver/src/orderbook/streamed/updating_orderbook.rs
+++ b/driver/src/orderbook/streamed/updating_orderbook.rs
@@ -80,11 +80,9 @@ impl UpdatingOrderbook {
             .past_events(BlockNumber::Number(from_block.into()), to_block)
             .await?;
         self.handle_events(context, events, from_block).await?;
-        if self.filestore.is_some() {
-            if let Err(write_error) = context
-                .orderbook
-                .write_to_file(&self.filestore.as_ref().unwrap())
-            {
+        // Update the orderbook on disk before exit.
+        if let Some(filestore) = &self.filestore {
+            if let Err(write_error) = context.orderbook.write_to_file(filestore) {
                 error!("Failed to write to orderbook {}", write_error);
             }
         }


### PR DESCRIPTION
- Initialize Event Based Orderbook from disk in constructor, (Using default if file not available) 
- Write orderbook to file at the end of each update. 
- Include new configuration parameter `orderbook_filepath` with default value of `/var/db/stablex_orderbook.ron`

Looking for suggestions on how to test this.
