### PR TITLE
Improve pricegraph fuzzing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2228,6 +2228,7 @@ dependencies = [
 name = "pricegraph-fuzz"
 version = "0.0.0"
 dependencies = [
+ "arbitrary",
  "libfuzzer-sys",
  "pricegraph",
 ]

--- a/pricegraph/fuzz/Cargo.toml
+++ b/pricegraph/fuzz/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
+arbitrary = { version = "0.4", features = ["derive"] }
 libfuzzer-sys = "0.3"
 pricegraph = { path = "..", features = ["arbitrary"] }
 
@@ -17,5 +18,5 @@ name = "element_read_all"
 path = "fuzz_targets/element_read_all.rs"
 
 [[bin]]
-name = "orderbook"
-path = "fuzz_targets/orderbook.rs"
+name = "pricegraph"
+path = "fuzz_targets/pricegraph.rs"

--- a/pricegraph/fuzz/fuzz_targets/orderbook.rs
+++ b/pricegraph/fuzz/fuzz_targets/orderbook.rs
@@ -1,9 +1,0 @@
-#![no_main]
-use libfuzzer_sys::fuzz_target;
-use pricegraph::{Element, Orderbook};
-
-// Fuzz creation and usage of Orderbook.
-
-fuzz_target!(|elements: Vec<Element>| {
-    let _ = Orderbook::from_elements(elements);
-});

--- a/pricegraph/fuzz/fuzz_targets/pricegraph.rs
+++ b/pricegraph/fuzz/fuzz_targets/pricegraph.rs
@@ -1,0 +1,62 @@
+#![no_main]
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use pricegraph::{Element, Pricegraph, TokenId, TokenPair};
+use std::iter::once;
+
+// Limit the maximum token id that is allowed to appear in the generated orders. Without this we can
+// make orderbook creation too slow if one order contains a large buy or sell token id.
+const MAX_TOKEN_ID: u16 = 16;
+
+// Fuzz creation and usage of Orderbook.
+
+#[derive(Arbitrary, Debug)]
+enum Operation {
+    OrderForSellAmount {
+        pair: TokenPair,
+        sell_amount: f64,
+    },
+    TransitiveOrderbook {
+        base: TokenId,
+        quote: TokenId,
+        spread: Option<f64>,
+    },
+}
+
+#[derive(Arbitrary, Debug)]
+struct Arguments {
+    elements: Vec<Element>,
+    operation: Operation,
+}
+
+fn largest_token_id(elements: &[Element]) -> Option<TokenId> {
+    elements
+        .iter()
+        .flat_map(|e| once(e.pair.buy).chain(once(e.pair.sell)))
+        .max()
+}
+
+fuzz_target!(|arguments: Arguments| {
+    if largest_token_id(&arguments.elements).unwrap_or(0) > MAX_TOKEN_ID {
+        return;
+    }
+
+    let pricegraph = Pricegraph::new(arguments.elements);
+    match arguments.operation {
+        Operation::OrderForSellAmount { pair, sell_amount } => {
+            pricegraph.order_for_sell_amount(pair, sell_amount);
+        }
+        Operation::TransitiveOrderbook {
+            base,
+            quote,
+            spread,
+        } => {
+            if let Some(spread) = spread {
+                if !spread.is_finite() || spread <= 0.0 {
+                    return;
+                }
+            }
+            pricegraph.transitive_orderbook(base, quote, spread);
+        }
+    };
+});


### PR DESCRIPTION
In addition to fuzzing the building of the orderbook this commit enables
fuzzing of the other public methods.

### Test Plan
Fuzzing still works. This quickly finds the panic #916 currently so it isn't very useful until that is fixed.