### PR TITLE
Use arbitrary size integers for event based orderbook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,6 +618,7 @@ dependencies = [
  "lazy_static",
  "log 0.4.8",
  "mockall",
+ "num",
  "prometheus",
  "rouille",
  "rustc-hex",
@@ -1606,6 +1607,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "num"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg 1.0.0",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+dependencies = [
+ "autocfg 1.0.0",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,6 +1651,30 @@ checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 dependencies = [
  "autocfg 1.0.0",
  "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfb0800a0291891dd9f4fe7bd9c19384f98f7fbe0cd0f39a2c6b88b9868bbc00"
+dependencies = [
+ "autocfg 1.0.0",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+dependencies = [
+ "autocfg 1.0.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -15,6 +15,7 @@ futures = { version = "0.3.5", features = ["compat"] }
 isahc = { version = "0.9.2", features = ["json"] }
 lazy_static = "1.4.0"
 log = "0.4.8"
+num = { version = "0.2", features = ["serde"] }
 prometheus = "0.9.0"
 rouille = "3.0.0"
 rustc-hex = "2.1.0"

--- a/driver/src/orderbook/streamed/balance.rs
+++ b/driver/src/orderbook/streamed/balance.rs
@@ -1,53 +1,25 @@
 use super::*;
 use anyhow::{anyhow, ensure, Result};
+use num::BigInt;
+use num::Zero as _;
 use serde::{Deserialize, Serialize};
 
-/// Balance change from a potential solution that might still get replaced by a better solution in
-/// the same batch.
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
-struct Proceeds {
-    batch_id: BatchId,
-    // Two fields instead of one I256 because although unlikely it could be possible to overflow a
-    // I256 with multiple trades in one batch.
-    increase: U256,
-    decrease: U256,
-}
-
-enum TradeType {
-    Sell,
-    Buy,
-}
-
-impl Proceeds {
-    fn get_field(&mut self, operation: TradeType) -> &mut U256 {
-        match operation {
-            TradeType::Sell => &mut self.decrease,
-            TradeType::Buy => &mut self.increase,
-        }
-    }
-}
-
 /// The balance of a token for a user.
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Balance {
-    balance: U256,
+    balance: BigInt,
     deposit: Flux,
     withdraw: Flux,
-    proceeds: Proceeds,
+    proceeds: Flux,
 }
 
 impl Balance {
-    pub fn deposit(&mut self, amount: U256, batch_id: BatchId) -> Result<()> {
-        self.apply_existing_deposit_and_proceeds(batch_id)?;
+    pub fn deposit(&mut self, amount: U256, batch_id: BatchId) {
+        self.apply_existing_deposit_and_proceeds(batch_id);
         // Works like in the smart contract: If there is an existing deposit we override the
         // batch id and add to the amount.
         self.deposit.batch_id = batch_id;
-        self.deposit.amount = self
-            .deposit
-            .amount
-            .checked_add(amount)
-            .ok_or_else(|| anyhow!("overflow"))?;
-        Ok(())
+        self.deposit.amount += bigint_u256::u256_to_bigint(amount);
     }
 
     pub fn withdraw_request(
@@ -60,137 +32,124 @@ impl Balance {
         // withdraw request because the smart contract should have emitted a withdraw event for the
         // previous one first.
         ensure!(
-            self.withdraw.batch_id >= current_batch_id || self.withdraw.amount == U256::zero(),
+            self.withdraw.batch_id >= current_batch_id || self.withdraw.amount.is_zero(),
             "new withdraw request before clearing of previous withdraw request"
         );
         self.withdraw.batch_id = batch_id;
-        self.withdraw.amount = amount;
+        self.withdraw.amount = bigint_u256::u256_to_bigint(amount);
         Ok(())
     }
 
     pub fn withdraw(&mut self, amount: U256, batch_id: BatchId) -> Result<()> {
-        ensure!(
-            self.withdraw.batch_id < batch_id,
-            anyhow!("withdraw earlier than requested {}", self.withdraw.batch_id)
-        );
-        ensure!(
-            self.withdraw.amount >= amount,
-            anyhow!("withdraw more than requested {}", self.withdraw.amount)
-        );
+        let amount = bigint_u256::u256_to_bigint(amount);
         // Works like in the smart contract: Any withdraw unconditionally removes the withdraw
         // request even if the amount is smaller than requested.
-        self.withdraw.amount = 0.into();
-        self.apply_existing_deposit_and_proceeds(batch_id)?;
-        self.balance = self
-            .balance
-            .checked_sub(amount)
-            .ok_or_else(|| anyhow!("withdraw more than balance"))?;
+        ensure!(
+            self.withdraw.amount_and_zero(batch_id) >= amount,
+            anyhow!("withdraw does not match withdraw request")
+        );
+        self.apply_existing_deposit_and_proceeds(batch_id);
+        self.balance -= amount;
         Ok(())
     }
 
-    pub fn get_balance(&self, batch_id: BatchId) -> Result<U256> {
-        let mut balance = self.balance_with_deposit_and_proceeds(batch_id)?;
-        if self.withdraw.batch_id < batch_id {
-            // Saturating because withdraw requests can be for amounts larger than balance.
-            balance = balance.saturating_sub(self.withdraw.amount);
+    pub fn get_balance(&self, batch_id: BatchId) -> BigInt {
+        let balance = self.balance_with_deposit_and_proceeds(batch_id);
+        // Withdraw requests can be for amounts larger than balance.
+        match self.withdraw.amount(batch_id) {
+            Some(amount) if amount < &balance => balance - amount,
+            _ => BigInt::zero(),
         }
-        Ok(balance)
     }
 
     pub fn sell(&mut self, amount: u128, batch_id: BatchId) -> Result<()> {
-        self.sell_buy_internal(amount.into(), batch_id, TradeType::Sell)
+        self.sell_buy_internal(-BigInt::from(amount), batch_id)
     }
 
     pub fn buy(&mut self, amount: u128, batch_id: BatchId) -> Result<()> {
-        self.sell_buy_internal(amount.into(), batch_id, TradeType::Buy)
+        self.sell_buy_internal(BigInt::from(amount), batch_id)
     }
 
     pub fn revert_sell(&mut self, amount: u128, batch_id: BatchId) -> Result<()> {
-        self.revert_sell_buy_internal(amount.into(), batch_id, TradeType::Sell)
+        self.revert_sell_buy_internal(-BigInt::from(amount), batch_id)
     }
 
     pub fn revert_buy(&mut self, amount: u128, batch_id: BatchId) -> Result<()> {
-        self.revert_sell_buy_internal(amount.into(), batch_id, TradeType::Buy)
+        self.revert_sell_buy_internal(BigInt::from(amount), batch_id)
     }
 
     pub fn solution_submission(&mut self, fee: U256, batch_id: BatchId) -> Result<()> {
         // We are reusing the `Proceeds` machinery here because the extra balance from a solution
         // submission behaves the same way.
-        self.sell_buy_internal(fee, batch_id, TradeType::Buy)
+        self.sell_buy_internal(bigint_u256::u256_to_bigint(fee), batch_id)
     }
 
     pub fn revert_solution_submission(&mut self, fee: U256, batch_id: BatchId) -> Result<()> {
-        self.revert_sell_buy_internal(fee, batch_id, TradeType::Buy)
+        self.revert_sell_buy_internal(bigint_u256::u256_to_bigint(fee), batch_id)
     }
 
-    fn sell_buy_internal(
-        &mut self,
-        amount: U256,
-        batch_id: BatchId,
-        operation: TradeType,
-    ) -> Result<()> {
+    /// Adds the amount to the proceeds.
+    fn sell_buy_internal(&mut self, amount: BigInt, batch_id: BatchId) -> Result<()> {
         ensure!(self.proceeds.batch_id <= batch_id, "trade for past batch");
-        self.apply_existing_deposit_and_proceeds(batch_id)?;
+        self.apply_existing_deposit_and_proceeds(batch_id);
         // Now old proceeds have been cleared. If there is an existing proceed for this batch then
         // setting the batch_id does nothing and we add to the field.
         self.proceeds.batch_id = batch_id;
-        let field = self.proceeds.get_field(operation);
-        *field = field
-            .checked_add(amount)
-            .ok_or_else(|| anyhow!("math overflow"))?;
+        self.proceeds.amount += amount;
         Ok(())
     }
 
-    fn revert_sell_buy_internal(
-        &mut self,
-        amount: U256,
-        batch_id: BatchId,
-        operation: TradeType,
-    ) -> Result<()> {
+    /// Subtracts the amount from the proceeds.
+    fn revert_sell_buy_internal(&mut self, amount: BigInt, batch_id: BatchId) -> Result<()> {
         ensure!(
             self.proceeds.batch_id == batch_id,
             "reverting non existent trade"
         );
-        let field = self.proceeds.get_field(operation);
-        *field = field
-            .checked_sub(amount)
-            .ok_or_else(|| anyhow!("math underflow"))?;
+        self.proceeds.amount -= amount;
         Ok(())
     }
 
-    fn balance_with_deposit_and_proceeds(&self, current_batch_id: BatchId) -> Result<U256> {
-        let mut balance = self.balance;
-        if self.deposit.batch_id < current_batch_id {
-            balance = balance
-                .checked_add(self.deposit.amount)
-                .ok_or_else(|| anyhow!("math overflow"))?;
+    fn balance_with_deposit_and_proceeds(&self, current_batch_id: BatchId) -> BigInt {
+        let mut result = self.balance.clone();
+        if let Some(deposit) = self.deposit.amount(current_batch_id) {
+            result += deposit
         }
-        if self.proceeds.batch_id < current_batch_id {
-            balance = balance
-                .checked_add(self.proceeds.increase)
-                .ok_or_else(|| anyhow!("math overflow"))?
-                .checked_sub(self.proceeds.decrease)
-                .ok_or_else(|| anyhow!("math underflow"))?;
+        if let Some(proceed) = self.proceeds.amount(current_batch_id) {
+            result += proceed
         }
-        Ok(balance)
+        result
     }
 
-    fn apply_existing_deposit_and_proceeds(&mut self, current_batch_id: BatchId) -> Result<()> {
-        self.balance = self.balance_with_deposit_and_proceeds(current_batch_id)?;
-        if self.deposit.batch_id < current_batch_id {
-            self.deposit.amount = U256::zero();
-        }
-        if self.proceeds.batch_id < current_batch_id {
-            self.proceeds.increase = U256::zero();
-            self.proceeds.decrease = U256::zero();
-        }
-        Ok(())
+    fn apply_existing_deposit_and_proceeds(&mut self, current_batch_id: BatchId) {
+        self.balance += self.deposit.amount_and_zero(current_batch_id);
+        self.balance += self.proceeds.amount_and_zero(current_batch_id);
     }
 }
 
 /// A change in balance starting at some batch id.
-#[derive(Copy, Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 struct Flux {
     batch_id: BatchId,
-    amount: U256,
+    amount: BigInt,
+}
+
+impl Flux {
+    /// Returns the amount if the batch id is smaller than the self.batch_id, None otherwise.
+    fn amount(&self, batch_id: BatchId) -> Option<&BigInt> {
+        if self.batch_id < batch_id {
+            Some(&self.amount)
+        } else {
+            None
+        }
+    }
+
+    /// If self.batch_id is smaller than batch_id, replaces self.amount with 0 and returns the
+    /// original. Returns 0 without replacing otherwise.
+    fn amount_and_zero(&mut self, batch_id: BatchId) -> BigInt {
+        if self.batch_id < batch_id {
+            std::mem::replace(&mut self.amount, BigInt::zero())
+        } else {
+            BigInt::zero()
+        }
+    }
 }

--- a/driver/src/orderbook/streamed/bigint_u256.rs
+++ b/driver/src/orderbook/streamed/bigint_u256.rs
@@ -1,0 +1,57 @@
+use ethcontract::U256;
+use num::{bigint::Sign, BigInt, BigUint};
+
+/// None if U256 cannot represent the number.
+pub fn bigint_to_u256(n: &BigInt) -> Option<U256> {
+    match n.to_bytes_le() {
+        (Sign::NoSign, _) => Some(U256::zero()),
+        (Sign::Plus, bytes) if bytes.len() <= 256 / 8 => Some(U256::from_little_endian(&bytes)),
+        _ => None,
+    }
+}
+
+pub fn u256_to_biguint(n: U256) -> BigUint {
+    let mut bytes = [0u8; 256 / 8];
+    n.to_little_endian(&mut bytes);
+    BigUint::from_bytes_le(&bytes)
+}
+
+pub fn u256_to_bigint(n: U256) -> BigInt {
+    BigInt::from_biguint(Sign::Plus, u256_to_biguint(n))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use num::pow::Pow;
+
+    #[test]
+    fn zero() {
+        assert_eq!(bigint_to_u256(&BigInt::from(0)), Some(U256::from(0)));
+        assert_eq!(u256_to_bigint(U256::from(0)), BigInt::from(0));
+    }
+
+    #[test]
+    fn negative() {
+        assert_eq!(bigint_to_u256(&BigInt::from(-1)), None);
+    }
+
+    #[test]
+    fn positive() {
+        assert_eq!(bigint_to_u256(&BigInt::from(1)), Some(U256::from(1)));
+        assert_eq!(u256_to_bigint(U256::from(1)), BigInt::from(1));
+    }
+
+    #[test]
+    fn large() {
+        let bigint = BigInt::from(2).pow(256u32) - BigInt::from(1);
+        let u256 = U256::MAX;
+        assert_eq!(bigint_to_u256(&bigint), Some(u256));
+        assert_eq!(u256_to_bigint(u256), bigint);
+    }
+
+    #[test]
+    fn too_large() {
+        assert_eq!(bigint_to_u256(&BigInt::from(2).pow(256u32)), None);
+    }
+}

--- a/driver/src/orderbook/streamed/mod.rs
+++ b/driver/src/orderbook/streamed/mod.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 mod balance;
+mod bigint_u256;
 mod block_timestamp_reading;
 mod order;
 mod orderbook;


### PR DESCRIPTION
Currently we use 256 bit integers, like the smart contract to keep track
of account balances and how they change with trades.
This commit changes this to use arbitrary size integers. This has the
advantage of making the code simpler because we can get rid of some
error conditions and no longer need to keep track of positive and
negative balance changes separately.
This is also a disadvantage because the new code is less accurate: It
does not detect some invalid event chains that the old would have
detected.
Another disadvantage is that arbitrary sized integers by design allocate
and live on the heap which makes the new code slower. Although I do not
expect the change in speed to matter.

fixes #750 

### Test Plan
Existing unit tests test this code and I will test that the result still still matches the filtered orderbook.