### PR TITLE
[Easy/Pricegraph] assert orders aren't overlapping after reducing

### DIFF
--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -136,6 +136,8 @@ impl Orderbook {
     pub fn reduce_overlapping_orders(&mut self) {
         Subgraphs::new(self.projection.node_indices())
             .for_each(|token| self.reduced_shortest_paths(token));
+
+        debug_assert!(!self.is_overlapping());
     }
 
     /// Fill a market order in the current orderbook graph returning the maximum


### PR DESCRIPTION
This PR adds a debug assertion that there is no more overlaps after reducing overlaps.

### Test Plan

This debug assertion can be used by the fuzzer to ensure that the invariant indeed holds.