### PR TITLE
[Easy] Log options to single line

### DIFF
--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -198,7 +198,7 @@ struct Options {
 fn main() {
     let options = Options::from_args();
     let (_, _guard) = logging::init(&options.log_filter);
-    info!("Starting driver with runtime options: {:#?}", options);
+    info!("Starting driver with runtime options: {:?}", options);
 
     // Set up metrics and serve in separate thread.
     let prometheus_registry = Arc::new(Registry::new());


### PR DESCRIPTION
This PR changes the initial log message the prints the startup options used by the driver to be a single line. This is done to make it easier to find the startup logs, since our logging service splits each separate line into a separate log document, making it very hard to actually see what the command line arguments actually are.