### PR TITLE
[Coverage] Ignore derives/automock/test code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ jobs:
         # message which made the build fail (probably travis related).
         - env CARGO_INCREMENTAL=0 RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Awarnings" cargo +nightly test
         # Ignore untested cargo files in travis root and auto-generated eth-contract code
-        - ./grcov --branch --ignore-not-existing --llvm --ignore "/*" --ignore "target/debug/build/**" target/debug/ --output-path coveralls.json --output-type "coveralls+" --source-dir . --service-name travis-pro --service-job-id $TRAVIS_JOB_ID
+        - ./grcov --branch --ignore-not-existing --llvm --excl-start "mod test" --excl-line "#\[cfg_attr\(test, mockall::automock\)\]|#\[derive" --ignore "/*" --ignore "target/debug/build/**" target/debug/ --output-path coveralls.json --output-type "coveralls+" --source-dir . --service-name travis-pro --service-job-id $TRAVIS_JOB_ID
         - curl --form json_file=@coveralls.json https://coveralls.io/api/v1/jobs
     
     - name: Deploy


### PR DESCRIPTION
While looking at our coverage report I noticed that we are getting a lot of branch misses on lines that we are not realistically going to test:

1) [#[cfg_attr(test, automock)]](https://coveralls.io/builds/31090980/source?filename=driver%2Fsrc%2Fcontracts%2Fstablex_contract.rs#L78)
2) [#[derive(...)]](https://coveralls.io/builds/31090980/source?filename=driver%2Fsrc%2Fprice_finding%2Foptimization_price_finder.rs#L61)
3) [unit test themselves](https://coveralls.io/builds/31090980/source?filename=driver%2Fsrc%2Fcontracts%2Fstablex_contract.rs#L435)

This PR uses the `--exclude` regex arguments of grcov to filter out these lines/sections

### Test Plan
Locally inspect coverage report (generated html) and double check with coveralls after merging