### PR TITLE
[Easy] add github PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,4 @@
+[Optional] 
 Fixes #issue
 
 *<Context of what this change does, why it is needed and how it is accomplished>*

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+Fixes #issue
+
+*<Context of what this change does, why it is needed and how it is accomplished>*
+
+### Test Plan
+*<Explain how you and a reviewer have/intend to test this change>*


### PR DESCRIPTION
This will hopefully make it easier for us to make a good description and most importantly a test plan for PRs going forward. I Followed this tutorial: https://medium.com/better-programming/github-templates-the-smarter-way-to-formalize-pull-requests-among-development-teams-89f8d6a204f

### Test Plan

I was hoping the template would already show up here, but I guess it has to be merged into master first. Will try to create a new PR with this template after merging.