### PR TITLE
[Easy] Exclude expected "file doesn't exist" warning 

### DIFF
--- a/driver/src/orderbook/streamed/updating_orderbook.rs
+++ b/driver/src/orderbook/streamed/updating_orderbook.rs
@@ -53,12 +53,13 @@ impl UpdatingOrderbook {
                     orderbook
                 }
                 Err(error) => {
-                    // This will always happen when file does not exist (i.e. on first startup)
-                    // TODO: match on this error and don't warn when file doesn't exist.
-                    warn!(
-                        "Failed to construct orderbook from path (using default): {}",
-                        error
-                    );
+                    if path.exists() {
+                        // Exclude warning when file doesn't exist (i.e. on first startup)
+                        warn!(
+                            "Failed to construct orderbook from path (using default): {}",
+                            error
+                        );
+                    }
                     Orderbook::default()
                 }
             },


### PR DESCRIPTION
One missing suggestion made on PR #809 that was missed before merge. We already know that this warning would have been logged on first startup, so why not exclude that scenario right off the bat.