### PR TITLE
Use python3-pip instead of python2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
       env: CARGO_INCREMENTAL=0
       before_install:
         - rustup component add clippy rustfmt
-        - sudo apt-get update && sudo apt-get install -y python-pip && sudo pip install awscli
+        - sudo apt-get update && sudo apt-get install -y python3-pip python3-setuptools && pip3 install --upgrade --user awscli
         - $(aws ecr get-login --no-include-email --region $AWS_REGION)
       script:
         - cargo build --all-targets --locked

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 image_name=$1
 
-sudo apt-get update && sudo apt-get install -y python-pip && sudo pip install awscli
+sudo apt-get update && sudo apt-get install -y python3-pip python3-setuptools && pip3 install --upgrade --user awscli
 
 # Get login token and execute login
 $(aws ecr get-login --no-include-email --region $AWS_REGION)


### PR DESCRIPTION
I noticed warnings in CI about python2 hitting end of life. Following
the amazon documentation this commit changes the way we install the aws
sdk to python3. Also removes sudo from the pip command because it is not
needed.

### Test Plan
CI