### PR TITLE
[Trivial] Bump Ethcontracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2a203f1daee89dc2d9f71c89a5571f615e556ec803ac1d55e0620ab28f1bee"
+checksum = "deffc048863bfac48885716f4eb58716b8d93a60a8bb058555634403765d8891"
 dependencies = [
  "ethabi 9.0.1",
  "ethcontract-common",
@@ -730,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-common"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7898f63c78b866bc55d62df1a7598b9da9a54e323a3ac056929ec2947b1914aa"
+checksum = "242063b3dd393bcf09b2ce009b39b8d28a30ebc732be760859cd01671403cf45"
 dependencies = [
  "ethabi 12.0.0",
  "hex",
@@ -746,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-derive"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037f6f651ff95c8865e7261a35c3c372ade05aef33ede586ade2e7d51642cdb9"
+checksum = "b05cceba850b7b0665a4b434ddd95e855c6e26380d732b35c77a7decddce53f8"
 dependencies = [
  "ethcontract-common",
  "ethcontract-generate",
@@ -759,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-generate"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0e22f4249553b97125610821634fa193da4a301da5100072e238823a247411"
+checksum = "6560d8d2e27b0414e78e0d1553026e7abcc55ae5264ed0310e5375da607e2ccb"
 dependencies = [
  "Inflector",
  "anyhow",

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1"
 byteorder = "1.3.4"
 chrono = "0.4.11"
 crossbeam-utils = "0.7"
-ethcontract = "0.7.1"
+ethcontract = "0.7.2"
 futures = { version = "0.3.4", features = ["compat"] }
 isahc = { version = "0.9.1", features = ["json"] }
 lazy_static = "1.4.0"
@@ -36,4 +36,4 @@ url = "2.1.1"
 mockall = "0.7.0"
 
 [build-dependencies]
-ethcontract-generate = "0.7.1"
+ethcontract-generate = "0.7.2"

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
-ethcontract = "0.7.1"
+ethcontract = "0.7.2"
 futures = { version = "0.3.4", features = ["compat"] }


### PR DESCRIPTION
This should hopefully fix the alerts we are seeing like:

> ERROR (pod: dev-dfusion-standard-solver-mainnet-master-68bcc79797-2g5r8): 
Apr 30 08:32:41.690 ERRO [driver::driver::scheduler::system] Batch 5294117 failed with unretryable error: method 'submitSolution(uint32,uint256,address[],uint16[],uint128[],uint128[],uint16[]):(uint256)' failure: web3 error: RPC error: Error { code: ServerError(-32000), message: "Filter not found", data: None }

Since this version is now falling back to polling if we lose the filter

### Test Plan

No longer see this alerts after merging this PR.