### PR TITLE
[FilteredOrderbook] Filter balance for which there are no sell orders

### DIFF
--- a/driver/src/models/account_state.rs
+++ b/driver/src/models/account_state.rs
@@ -15,6 +15,15 @@ impl AccountState {
     }
 }
 
+impl IntoIterator for AccountState {
+    type Item = ((Address, u16), u128);
+    type IntoIter = <HashMap<(Address, u16), u128> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 #[cfg(test)]
 mod test_util {
     use super::*;

--- a/driver/src/orderbook/filtered_orderbook.rs
+++ b/driver/src/orderbook/filtered_orderbook.rs
@@ -93,7 +93,7 @@ impl<'a> StableXOrderBookReading for FilteredOrderbookReader<'a> {
                 true
             }
         });
-        Ok(util::filter_auction_data(state, user_filtered_orders))
+        Ok(util::normalize_auction_data(state, user_filtered_orders))
     }
 }
 

--- a/driver/src/orderbook/filtered_orderbook.rs
+++ b/driver/src/orderbook/filtered_orderbook.rs
@@ -93,10 +93,7 @@ impl<'a> StableXOrderBookReading for FilteredOrderbookReader<'a> {
                 true
             }
         });
-        Ok(util::filter_auction_data(
-            state.into_iter(),
-            user_filtered_orders,
-        ))
+        Ok(util::filter_auction_data(state, user_filtered_orders))
     }
 }
 

--- a/driver/src/orderbook/mod.rs
+++ b/driver/src/orderbook/mod.rs
@@ -4,6 +4,7 @@ mod onchain_filtered_orderbook;
 mod paginated_orderbook;
 mod shadow_orderbook;
 mod streamed;
+mod util;
 
 pub use self::filtered_orderbook::{FilteredOrderbookReader, OrderbookFilter};
 pub use self::onchain_filtered_orderbook::OnchainFilteredOrderBookReader;

--- a/driver/src/orderbook/streamed/orderbook.rs
+++ b/driver/src/orderbook/streamed/orderbook.rs
@@ -1,6 +1,6 @@
 use super::{
     state::{Batch, State},
-    BatchId, TokenId, UserId,
+    BatchId,
 };
 use crate::{
     contracts::stablex_contract::batch_exchange,
@@ -130,27 +130,6 @@ impl TryFrom<&Path> for Orderbook {
     }
 }
 
-fn filter_auction_data(
-    account_states: impl IntoIterator<Item = ((UserId, TokenId), U256)>,
-    orders: impl IntoIterator<Item = Order>,
-) -> (AccountState, Vec<Order>) {
-    let orders = orders
-        .into_iter()
-        .filter(|order| order.sell_amount > 0)
-        .collect::<Vec<_>>();
-    let account_states = account_states
-        .into_iter()
-        .filter(|((user, token), _)| {
-            orders
-                .iter()
-                .any(|order| order.account_id == *user && order.sell_token == *token)
-        })
-        // TODO: change AccountState to use U256
-        .map(|(key, value)| (key, value.low_u128()))
-        .collect();
-    (AccountState(account_states), orders)
-}
-
 impl StableXOrderBookReading for Orderbook {
     fn get_auction_data(&self, batch_id_to_solve: U256) -> Result<(AccountState, Vec<Order>)> {
         // TODO: Handle future batch ids for when we want to do optimistic solving.
@@ -161,7 +140,7 @@ impl StableXOrderBookReading for Orderbook {
         // to increment it.
         let (account_state, orders) =
             state.orderbook_for_batch(Batch::Future(batch_id_to_solve.low_u32() + 1))?;
-        let (account_state, orders) = util::filter_auction_data(
+        let (account_state, orders) = util::normalize_auction_data(
             account_state.map(|(key, balance)| (key, balance.low_u128())),
             orders,
         );

--- a/driver/src/orderbook/util.rs
+++ b/driver/src/orderbook/util.rs
@@ -1,9 +1,9 @@
 use crate::models::{AccountState, Order};
 use ethcontract::Address;
 
-/// Filters empty orders and account balances for tokens for which there is
-/// not at least one sell order by a user
-pub fn filter_auction_data(
+/// Removes empty orders and token balances for which there is
+/// not at least one sell order by that user
+pub fn normalize_auction_data(
     account_states: impl IntoIterator<Item = ((Address, u16), u128)>,
     orders: impl IntoIterator<Item = Order>,
 ) -> (AccountState, Vec<Order>) {
@@ -53,7 +53,7 @@ mod tests {
             ((Address::zero(), 2), 5),
         ];
 
-        let (account_state, orders) = filter_auction_data(account_states, orders);
+        let (account_state, orders) = normalize_auction_data(account_states, orders);
         assert_eq!(account_state.0.len(), 1);
         assert_eq!(account_state.read_balance(1, Address::zero()), 4);
         assert_eq!(orders.len(), 1);

--- a/driver/src/orderbook/util.rs
+++ b/driver/src/orderbook/util.rs
@@ -1,0 +1,62 @@
+use crate::models::{AccountState, Order};
+use ethcontract::Address;
+
+/// Filters empty orders as and account balances for tokens for which there is
+/// not at least one sell order by a user
+pub fn filter_auction_data(
+    account_states: impl IntoIterator<Item = ((Address, u16), u128)>,
+    orders: impl IntoIterator<Item = Order>,
+) -> (AccountState, Vec<Order>) {
+    let orders = orders
+        .into_iter()
+        .filter(|order| order.sell_amount > 0)
+        .collect::<Vec<_>>();
+    let account_states = account_states
+        .into_iter()
+        .filter(|((user, token), _)| {
+            orders
+                .iter()
+                .any(|order| order.account_id == *user && order.sell_token == *token)
+        })
+        .map(|(key, value)| (key, value))
+        .collect();
+    (AccountState(account_states), orders)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_filter_account_state() {
+        let orders = vec![
+            Order {
+                id: 0,
+                account_id: Address::zero(),
+                buy_token: 0,
+                sell_token: 1,
+                buy_amount: 1,
+                sell_amount: 1,
+            },
+            Order {
+                id: 0,
+                account_id: Address::repeat_byte(1),
+                buy_token: 0,
+                sell_token: 2,
+                buy_amount: 0,
+                sell_amount: 0,
+            },
+        ];
+        let account_states = vec![
+            ((Address::zero(), 0), 3),
+            ((Address::zero(), 1), 4),
+            ((Address::zero(), 2), 5),
+        ];
+
+        let (account_state, orders) = filter_auction_data(account_states, orders);
+        assert_eq!(account_state.0.len(), 1);
+        assert_eq!(account_state.read_balance(1, Address::zero()), 4);
+        assert_eq!(orders.len(), 1);
+        assert_eq!(orders[0].account_id, Address::zero());
+    }
+}

--- a/driver/src/orderbook/util.rs
+++ b/driver/src/orderbook/util.rs
@@ -1,7 +1,7 @@
 use crate::models::{AccountState, Order};
 use ethcontract::Address;
 
-/// Filters empty orders as and account balances for tokens for which there is
+/// Filters empty orders and account balances for tokens for which there is
 /// not at least one sell order by a user
 pub fn filter_auction_data(
     account_states: impl IntoIterator<Item = ((Address, u16), u128)>,


### PR DESCRIPTION
This fixes the alerts in the fallback solver we saw today about having balances in the primary orderbook but not in the shadow orderbook.

The on-chain filtered orderbook doesn't return orders (and thus also doesn't return balances) that are not between whitelisted tokens. Thus any balance for tokens >18 (and any balance for tokens that only have an order to a non-whitelisted one) are missing in this implementation.

The client side filtered orderbook also omits orders from such tokens, however it doesn't prune the account balance state. Thus, if we fetched orders using the event based orderbook that contained excluded tokens, their balances will still be reflected in the resulting instance file.

This PR moves the filtering logic that we were also using to exclude balances for which there are no orders at all (even including non-whitelisted tokens) into a common util crate for reuse.

### Test Plan

Added a unit test and made sure (this time on mainnet) that primary and staging orderbooks are consistent with with one another.

Note, there seems to be an issue with the BatchExchangeViewer when running with page size of 100 (@nlordell is working on a fix), however it works with a page size of 1000 which is what we are using in staging.