### PR TITLE
[Easy] Bump solver version to v0.7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ language: rust
 env:
   global:
     - OPEN_SOLVER_VERSION=v0.0.10
-    - PRIVATE_SOLVER_VERSION=v0.7.1
+    - PRIVATE_SOLVER_VERSION=v0.7.2
 
 install:
   - nvm install 12 && nvm alias default 12 && npm install -g yarn@latest && yarn --version


### PR DESCRIPTION
This PR increases the solver version from v0.7.1 to v0.7.2. 

Fixes https://github.com/gnosis/dex-solver/issues/261 (invalid JSON in solution file)

### Test Plan
---