### PR TITLE
Allow specifying the internal solver used by the solver

### DIFF
--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -73,6 +73,11 @@ struct Options {
     #[structopt(long, env = "SOLVER_TYPE", default_value = "naive-solver")]
     solver_type: SolverType,
 
+    /// Which optimization solver the solver should use internally. Is passed as
+    /// `--solver` to the solver.
+    #[structopt(long, env = "SOLVER_INTERNAL_SOLVER")]
+    solver_internal_solver: Option<String>,
+
     /// JSON encoded backup token information to provide to the solver.
     ///
     /// For example: '{
@@ -234,6 +239,7 @@ fn main() {
         options.solver_type,
         price_oracle,
         options.min_avg_fee_per_order,
+        options.solver_internal_solver,
     );
 
     // Create the orderbook reader.

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -30,7 +30,7 @@ use crate::orderbook::{
     ShadowedOrderbookReader, StableXOrderBookReading,
 };
 use crate::price_estimation::{PriceOracle, TokenData};
-use crate::price_finding::{Fee, SolverType};
+use crate::price_finding::{Fee, InternalOptimizer, SolverType};
 use crate::solution_submission::StableXSolutionSubmitter;
 
 use ethcontract::PrivateKey;
@@ -73,10 +73,10 @@ struct Options {
     #[structopt(long, env = "SOLVER_TYPE", default_value = "naive-solver")]
     solver_type: SolverType,
 
-    /// Which optimization solver the solver should use internally. Is passed as
-    /// `--solver` to the solver.
-    #[structopt(long, env = "SOLVER_INTERNAL_SOLVER")]
-    solver_internal_solver: Option<String>,
+    /// Which internal optimizer the solver should use. It is passed as
+    /// `--solver` to the solver. Choices are "scip" and "gurobi".
+    #[structopt(long, env = "SOLVER_INTERNAL_SOLVER", default_value = "scip")]
+    solver_internal_optimizer: InternalOptimizer,
 
     /// JSON encoded backup token information to provide to the solver.
     ///
@@ -239,7 +239,7 @@ fn main() {
         options.solver_type,
         price_oracle,
         options.min_avg_fee_per_order,
-        options.solver_internal_solver,
+        options.solver_internal_optimizer,
     );
 
     // Create the orderbook reader.

--- a/driver/src/price_finding/mod.rs
+++ b/driver/src/price_finding/mod.rs
@@ -5,7 +5,9 @@ pub mod price_finder_interface;
 use crate::price_estimation::PriceEstimating;
 pub use crate::price_finding::naive_solver::NaiveSolver;
 pub use crate::price_finding::optimization_price_finder::OptimisationPriceFinder;
-pub use crate::price_finding::price_finder_interface::{Fee, PriceFinding, SolverType};
+pub use crate::price_finding::price_finder_interface::{
+    Fee, InternalOptimizer, PriceFinding, SolverType,
+};
 use log::info;
 
 pub fn create_price_finder(
@@ -13,7 +15,7 @@ pub fn create_price_finder(
     solver_type: SolverType,
     price_oracle: impl PriceEstimating + Sync + 'static,
     min_avg_fee_per_order: u128,
-    internal_solver: Option<String>,
+    internal_optimizer: InternalOptimizer,
 ) -> Box<dyn PriceFinding + Sync> {
     if solver_type == SolverType::NaiveSolver {
         info!("Using naive price finder");
@@ -25,7 +27,7 @@ pub fn create_price_finder(
             solver_type,
             price_oracle,
             min_avg_fee_per_order,
-            internal_solver,
+            internal_optimizer,
         ))
     }
 }

--- a/driver/src/price_finding/mod.rs
+++ b/driver/src/price_finding/mod.rs
@@ -13,6 +13,7 @@ pub fn create_price_finder(
     solver_type: SolverType,
     price_oracle: impl PriceEstimating + Sync + 'static,
     min_avg_fee_per_order: u128,
+    internal_solver: Option<String>,
 ) -> Box<dyn PriceFinding + Sync> {
     if solver_type == SolverType::NaiveSolver {
         info!("Using naive price finder");
@@ -24,6 +25,7 @@ pub fn create_price_finder(
             solver_type,
             price_oracle,
             min_avg_fee_per_order,
+            internal_solver,
         ))
     }
 }

--- a/driver/src/price_finding/optimization_price_finder.rs
+++ b/driver/src/price_finding/optimization_price_finder.rs
@@ -165,7 +165,7 @@ mod solver_input {
 #[cfg_attr(test, mockall::automock)]
 trait Io {
     fn write_input(&self, input_file: &str, input: &str) -> std::io::Result<()>;
-    fn run_solver<'a>(
+    fn run_solver(
         &self,
         input_file: &str,
         result_folder: &str,

--- a/driver/src/price_finding/optimization_price_finder.rs
+++ b/driver/src/price_finding/optimization_price_finder.rs
@@ -163,13 +163,14 @@ mod solver_input {
 #[cfg_attr(test, mockall::automock)]
 trait Io {
     fn write_input(&self, input_file: &str, input: &str) -> std::io::Result<()>;
-    fn run_solver(
+    fn run_solver<'a>(
         &self,
         input_file: &str,
         result_folder: &str,
         solver_type: SolverType,
         time_limit: Duration,
         min_avg_fee_per_order: u128,
+        internal_solver: Option<&'a str>,
     ) -> Result<()>;
     fn read_output(&self, result_folder: &str) -> std::io::Result<String>;
 }
@@ -180,6 +181,7 @@ pub struct OptimisationPriceFinder {
     solver_type: SolverType,
     price_oracle: Box<dyn PriceEstimating + Sync>,
     min_avg_fee_per_order: u128,
+    internal_solver: Option<String>,
 }
 
 impl OptimisationPriceFinder {
@@ -188,6 +190,7 @@ impl OptimisationPriceFinder {
         solver_type: SolverType,
         price_oracle: impl PriceEstimating + Sync + 'static,
         min_avg_fee_per_order: u128,
+        internal_solver: Option<String>,
     ) -> Self {
         OptimisationPriceFinder {
             io_methods: Box::new(DefaultIo),
@@ -195,6 +198,7 @@ impl OptimisationPriceFinder {
             solver_type,
             price_oracle: Box::new(price_oracle),
             min_avg_fee_per_order,
+            internal_solver,
         }
     }
 }
@@ -269,6 +273,7 @@ impl PriceFinding for OptimisationPriceFinder {
                 self.solver_type,
                 time_limit,
                 self.min_avg_fee_per_order,
+                self.internal_solver.as_ref().map(|s| s.as_ref()),
             )
             .with_context(|| format!("error running {:?} solver", self.solver_type))?;
         let result = self
@@ -297,10 +302,16 @@ impl Io for DefaultIo {
         solver: SolverType,
         time_limit: Duration,
         min_avg_fee_per_order: u128,
+        internal_solver: Option<&str>,
     ) -> Result<()> {
         let time_limit = (time_limit.as_secs_f64().round() as u64).to_string();
-        let output =
-            solver.execute(result_folder, input_file, time_limit, min_avg_fee_per_order)?;
+        let output = solver.execute(
+            result_folder,
+            input_file,
+            time_limit,
+            min_avg_fee_per_order,
+            internal_solver,
+        )?;
 
         if !output.status.success() {
             error!(
@@ -600,7 +611,7 @@ pub mod tests {
         io_methods
             .expect_run_solver()
             .times(1)
-            .returning(|_, _, _, _, _| Ok(()));
+            .returning(|_, _, _, _, _, _| Ok(()));
         io_methods
             .expect_read_output()
             .times(1)
@@ -611,6 +622,7 @@ pub mod tests {
             min_avg_fee_per_order: 0,
             solver_type: SolverType::StandardSolver,
             price_oracle: Box::new(price_oracle),
+            internal_solver: None,
         };
         let orders = vec![];
         assert!(solver

--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -53,17 +53,19 @@ impl SolverType {
         input_file: &str,
         time_limit: String,
         min_avg_fee_per_order: u128,
+        internal_solver: Option<&str>,
     ) -> Result<Output> {
         match self {
             SolverType::OpenSolver => {
                 execute_open_solver(result_folder, input_file, min_avg_fee_per_order)
             }
-            SolverType::StandardSolver => {
-                execute_private_solver(result_folder, input_file, time_limit, min_avg_fee_per_order)
-            }
-            SolverType::FallbackSolver => {
-                execute_private_solver(result_folder, input_file, time_limit, min_avg_fee_per_order)
-            }
+            SolverType::StandardSolver | SolverType::FallbackSolver => execute_private_solver(
+                result_folder,
+                input_file,
+                time_limit,
+                min_avg_fee_per_order,
+                internal_solver,
+            ),
             SolverType::NaiveSolver => {
                 panic!("fn execute should not be called by the naive solver")
             }
@@ -98,6 +100,7 @@ pub fn execute_private_solver(
     input_file: &str,
     time_limit: String,
     min_avg_fee_per_order: u128,
+    internal_solver: Option<&str>,
 ) -> Result<Output> {
     let mut command = Command::new("python");
     let private_solver_command = command
@@ -108,6 +111,10 @@ pub fn execute_private_solver(
         .args(&["--solverTimeLimit", &time_limit])
         .arg(format!("--minAvgFeePerOrder={}", min_avg_fee_per_order))
         .arg(String::from("--useExternalPrices"));
+    if let Some(string) = internal_solver {
+        private_solver_command.arg(format!("--solver={}", string));
+    }
+
     debug!(
         "Using private-solver command `{:?}`",
         private_solver_command

--- a/driver/src/price_finding/price_finder_interface.rs
+++ b/driver/src/price_finding/price_finder_interface.rs
@@ -43,7 +43,7 @@ impl FromStr for InternalOptimizer {
 }
 
 impl InternalOptimizer {
-    fn to_argument(&self) -> &'static str {
+    fn to_argument(self) -> &'static str {
         match self {
             InternalOptimizer::Scip => "SCIP",
             InternalOptimizer::Gurobi => "GUROBI",


### PR DESCRIPTION
This adds support for the gurobi solver.

I intentionally did not create an enum for the internal solver type
because then we would end up duplicating this from the solver. Instead
we just forward the argument.

https://github.com/gnosis/dex-solver/blob/2122d7aad044b14a2bf0a54698d8d3b4ed65d511/src/util/Parameters.py#L104
https://github.com/gnosis/dex-solver/blob/2122d7aad044b14a2bf0a54698d8d3b4ed65d511/src/util/enums/Solver.py#L7

closes #737 

### Test Plan
This change does not yet do anything. Once this and the corresponding gnosis staging PR is merged I will test that it works.