### PR TITLE
[Easy] Log solver output to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ pricegraph/data/node_modules/
 
 # WASM
 pricegraph/wasm/pkg/
+
+# Driver runtime files
+instances/
+results/

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -67,9 +67,10 @@ struct Options {
     #[structopt(short = "i", long, env = "NETWORK_ID")]
     network_id: u64,
 
-    /// Which style of solver to use. Can be one of: 'NAIVE' for the naive
-    /// solver; 'MIP' for mixed integer programming solver; 'NLP' for non-linear
-    /// programming solver.
+    /// Which style of solver to use.  Can be one of: 'naive-solver' for the
+    /// naive solver; 'standard-solver' for mixed integer programming solver;
+    /// 'fallback-solver' for non-linear programming solver and 'open-solver'
+    /// for the open source solver.
     #[structopt(long, env = "SOLVER_TYPE", default_value = "naive-solver")]
     solver_type: SolverType,
 


### PR DESCRIPTION
Parsing the output of the open solver when there are errors is very difficult in the logs because each line is considered a separate document, and since they all happen at the same time, the order gets jumbled.

This PR writes the solver stdout and stderr to file when it exits with an error code.

### Test Plan

First, create a fake solver for the driver to run:
```
mkdir -p /app/open_solver/src
touch /app/open_solver/src/__init__.py
cat > /app/open_solver/src/match.py << EOF
import sys
if __name__ == "__main__":
    print("some stdout message with args", sys.argv)
    print("some stderr message", file=sys.stderr)
    sys.exit(1)
EOF
```

Start ganace and run the driver:
```
cargo run -- --network-id 5777 --node-url http://localhost:8545 --solver-type open-solver --scheduler evm
```

And the ganache e2e test
```
cargo test -p e2e ganache -- --nocapture
```

Observe the driver output:
```
May 15 08:02:00.056 ERRO [driver::price_finding::optimization_price_finder] Solver failed, writing stdout to 'results/2020-05-15/instance_5298431_2020-05-15T08:02:00.036950761+00:00/stdout.txt' and stderr to 'results/2020-05-15/instance_5298431_2020-05-15T08:02:00.036950761+00:00/stderr.txt'
```

And inspect the `{stdout,stderr}.txt` files for ensure that the solver output was indeed recorded:
```
$ cat results/2020-05-15/*/stdout.txt
some stdout message with args ['/app/open_solver/src/match.py', '/app/instances/2020-05-15/instance_5298431_2020-05-15T08:02:00.036950761+00:00.json', '--solution=/app/results/2020-05-15/instance_5298431_2020-05-15T08:02:00.036950761+00:00/06_solution_int_valid.json', '--min-avg-fee-per-order=0', 'best-token-pair']
$ cat results/2020-05-15/*/stderr.txt
some stderr message
```