### PR TITLE
[Pricegraph] Remove dust orders

### DIFF
--- a/pricegraph/src/num.rs
+++ b/pricegraph/src/num.rs
@@ -4,6 +4,10 @@ use primitive_types::U256;
 use std::cmp;
 use std::f64;
 
+/// The maximum rounding error, used for asserting that amounts and balances
+/// remain coherent for tests and when built in `debug` profile.
+pub const MAX_ROUNDING_ERROR: f64 = 0.1;
+
 /// Convert an unsigned 256-bit integer into a `f64`.
 pub fn u256_to_f64(u: U256) -> f64 {
     let (u, factor) = match u {

--- a/pricegraph/src/orderbook/user.rs
+++ b/pricegraph/src/orderbook/user.rs
@@ -1,7 +1,7 @@
 //! Module implementing user and user token balance management.
 
 use crate::encoding::{Element, TokenId, UserId};
-use crate::num;
+use crate::num::{self, MAX_ROUNDING_ERROR};
 use std::collections::{hash_map, HashMap};
 
 /// A type definiton for a mapping between user IDs to user data.
@@ -30,31 +30,35 @@ impl User {
 
     /// Deducts an amount from the balance for the given token. Returns the new
     /// balance or `None` if the user no longer has any balance.
-    pub fn deduct_from_balance(&mut self, token: TokenId, amount: f64) -> Option<f64> {
-        const ROUNDING_ERROR: f64 = 0.1;
-
+    pub fn deduct_from_balance(&mut self, token: TokenId, amount: f64) -> f64 {
         if let hash_map::Entry::Occupied(mut entry) = self.balances.entry(token) {
             let balance = entry.get_mut();
             *balance -= amount;
 
             debug_assert!(
-                *balance >= -ROUNDING_ERROR,
+                *balance >= -MAX_ROUNDING_ERROR,
                 "user balance underflow for token {}",
                 token,
             );
 
             if *balance > 0.0 {
-                return Some(*balance);
+                *balance
+            } else {
+                entry.remove_entry();
+                0.0
             }
-            entry.remove_entry();
         } else {
             debug_assert!(
                 false,
                 "deducted amount from user with empty balace for token {}",
                 token,
             );
+            0.0
         }
+    }
 
-        None
+    /// Clears the user balance for a specific token.
+    pub fn clear_balance(&mut self, token: TokenId) {
+        self.balances.remove(&token);
     }
 }


### PR DESCRIPTION
This PR filters out orders and users whose effective balances are below the minimum amount. This reduces the amount of orders being considered by the path finding algorithm and speeds things up!

This will also increase the accuracy of the price estimation by not taking orders that are ignored by the solver into account.

### Test Plan

Unit tests still pass (CI), and new benchmarks show a significant performance increase (up to 30% for reducing negative cycles, which is by far the most expensive operation) by not considering orders that are rejected by the solver anyway:
```
Orderbook::read         time:   [482.32 us 488.44 us 495.57 us]                           
                        change: [-37.291% -36.359% -35.434%] (p = 0.00 < 0.05)
                        Performance has improved.

Orderbook::is_overlapping
                        time:   [39.150 us 40.306 us 41.702 us]
                        change: [-13.156% -10.970% -8.4677%] (p = 0.00 < 0.05)
                        Performance has improved.

Orderbook::reduce_overlapping_orders
                        time:   [8.3049 ms 8.4057 ms 8.5124 ms]
                        change: [-33.913% -30.653% -27.387%] (p = 0.00 < 0.05)
                        Performance has improved.

Orderbook::fill_market_order/100000000000000000
                        time:   [8.3627 ms 8.4184 ms 8.4957 ms]
                        change: [-24.331% -21.662% -19.143%] (p = 0.00 < 0.05)
                        Performance has improved.
Orderbook::fill_market_order/1000000000000000000
                        time:   [8.3659 ms 8.4913 ms 8.5809 ms]
                        change: [-30.703% -28.716% -26.811%] (p = 0.00 < 0.05)
                        Performance has improved.
Orderbook::fill_market_order/10000000000000000000
                        time:   [8.4522 ms 8.5400 ms 8.6185 ms]
                        change: [-26.355% -24.829% -23.244%] (p = 0.00 < 0.05)
                        Performance has improved.
Orderbook::fill_market_order/100000000000000000000
                        time:   [8.5807 ms 8.6755 ms 8.7877 ms]
                        change: [-35.105% -33.054% -30.871%] (p = 0.00 < 0.05)
                        Performance has improved.
Orderbook::fill_market_order/1000000000000000000000
                        time:   [8.6829 ms 9.2615 ms 9.8062 ms]
                        change: [-27.485% -24.942% -22.012%] (p = 0.00 < 0.05)
                        Performance has improved.

Orderbook::fill_market_order(reduced)/100000000000000000
                        time:   [67.107 us 67.739 us 68.447 us]
                        change: [-3.5446% +0.2185% +4.0464%] (p = 0.91 > 0.05)
                        No change in performance detected.
Orderbook::fill_market_order(reduced)/1000000000000000000
                        time:   [72.472 us 74.399 us 76.681 us]
                        change: [-0.6806% +3.9084% +9.4373%] (p = 0.13 > 0.05)
                        No change in performance detected.
Orderbook::fill_market_order(reduced)/10000000000000000000
                        time:   [148.32 us 150.30 us 152.43 us]
                        change: [-1.3013% +3.5077% +8.7526%] (p = 0.17 > 0.05)
                        No change in performance detected.
Orderbook::fill_market_order(reduced)/100000000000000000000
                        time:   [297.27 us 303.92 us 308.08 us]
                        change: [-12.113% -7.9073% -2.9835%] (p = 0.00 < 0.05)
                        Performance has improved.
Orderbook::fill_market_order(reduced)/1000000000000000000000
                        time:   [668.83 us 674.07 us 678.46 us]
                        change: [-11.052% -9.0743% -7.1406%] (p = 0.00 < 0.05)
                        Performance has improved.
```