### PR TITLE
move `Arbitrary` implementation to the fuzz crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,7 +1948,6 @@ dependencies = [
 name = "pricegraph"
 version = "0.1.0"
 dependencies = [
- "arbitrary",
  "assert_approx_eq",
  "criterion",
  "data-encoding",
@@ -1962,6 +1961,7 @@ dependencies = [
 name = "pricegraph-fuzz"
 version = "0.0.0"
 dependencies = [
+ "arbitrary",
  "libfuzzer-sys",
  "pricegraph",
 ]

--- a/pricegraph/Cargo.toml
+++ b/pricegraph/Cargo.toml
@@ -9,7 +9,6 @@ name = "orderbook"
 harness = false
 
 [dependencies]
-arbitrary = { version = "0.4", optional = true, features = ["derive"] }
 petgraph = "0.5"
 primitive-types = "0.7"
 thiserror = "1"

--- a/pricegraph/fuzz/Cargo.toml
+++ b/pricegraph/fuzz/Cargo.toml
@@ -9,8 +9,9 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
+arbitrary = { version = "0.4", features = ["derive"] }
 libfuzzer-sys = "0.3"
-pricegraph = { path = "..", features = ["arbitrary"] }
+pricegraph = { path = ".." }
 
 [[bin]]
 name = "element_read_all"

--- a/pricegraph/fuzz/fuzz_targets/orderbook.rs
+++ b/pricegraph/fuzz/fuzz_targets/orderbook.rs
@@ -1,9 +1,47 @@
 #![no_main]
+
+use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
-use pricegraph::{Element, Orderbook};
+use pricegraph::{Element, Orderbook, Price, TokenPair, Validity, H160, U256};
 
 // Fuzz creation and usage of Orderbook.
 
-fuzz_target!(|elements: Vec<Element>| {
-    let _ = Orderbook::from_elements(elements);
+fuzz_target!(|elements: Vec<ArbitraryElement>| {
+    let _ = Orderbook::from_elements(elements.into_iter().map(|element| element.into()));
 });
+
+/// Remote `Arbitrary` implementation for `Element` as Cargo lock files (and
+/// therefore workspaces) only allow one set of features per dependency.
+#[derive(Arbitrary, Debug)]
+struct ArbitraryElement {
+    user: [u8; 20],
+    balance: [u64; 4],
+    pair: (u16, u16),
+    valid: (u32, u32),
+    price: (u128, u128),
+    remaining_sell_amount: u128,
+    id: u16,
+}
+
+impl Into<Element> for ArbitraryElement {
+    fn into(self) -> Element {
+        Element {
+            user: H160(self.user),
+            balance: U256(self.balance),
+            pair: TokenPair {
+                buy: self.pair.0,
+                sell: self.pair.1,
+            },
+            valid: Validity {
+                from: self.valid.0,
+                to: self.valid.1,
+            },
+            price: Price {
+                numerator: self.price.0,
+                denominator: self.price.1,
+            },
+            remaining_sell_amount: self.remaining_sell_amount,
+            id: self.id,
+        }
+    }
+}

--- a/pricegraph/src/encoding.rs
+++ b/pricegraph/src/encoding.rs
@@ -21,7 +21,6 @@ pub type UserId = H160;
 
 /// A struct representing a buy/sell token pair.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TokenPair {
     /// The buy token.
     pub buy: TokenId,
@@ -31,7 +30,6 @@ pub struct TokenPair {
 
 /// A struct representing the validity of an order.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Validity {
     /// The batch starting from which the order is valid.
     pub from: BatchId,
@@ -41,7 +39,6 @@ pub struct Validity {
 
 /// A price expressed as a fraction of buy and sell amounts.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Price {
     /// The price numerator, or the buy amount.
     pub numerator: u128,
@@ -121,69 +118,6 @@ impl Element {
                 id: read!(u16),
             }
         }))
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-mod abitrary_impl {
-    use super::*;
-    use arbitrary::{Arbitrary, Result, Unstructured};
-
-    // We want Element to implement Arbitrary but cannot derive it because Element contains H160
-    // and U256 which do not implement arbitrary and come from foreign crates. Instead of
-    // implementing Arbitrary manually or introducing wrappers for H160 and U256 we create an
-    // equivalent to Element which can derive Arbitrary and forward all methods.
-
-    #[derive(Arbitrary)]
-    struct ArbitraryElement {
-        user: [u8; 20],
-        balance: [u8; 32],
-        pair: TokenPair,
-        valid: Validity,
-        price: Price,
-        remaining_sell_amount: u128,
-        id: OrderId,
-    }
-
-    impl ArbitraryElement {
-        fn from_element(e: &Element) -> Self {
-            let mut balance = [0u8; 32];
-            e.balance.to_little_endian(&mut balance);
-            Self {
-                user: e.user.to_fixed_bytes(),
-                balance,
-                pair: e.pair,
-                valid: e.valid,
-                price: e.price,
-                remaining_sell_amount: e.remaining_sell_amount,
-                id: e.id,
-            }
-        }
-        fn to_element(&self) -> Element {
-            Element {
-                user: H160::from_slice(&self.user),
-                balance: U256::from_little_endian(&self.balance),
-                pair: self.pair,
-                valid: self.valid,
-                price: self.price,
-                remaining_sell_amount: self.remaining_sell_amount,
-                id: self.id,
-            }
-        }
-    }
-
-    impl arbitrary::Arbitrary for Element {
-        fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
-            Ok(ArbitraryElement::arbitrary(u)?.to_element())
-        }
-        fn size_hint(depth: usize) -> (usize, Option<usize>) {
-            ArbitraryElement::size_hint(depth)
-        }
-        fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
-            let box_iterator = ArbitraryElement::from_element(self).shrink();
-            let mapped = box_iterator.map(|a| a.to_element());
-            Box::new(mapped)
-        }
     }
 }
 

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -9,3 +9,4 @@ mod data;
 
 pub use encoding::*;
 pub use orderbook::Orderbook;
+pub use primitive_types::{H160, U256};


### PR DESCRIPTION
I noticed this when building services, that even if `fuzz` crate is not being built, the `abitrary` feature is enabled for pricegraph. This is because a single `Cargo.lock` file only has one set of features per dependency.

This PR just moves the `Arbitrary` implementation into the `fuzz` crate so it is no longer a dependency of `pricegraph`.

### Test Plan

Run the fuzzer as per the README instructions - see magic happen.