### PR TITLE
Use alternative Serialization Type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,10 +110,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
-name = "base64"
-version = "0.12.0"
+name = "bincode"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5ca2cd0adc3f48f9e9ea5a6bbdf9ccc0bfade884847e484d452414c7ccffb3"
+checksum = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
+dependencies = [
+ "byteorder",
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -583,6 +587,7 @@ name = "driver"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode",
  "byteorder",
  "chrono",
  "crossbeam-utils",
@@ -594,7 +599,6 @@ dependencies = [
  "log 0.4.8",
  "mockall",
  "prometheus",
- "ron",
  "rouille",
  "rustc-hex",
  "serde",
@@ -2230,16 +2234,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a7d3f9bed94764eac15b8f14af59fac420c236adaff743b7bcc88e265cb4345"
 dependencies = [
  "rustc-hex",
-]
-
-[[package]]
-name = "ron"
-version = "0.5.2"
-source = "git+https://github.com/e00E/ron?branch=i128-support#0fc43bfbdd0989a1c0e1dc1bf5d9ac680c9d1b13"
-dependencies = [
- "base64 0.12.0",
- "bitflags 1.2.1",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,18 +105,15 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+
+[[package]]
+name = "base64"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5ca2cd0adc3f48f9e9ea5a6bbdf9ccc0bfade884847e484d452414c7ccffb3"
 
 [[package]]
 name = "bitflags"
@@ -2237,11 +2234,10 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ece421e0c4129b90e4a35b6f625e472e96c552136f5093a2f4fa2bbb75a62d5"
+version = "0.5.2"
+source = "git+https://github.com/e00E/ron?branch=i128-support#0fc43bfbdd0989a1c0e1dc1bf5d9ac680c9d1b13"
 dependencies = [
- "base64 0.10.1",
+ "base64 0.12.0",
  "bitflags 1.2.1",
  "serde",
 ]

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
+bincode = "1.2.1"
 byteorder = "1.3.4"
 chrono = "0.4.11"
 crossbeam-utils = "0.7"
@@ -15,7 +16,6 @@ isahc = { version = "0.9.1", features = ["json"] }
 lazy_static = "1.4.0"
 log = "0.4.8"
 prometheus = "0.8.0"
-ron = { git = "https://github.com/e00E/ron", branch = "i128-support" }
 rouille = "3.0.0"
 rustc-hex = "2.1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -15,7 +15,7 @@ isahc = { version = "0.9.1", features = ["json"] }
 lazy_static = "1.4.0"
 log = "0.4.8"
 prometheus = "0.8.0"
-ron = "0.5.1"
+ron = { git = "https://github.com/e00E/ron", branch = "i128-support" }
 rouille = "3.0.0"
 rustc-hex = "2.1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/driver/src/orderbook/streamed/orderbook.rs
+++ b/driver/src/orderbook/streamed/orderbook.rs
@@ -161,23 +161,37 @@ mod tests {
 
     #[test]
     fn test_serialize_deserialize_orderbook() {
-        let event_key = EventSortKey {
-            block_number: 0,
-            block_hash: H256::zero(),
-            log_index: 1,
-        };
-        let event = Event::Deposit(Deposit {
-            user: Address::from_low_u64_be(1),
-            token: Address::from_low_u64_be(2),
-            amount: 1.into(),
-            batch_id: 2,
-        });
-        let value = Value { event, batch_id: 0 };
+        let event_list: Vec<Event> = vec![
+            Event::Deposit(Deposit::default()),
+            Event::WithdrawRequest(WithdrawRequest::default()),
+            Event::Withdraw(Withdraw::default()),
+            Event::TokenListing(TokenListing::default()),
+            Event::OrderPlacement(OrderPlacement::default()),
+            Event::OrderCancellation(OrderCancellation::default()),
+            Event::OrderDeletion(OrderDeletion::default()),
+            Event::Trade(Trade::default()),
+            Event::TradeReversion(TradeReversion::default()),
+            Event::SolutionSubmission(SolutionSubmission::default()),
+        ];
 
-        let mut events = BTreeMap::new();
-        events.insert(event_key, value);
+        let events: BTreeMap<EventSortKey, Value> = event_list
+            .iter()
+            .enumerate()
+            .map(|(i, event)| {
+                (
+                    EventSortKey {
+                        block_number: i as u64,
+                        block_hash: H256::zero(),
+                        log_index: 1,
+                    },
+                    Value {
+                        event: event.clone(),
+                        batch_id: 0,
+                    },
+                )
+            })
+            .collect();
         let orderbook = Orderbook { events };
-
         let serialized_orderbook =
             ron::ser::to_string_pretty(&orderbook, ron::ser::PrettyConfig::default()).unwrap();
         let deserialized_orderbook = Orderbook::try_from(serialized_orderbook.as_bytes()).unwrap();

--- a/driver/src/orderbook/streamed/orderbook.rs
+++ b/driver/src/orderbook/streamed/orderbook.rs
@@ -192,8 +192,10 @@ mod tests {
             })
             .collect();
         let orderbook = Orderbook { events };
-        let serialized_orderbook = bincode::serialize(&orderbook).unwrap();
-        let deserialized_orderbook = Orderbook::try_from(&serialized_orderbook[..]).unwrap();
+        let serialized_orderbook =
+            bincode::serialize(&orderbook).expect("Failed to serialize orderbook");
+        let deserialized_orderbook = Orderbook::try_from(&serialized_orderbook[..])
+            .expect("Failed to deserialize orderbook");
         assert_eq!(orderbook.events, deserialized_orderbook.events);
     }
 


### PR DESCRIPTION
Turns out RON does not yet support `u128` so we will need a new serialization type. First commit includes more thorough test highlighting RON's the incapability. Failing travis should say this:

```
thread 'orderbook::streamed::orderbook::tests::test_serialize_deserialize_orderbook' panicked at 'called `Result::unwrap()` on an `Err` value: Message("u128 is not supported")'
```

Still need to find an alternative. It was suggested by @e00E that we look into using [bincode](https://github.com/servo/bincode). The file format is not human readable (which doesn't matter) but we would get smaller filesizes.


Closes #820 