### PR TITLE
[RFC] Refactor the semantics of batchID in event based orderbook

### DIFF
--- a/driver/src/orderbook/streamed/balance.rs
+++ b/driver/src/orderbook/streamed/balance.rs
@@ -53,7 +53,7 @@ impl Balance {
         Ok(())
     }
 
-    pub fn get_balance(&self, batch_id: BatchId) -> BigInt {
+    pub fn get_balance_at_beginning_of_batch(&self, batch_id: BatchId) -> BigInt {
         let balance = self.balance_with_deposit_and_proceeds(batch_id);
         // Withdraw requests can be for amounts larger than balance.
         match self.withdraw.amount(batch_id) {
@@ -160,7 +160,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn get_balance() {
+    fn get_balance_at_beginning_of_batch() {
         let overdrawn_request = Balance {
             balance: BigInt::from(2),
             deposit: Flux::default(),
@@ -170,9 +170,18 @@ mod tests {
             },
             proceeds: Flux::default(),
         };
-        assert_eq!(overdrawn_request.get_balance(0), BigInt::from(2));
-        assert_eq!(overdrawn_request.get_balance(1), BigInt::from(2));
-        assert_eq!(overdrawn_request.get_balance(2), BigInt::zero());
+        assert_eq!(
+            overdrawn_request.get_balance_at_beginning_of_batch(0),
+            BigInt::from(2)
+        );
+        assert_eq!(
+            overdrawn_request.get_balance_at_beginning_of_batch(1),
+            BigInt::from(2)
+        );
+        assert_eq!(
+            overdrawn_request.get_balance_at_beginning_of_batch(2),
+            BigInt::zero()
+        );
 
         let standard_request = Balance {
             balance: BigInt::from(2),
@@ -183,9 +192,18 @@ mod tests {
             },
             proceeds: Flux::default(),
         };
-        assert_eq!(standard_request.get_balance(0), BigInt::from(2));
-        assert_eq!(standard_request.get_balance(1), BigInt::from(2));
-        assert_eq!(standard_request.get_balance(2), BigInt::from(1));
+        assert_eq!(
+            standard_request.get_balance_at_beginning_of_batch(0),
+            BigInt::from(2)
+        );
+        assert_eq!(
+            standard_request.get_balance_at_beginning_of_batch(1),
+            BigInt::from(2)
+        );
+        assert_eq!(
+            standard_request.get_balance_at_beginning_of_batch(2),
+            BigInt::from(1)
+        );
 
         let no_request = Balance {
             balance: BigInt::from(1),
@@ -193,8 +211,17 @@ mod tests {
             withdraw: Flux::default(),
             proceeds: Flux::default(),
         };
-        assert_eq!(no_request.get_balance(0), BigInt::from(1));
-        assert_eq!(no_request.get_balance(1), BigInt::from(1));
-        assert_eq!(no_request.get_balance(2), BigInt::from(1));
+        assert_eq!(
+            no_request.get_balance_at_beginning_of_batch(0),
+            BigInt::from(1)
+        );
+        assert_eq!(
+            no_request.get_balance_at_beginning_of_batch(1),
+            BigInt::from(1)
+        );
+        assert_eq!(
+            no_request.get_balance_at_beginning_of_batch(2),
+            BigInt::from(1)
+        );
     }
 }

--- a/driver/src/orderbook/streamed/order.rs
+++ b/driver/src/orderbook/streamed/order.rs
@@ -68,7 +68,7 @@ impl Order {
         }
     }
 
-    pub fn get_remaining_amount(&self, batch_id: BatchId) -> u128 {
+    pub fn get_remaining_amount_at_beginning_of_batch(&self, batch_id: BatchId) -> u128 {
         // Cannot fail because of the invariant.
         self.price_denominator
             .checked_sub(self.get_used_amount(batch_id))
@@ -117,7 +117,9 @@ impl Order {
         let (buy_amount, sell_amount) = stablex_auction_element::compute_buy_sell_amounts(
             self.price_numerator,
             self.price_denominator,
-            self.get_remaining_amount(batch_id),
+            // Remaining amount needs to incorporate trades that happened while collecting orders
+            // for the batch we are trying to solve. Thus query balance as of beginning of the next.
+            self.get_remaining_amount_at_beginning_of_batch(batch_id + 1),
         );
         ModelOrder {
             id: order_id,

--- a/driver/src/orderbook/streamed/order.rs
+++ b/driver/src/orderbook/streamed/order.rs
@@ -117,9 +117,7 @@ impl Order {
         let (buy_amount, sell_amount) = stablex_auction_element::compute_buy_sell_amounts(
             self.price_numerator,
             self.price_denominator,
-            // Remaining amount needs to incorporate trades that happened while collecting orders
-            // for the batch we are trying to solve. Thus query balance as of beginning of the next.
-            self.get_remaining_amount_at_beginning_of_batch(batch_id + 1),
+            self.get_remaining_amount_at_beginning_of_batch(batch_id),
         );
         ModelOrder {
             id: order_id,

--- a/driver/src/orderbook/streamed/orderbook.rs
+++ b/driver/src/orderbook/streamed/orderbook.rs
@@ -138,14 +138,9 @@ impl StableXOrderBookReading for Orderbook {
         batch_id_to_solve: U256,
     ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>> {
         async move {
-            // TODO: Handle future batch ids for when we want to do optimistic solving.
             let state = self.create_state()?;
-            // `orderbook_for_batch` takes the index of the auction that is currently collecting orders and returns
-            // the orderbook for the batch index that is currently being solved. `get_auction_data` passed in the
-            // index for the auction that orders should be valid for (the one currently being solved). Thus we need
-            // to increment it.
             let (account_state, orders) =
-                state.orderbook_for_batch(batch_id_to_solve.low_u32() + 1)?;
+                state.orderbook_to_solve_batch(batch_id_to_solve.low_u32())?;
             let (account_state, orders) = util::normalize_auction_data(account_state, orders);
             Ok((account_state, orders))
         }
@@ -278,7 +273,7 @@ mod tests {
         orderbook.handle_event_data(deposit_2, 2, 0, H256::zero(), 0);
 
         let auction_data = orderbook
-            .get_auction_data(1.into())
+            .get_auction_data(2.into())
             .now_or_never()
             .unwrap()
             .unwrap();

--- a/driver/src/orderbook/streamed/orderbook.rs
+++ b/driver/src/orderbook/streamed/orderbook.rs
@@ -139,8 +139,9 @@ impl StableXOrderBookReading for Orderbook {
     ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>> {
         async move {
             let state = self.create_state()?;
+            // In order to solve batch t we need the orderbook at the beginning of batch t+1's collection process
             let (account_state, orders) =
-                state.orderbook_to_solve_batch(batch_id_to_solve.low_u32())?;
+                state.orderbook_at_beginning_of_batch(batch_id_to_solve.low_u32() + 1)?;
             let (account_state, orders) = util::normalize_auction_data(account_state, orders);
             Ok((account_state, orders))
         }

--- a/driver/src/orderbook/streamed/state.rs
+++ b/driver/src/orderbook/streamed/state.rs
@@ -37,20 +37,22 @@ struct LastSolution {
 }
 
 impl State {
+    /// Returns the orderbook to solve the requested batch given all events received until now.
+    ///
     /// Errors if State has only received a partial solution which would make the result
     /// inconsistent.
-    /// Errors if the batch is in the past as information about historic balances/orders is not preserved.
+    /// Errors if the target batch is more than one batch in the past.
     /// Account balances that overflow a U256 are skipped.
-    pub fn orderbook_for_batch(
+    pub fn orderbook_to_solve_batch(
         &self,
         batch_id: BatchId,
     ) -> Result<(
         impl Iterator<Item = ((UserId, TokenId), U256)> + '_,
         impl Iterator<Item = ModelOrder> + '_,
     )> {
-        // We allow the batch ids being equal to prevent race conditions where the State gets
-        // a new event right before we want to get the orderbook.
-        ensure!(self.last_batch_id <= batch_id, "batch is in the past");
+        // We can only serve state for up to one batch in the past, as we are not keeping
+        // historic information about orders and balance updates around.
+        ensure!(self.last_batch_id <= batch_id + 1, "batch is in the past");
         // The orderbook should never be retrieved with a partially applied solution. If
         // this happens, it is an error as events are applied per block and solutions are
         // applied in a single block.
@@ -73,11 +75,12 @@ impl State {
                 let token_id = self.tokens.get_id_by_address(*token_address)?;
                 Some((
                     (*user_id, token_id),
+                    // We fetch the balance including all trades/deposits that happened while collecting orders
+                    // for the batch we are trying to solve (balance at the beginning of the next batch).
                     // Can fail if user's balance exceeds U256::max.
-                    // Can fail while not all trades of a solution have been received and batch_id
-                    // is the next batch_id so that we assume that the current solution won't be be
-                    // reverted.
-                    bigint_u256::bigint_to_u256(&balance.get_balance(batch_id))?,
+                    bigint_u256::bigint_to_u256(
+                        &balance.get_balance_at_beginning_of_batch(batch_id + 1),
+                    )?,
                 ))
             })
     }
@@ -87,7 +90,7 @@ impl State {
             .iter()
             // State is returned **excluding** the given `batch_id` however order validity is internally stored
             // **including** `batch_id`. Thus we need subtract 1 here to get all orders valid for batch_id -1.
-            .filter(move |(_, order)| order.is_valid_in_batch(batch_id - 1))
+            .filter(move |(_, order)| order.is_valid_in_batch(batch_id))
             .map(move |((user_id, order_id), order)| {
                 order.as_model_order(batch_id, *user_id, *order_id)
             })
@@ -401,7 +404,7 @@ mod tests {
     }
 
     macro_rules! assert_balance {
-        (in $state:ident for batch $batch:expr; user $user:expr, has token $token:expr, balance $balance:expr) => {
+        (in $state:ident solving batch $batch:expr; user $user:expr, has token $token:expr, balance $balance:expr) => {
             assert_eq!(
                 account_state(&$state, $batch).read_balance($token, address($user)),
                 U256::from($balance)
@@ -439,9 +442,9 @@ mod tests {
     #[test]
     fn account_state_respects_deposit_batch() {
         let mut state = state_with_fee();
-        apply_event!(to state for batch 0; Deposit token 0, to user 3, amount 1);
-        assert_balance!(in state for batch 0; user 3, has token 0, balance 0);
-        assert_balance!(in state for batch 1; user 3, has token 0, balance 1);
+        apply_event!(to state for batch 1; Deposit token 0, to user 3, amount 1);
+        assert_balance!(in state solving batch 0; user 3, has token 0, balance 0);
+        assert_balance!(in state solving batch 1; user 3, has token 0, balance 1);
     }
 
     #[test]
@@ -450,12 +453,12 @@ mod tests {
         // token id 1 is not listed
         apply_event!(to state for batch 0; Deposit token 0, to user 3, amount 1);
         apply_event!(to state for batch 0; Deposit token 1, to user 3, amount 1);
-        assert_balance!(in state for batch 1; user 3, has token 0, balance 1);
-        assert_balance!(in state for batch 1; user 3, has token 1, balance 0);
+        assert_balance!(in state solving batch 1; user 3, has token 0, balance 1);
+        assert_balance!(in state solving batch 1; user 3, has token 1, balance 0);
 
         apply_event!(to state for batch 1; TokenListing token 1);
-        assert_balance!(in state for batch 1; user 3, has token 0, balance 1);
-        assert_balance!(in state for batch 1; user 3, has token 1, balance 1);
+        assert_balance!(in state solving batch 1; user 3, has token 0, balance 1);
+        assert_balance!(in state solving batch 1; user 3, has token 1, balance 1);
     }
 
     #[test]
@@ -463,7 +466,7 @@ mod tests {
         let mut state = state_with_fee();
         for i in 0..3 {
             apply_event!(to state for batch i; Deposit token 0, to user 1, amount 1);
-            assert_balance!(in state for batch i + 2; user 1, has token 0, balance i + 1);
+            assert_balance!(in state solving batch i + 2; user 1, has token 0, balance i + 1);
         }
     }
 
@@ -472,7 +475,7 @@ mod tests {
         let mut state = state_with_fee();
         for i in 0..3 {
             apply_event!(to state for batch 0; Deposit token 0, to user 1, amount 1);
-            assert_balance!(in state for batch 1; user 1, has token 0, balance i + 1);
+            assert_balance!(in state solving batch 1; user 1, has token 0, balance i + 1);
         }
     }
 
@@ -481,7 +484,7 @@ mod tests {
         let mut state = state_with_fee();
         apply_event!(to state for batch 0; Deposit token 0, to user 1, amount 2);
         apply_event!(to state for batch 0; WithdrawRequest from user 1, of token 0, amount 1, valid after batch 0);
-        assert_balance!(in state for batch 1; user 1, has token 0, balance 1);
+        assert_balance!(in state solving batch 1; user 1, has token 0, balance 1);
     }
 
     #[test]
@@ -489,7 +492,7 @@ mod tests {
         let mut state = state_with_fee();
         apply_event!(to state for batch 0; Deposit token 0, to user 1, amount 2);
         apply_event!(to state for batch 1; WithdrawRequest from user 1, of token 0, amount 3, valid after batch 2);
-        assert_balance!(in state for batch 3; user 1, has token 0, balance 0);
+        assert_balance!(in state solving batch 3; user 1, has token 0, balance 0);
     }
 
     #[test]
@@ -498,7 +501,7 @@ mod tests {
         apply_event!(to state for batch 0; Deposit token 0, to user 1, amount 2);
         apply_event!(to state for batch 0; WithdrawRequest from user 1, of token 0, amount 2, valid after batch 0);
         apply_event!(to state for batch 1; Withdraw from user 1, of token 0, amount 1);
-        assert_balance!(in state for batch 1; user 1, has token 0, balance 1);
+        assert_balance!(in state solving batch 1; user 1, has token 0, balance 1);
     }
 
     #[test]
@@ -506,9 +509,9 @@ mod tests {
         let mut state = state_with_fee();
         apply_event!(to state for batch 0; Deposit token 0, to user 1, amount 3);
         apply_event!(to state for batch 0; WithdrawRequest from user 1, of token 0, amount 2, valid after batch 0);
-        assert_balance!(in state for batch 1; user 1, has token 0, balance 1);
+        assert_balance!(in state solving batch 1; user 1, has token 0, balance 1);
         apply_event!(to state for batch 1; Withdraw from user 1, of token 0, amount 1);
-        assert_balance!(in state for batch 2; user 1, has token 0, balance 2);
+        assert_balance!(in state solving batch 2; user 1, has token 0, balance 2);
     }
 
     #[test]
@@ -520,7 +523,7 @@ mod tests {
             selling 3, of token 1, for at least 4, of token 0, for batch interval [1, 2]
         );
 
-        assert_eq!(state.orders(1).next(), None);
+        assert_eq!(state.orders(0).next(), None);
         let expected_orders = vec![ModelOrder {
             id: 0,
             account_id: address(2),
@@ -529,9 +532,9 @@ mod tests {
             buy_amount: 3,
             sell_amount: 4,
         }];
+        assert_eq!(state.orders(1).collect::<Vec<_>>(), expected_orders);
         assert_eq!(state.orders(2).collect::<Vec<_>>(), expected_orders);
-        assert_eq!(state.orders(3).collect::<Vec<_>>(), expected_orders);
-        assert_eq!(state.orders(4).next(), None);
+        assert_eq!(state.orders(3).next(), None);
 
         let event = OrderCancellation {
             owner: address(2),
@@ -541,10 +544,10 @@ mod tests {
             .apply_event(&Event::OrderCancellation(event), 2)
             .unwrap();
 
-        assert_eq!(state.orders(1).next(), None);
-        assert_eq!(state.orders(2).collect::<Vec<_>>(), expected_orders);
+        assert_eq!(state.orders(0).next(), None);
+        assert_eq!(state.orders(1).collect::<Vec<_>>(), expected_orders);
+        assert_eq!(state.orders(2).next(), None);
         assert_eq!(state.orders(3).next(), None);
-        assert_eq!(state.orders(4).next(), None);
 
         let event = Event::OrderDeletion(OrderDeletion {
             owner: address(2),
@@ -552,10 +555,10 @@ mod tests {
         });
         assert!(state.clone().apply_event(&event, 2).is_err());
         state = state.apply_event(&event, 3).unwrap();
+        assert_eq!(state.orders(0).next(), None);
         assert_eq!(state.orders(1).next(), None);
         assert_eq!(state.orders(2).next(), None);
         assert_eq!(state.orders(3).next(), None);
-        assert_eq!(state.orders(4).next(), None);
     }
 
     #[test]
@@ -582,11 +585,11 @@ mod tests {
         apply_event!(to state for batch 1; Trade order number 0, from user 3, selling 2, for 1);
         apply_event!(to state for batch 1; SolutionSubmission from user 4, with fee 23);
 
-        assert_balance!(in state for batch 2; user 2, has token 0, balance 12);
-        assert_balance!(in state for batch 2; user 2, has token 1, balance 9);
-        assert_balance!(in state for batch 2; user 3, has token 0, balance 8);
-        assert_balance!(in state for batch 2; user 3, has token 1, balance 11);
-        assert_balance!(in state for batch 2; user 4, has token 0, balance 23);
+        assert_balance!(in state solving batch 2; user 2, has token 0, balance 12);
+        assert_balance!(in state solving batch 2; user 2, has token 1, balance 9);
+        assert_balance!(in state solving batch 2; user 3, has token 0, balance 8);
+        assert_balance!(in state solving batch 2; user 3, has token 1, balance 11);
+        assert_balance!(in state solving batch 2; user 4, has token 0, balance 23);
         assert_used_amount!(in state for batch 2; of order number 0, from user 2, is 1);
         assert_used_amount!(in state for batch 2; of order number 0, from user 3, is 2);
 
@@ -594,11 +597,11 @@ mod tests {
         apply_event!(to state for batch 1; TradeReversion order number 0, from user 2, selling 1, for 2);
         apply_event!(to state for batch 1; SolutionSubmission from user 4, with fee 42);
 
-        assert_balance!(in state for batch 2; user 2, has token 0, balance 10);
-        assert_balance!(in state for batch 2; user 2, has token 1, balance 10);
-        assert_balance!(in state for batch 2; user 3, has token 0, balance 10);
-        assert_balance!(in state for batch 2; user 3, has token 1, balance 10);
-        assert_balance!(in state for batch 2; user 4, has token 0, balance 42);
+        assert_balance!(in state solving batch 2; user 2, has token 0, balance 10);
+        assert_balance!(in state solving batch 2; user 2, has token 1, balance 10);
+        assert_balance!(in state solving batch 2; user 3, has token 0, balance 10);
+        assert_balance!(in state solving batch 2; user 3, has token 1, balance 10);
+        assert_balance!(in state solving batch 2; user 4, has token 0, balance 42);
         assert_used_amount!(in state for batch 2; of order number 0, from user 2, is 0);
         assert_used_amount!(in state for batch 2; of order number 0, from user 3, is 0);
     }
@@ -607,9 +610,21 @@ mod tests {
     fn orderbook_batch_id() {
         let mut state = state_with_fee();
         apply_event!(to state for batch 1; Deposit token 0, to user 3, amount 1);
-        let balance = state.orderbook_for_batch(1).unwrap().0.next().unwrap().1;
+        let balance = state
+            .orderbook_to_solve_batch(0)
+            .unwrap()
+            .0
+            .next()
+            .unwrap()
+            .1;
         assert_eq!(balance, U256::zero());
-        let balance = state.orderbook_for_batch(2).unwrap().0.next().unwrap().1;
+        let balance = state
+            .orderbook_to_solve_batch(1)
+            .unwrap()
+            .0
+            .next()
+            .unwrap()
+            .1;
         assert_eq!(balance, U256::one());
     }
 
@@ -626,12 +641,12 @@ mod tests {
         );
         apply_event!(to state for batch 1; Trade order number 0, from user 2, selling 1, for 2);
 
-        assert!(state.orderbook_for_batch(1).is_err());
+        assert!(state.orderbook_to_solve_batch(1).is_err());
 
         apply_event!(to state for batch 1; SolutionSubmission from user 4, with fee 42);
 
-        assert_balance!(in state for batch 2; user 2, has token 0, balance 12);
-        assert_balance!(in state for batch 2; user 2, has token 1, balance 9);
+        assert_balance!(in state solving batch 2; user 2, has token 0, balance 12);
+        assert_balance!(in state solving batch 2; user 2, has token 1, balance 9);
     }
 
     #[test]
@@ -662,14 +677,14 @@ mod tests {
         apply_event!(to state for batch 1; Trade order number 1, from user 3, selling 4, for 4);
         apply_event!(to state for batch 1; SolutionSubmission from user 4, with fee 42);
 
-        assert_balance!(in state for batch 1; user 2, has token 0, balance 20);
-        assert_balance!(in state for batch 1; user 2, has token 1, balance 0);
-        assert_balance!(in state for batch 1; user 3, has token 0, balance 0);
-        assert_balance!(in state for batch 1; user 3, has token 1, balance 20);
+        assert_balance!(in state solving batch 0; user 2, has token 0, balance 20);
+        assert_balance!(in state solving batch 0; user 2, has token 1, balance 0);
+        assert_balance!(in state solving batch 0; user 3, has token 0, balance 0);
+        assert_balance!(in state solving batch 0; user 3, has token 1, balance 20);
 
-        assert_balance!(in state for batch 2; user 2, has token 0, balance 12);
-        assert_balance!(in state for batch 2; user 2, has token 1, balance 8);
-        assert_balance!(in state for batch 2; user 3, has token 0, balance 8);
-        assert_balance!(in state for batch 2; user 3, has token 1, balance 12);
+        assert_balance!(in state solving batch 1; user 2, has token 0, balance 12);
+        assert_balance!(in state solving batch 1; user 2, has token 1, balance 8);
+        assert_balance!(in state solving batch 1; user 3, has token 0, balance 8);
+        assert_balance!(in state solving batch 1; user 3, has token 1, balance 12);
     }
 }

--- a/driver/src/orderbook/streamed/state.rs
+++ b/driver/src/orderbook/streamed/state.rs
@@ -37,22 +37,22 @@ struct LastSolution {
 }
 
 impl State {
-    /// Returns the orderbook to solve the requested batch given all events received until now.
+    /// Returns the orderbook when the requested batch started collecting orders given all events received so far.
     ///
     /// Errors if State has only received a partial solution which would make the result
     /// inconsistent.
-    /// Errors if the target batch is more than one batch in the past.
+    /// Errors if the target batch is in the past.
     /// Account balances that overflow a U256 are skipped.
-    pub fn orderbook_to_solve_batch(
+    pub fn orderbook_at_beginning_of_batch(
         &self,
         batch_id: BatchId,
     ) -> Result<(
         impl Iterator<Item = ((UserId, TokenId), U256)> + '_,
         impl Iterator<Item = ModelOrder> + '_,
     )> {
-        // We can only serve state for up to one batch in the past, as we are not keeping
+        // We can only serve state up until the most recent batch, as we are not keeping
         // historic information about orders and balance updates around.
-        ensure!(self.last_batch_id <= batch_id + 1, "batch is in the past");
+        ensure!(self.last_batch_id <= batch_id, "batch is in the past");
         // The orderbook should never be retrieved with a partially applied solution. If
         // this happens, it is an error as events are applied per block and solutions are
         // applied in a single block.
@@ -75,11 +75,9 @@ impl State {
                 let token_id = self.tokens.get_id_by_address(*token_address)?;
                 Some((
                     (*user_id, token_id),
-                    // We fetch the balance including all trades/deposits that happened while collecting orders
-                    // for the batch we are trying to solve (balance at the beginning of the next batch).
                     // Can fail if user's balance exceeds U256::max.
                     bigint_u256::bigint_to_u256(
-                        &balance.get_balance_at_beginning_of_batch(batch_id + 1),
+                        &balance.get_balance_at_beginning_of_batch(batch_id),
                     )?,
                 ))
             })
@@ -90,7 +88,7 @@ impl State {
             .iter()
             // State is returned **excluding** the given `batch_id` however order validity is internally stored
             // **including** `batch_id`. Thus we need subtract 1 here to get all orders valid for batch_id -1.
-            .filter(move |(_, order)| order.is_valid_in_batch(batch_id))
+            .filter(move |(_, order)| order.is_valid_in_batch(batch_id - 1))
             .map(move |((user_id, order_id), order)| {
                 order.as_model_order(batch_id, *user_id, *order_id)
             })
@@ -404,7 +402,7 @@ mod tests {
     }
 
     macro_rules! assert_balance {
-        (in $state:ident solving batch $batch:expr; user $user:expr, has token $token:expr, balance $balance:expr) => {
+        (in $state:ident at beginning of batch $batch:expr; user $user:expr, has token $token:expr, balance $balance:expr) => {
             assert_eq!(
                 account_state(&$state, $batch).read_balance($token, address($user)),
                 U256::from($balance)
@@ -442,9 +440,9 @@ mod tests {
     #[test]
     fn account_state_respects_deposit_batch() {
         let mut state = state_with_fee();
-        apply_event!(to state for batch 1; Deposit token 0, to user 3, amount 1);
-        assert_balance!(in state solving batch 0; user 3, has token 0, balance 0);
-        assert_balance!(in state solving batch 1; user 3, has token 0, balance 1);
+        apply_event!(to state for batch 0; Deposit token 0, to user 3, amount 1);
+        assert_balance!(in state at beginning of batch 0; user 3, has token 0, balance 0);
+        assert_balance!(in state at beginning of batch 1; user 3, has token 0, balance 1);
     }
 
     #[test]
@@ -453,12 +451,12 @@ mod tests {
         // token id 1 is not listed
         apply_event!(to state for batch 0; Deposit token 0, to user 3, amount 1);
         apply_event!(to state for batch 0; Deposit token 1, to user 3, amount 1);
-        assert_balance!(in state solving batch 1; user 3, has token 0, balance 1);
-        assert_balance!(in state solving batch 1; user 3, has token 1, balance 0);
+        assert_balance!(in state at beginning of batch 1; user 3, has token 0, balance 1);
+        assert_balance!(in state at beginning of batch 1; user 3, has token 1, balance 0);
 
         apply_event!(to state for batch 1; TokenListing token 1);
-        assert_balance!(in state solving batch 1; user 3, has token 0, balance 1);
-        assert_balance!(in state solving batch 1; user 3, has token 1, balance 1);
+        assert_balance!(in state at beginning of batch 1; user 3, has token 0, balance 1);
+        assert_balance!(in state at beginning of batch 1; user 3, has token 1, balance 1);
     }
 
     #[test]
@@ -466,7 +464,7 @@ mod tests {
         let mut state = state_with_fee();
         for i in 0..3 {
             apply_event!(to state for batch i; Deposit token 0, to user 1, amount 1);
-            assert_balance!(in state solving batch i + 2; user 1, has token 0, balance i + 1);
+            assert_balance!(in state at beginning of batch i + 2; user 1, has token 0, balance i + 1);
         }
     }
 
@@ -475,7 +473,7 @@ mod tests {
         let mut state = state_with_fee();
         for i in 0..3 {
             apply_event!(to state for batch 0; Deposit token 0, to user 1, amount 1);
-            assert_balance!(in state solving batch 1; user 1, has token 0, balance i + 1);
+            assert_balance!(in state at beginning of batch 1; user 1, has token 0, balance i + 1);
         }
     }
 
@@ -484,7 +482,7 @@ mod tests {
         let mut state = state_with_fee();
         apply_event!(to state for batch 0; Deposit token 0, to user 1, amount 2);
         apply_event!(to state for batch 0; WithdrawRequest from user 1, of token 0, amount 1, valid after batch 0);
-        assert_balance!(in state solving batch 1; user 1, has token 0, balance 1);
+        assert_balance!(in state at beginning of batch 1; user 1, has token 0, balance 1);
     }
 
     #[test]
@@ -492,7 +490,7 @@ mod tests {
         let mut state = state_with_fee();
         apply_event!(to state for batch 0; Deposit token 0, to user 1, amount 2);
         apply_event!(to state for batch 1; WithdrawRequest from user 1, of token 0, amount 3, valid after batch 2);
-        assert_balance!(in state solving batch 3; user 1, has token 0, balance 0);
+        assert_balance!(in state at beginning of batch 3; user 1, has token 0, balance 0);
     }
 
     #[test]
@@ -501,7 +499,7 @@ mod tests {
         apply_event!(to state for batch 0; Deposit token 0, to user 1, amount 2);
         apply_event!(to state for batch 0; WithdrawRequest from user 1, of token 0, amount 2, valid after batch 0);
         apply_event!(to state for batch 1; Withdraw from user 1, of token 0, amount 1);
-        assert_balance!(in state solving batch 1; user 1, has token 0, balance 1);
+        assert_balance!(in state at beginning of batch 1; user 1, has token 0, balance 1);
     }
 
     #[test]
@@ -509,9 +507,9 @@ mod tests {
         let mut state = state_with_fee();
         apply_event!(to state for batch 0; Deposit token 0, to user 1, amount 3);
         apply_event!(to state for batch 0; WithdrawRequest from user 1, of token 0, amount 2, valid after batch 0);
-        assert_balance!(in state solving batch 1; user 1, has token 0, balance 1);
+        assert_balance!(in state at beginning of batch 1; user 1, has token 0, balance 1);
         apply_event!(to state for batch 1; Withdraw from user 1, of token 0, amount 1);
-        assert_balance!(in state solving batch 2; user 1, has token 0, balance 2);
+        assert_balance!(in state at beginning of batch 2; user 1, has token 0, balance 2);
     }
 
     #[test]
@@ -523,7 +521,7 @@ mod tests {
             selling 3, of token 1, for at least 4, of token 0, for batch interval [1, 2]
         );
 
-        assert_eq!(state.orders(0).next(), None);
+        assert_eq!(state.orders(1).next(), None);
         let expected_orders = vec![ModelOrder {
             id: 0,
             account_id: address(2),
@@ -532,9 +530,9 @@ mod tests {
             buy_amount: 3,
             sell_amount: 4,
         }];
-        assert_eq!(state.orders(1).collect::<Vec<_>>(), expected_orders);
         assert_eq!(state.orders(2).collect::<Vec<_>>(), expected_orders);
-        assert_eq!(state.orders(3).next(), None);
+        assert_eq!(state.orders(3).collect::<Vec<_>>(), expected_orders);
+        assert_eq!(state.orders(4).next(), None);
 
         let event = OrderCancellation {
             owner: address(2),
@@ -544,10 +542,10 @@ mod tests {
             .apply_event(&Event::OrderCancellation(event), 2)
             .unwrap();
 
-        assert_eq!(state.orders(0).next(), None);
-        assert_eq!(state.orders(1).collect::<Vec<_>>(), expected_orders);
-        assert_eq!(state.orders(2).next(), None);
+        assert_eq!(state.orders(1).next(), None);
+        assert_eq!(state.orders(2).collect::<Vec<_>>(), expected_orders);
         assert_eq!(state.orders(3).next(), None);
+        assert_eq!(state.orders(4).next(), None);
 
         let event = Event::OrderDeletion(OrderDeletion {
             owner: address(2),
@@ -555,10 +553,10 @@ mod tests {
         });
         assert!(state.clone().apply_event(&event, 2).is_err());
         state = state.apply_event(&event, 3).unwrap();
-        assert_eq!(state.orders(0).next(), None);
         assert_eq!(state.orders(1).next(), None);
         assert_eq!(state.orders(2).next(), None);
         assert_eq!(state.orders(3).next(), None);
+        assert_eq!(state.orders(4).next(), None);
     }
 
     #[test]
@@ -585,11 +583,11 @@ mod tests {
         apply_event!(to state for batch 1; Trade order number 0, from user 3, selling 2, for 1);
         apply_event!(to state for batch 1; SolutionSubmission from user 4, with fee 23);
 
-        assert_balance!(in state solving batch 2; user 2, has token 0, balance 12);
-        assert_balance!(in state solving batch 2; user 2, has token 1, balance 9);
-        assert_balance!(in state solving batch 2; user 3, has token 0, balance 8);
-        assert_balance!(in state solving batch 2; user 3, has token 1, balance 11);
-        assert_balance!(in state solving batch 2; user 4, has token 0, balance 23);
+        assert_balance!(in state at beginning of batch 2; user 2, has token 0, balance 12);
+        assert_balance!(in state at beginning of batch 2; user 2, has token 1, balance 9);
+        assert_balance!(in state at beginning of batch 2; user 3, has token 0, balance 8);
+        assert_balance!(in state at beginning of batch 2; user 3, has token 1, balance 11);
+        assert_balance!(in state at beginning of batch 2; user 4, has token 0, balance 23);
         assert_used_amount!(in state for batch 2; of order number 0, from user 2, is 1);
         assert_used_amount!(in state for batch 2; of order number 0, from user 3, is 2);
 
@@ -597,11 +595,11 @@ mod tests {
         apply_event!(to state for batch 1; TradeReversion order number 0, from user 2, selling 1, for 2);
         apply_event!(to state for batch 1; SolutionSubmission from user 4, with fee 42);
 
-        assert_balance!(in state solving batch 2; user 2, has token 0, balance 10);
-        assert_balance!(in state solving batch 2; user 2, has token 1, balance 10);
-        assert_balance!(in state solving batch 2; user 3, has token 0, balance 10);
-        assert_balance!(in state solving batch 2; user 3, has token 1, balance 10);
-        assert_balance!(in state solving batch 2; user 4, has token 0, balance 42);
+        assert_balance!(in state at beginning of batch 2; user 2, has token 0, balance 10);
+        assert_balance!(in state at beginning of batch 2; user 2, has token 1, balance 10);
+        assert_balance!(in state at beginning of batch 2; user 3, has token 0, balance 10);
+        assert_balance!(in state at beginning of batch 2; user 3, has token 1, balance 10);
+        assert_balance!(in state at beginning of batch 2; user 4, has token 0, balance 42);
         assert_used_amount!(in state for batch 2; of order number 0, from user 2, is 0);
         assert_used_amount!(in state for batch 2; of order number 0, from user 3, is 0);
     }
@@ -611,7 +609,7 @@ mod tests {
         let mut state = state_with_fee();
         apply_event!(to state for batch 1; Deposit token 0, to user 3, amount 1);
         let balance = state
-            .orderbook_to_solve_batch(0)
+            .orderbook_at_beginning_of_batch(1)
             .unwrap()
             .0
             .next()
@@ -619,7 +617,7 @@ mod tests {
             .1;
         assert_eq!(balance, U256::zero());
         let balance = state
-            .orderbook_to_solve_batch(1)
+            .orderbook_at_beginning_of_batch(2)
             .unwrap()
             .0
             .next()
@@ -641,12 +639,12 @@ mod tests {
         );
         apply_event!(to state for batch 1; Trade order number 0, from user 2, selling 1, for 2);
 
-        assert!(state.orderbook_to_solve_batch(1).is_err());
+        assert!(state.orderbook_at_beginning_of_batch(1).is_err());
 
         apply_event!(to state for batch 1; SolutionSubmission from user 4, with fee 42);
 
-        assert_balance!(in state solving batch 2; user 2, has token 0, balance 12);
-        assert_balance!(in state solving batch 2; user 2, has token 1, balance 9);
+        assert_balance!(in state at beginning of batch 2; user 2, has token 0, balance 12);
+        assert_balance!(in state at beginning of batch 2; user 2, has token 1, balance 9);
     }
 
     #[test]
@@ -677,14 +675,14 @@ mod tests {
         apply_event!(to state for batch 1; Trade order number 1, from user 3, selling 4, for 4);
         apply_event!(to state for batch 1; SolutionSubmission from user 4, with fee 42);
 
-        assert_balance!(in state solving batch 0; user 2, has token 0, balance 20);
-        assert_balance!(in state solving batch 0; user 2, has token 1, balance 0);
-        assert_balance!(in state solving batch 0; user 3, has token 0, balance 0);
-        assert_balance!(in state solving batch 0; user 3, has token 1, balance 20);
+        assert_balance!(in state at beginning of batch 1; user 2, has token 0, balance 20);
+        assert_balance!(in state at beginning of batch 1; user 2, has token 1, balance 0);
+        assert_balance!(in state at beginning of batch 1; user 3, has token 0, balance 0);
+        assert_balance!(in state at beginning of batch 1; user 3, has token 1, balance 20);
 
-        assert_balance!(in state solving batch 1; user 2, has token 0, balance 12);
-        assert_balance!(in state solving batch 1; user 2, has token 1, balance 8);
-        assert_balance!(in state solving batch 1; user 3, has token 0, balance 8);
-        assert_balance!(in state solving batch 1; user 3, has token 1, balance 12);
+        assert_balance!(in state at beginning of batch 2; user 2, has token 0, balance 12);
+        assert_balance!(in state at beginning of batch 2; user 2, has token 1, balance 8);
+        assert_balance!(in state at beginning of batch 2; user 3, has token 0, balance 8);
+        assert_balance!(in state at beginning of batch 2; user 3, has token 1, balance 12);
     }
 }


### PR DESCRIPTION
Continues #833 

This PR tries to make the semantics of the variable batchID more explicit in the streamed orderbook.

The problem originates in the fact that events come in with a batchID corresponding to the batch that is currently collecting orders (e.g. Deposit events that come in when batch `t` is collecting orders are valid when batch `t+1` is starting to collect orders). 
Consumers are most likely interested in getting the state to solve a certain batch (completed or still in progress). For this they need to include events that were received while this batch was collecting orders. In the example above, if we try to solve batch t, we need to include the deposit (as it is valid) and thus specify all events until t+1.

This is true for balances but not order validity as those explicitly expressed the batchIDs for which this they should be considered in the payload (and not via timestamp metadata on the event occurred).

In this PR I changed the consumer facing method to accept the batchID that is supposed to be solved and renamed some methods to make they semantics more explicit.
I don't think this goes far enough and am looking for feedback/suggestions on how we can make the behaviour easy to understand when we revisit this code in 6 months.

Arguably we could also make the State expose its data in terms of "at the beginning of a batch that is currently being collected", and keep the +1 in the StablexOrderbookReading implementations.

Let's discuss what's most intuitive on this PR.

### Test Plan

Updated unit tests.