### PR TITLE
Make OrderBookReading implementations Send

### DIFF
--- a/driver/src/driver/stablex_driver.rs
+++ b/driver/src/driver/stablex_driver.rs
@@ -23,7 +23,7 @@ pub trait StableXDriver {
 
 pub struct StableXDriverImpl<'a> {
     price_finder: &'a (dyn PriceFinding + Sync),
-    orderbook_reader: &'a (dyn StableXOrderBookReading + Sync),
+    orderbook_reader: &'a (dyn StableXOrderBookReading),
     solution_submitter: &'a (dyn StableXSolutionSubmitting + Sync),
     metrics: &'a StableXMetrics,
 }
@@ -31,7 +31,7 @@ pub struct StableXDriverImpl<'a> {
 impl<'a> StableXDriverImpl<'a> {
     pub fn new(
         price_finder: &'a (dyn PriceFinding + Sync),
-        orderbook_reader: &'a (dyn StableXOrderBookReading + Sync),
+        orderbook_reader: &'a (dyn StableXOrderBookReading),
         solution_submitter: &'a (dyn StableXSolutionSubmitting + Sync),
         metrics: &'a StableXMetrics,
     ) -> Self {

--- a/driver/src/orderbook.rs
+++ b/driver/src/orderbook.rs
@@ -25,7 +25,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 #[cfg_attr(test, automock)]
-pub trait StableXOrderBookReading {
+pub trait StableXOrderBookReading: Send + Sync {
     /// Returns the current state of the order book, including account balances
     /// and open orders or an error in case it cannot get this information.
     ///
@@ -63,7 +63,7 @@ impl OrderbookReaderKind {
         orderbook_filter: &OrderbookFilter,
         web3: Web3,
         file_path: Option<PathBuf>,
-    ) -> Box<dyn StableXOrderBookReading + Sync> {
+    ) -> Box<dyn StableXOrderBookReading> {
         match self {
             OrderbookReaderKind::Paginated => Box::new(PaginatedStableXOrderBookReader::new(
                 contract,

--- a/driver/src/orderbook/filtered_orderbook.rs
+++ b/driver/src/orderbook/filtered_orderbook.rs
@@ -55,21 +55,18 @@ impl FromStr for OrderbookFilter {
     }
 }
 
-pub struct FilteredOrderbookReader<'a> {
-    orderbook: &'a (dyn StableXOrderBookReading + Sync),
+pub struct FilteredOrderbookReader {
+    orderbook: Box<dyn StableXOrderBookReading>,
     filter: OrderbookFilter,
 }
 
-impl<'a> FilteredOrderbookReader<'a> {
-    pub fn new(
-        orderbook: &'a (dyn StableXOrderBookReading + Sync),
-        filter: OrderbookFilter,
-    ) -> Self {
+impl FilteredOrderbookReader {
+    pub fn new(orderbook: Box<dyn StableXOrderBookReading>, filter: OrderbookFilter) -> Self {
         Self { orderbook, filter }
     }
 }
 
-impl<'a> StableXOrderBookReading for FilteredOrderbookReader<'a> {
+impl StableXOrderBookReading for FilteredOrderbookReader {
     fn get_auction_data<'b>(
         &'b self,
         batch_id_to_solve: U256,
@@ -214,7 +211,7 @@ mod test {
             .collect(),
         };
 
-        let reader = FilteredOrderbookReader::new(&inner, filter);
+        let reader = FilteredOrderbookReader::new(Box::new(inner), filter);
 
         let (_, filtered_orders) = reader
             .get_auction_data(U256::zero())
@@ -247,7 +244,7 @@ mod test {
             users: HashMap::new(),
         };
 
-        let reader = FilteredOrderbookReader::new(&inner, filter);
+        let reader = FilteredOrderbookReader::new(Box::new(inner), filter);
 
         let (_, filtered_orders) = reader
             .get_auction_data(U256::zero())
@@ -271,7 +268,7 @@ mod test {
             users: HashMap::new(),
         };
 
-        let reader = FilteredOrderbookReader::new(&inner, filter);
+        let reader = FilteredOrderbookReader::new(Box::new(inner), filter);
 
         let (state, filtered_orders) = reader
             .get_auction_data(U256::zero())


### PR DESCRIPTION
Closes #806

See issue for more context. This PR makes it so that the orderbook layering chain owns each inner orderbook. This allows making all implementations Send which on the other hand will make them more plug and playable (e.g. ShadowOrderbook requires Send for shadow)

### Test Plan
rustc