### PR TITLE
[Bug] Get balance should return balance when no withdraw

### DIFF
--- a/driver/src/orderbook/streamed/balance.rs
+++ b/driver/src/orderbook/streamed/balance.rs
@@ -160,7 +160,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_get_balance() {
+    fn get_balance() {
         let overdrawn_request = Balance {
             balance: BigInt::from(2),
             deposit: Flux::default(),


### PR DESCRIPTION
Earlier today, we were experiencing the following shadow_orderbook error:

```
ERROR (pod: dev-dfusion-fallback-solver-mainnet-master-54979446f9-tsl7v):
2020-05-20T13:49:39.504Z ERRO [driver::orderbook::shadow_orderbook] user 0xb210d9afde9cda1b8af0d260ad8602f5134f6cac token 4 primary balance of 0 but shadow balance 115680443
```

After some investigation with @nlordell  we determined that at case had been missed in the `get_balance` function with recent changes in #750


See [thread](https://gnosisinc.slack.com/archives/CQZBU9T5J/p1589982607008800) for further details.


### Test Plan
Run the new unit test:

```sh
cargo test get_balance
```