### PR TITLE
[Easy] Always query orderbook at a pinned block number

### DIFF
--- a/driver/src/orderbook/onchain_filtered_orderbook.rs
+++ b/driver/src/orderbook/onchain_filtered_orderbook.rs
@@ -6,7 +6,7 @@ use super::filtered_orderbook::OrderbookFilter;
 use super::StableXOrderBookReading;
 
 use anyhow::Result;
-use ethcontract::{Address, BlockNumber, U256};
+use ethcontract::{Address, U256};
 use std::sync::Arc;
 
 pub struct OnchainFilteredOrderBookReader {
@@ -51,7 +51,7 @@ impl StableXOrderBookReading for OnchainFilteredOrderBookReader {
                 self.page_size,
                 auction_data.next_page_user,
                 auction_data.next_page_user_offset,
-                last_block.map(BlockNumber::from),
+                Some(last_block.into()),
             )?;
             reader.apply_page(&auction_data.indexed_elements);
         }
@@ -99,7 +99,7 @@ mod tests {
 
         contract
             .expect_get_last_block_for_batch()
-            .returning(|_| Ok(Some(42)));
+            .returning(|_| Ok(42));
         contract
             .expect_get_filtered_auction_data_paginated()
             .times(1)
@@ -129,7 +129,7 @@ mod tests {
 
         contract
             .expect_get_last_block_for_batch()
-            .returning(|_| Ok(Some(42)));
+            .returning(|_| Ok(42));
         contract
             .expect_get_filtered_auction_data_paginated()
             .times(1)
@@ -172,7 +172,7 @@ mod tests {
 
         contract
             .expect_get_last_block_for_batch()
-            .returning(|_| Ok(Some(42)));
+            .returning(|_| Ok(42));
         contract
             .expect_get_filtered_auction_data_paginated()
             .times(1)


### PR DESCRIPTION
This PR modifies the `get_last_block_for_batch` method to return the "latest" block number instead of `None` when the batch isn't finalized.

Fixes #811 

### Test Plan

CI, Rinkeby e2e test will use this new logic.