### PR TITLE
Make PriceFinding async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee77a98872673f1839c1a434e98b7652b3adb54a4c485735ea5937b66da5800"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "once_cell",
+ "parking",
+ "waker-fn",
+]
+
+[[package]]
 name = "brotli-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +619,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode",
+ "blocking",
  "byteorder",
  "chrono",
  "crossbeam-utils",
@@ -1753,6 +1767,12 @@ dependencies = [
  "byte-slice-cast",
  "serde",
 ]
+
+[[package]]
+name = "parking"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7fad362df89617628a7508b3e9d588ade1b0ac31aa25de168193ad999c2dd4"
 
 [[package]]
 name = "parking_lot"
@@ -3339,6 +3359,12 @@ name = "version_check"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+
+[[package]]
+name = "waker-fn"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9571542c2ce85ce642e6b58b3364da2fb53526360dfb7c211add4f5c23105ff7"
 
 [[package]]
 name = "walkdir"

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1"
 bincode = "1.2.1"
+blocking = "0.4.4"
 byteorder = "1.3.4"
 chrono = "0.4.11"
 crossbeam-utils = "0.7"

--- a/driver/src/price_finding/naive_solver.rs
+++ b/driver/src/price_finding/naive_solver.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use ethcontract::U256;
+use futures::future::{BoxFuture, FutureExt as _};
 
 const BASE_UNIT: u128 = 1_000_000_000_000_000_000u128;
 const BASE_PRICE: u128 = BASE_UNIT;
@@ -122,7 +123,12 @@ type OrderPair = [Order; 2];
 type ExecutedOrderPair = [ExecutedOrder; 2];
 
 impl PriceFinding for NaiveSolver {
-    fn find_prices(&self, orders: &[Order], state: &AccountState, _: Duration) -> Result<Solution> {
+    fn find_prices<'a>(
+        &'a self,
+        orders: &'a [Order],
+        state: &'a AccountState,
+        _: Duration,
+    ) -> BoxFuture<'a, Result<Solution>> {
         let solution = if let Some(first_match) = find_first_match(orders, state, &self.fee) {
             let (executed_orders, prices) = create_executed_orders(&first_match, &self.fee);
             if let Some(ref fee) = self.fee {
@@ -136,7 +142,7 @@ impl PriceFinding for NaiveSolver {
         } else {
             Solution::trivial()
         };
-        Ok(solution)
+        async move { Ok(solution) }.boxed()
     }
 }
 
@@ -327,6 +333,8 @@ pub mod tests {
         let solver = NaiveSolver::new(None);
         let res = solver
             .find_prices(&orders, &state, Duration::default())
+            .now_or_never()
+            .unwrap()
             .unwrap();
 
         assert_eq!(
@@ -354,6 +362,8 @@ pub mod tests {
         let solver = NaiveSolver::new(fee.clone());
         let res = solver
             .find_prices(&orders, &state, Duration::default())
+            .now_or_never()
+            .unwrap()
             .unwrap();
         check_solution(&orders, res, &fee).unwrap();
     }
@@ -367,6 +377,8 @@ pub mod tests {
         let solver = NaiveSolver::new(None);
         let res = solver
             .find_prices(&orders, &state, Duration::default())
+            .now_or_never()
+            .unwrap()
             .unwrap();
 
         assert_eq!(
@@ -395,6 +407,8 @@ pub mod tests {
         let solver = NaiveSolver::new(fee.clone());
         let res = solver
             .find_prices(&orders, &state, Duration::default())
+            .now_or_never()
+            .unwrap()
             .unwrap();
         check_solution(&orders, res, &fee).unwrap();
     }
@@ -407,6 +421,8 @@ pub mod tests {
         let solver = NaiveSolver::new(None);
         let res = solver
             .find_prices(&orders, &state, Duration::default())
+            .now_or_never()
+            .unwrap()
             .unwrap();
 
         assert_eq!(
@@ -433,6 +449,8 @@ pub mod tests {
         let solver = NaiveSolver::new(fee.clone());
         let res = solver
             .find_prices(&orders, &state, Duration::default())
+            .now_or_never()
+            .unwrap()
             .unwrap();
         check_solution(&orders, res, &fee).unwrap();
     }
@@ -494,6 +512,8 @@ pub mod tests {
         let solver = NaiveSolver::new(None);
         let res = solver
             .find_prices(&orders, &state, Duration::default())
+            .now_or_never()
+            .unwrap()
             .unwrap();
 
         assert_eq!(
@@ -535,6 +555,8 @@ pub mod tests {
         let solver = NaiveSolver::new(None);
         let res = solver
             .find_prices(&orders, &state, Duration::default())
+            .now_or_never()
+            .unwrap()
             .unwrap();
         assert!(!res.is_non_trivial());
     }
@@ -564,6 +586,8 @@ pub mod tests {
         let solver = NaiveSolver::new(None);
         let res = solver
             .find_prices(&orders, &state, Duration::default())
+            .now_or_never()
+            .unwrap()
             .unwrap();
         assert!(!res.is_non_trivial());
     }
@@ -597,6 +621,8 @@ pub mod tests {
         let solver = NaiveSolver::new(fee.clone());
         let res = solver
             .find_prices(&orders, &state, Duration::default())
+            .now_or_never()
+            .unwrap()
             .unwrap();
 
         assert_eq!(
@@ -647,6 +673,8 @@ pub mod tests {
         let solver = NaiveSolver::new(fee.clone());
         let res = solver
             .find_prices(&orders, &state, Duration::default())
+            .now_or_never()
+            .unwrap()
             .unwrap();
 
         assert!(res.is_non_trivial());
@@ -682,6 +710,8 @@ pub mod tests {
         let solver = NaiveSolver::new(fee);
         let res = solver
             .find_prices(&orders, &state, Duration::default())
+            .now_or_never()
+            .unwrap()
             .unwrap();
         assert!(!res.is_non_trivial());
     }
@@ -694,6 +724,8 @@ pub mod tests {
         let solver = NaiveSolver::new(None);
         let res = solver
             .find_prices(&orders, &state, Duration::default())
+            .now_or_never()
+            .unwrap()
             .unwrap();
         assert_eq!(res, Solution::trivial());
     }
@@ -723,6 +755,8 @@ pub mod tests {
         let solver = NaiveSolver::new(None);
         let res = solver
             .find_prices(&orders, &state, Duration::default())
+            .now_or_never()
+            .unwrap()
             .unwrap();
         assert!(!res.is_non_trivial());
     }
@@ -764,6 +798,8 @@ pub mod tests {
         let solver = NaiveSolver::new(fee.clone());
         let res = solver
             .find_prices(&orders, &state, Duration::default())
+            .now_or_never()
+            .unwrap()
             .unwrap();
         check_solution(&orders, res, &fee).unwrap();
     }
@@ -813,6 +849,8 @@ pub mod tests {
         let solver = NaiveSolver::new(fee.clone());
         let res = solver
             .find_prices(&orders, &state, Duration::default())
+            .now_or_never()
+            .unwrap()
             .unwrap();
         check_solution(&orders, res, &fee).unwrap();
     }


### PR DESCRIPTION
I decided to use the "blocking" crate to handle the blocking io for
running the solver. I prefer this over using asyncstd or tokio because
* It makes the code stay executor agnostic and use a more light weight
dependency for the same task.
* It creates less churn in our code because we do not need to change the
Io trait to async.
* The `Command` module we use to run the solver does not yet have an
async-std equivalent.

#843 

### Test Plan
CI