### PR TITLE
Do not test rinkeby in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,10 +47,6 @@ matrix:
         - docker-compose -f docker-compose.yml -f docker-compose.private-solver.yml up -d stablex
         - cargo test -p e2e ganache -- --nocapture
         - docker-compose logs
-        # StableX e2e Tests (Rinkeby)
-        - docker-compose down && docker-compose -f docker-compose.yml -f docker-compose.rinkeby.yml -f docker-compose.private-solver.yml up -d stablex
-        - cargo test -p e2e rinkeby -- --nocapture
-        - docker-compose logs
       deploy:
         - provider: script
           script: ./docker/deploy.sh $TRAVIS_BRANCH


### PR DESCRIPTION
The rinkeby test is flaky because the network can be down. We decided to
no longer test as part of CI.
I have kept the configuration and test in the repository because there
can still be value in executing the test manually.

Fixes #845

### Test Plan
Check the CI output to see that we no longer do the test.