### PR TITLE
Update nodejs version to 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ dist: xenial
 language: rust
 
 install:
-  - nvm install 10 && nvm alias default 10 && npm install -g yarn@latest && yarn --version
+  - nvm install 12 && nvm alias default 12 && npm install -g yarn@latest && yarn --version
   - (cd dex-contracts && yarn --frozen-lockfile && yarn run prepack)
+  - ./scripts/setup_contracts.sh
 
 jobs:
   fast_finish: true
@@ -22,7 +23,6 @@ jobs:
       rust: stable
       cache:
         directories:
-          - $HOME/.cache/node-gyp
           - $HOME/.cache/yarn
           - $HOME/.cargo/bin
       before_cache:
@@ -33,7 +33,6 @@ jobs:
         - sudo apt-get update && sudo apt-get install -y python-pip && sudo pip install awscli
         - $(aws ecr get-login --no-include-email --region $AWS_REGION)
       script:
-        - ./scripts/setup_contracts.sh
         - cargo build --all-targets --locked
         # Unit Tests and Linting
         - cargo test
@@ -65,9 +64,6 @@ jobs:
 
     - name: Coverage
       rust: nightly
-      before_install:
-        # TODO vk: Not sure why this is needed but without it I get some errors related to gyp.
-        - rm -rf /home/travis/.cache/node-gyp
       script:
         - curl --location https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
         # These flags are recommended by https://github.com/mozilla/grcov#grcov-with-travis .


### PR DESCRIPTION
#871 

dex-contracts works with a newer version so we should switch.

Removes caching of node-gyp because it is causing problems on CI. We can
reintroduce it later again.