### PR TITLE
[Coverage] re-ignore / folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,8 @@ jobs:
         # generated contract code which caused the whole file to be printed as part of the warning
         # message which made the build fail (probably travis related).
         - env CARGO_INCREMENTAL=0 RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Awarnings" cargo +nightly test
-        - ./grcov --branch --ignore-not-existing --llvm --ignore "target/debug/build/** --ignore "/*" target/debug/ --output-path coveralls.json --output-type "coveralls+" --source-dir . --service-name travis-pro --service-job-id $TRAVIS_JOB_ID
+        # Ignore untested cargo files in travis root and auto-generated eth-contract code
+        - ./grcov --branch --ignore-not-existing --llvm --ignore "/*" --ignore "target/debug/build/**" target/debug/ --output-path coveralls.json --output-type "coveralls+" --source-dir . --service-name travis-pro --service-job-id $TRAVIS_JOB_ID
         - curl --form json_file=@coveralls.json https://coveralls.io/api/v1/jobs
     
     - name: Deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ jobs:
         # generated contract code which caused the whole file to be printed as part of the warning
         # message which made the build fail (probably travis related).
         - env CARGO_INCREMENTAL=0 RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Awarnings" cargo +nightly test
-        - ./grcov --branch --ignore-not-existing --llvm --ignore "target/debug/build/**" target/debug/ --output-path coveralls.json --output-type "coveralls+" --source-dir . --service-name travis-pro --service-job-id $TRAVIS_JOB_ID
+        - ./grcov --branch --ignore-not-existing --llvm --ignore "target/debug/build/** --ignore "/*" target/debug/ --output-path coveralls.json --output-type "coveralls+" --source-dir . --service-name travis-pro --service-job-id $TRAVIS_JOB_ID
         - curl --form json_file=@coveralls.json https://coveralls.io/api/v1/jobs
     
     - name: Deploy


### PR DESCRIPTION
#919 actually decreased coverage (https://coveralls.io/github/gnosis/dex-services) because we stopped ignoring the `/` directory. This doesn't generate any code when testing locally, however on travis there is a significant amount of cached cargo code in this directory which doesn't have any test coverage and thus distorts our report.

This PR re-ignores this directory

### Test Plan
See test coverage increasing on coveralls after this is merged.