### PR TITLE
Only enable logging for driver

### DIFF
--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -55,7 +55,7 @@ struct Options {
     /// The log filter to use.
     ///
     /// This follows the `slog-envlogger` syntax (e.g. 'info,driver=debug').
-    #[structopt(long, env = "DFUSION_LOG", default_value = "info")]
+    #[structopt(long, env = "DFUSION_LOG", default_value = "warn,driver=info")]
     log_filter: String,
 
     /// The Ethereum node URL to connect to. Make sure that the node allows for


### PR DESCRIPTION
Currently we enable info logging globally which includes code from our
dependencies. I noticed this becaus new log messages related to
isahc started appearing ("send_async").
This commit changes our default logging to enable only the driver
module. I do not think we intentionally enabled logging from our
dependencies before.

For our deployment this will be a separate change because we override the logging options there.

### Test Plan
Before this change:
Running the driver prints out "send_async" log messages.
After this change:
Running the driver does not print out "send_async" log messages but still contains other log messages.