### PR TITLE
Fuzz pricegraph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 
 [[package]]
+name = "arbitrary"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5eb01a9ab8a3369f2f7632b9461c34f5920bd454774bab5b9fc6744f21d6143"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,6 +521,17 @@ dependencies = [
  "adler32",
  "byteorder",
  "gzip-header",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee758ebd1c79a9c6fb95f242dcc30bdbf555c28369ae908d21fdaf81537496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1855,6 +1875,7 @@ dependencies = [
 name = "pricegraph"
 version = "0.1.0"
 dependencies = [
+ "arbitrary",
  "assert_approx_eq",
  "criterion",
  "data-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,6 +1371,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
 
 [[package]]
+name = "libfuzzer-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d718794b8e23533b9069bd2c4597d69e41cc7ab1c02700a502971aca0cdcf24"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
+
+[[package]]
 name = "libnghttp2-sys"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,6 +1893,14 @@ dependencies = [
  "petgraph",
  "primitive-types 0.7.2",
  "thiserror",
+]
+
+[[package]]
+name = "pricegraph-fuzz"
+version = "0.0.0"
+dependencies = [
+ "libfuzzer-sys",
+ "pricegraph",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "e2e",
     "pricegraph",
     "pricegraph/wasm",
+    "pricegraph/fuzz",
 ]
 default-members = [
     "driver",

--- a/pricegraph/Cargo.toml
+++ b/pricegraph/Cargo.toml
@@ -9,6 +9,7 @@ name = "orderbook"
 harness = false
 
 [dependencies]
+arbitrary = { version = "0.4", optional = true, features = ["derive"] }
 petgraph = "0.5"
 primitive-types = "0.7"
 thiserror = "1"

--- a/pricegraph/README.md
+++ b/pricegraph/README.md
@@ -1,0 +1,9 @@
+# Fuzzing
+
+This crate can be fuzzed with [cargo fuzz](https://github.com/rust-fuzz/cargo-fuzz).
+
+Fuzzing requires nightly which can be installed with `rustup install nightly`. Then install *cargo fuzz* with `cargo +nightly install cargo-fuzz`.
+
+List fuzz targets with `cargo +nightly fuzz list`.
+
+Run a fuzz target with `cargo +nightly fuzz run orderbook`.

--- a/pricegraph/fuzz/.gitignore
+++ b/pricegraph/fuzz/.gitignore
@@ -1,0 +1,2 @@
+corpus
+artifacts

--- a/pricegraph/fuzz/Cargo.toml
+++ b/pricegraph/fuzz/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "pricegraph-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.3"
+pricegraph = { path = "..", features = ["arbitrary"] }
+
+[[bin]]
+name = "element_read_all"
+path = "fuzz_targets/element_read_all.rs"
+
+[[bin]]
+name = "orderbook"
+path = "fuzz_targets/orderbook.rs"

--- a/pricegraph/fuzz/fuzz_targets/element_read_all.rs
+++ b/pricegraph/fuzz/fuzz_targets/element_read_all.rs
@@ -1,0 +1,13 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use pricegraph::Element;
+
+// Fuzz Element::read_all .
+// This is unlikely to find any panic because the implementation is simple.
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(elements) = Element::read_all(data) {
+        // Iterate to consume the iterator.
+        for _ in elements {}
+    }
+});

--- a/pricegraph/fuzz/fuzz_targets/orderbook.rs
+++ b/pricegraph/fuzz/fuzz_targets/orderbook.rs
@@ -1,0 +1,9 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use pricegraph::{Element, Orderbook};
+
+// Fuzz creation and usage of Orderbook.
+
+fuzz_target!(|elements: Vec<Element>| {
+    let _ = Orderbook::from_elements(elements);
+});

--- a/pricegraph/src/encoding.rs
+++ b/pricegraph/src/encoding.rs
@@ -21,6 +21,7 @@ pub type UserId = H160;
 
 /// A struct representing a buy/sell token pair.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TokenPair {
     /// The buy token.
     pub buy: TokenId,
@@ -29,7 +30,8 @@ pub struct TokenPair {
 }
 
 /// A struct representing the validity of an order.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Validity {
     /// The batch starting from which the order is valid.
     pub from: BatchId,
@@ -38,7 +40,8 @@ pub struct Validity {
 }
 
 /// A price expressed as a fraction of buy and sell amounts.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Price {
     /// The price numerator, or the buy amount.
     pub numerator: u128,
@@ -47,7 +50,7 @@ pub struct Price {
 }
 
 /// An orderbook element that is retrieved from the smart contract.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Element {
     /// The user that placed the order.
     pub user: UserId,
@@ -118,6 +121,69 @@ impl Element {
                 id: read!(u16),
             }
         }))
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+mod abitrary_impl {
+    use super::*;
+    use arbitrary::{Arbitrary, Result, Unstructured};
+
+    // We want Element to implement Arbitrary but cannot derive it because Element contains H160
+    // and U256 which do not implement arbitrary and come from foreign crates. Instead of
+    // implementing Arbitrary manually or introducing wrappers for H160 and U256 we create an
+    // equivalent to Element which can derive Arbitrary and forward all methods.
+
+    #[derive(Arbitrary)]
+    struct ArbitraryElement {
+        user: [u8; 20],
+        balance: [u8; 32],
+        pair: TokenPair,
+        valid: Validity,
+        price: Price,
+        remaining_sell_amount: u128,
+        id: OrderId,
+    }
+
+    impl ArbitraryElement {
+        fn from_element(e: &Element) -> Self {
+            let mut balance = [0u8; 32];
+            e.balance.to_little_endian(&mut balance);
+            Self {
+                user: e.user.to_fixed_bytes(),
+                balance,
+                pair: e.pair,
+                valid: e.valid,
+                price: e.price,
+                remaining_sell_amount: e.remaining_sell_amount,
+                id: e.id,
+            }
+        }
+        fn to_element(&self) -> Element {
+            Element {
+                user: H160::from_slice(&self.user),
+                balance: U256::from_little_endian(&self.balance),
+                pair: self.pair,
+                valid: self.valid,
+                price: self.price,
+                remaining_sell_amount: self.remaining_sell_amount,
+                id: self.id,
+            }
+        }
+    }
+
+    impl arbitrary::Arbitrary for Element {
+        fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
+            Ok(ArbitraryElement::arbitrary(u)?.to_element())
+        }
+        fn size_hint(depth: usize) -> (usize, Option<usize>) {
+            ArbitraryElement::size_hint(depth)
+        }
+        fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+            let box_iterator = ArbitraryElement::from_element(self).shrink();
+            let mapped = box_iterator.map(|a| a.to_element());
+            Box::new(mapped)
+        }
     }
 }
 

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -7,5 +7,5 @@ mod orderbook;
 #[path = "../data/mod.rs"]
 mod data;
 
-pub use encoding::{TokenId, TokenPair};
+pub use encoding::{Element, TokenId, TokenPair};
 pub use orderbook::Orderbook;

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -7,5 +7,5 @@ mod orderbook;
 #[path = "../data/mod.rs"]
 mod data;
 
-pub use encoding::{Element, TokenId, TokenPair};
+pub use encoding::*;
 pub use orderbook::Orderbook;

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -52,7 +52,7 @@ impl Orderbook {
     }
 
     /// Creates an orderbook from an iterator over decoded auction elements.
-    fn from_elements(elements: impl IntoIterator<Item = Element>) -> Self {
+    pub fn from_elements(elements: impl IntoIterator<Item = Element>) -> Self {
         let mut max_token = 0;
         let mut orders = OrderCollector::default();
         let mut users = UserMap::default();


### PR DESCRIPTION
Allow fuzzing pricegraph using https://github.com/rust-fuzz/cargo-fuzz . For people that don't know how fuzzing works I recommend reading the fuzzing book linked in that repo.
The fuzzer runs your code with automatically generated inputs and tries to find panics. This can surface unintentional panics like the NaN panic we just fixed. This works well with use of of `debug_assert` to check invariants.

I have split the PR up into 3 commits that can be read individually.

### Test Plan
Run the fuzz commands from the readme  `cargo +nightly fuzz run orderbook`. CI.