### PR TITLE
Use 256 bit integer to represent balance instead of 128

### DIFF
--- a/driver/src/models/account_state.rs
+++ b/driver/src/models/account_state.rs
@@ -1,13 +1,17 @@
 use ethcontract::Address;
+use ethcontract::U256;
 use std::collections::HashMap;
 
 /// Maps a user and a token id to the balance the user has of this token.
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct AccountState(pub HashMap<(Address, u16), u128>);
+pub struct AccountState(pub HashMap<(Address, u16), U256>);
 
 impl AccountState {
-    pub fn read_balance(&self, token_id: u16, account_id: Address) -> u128 {
-        self.0.get(&(account_id, token_id)).cloned().unwrap_or(0)
+    pub fn read_balance(&self, token_id: u16, account_id: Address) -> U256 {
+        self.0
+            .get(&(account_id, token_id))
+            .cloned()
+            .unwrap_or_else(U256::zero)
     }
 
     pub fn user_token_pairs(&self) -> impl Iterator<Item = (Address, u16)> + '_ {
@@ -16,8 +20,8 @@ impl AccountState {
 }
 
 impl IntoIterator for AccountState {
-    type Item = ((Address, u16), u128);
-    type IntoIter = <HashMap<(Address, u16), u128> as IntoIterator>::IntoIter;
+    type Item = ((Address, u16), U256);
+    type IntoIter = <HashMap<(Address, u16), U256> as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
@@ -45,7 +49,7 @@ mod test_util {
                         .enumerate()
                         .map(move |(token, balance)| {
                             let key = (Address::from_low_u64_be(account as u64), token as u16);
-                            (key, *balance)
+                            (key, U256::from(*balance))
                         })
                 })
                 .collect();
@@ -65,7 +69,7 @@ mod test_util {
         }
 
         pub fn increase_balance(&mut self, account_id: Address, token_id: u16, amount: u128) {
-            *self.0.entry((account_id, token_id)).or_default() += amount;
+            *self.0.entry((account_id, token_id)).or_default() += U256::from(amount);
         }
     }
 }

--- a/driver/src/orderbook/shadow_orderbook.rs
+++ b/driver/src/orderbook/shadow_orderbook.rs
@@ -123,8 +123,8 @@ impl Diff {
 struct BalanceChange {
     user: Address,
     token: TokenId,
-    primary: u128,
-    shadow: u128,
+    primary: U256,
+    shadow: U256,
 }
 
 impl BalanceChange {
@@ -282,9 +282,9 @@ mod tests {
         let mut diff = Diff::compare(
             &(
                 AccountState(hash_map! {
-                    (addr(1), 0) => 100,
-                    (addr(1), 1) => 100,
-                    (addr(3), 3) => 100,
+                    (addr(1), 0) => U256::from(100),
+                    (addr(1), 1) => U256::from(100),
+                    (addr(3), 3) => U256::from(100),
                 }),
                 vec![
                     Order {
@@ -315,9 +315,9 @@ mod tests {
             ),
             &(
                 AccountState(hash_map! {
-                    (addr(1), 0) => 100,
-                    (addr(2), 1) => 100,
-                    (addr(3), 3) => 101,
+                    (addr(1), 0) => U256::from(100),
+                    (addr(2), 1) => U256::from(100),
+                    (addr(3), 3) => U256::from(101),
                 }),
                 vec![
                     Order {
@@ -360,20 +360,20 @@ mod tests {
                     BalanceChange {
                         user: addr(1),
                         token: TokenId(1),
-                        primary: 100,
-                        shadow: 0,
+                        primary: U256::from(100),
+                        shadow: U256::from(0),
                     },
                     BalanceChange {
                         user: addr(2),
                         token: TokenId(1),
-                        primary: 0,
-                        shadow: 100,
+                        primary: U256::from(0),
+                        shadow: U256::from(100),
                     },
                     BalanceChange {
                         user: addr(3),
                         token: TokenId(3),
-                        primary: 100,
-                        shadow: 101,
+                        primary: U256::from(100),
+                        shadow: U256::from(101),
                     },
                 ],
                 vec![

--- a/driver/src/orderbook/streamed/orderbook.rs
+++ b/driver/src/orderbook/streamed/orderbook.rs
@@ -144,10 +144,7 @@ impl StableXOrderBookReading for Orderbook {
         // to increment it.
         let (account_state, orders) =
             state.orderbook_for_batch(Batch::Future(batch_id_to_solve.low_u32() + 1))?;
-        let (account_state, orders) = util::normalize_auction_data(
-            account_state.map(|(key, balance)| (key, balance.low_u128())),
-            orders,
-        );
+        let (account_state, orders) = util::normalize_auction_data(account_state, orders);
         Ok((account_state, orders))
     }
 }
@@ -279,13 +276,13 @@ mod tests {
         let auction_data = orderbook.get_auction_data(1.into()).unwrap();
         assert_eq!(
             auction_data.0.read_balance(0, Address::from_low_u64_be(2)),
-            3
+            U256::from(3)
         );
         orderbook.delete_events_starting_at_block(1);
         let auction_data = orderbook.get_auction_data(1.into()).unwrap();
         assert_eq!(
             auction_data.0.read_balance(0, Address::from_low_u64_be(2)),
-            1
+            U256::from(1)
         );
     }
 
@@ -340,7 +337,7 @@ mod tests {
         let auction_data = orderbook.get_auction_data(2.into()).unwrap();
         assert_eq!(
             auction_data.0.read_balance(0, Address::from_low_u64_be(2)),
-            7
+            U256::from(7)
         );
     }
 }

--- a/driver/src/orderbook/streamed/state.rs
+++ b/driver/src/orderbook/streamed/state.rs
@@ -337,12 +337,7 @@ mod tests {
     }
 
     fn account_state(state: &State, batch_id: BatchId) -> AccountState {
-        AccountState(
-            state
-                .account_state(batch_id)
-                .map(|(key, balance)| (key, balance.low_u128()))
-                .collect(),
-        )
+        AccountState(state.account_state(batch_id).collect())
     }
 
     #[test]
@@ -356,9 +351,9 @@ mod tests {
         };
         state = state.apply_event(&Event::Deposit(event), 0).unwrap();
         let account_state_ = account_state(&state, 0);
-        assert_eq!(account_state_.read_balance(0, address(3)), 0);
+        assert_eq!(account_state_.read_balance(0, address(3)), U256::from(0));
         let account_state_ = account_state(&state, 1);
-        assert_eq!(account_state_.read_balance(0, address(3)), 1);
+        assert_eq!(account_state_.read_balance(0, address(3)), U256::from(1));
     }
 
     #[test]
@@ -376,7 +371,7 @@ mod tests {
         }
 
         let account_state_ = account_state(&state, 1);
-        assert_eq!(account_state_.read_balance(0, address(3)), 1);
+        assert_eq!(account_state_.read_balance(0, address(3)), U256::from(1));
 
         let event = TokenListing {
             token: address(1),
@@ -385,8 +380,8 @@ mod tests {
         state = state.apply_event(&Event::TokenListing(event), 0).unwrap();
 
         let account_state_ = account_state(&state, 1);
-        assert_eq!(account_state_.read_balance(0, address(3)), 1);
-        assert_eq!(account_state_.read_balance(1, address(3)), 1);
+        assert_eq!(account_state_.read_balance(0, address(3)), U256::from(1));
+        assert_eq!(account_state_.read_balance(1, address(3)), U256::from(1));
     }
 
     #[test]
@@ -402,7 +397,10 @@ mod tests {
             state = state.apply_event(&Event::Deposit(event), i).unwrap();
 
             let account_state_ = account_state(&state, i + 2);
-            assert_eq!(account_state_.read_balance(0, address(1)), i as u128 + 1);
+            assert_eq!(
+                account_state_.read_balance(0, address(1)),
+                U256::from(i + 1)
+            );
         }
     }
 
@@ -419,9 +417,12 @@ mod tests {
             state = state.apply_event(&Event::Deposit(event), 0).unwrap();
 
             let account_state_ = account_state(&state, 0);
-            assert_eq!(account_state_.read_balance(0, address(1)), 0);
+            assert_eq!(account_state_.read_balance(0, address(1)), U256::from(0));
             let account_state_ = account_state(&state, 1);
-            assert_eq!(account_state_.read_balance(0, address(1)), i + 1);
+            assert_eq!(
+                account_state_.read_balance(0, address(1)),
+                U256::from(i + 1)
+            );
         }
     }
 
@@ -445,7 +446,7 @@ mod tests {
             .apply_event(&Event::WithdrawRequest(event), 0)
             .unwrap();
         let account_state_ = account_state(&state, 1);
-        assert_eq!(account_state_.read_balance(0, address(1)), 1);
+        assert_eq!(account_state_.read_balance(0, address(1)), U256::from(1));
     }
 
     #[test]
@@ -468,7 +469,7 @@ mod tests {
             .apply_event(&Event::WithdrawRequest(event), 1)
             .unwrap();
         let account_state_ = account_state(&state, 3);
-        assert_eq!(account_state_.read_balance(0, address(1)), 0);
+        assert_eq!(account_state_.read_balance(0, address(1)), U256::from(0));
     }
 
     #[test]
@@ -497,7 +498,7 @@ mod tests {
         };
         state = state.apply_event(&Event::Withdraw(event), 1).unwrap();
         let account_state_ = account_state(&state, 1);
-        assert_eq!(account_state_.read_balance(0, address(1)), 1);
+        assert_eq!(account_state_.read_balance(0, address(1)), U256::from(1));
     }
 
     #[test]
@@ -520,7 +521,7 @@ mod tests {
             .apply_event(&Event::WithdrawRequest(event), 0)
             .unwrap();
         let account_state_ = account_state(&state, 1);
-        assert_eq!(account_state_.read_balance(0, address(1)), 1);
+        assert_eq!(account_state_.read_balance(0, address(1)), U256::from(1));
         let event = Withdraw {
             user: address(1),
             token: address(0),
@@ -528,7 +529,7 @@ mod tests {
         };
         state = state.apply_event(&Event::Withdraw(event), 1).unwrap();
         let account_state_ = account_state(&state, 2);
-        assert_eq!(account_state_.read_balance(0, address(1)), 2);
+        assert_eq!(account_state_.read_balance(0, address(1)), U256::from(2));
     }
 
     #[test]
@@ -673,11 +674,11 @@ mod tests {
             .unwrap();
 
         let account_state_ = account_state(&state, 2);
-        assert_eq!(account_state_.read_balance(0, address(2)), 12);
-        assert_eq!(account_state_.read_balance(1, address(2)), 9);
-        assert_eq!(account_state_.read_balance(0, address(3)), 8);
-        assert_eq!(account_state_.read_balance(1, address(3)), 11);
-        assert_eq!(account_state_.read_balance(0, address(4)), 42);
+        assert_eq!(account_state_.read_balance(0, address(2)), U256::from(12));
+        assert_eq!(account_state_.read_balance(1, address(2)), U256::from(9));
+        assert_eq!(account_state_.read_balance(0, address(3)), U256::from(8));
+        assert_eq!(account_state_.read_balance(1, address(3)), U256::from(11));
+        assert_eq!(account_state_.read_balance(0, address(4)), U256::from(42));
         assert_eq!(
             state
                 .orders

--- a/driver/src/orderbook/util.rs
+++ b/driver/src/orderbook/util.rs
@@ -1,10 +1,10 @@
 use crate::models::{AccountState, Order};
-use ethcontract::Address;
+use ethcontract::{Address, U256};
 
 /// Removes empty orders and token balances for which there is
 /// not at least one sell order by that user
 pub fn normalize_auction_data(
-    account_states: impl IntoIterator<Item = ((Address, u16), u128)>,
+    account_states: impl IntoIterator<Item = ((Address, u16), U256)>,
     orders: impl IntoIterator<Item = Order>,
 ) -> (AccountState, Vec<Order>) {
     let orders = orders
@@ -48,14 +48,17 @@ mod tests {
             },
         ];
         let account_states = vec![
-            ((Address::zero(), 0), 3),
-            ((Address::zero(), 1), 4),
-            ((Address::zero(), 2), 5),
+            ((Address::zero(), 0), U256::from(3)),
+            ((Address::zero(), 1), U256::from(4)),
+            ((Address::zero(), 2), U256::from(5)),
         ];
 
         let (account_state, orders) = normalize_auction_data(account_states, orders);
         assert_eq!(account_state.0.len(), 1);
-        assert_eq!(account_state.read_balance(1, Address::zero()), 4);
+        assert_eq!(
+            account_state.read_balance(1, Address::zero()),
+            U256::from(4)
+        );
         assert_eq!(orders.len(), 1);
         assert_eq!(orders[0].account_id, Address::zero());
     }

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -52,7 +52,7 @@ impl Matchable for Order {
     }
 
     fn sufficient_seller_funds(&self, state: &AccountState) -> bool {
-        state.read_balance(self.sell_token, self.account_id) >= self.sell_amount
+        state.read_balance(self.sell_token, self.account_id) >= U256::from(self.sell_amount)
     }
 
     fn match_compare(


### PR DESCRIPTION
In the smart contract account balances are serialized as 256 bit
integers but our current implementation uses 128 bit integers instead
and asserts that balances are never larger than the maximum 128 bit
integer.
It is more correct to use the same number type which allows us to
represent all balances and gets rid of the panic.

### Test Plan
CI. Relevant code that decodes an auction element and serializes numbers to the solver is already being tested.