### PR TITLE
Remove mockall workaround

### DIFF
--- a/driver/src/price_estimation.rs
+++ b/driver/src/price_estimation.rs
@@ -112,7 +112,7 @@ impl PriceOracle {
     }
 
     /// Gets price estimates for some tokens
-    fn get_prices(&self, tokens: &[Token]) -> HashMap<TokenId, u128> {
+    fn get_prices(&self, tokens: Vec<Token>) -> HashMap<TokenId, u128> {
         if tokens.is_empty() {
             return HashMap::new();
         }
@@ -130,7 +130,7 @@ impl PriceOracle {
 impl PriceEstimating for PriceOracle {
     fn get_token_prices(&self, orders: &[Order]) -> Tokens {
         let (tokens_to_price, unpriced_token_ids) = self.split_order_tokens(orders);
-        let prices = self.get_prices(&tokens_to_price);
+        let prices = self.get_prices(tokens_to_price.clone());
 
         tokens_to_price
             .into_iter()
@@ -268,7 +268,7 @@ mod tests {
         let mut source = MockPriceSource::new();
         source
             .expect_get_prices()
-            .withf(|tokens| tokens == [Token::new(2, "USDT", 6)])
+            .withf(|tokens| tokens.as_slice() == &[Token::new(2, "USDT", 6)])
             .returning(|_| {
                 async {
                     Ok(hash_map! {

--- a/driver/src/price_estimation/average_price_source.rs
+++ b/driver/src/price_estimation/average_price_source.rs
@@ -23,11 +23,11 @@ where
 {
     fn get_prices<'a>(
         &'a self,
-        tokens: &'a [Token],
+        tokens: Vec<Token>,
     ) -> BoxFuture<'a, Result<HashMap<TokenId, u128>>> {
         async move {
             let prices = future::join(
-                self.source_0.get_prices(tokens),
+                self.source_0.get_prices(tokens.clone()),
                 self.source_1.get_prices(tokens),
             )
             .await;

--- a/driver/src/price_estimation/kraken.rs
+++ b/driver/src/price_estimation/kraken.rs
@@ -73,11 +73,11 @@ where
 {
     fn get_prices<'a>(
         &'a self,
-        tokens: &'a [Token],
+        tokens: Vec<Token>,
     ) -> BoxFuture<'a, Result<HashMap<TokenId, u128>>> {
         async move {
             let token_asset_pairs = self
-                .get_token_asset_pairs(tokens)
+                .get_token_asset_pairs(&tokens)
                 .await
                 .context("failed to generate asset pairs mapping for tokens")?;
 
@@ -179,7 +179,7 @@ mod tests {
             });
 
         let client = KrakenClient::with_api(api);
-        let prices = client.get_prices(&tokens).now_or_never().unwrap().unwrap();
+        let prices = client.get_prices(tokens).now_or_never().unwrap().unwrap();
 
         assert_eq!(
             prices,
@@ -217,7 +217,7 @@ mod tests {
         let start_time = Instant::now();
         {
             let client = KrakenClient::new(&HttpFactory::default()).unwrap();
-            let prices = client.get_prices(&tokens).wait().unwrap();
+            let prices = client.get_prices(tokens).wait().unwrap();
 
             println!("{:#?}", prices);
             assert!(


### PR DESCRIPTION
Instead of using the workaround we change the trait to require and owned
value even this is technically not needed. This is an advantage because
the workaround is hacky and performance of cloning the tokens doesn't
matter.

### Test Plan
CI