### PR TITLE
Print errors with more detail

### DIFF
--- a/driver/src/driver/scheduler/evm.rs
+++ b/driver/src/driver/scheduler/evm.rs
@@ -118,7 +118,7 @@ impl Scheduler for EvmScheduler<'_> {
     fn start(&mut self) -> ! {
         loop {
             if let Err(err) = self.step() {
-                error!("EVM scheduler error: {}", err);
+                error!("EVM scheduler error: {:?}", err);
             }
             thread::sleep(POLL_TIMEOUT);
         }

--- a/driver/src/driver/scheduler/system.rs
+++ b/driver/src/driver/scheduler/system.rs
@@ -122,11 +122,12 @@ impl<'a> SystemScheduler<'a> {
 fn log_driver_result(batch_id: BatchId, driver_result: &DriverResult) {
     match driver_result {
         DriverResult::Ok => info!("Batch {} solved successfully.", batch_id.0),
-        DriverResult::Retry(err) => {
-            error!("Batch {} failed with retryable error: {}", batch_id.0, err)
-        }
+        DriverResult::Retry(err) => error!(
+            "Batch {} failed with retryable error: {:?}",
+            batch_id.0, err
+        ),
         DriverResult::Skip(err) => error!(
-            "Batch {} failed with unretryable error: {}",
+            "Batch {} failed with unretryable error: {:?}",
             batch_id.0, err
         ),
     }
@@ -147,7 +148,7 @@ impl<'a> Scheduler for SystemScheduler<'a> {
                         self.start_solving_in_thread(batch_id, Instant::now() + duration, scope)
                     }
                     Err(err) => {
-                        error!("Scheduler error: {}", err);
+                        error!("Scheduler error: {:?}", err);
                         thread::sleep(RETRY_SLEEP_DURATION);
                     }
                 };


### PR DESCRIPTION
As the anyhow documentation states, printing an error using `{}` only
shows the outermost error. By using `{:?}` we get the most information:
the full error chain and a backtrace.

### Test Plan
Only affects logging.