### PR TITLE
Use private solver instead of naive solver on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
         - docker-compose logs
         # Build and publish compact image with compiled binary
         - docker build --tag stablex-binary-private --build-arg SOLVER_BASE=163030813197.dkr.ecr.eu-central-1.amazonaws.com/dex-solver:v0.6.4 --build-arg RUST_BASE=rust-binary -f docker/rust/Dockerfile .
-        # StableX e2e Tests (Ganache) - naive solver
+        # StableX e2e Tests (Ganache) - private solver
         - docker-compose down
         - ./scripts/setup_contracts.sh
         - docker-compose -f docker-compose.yml -f docker-compose.private-solver.yml up -d stablex

--- a/docker-compose.private-solver.yml
+++ b/docker-compose.private-solver.yml
@@ -3,3 +3,5 @@ services:
   stablex:
     command: ./stablex
     image: stablex-binary-private
+    environment:
+      - SOLVER_TYPE=standard-solver


### PR DESCRIPTION
Now that we have a public, open solver it is no longer important to test
that the naive solver works. This commit changes the ci test from the
naive solver to the private solver.
We might want to remove the naive solver code in the future or replace
it with something from pricegraph.

### Test Plan
Check the CI output to see that the standard solver is used.