### PR TITLE
Use different log timestamp format

### DIFF
--- a/driver/src/logging.rs
+++ b/driver/src/logging.rs
@@ -1,3 +1,4 @@
+use chrono::Utc;
 use slog::Level;
 use slog::{o, Drain, Logger, OwnedKVList, Record};
 use slog_async::Async;
@@ -65,9 +66,9 @@ fn log_to_decorator(
     record: &Record,
     values: &OwnedKVList,
 ) -> std::result::Result<(), std::io::Error> {
-    decorator.with_record(record, values, |mut decorator| {
+    decorator.with_record(record, values, |decorator| {
         decorator.start_timestamp()?;
-        slog_term::timestamp_utc(&mut decorator)?;
+        write!(decorator, "{}", Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ"))?;
 
         decorator.start_whitespace()?;
         write!(decorator, " ")?;


### PR DESCRIPTION
This PR changes the datetime format used by the logger so that it matches an expected pattern. Our logging service will group logs using these timestamps as separators so that they show up as one document instead of one per line.

### Test Plan

Run and see new time format in the console:
```
2020-05-15T13:34:12.205Z INFO [driver] Starting driver with runtime options: Options {
```

This should match the format indicated by dear DevOps:
> Yes!
> @ Nick if you want to group them you should use one of these formats:
> - 2018-04-02T17:09:10.883Z [...]
> - 2018-04-02 15:04:29,228 [...]

I chose to use the first one as it indicates the timezone (here UTC).

Also, once in staging we should observe that the "Starting driver with runtime options" log message and the following runtime options will be grouped into a single log document.