### PR TITLE
Rename internal optimizer env variable

### DIFF
--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -75,7 +75,7 @@ struct Options {
 
     /// Which internal optimizer the solver should use. It is passed as
     /// `--solver` to the solver. Choices are "scip" and "gurobi".
-    #[structopt(long, env = "SOLVER_INTERNAL_SOLVER", default_value = "scip")]
+    #[structopt(long, env = "SOLVER_INTERNAL_OPTIMIZER", default_value = "scip")]
     solver_internal_optimizer: InternalOptimizer,
 
     /// JSON encoded backup token information to provide to the solver.


### PR DESCRIPTION
We changed the terminology to use optimizer instead of solver but I
didn't update the env variable.

This has no impact on staging because we have not set either env variable yet.