### PR TITLE
Turn batch id into u32 from U256

### DIFF
--- a/core/src/contracts/stablex_auction_element.rs
+++ b/core/src/contracts/stablex_auction_element.rs
@@ -10,14 +10,14 @@ pub const INDEXED_AUCTION_ELEMENT_WIDTH: usize = AUCTION_ELEMENT_WIDTH + 2;
 
 #[derive(Debug, PartialEq)]
 pub struct StableXAuctionElement {
-    valid_from: U256,
-    valid_until: U256,
+    valid_from: u32,
+    valid_until: u32,
     pub sell_token_balance: U256,
     pub order: Order,
 }
 
 impl StableXAuctionElement {
-    pub fn in_auction(&self, index: U256) -> bool {
+    pub fn in_auction(&self, index: u32) -> bool {
         self.valid_from <= index && index <= self.valid_until
     }
 
@@ -38,12 +38,8 @@ impl StableXAuctionElement {
         let sell_token_balance = U256::from_big_endian(&bytes[20..52]);
         let buy_token = u16::from_le_bytes([bytes[53], bytes[52]]);
         let sell_token = u16::from_le_bytes([bytes[55], bytes[54]]);
-        let valid_from = U256::from(u32::from_le_bytes([
-            bytes[59], bytes[58], bytes[57], bytes[56],
-        ]));
-        let valid_until = U256::from(u32::from_le_bytes([
-            bytes[63], bytes[62], bytes[61], bytes[60],
-        ]));
+        let valid_from = u32::from_le_bytes([bytes[59], bytes[58], bytes[57], bytes[56]]);
+        let valid_until = u32::from_le_bytes([bytes[63], bytes[62], bytes[61], bytes[60]]);
         let numerator = BigEndian::read_u128(&bytes[64..80]);
         let denominator = BigEndian::read_u128(&bytes[80..96]);
         let remaining = BigEndian::read_u128(&bytes[96..112]);
@@ -92,8 +88,8 @@ pub mod tests {
 
     fn emptyish_auction_element() -> StableXAuctionElement {
         StableXAuctionElement {
-            valid_from: U256::from(0),
-            valid_until: U256::from(0),
+            valid_from: 0,
+            valid_until: 0,
             sell_token_balance: U256::from(0),
             order: Order {
                 id: 0,
@@ -137,8 +133,8 @@ pub mod tests {
         ];
         let res = StableXAuctionElement::from_bytes(&bytes);
         let auction_element = StableXAuctionElement {
-            valid_from: U256::from(2),
-            valid_until: U256::from(261),
+            valid_from: 2,
+            valid_until: 261,
             sell_token_balance: U256::from(3),
             order: Order {
                 id: 0,
@@ -169,9 +165,9 @@ pub mod tests {
         ];
         let res = StableXAuctionElement::from_indexed_bytes(&bytes);
         let auction_element = StableXAuctionElement {
-            valid_from: U256::from(2),
-            valid_until: U256::from(261),
-            sell_token_balance: U256::from(2).pow(U256::from(255)) + U256::from(3),
+            valid_from: 2,
+            valid_until: 261,
+            sell_token_balance: U256::from(2).pow(U256::from(255)) + 3,
             order: Order {
                 id: 1,
                 account_id: Address::from_low_u64_be(1),
@@ -188,42 +184,34 @@ pub mod tests {
     #[test]
     fn not_in_auction_left() {
         let mut element = emptyish_auction_element();
-        element.valid_from = U256::from(2);
-        element.valid_until = U256::from(5);
-        assert_eq!(element.in_auction(U256::from(1)), false);
+        element.valid_from = 2;
+        element.valid_until = 5;
+        assert_eq!(element.in_auction(1), false);
     }
 
     #[test]
     fn not_in_auction_right() {
         let mut element = emptyish_auction_element();
-        element.valid_from = U256::from(2);
-        element.valid_until = U256::from(5);
-        assert_eq!(element.in_auction(U256::from(6)), false);
+        element.valid_from = 2;
+        element.valid_until = 5;
+        assert_eq!(element.in_auction(6), false);
     }
 
     #[test]
     fn in_auction_interior() {
         let mut element = emptyish_auction_element();
-        element.valid_from = U256::from(2);
-        element.valid_until = U256::from(5);
-        assert_eq!(element.in_auction(U256::from(3)), true);
+        element.valid_from = 2;
+        element.valid_until = 5;
+        assert_eq!(element.in_auction(3), true);
     }
 
     #[test]
     fn in_auction_boundary() {
         let mut element = emptyish_auction_element();
-        element.valid_from = U256::from(2);
-        element.valid_until = U256::from(5);
-        assert_eq!(
-            element.in_auction(U256::from(5)),
-            true,
-            "failed on right boundary"
-        );
-        assert_eq!(
-            element.in_auction(U256::from(2)),
-            true,
-            "failed on left boundary"
-        );
+        element.valid_from = 2;
+        element.valid_until = 5;
+        assert_eq!(element.in_auction(5), true, "failed on right boundary");
+        assert_eq!(element.in_auction(2), true, "failed on left boundary");
     }
 
     // tests for compute_buy_sell_amounts

--- a/core/src/contracts/stablex_contract.rs
+++ b/core/src/contracts/stablex_contract.rs
@@ -93,7 +93,7 @@ pub trait StableXContract {
     /// to only include orders valid at the given batchId.
     fn get_filtered_auction_data_paginated<'a>(
         &'a self,
-        batch_index: U256,
+        batch_index: u32,
         token_whitelist: Vec<u16>,
         page_size: u16,
         previous_page_user: Address,
@@ -115,14 +115,14 @@ pub trait StableXContract {
 
     fn get_solution_objective_value<'a>(
         &'a self,
-        batch_index: U256,
+        batch_index: u32,
         solution: Solution,
         block_number: Option<BlockNumber>,
     ) -> BoxFuture<'a, Result<U256>>;
 
     fn submit_solution<'a>(
         &'a self,
-        batch_index: U256,
+        batch_index: u32,
         solution: Solution,
         claimed_objective_value: U256,
         gas_price: U256,
@@ -185,7 +185,7 @@ impl StableXContract for StableXContractImpl {
 
     fn get_filtered_auction_data_paginated<'a>(
         &'a self,
-        batch_index: U256,
+        batch_index: u32,
         token_whitelist: Vec<u16>,
         page_size: u16,
         previous_page_user: Address,
@@ -193,7 +193,7 @@ impl StableXContract for StableXContractImpl {
         block_number: Option<BlockNumber>,
     ) -> BoxFuture<'a, Result<FilteredOrderPage>> {
         async move {
-            let target_batch = batch_index.low_u32();
+            let target_batch = batch_index;
             let mut builder = self.viewer.get_filtered_orders_paginated(
                 // Balances should be valid for the batch at which we are submitting (target batch + 1)
                 [target_batch, target_batch, target_batch + 1],
@@ -239,7 +239,7 @@ impl StableXContract for StableXContractImpl {
 
     fn get_solution_objective_value<'a>(
         &'a self,
-        batch_index: U256,
+        batch_index: u32,
         solution: Solution,
         block_number: Option<BlockNumber>,
     ) -> BoxFuture<'a, Result<U256>> {
@@ -250,7 +250,7 @@ impl StableXContract for StableXContractImpl {
             let mut builder = self
                 .instance
                 .submit_solution(
-                    batch_index.low_u32(),
+                    batch_index,
                     *MAX_OBJECTIVE_VALUE,
                     owners,
                     order_ids,
@@ -267,7 +267,7 @@ impl StableXContract for StableXContractImpl {
 
     fn submit_solution<'a>(
         &'a self,
-        batch_index: U256,
+        batch_index: u32,
         solution: Solution,
         claimed_objective_value: U256,
         gas_price: U256,
@@ -280,7 +280,7 @@ impl StableXContract for StableXContractImpl {
             let mut method = self
                 .instance
                 .submit_solution(
-                    batch_index.low_u32(),
+                    batch_index,
                     claimed_objective_value,
                     owners,
                     order_ids,

--- a/core/src/driver/scheduler/evm.rs
+++ b/core/src/driver/scheduler/evm.rs
@@ -88,7 +88,7 @@ impl<'a> EvmScheduler<'a> {
             batch_id,
             time_limit.as_secs_f64(),
         );
-        match self.driver.run(batch_id.into(), time_limit).wait() {
+        match self.driver.run(batch_id, time_limit).wait() {
             DriverResult::Ok => {
                 info!("successfully solved batch {}", batch_id);
                 self.last_batch = Some(batch_id);
@@ -131,7 +131,6 @@ mod tests {
     use crate::contracts::stablex_contract::MockStableXContract;
     use crate::driver::stablex_driver::MockStableXDriver;
     use anyhow::anyhow;
-    use ethcontract::U256;
     use futures::future::FutureExt as _;
     use mockall::predicate::eq;
     use mockall::Sequence;
@@ -149,7 +148,7 @@ mod tests {
         let mut driver = MockStableXDriver::new();
         driver
             .expect_run()
-            .with(eq(U256::from(41)), eq(Duration::from_secs(150)))
+            .with(eq(41), eq(Duration::from_secs(150)))
             .returning(|_, _| async { DriverResult::Ok }.boxed());
 
         let mut scheduler = EvmScheduler::with_defaults(&exchange, &driver);

--- a/core/src/driver/scheduler/system.rs
+++ b/core/src/driver/scheduler/system.rs
@@ -77,7 +77,7 @@ impl<'a> SystemScheduler<'a> {
         let driver = self.driver;
         scope.spawn(move |_| {
             while let Some(time_limit) = solver_deadline.checked_duration_since(Instant::now()) {
-                let driver_result = driver.run(batch_id.0.into(), time_limit).wait();
+                let driver_result = driver.run(batch_id.0 as u32, time_limit).wait();
                 log_driver_result(batch_id, &driver_result);
                 match driver_result {
                     DriverResult::Retry(_) => thread::sleep(RETRY_SLEEP_DURATION),
@@ -313,7 +313,7 @@ mod tests {
             log::info!(
                 "driver run called for the {}. time with batch {} time_limit {}",
                 counter,
-                batch.low_u64(),
+                batch,
                 time_limit.as_secs(),
             );
             counter += 1;

--- a/core/src/metrics/stablex_metrics.rs
+++ b/core/src/metrics/stablex_metrics.rs
@@ -73,7 +73,7 @@ impl StableXMetrics {
         }
     }
 
-    pub fn auction_processing_started(&self, res: &Result<U256>) {
+    pub fn auction_processing_started(&self, res: &Result<u32>) {
         // Reset values from previous batch
         for stage in ProcessingStage::ALL_STAGES {
             self.processing_times
@@ -91,7 +91,7 @@ impl StableXMetrics {
         };
     }
 
-    pub fn auction_orders_fetched(&self, batch: U256, res: &Result<(AccountState, Vec<Order>)>) {
+    pub fn auction_orders_fetched(&self, batch: u32, res: &Result<(AccountState, Vec<Order>)>) {
         let stage_label = &[ProcessingStage::OrdersFetched.as_ref()];
         let book_label = &[BookType::Orderbook.as_ref()];
         self.processing_times
@@ -113,7 +113,7 @@ impl StableXMetrics {
         }
     }
 
-    pub fn auction_solution_computed(&self, batch: U256, res: &Result<Solution>) {
+    pub fn auction_solution_computed(&self, batch: u32, res: &Result<Solution>) {
         let stage_label = &[ProcessingStage::Solved.as_ref()];
         let book_label = &[BookType::Solution.as_ref()];
         self.processing_times
@@ -141,7 +141,7 @@ impl StableXMetrics {
 
     pub fn auction_solution_verified(
         &self,
-        batch: U256,
+        batch: u32,
         res: &Result<U256, SolutionSubmissionError>,
     ) {
         let stage_label = &[ProcessingStage::Solved.as_ref()];
@@ -161,7 +161,7 @@ impl StableXMetrics {
 
     pub fn auction_solution_submitted(
         &self,
-        batch: U256,
+        batch: u32,
         res: &Result<(), SolutionSubmissionError>,
     ) {
         let stage_label = &[ProcessingStage::Submitted.as_ref()];
@@ -179,7 +179,7 @@ impl StableXMetrics {
         }
     }
 
-    pub fn auction_processed_but_not_submitted(&self, batch: U256) {
+    pub fn auction_processed_but_not_submitted(&self, batch: u32) {
         let stage_label = &[ProcessingStage::SolutionNotSubmitted.as_ref()];
         self.processing_times
             .with_label_values(stage_label)
@@ -188,10 +188,10 @@ impl StableXMetrics {
     }
 }
 
-fn time_elapsed_since_batch_start(batch: U256) -> i64 {
+fn time_elapsed_since_batch_start(batch: u32) -> i64 {
     let now = Utc::now().timestamp();
     // A new batch is created every 5 minutes and becomes solvable one batch later
-    let batch_start = (batch.low_u64() as i64 + 1) * 300;
+    let batch_start = (batch as i64 + 1) * 300;
     now - batch_start
 }
 

--- a/core/src/orderbook.rs
+++ b/core/src/orderbook.rs
@@ -16,7 +16,6 @@ use crate::contracts::{stablex_contract::StableXContractImpl, Web3};
 use crate::models::{AccountState, Order};
 
 use anyhow::{anyhow, Error, Result};
-use ethcontract::U256;
 use futures::future::{BoxFuture, FutureExt as _};
 #[cfg(test)]
 use mockall::automock;
@@ -33,7 +32,7 @@ pub trait StableXOrderBookReading: Send + Sync {
     /// * `batch_id_to_solve` - the index for which returned orders should be valid
     fn get_auction_data<'a>(
         &'a self,
-        batch_id_to_solve: U256,
+        batch_id_to_solve: u32,
     ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>>;
     /// Perform potential heavy initialization of the orderbook. If this fails or wasn't called
     // the orderbook will initialize on first use of `get_auction_data`.

--- a/core/src/orderbook/auction_data_reader.rs
+++ b/core/src/orderbook/auction_data_reader.rs
@@ -2,7 +2,7 @@ use crate::contracts::stablex_auction_element::{
     StableXAuctionElement, AUCTION_ELEMENT_WIDTH, INDEXED_AUCTION_ELEMENT_WIDTH,
 };
 use crate::models::{AccountState, Order};
-use ethcontract::{Address, U256};
+use ethcontract::Address;
 use std::collections::HashMap;
 
 /// Handles reading of auction data that has been encoded with the smart
@@ -13,13 +13,13 @@ pub struct AuctionDataReader {
     /// All unfiltered orders in the order they were received.
     orders: Vec<Order>,
     /// Used when reading data from the smart contract in batches.
-    index: U256,
+    index: u32,
     /// The total number of orders per user.
     user_order_counts: HashMap<Address, usize>,
 }
 
 impl AuctionDataReader {
-    pub fn new(index: U256) -> Self {
+    pub fn new(index: u32) -> Self {
         Self {
             account_state: AccountState::default(),
             orders: Vec::new(),
@@ -132,7 +132,7 @@ pub struct Pagination {
 
 impl PaginatedAuctionDataReader {
     /// Create a new PaginatedAuctionDataReader.
-    pub fn new(index: U256, page_size: usize) -> PaginatedAuctionDataReader {
+    pub fn new(index: u32, page_size: usize) -> PaginatedAuctionDataReader {
         PaginatedAuctionDataReader {
             reader: AuctionDataReader::new(index),
             next_page: Some(Pagination {
@@ -187,7 +187,7 @@ impl PaginatedAuctionDataReader {
 pub struct IndexedAuctionDataReader(AuctionDataReader);
 
 impl IndexedAuctionDataReader {
-    pub fn new(index: U256) -> Self {
+    pub fn new(index: u32) -> Self {
         Self(AuctionDataReader::new(index))
     }
 
@@ -308,7 +308,7 @@ pub mod tests {
 
     #[test]
     fn auction_data_reader_empty() {
-        let mut reader = AuctionDataReader::new(U256::from(3));
+        let mut reader = AuctionDataReader::new(3);
         reader.apply_page(&[]);
         assert_eq!(reader.orders.len(), 0);
     }
@@ -318,7 +318,7 @@ pub mod tests {
         let mut bytes = Vec::new();
         bytes.extend(ORDER_1_BYTES);
         bytes.extend(ORDER_2_BYTES);
-        let mut reader = AuctionDataReader::new(U256::from(3));
+        let mut reader = AuctionDataReader::new(3);
         reader.apply_page(&bytes);
 
         let mut account_state = AccountState::default();
@@ -332,7 +332,7 @@ pub mod tests {
     #[test]
     fn auction_data_reader_multiple_batches() {
         let mut account_state = AccountState::default();
-        let mut reader = AuctionDataReader::new(U256::from(3));
+        let mut reader = AuctionDataReader::new(3);
         let mut bytes = Vec::new();
 
         bytes.extend(ORDER_1_BYTES);
@@ -358,7 +358,7 @@ pub mod tests {
     #[test]
     fn auction_data_reader_multiple_batches_different_users() {
         let mut account_state = AccountState::default();
-        let mut reader = AuctionDataReader::new(U256::from(3));
+        let mut reader = AuctionDataReader::new(3);
         let mut bytes = Vec::new();
 
         bytes.extend(ORDER_1_BYTES);
@@ -381,7 +381,7 @@ pub mod tests {
         let mut bytes = Vec::new();
         bytes.extend(ORDER_1_BYTES);
         bytes.extend(ORDER_2_BYTES);
-        let mut reader = AuctionDataReader::new(U256::from(1000));
+        let mut reader = AuctionDataReader::new(1000);
         // the bytes contain two orders
         reader.apply_page(&bytes);
 
@@ -396,7 +396,7 @@ pub mod tests {
         let mut bytes = Vec::new();
         bytes.extend(ORDER_1_BYTES);
         bytes.extend(ORDER_2_BYTES);
-        let mut reader = PaginatedAuctionDataReader::new(U256::from(3), 2);
+        let mut reader = PaginatedAuctionDataReader::new(3, 2);
         reader.apply_page(&bytes);
 
         assert_eq!(
@@ -410,7 +410,7 @@ pub mod tests {
 
     #[test]
     fn paginated_auction_data_reader_multiple_batches() {
-        let mut reader = PaginatedAuctionDataReader::new(U256::from(3), 1);
+        let mut reader = PaginatedAuctionDataReader::new(3, 1);
         let mut bytes = Vec::new();
 
         bytes.extend(ORDER_1_BYTES);
@@ -452,7 +452,7 @@ pub mod tests {
 
     #[test]
     fn paginated_auction_data_reader_multiple_batches_different_users() {
-        let mut reader = PaginatedAuctionDataReader::new(U256::from(3), 2);
+        let mut reader = PaginatedAuctionDataReader::new(3, 2);
         let mut bytes = Vec::new();
 
         bytes.extend(ORDER_3_BYTES);

--- a/core/src/orderbook/filtered_orderbook.rs
+++ b/core/src/orderbook/filtered_orderbook.rs
@@ -69,7 +69,7 @@ impl FilteredOrderbookReader {
 impl StableXOrderBookReading for FilteredOrderbookReader {
     fn get_auction_data<'b>(
         &'b self,
-        batch_id_to_solve: U256,
+        batch_id_to_solve: u32,
     ) -> BoxFuture<'b, Result<(AccountState, Vec<Order>)>> {
         async move {
             let (state, orders) = self.orderbook.get_auction_data(batch_id_to_solve).await?;
@@ -213,11 +213,7 @@ mod test {
 
         let reader = FilteredOrderbookReader::new(Box::new(inner), filter);
 
-        let (_, filtered_orders) = reader
-            .get_auction_data(U256::zero())
-            .now_or_never()
-            .unwrap()
-            .unwrap();
+        let (_, filtered_orders) = reader.get_auction_data(0).now_or_never().unwrap().unwrap();
         assert_eq!(filtered_orders, vec![mixed_user_good_order]);
     }
 
@@ -246,11 +242,7 @@ mod test {
 
         let reader = FilteredOrderbookReader::new(Box::new(inner), filter);
 
-        let (_, filtered_orders) = reader
-            .get_auction_data(U256::zero())
-            .now_or_never()
-            .unwrap()
-            .unwrap();
+        let (_, filtered_orders) = reader.get_auction_data(0).now_or_never().unwrap().unwrap();
         assert_eq!(filtered_orders, vec![good_order]);
     }
 
@@ -270,11 +262,7 @@ mod test {
 
         let reader = FilteredOrderbookReader::new(Box::new(inner), filter);
 
-        let (state, filtered_orders) = reader
-            .get_auction_data(U256::zero())
-            .now_or_never()
-            .unwrap()
-            .unwrap();
+        let (state, filtered_orders) = reader.get_auction_data(0).now_or_never().unwrap().unwrap();
         assert_eq!(filtered_orders, vec![]);
         assert_eq!(state, AccountState::default());
     }

--- a/core/src/orderbook/onchain_filtered_orderbook.rs
+++ b/core/src/orderbook/onchain_filtered_orderbook.rs
@@ -6,7 +6,7 @@ use super::filtered_orderbook::OrderbookFilter;
 use super::StableXOrderBookReading;
 
 use anyhow::Result;
-use ethcontract::{Address, U256};
+use ethcontract::Address;
 use futures::future::{BoxFuture, FutureExt as _};
 use std::sync::Arc;
 
@@ -36,12 +36,12 @@ impl OnchainFilteredOrderBookReader {
 impl StableXOrderBookReading for OnchainFilteredOrderBookReader {
     fn get_auction_data<'a>(
         &'a self,
-        batch_id_to_solve: U256,
+        batch_id_to_solve: u32,
     ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>> {
         async move {
             let last_block = self
                 .contract
-                .get_last_block_for_batch(batch_id_to_solve.as_u32())
+                .get_last_block_for_batch(batch_id_to_solve)
                 .await?;
             let mut reader = IndexedAuctionDataReader::new(batch_id_to_solve);
             let mut auction_data = FilteredOrderPage {
@@ -133,7 +133,7 @@ mod tests {
             &OrderbookFilter::default(),
         );
         assert_eq!(
-            reader.get_auction_data(U256::from(42)).wait().unwrap(),
+            reader.get_auction_data(42).wait().unwrap(),
             (AccountState::default(), vec![])
         )
     }
@@ -178,7 +178,7 @@ mod tests {
         };
 
         assert_eq!(
-            reader.get_auction_data(U256::from(42)).wait().unwrap(),
+            reader.get_auction_data(42).wait().unwrap(),
             (state, vec![order])
         )
     }
@@ -251,9 +251,6 @@ mod tests {
             },
         ];
 
-        assert_eq!(
-            reader.get_auction_data(U256::from(42)).wait().unwrap(),
-            (state, orders)
-        )
+        assert_eq!(reader.get_auction_data(42).wait().unwrap(), (state, orders))
     }
 }

--- a/core/src/orderbook/paginated_orderbook.rs
+++ b/core/src/orderbook/paginated_orderbook.rs
@@ -4,7 +4,7 @@ use crate::models::{AccountState, Order};
 use super::auction_data_reader::PaginatedAuctionDataReader;
 use super::StableXOrderBookReading;
 use anyhow::Result;
-use ethcontract::{BlockNumber, U256};
+use ethcontract::BlockNumber;
 use futures::future::{BoxFuture, FutureExt as _};
 use std::convert::TryInto;
 use std::sync::Arc;
@@ -29,7 +29,7 @@ impl PaginatedStableXOrderBookReader {
 impl StableXOrderBookReading for PaginatedStableXOrderBookReader {
     fn get_auction_data<'a>(
         &'a self,
-        batch_id_to_solve: U256,
+        batch_id_to_solve: u32,
     ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>> {
         async move {
             let mut reader =

--- a/core/src/orderbook/streamed/updating_orderbook.rs
+++ b/core/src/orderbook/streamed/updating_orderbook.rs
@@ -196,7 +196,7 @@ impl StableXOrderBookReading for UpdatingOrderbook {
     /// Blocks on updating the orderbook. This can be expensive if `initialize` hasn't been called before.
     fn get_auction_data<'a>(
         &'a self,
-        batch_id_to_solve: U256,
+        batch_id_to_solve: u32,
     ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>> {
         self.do_with_context(move |context| context.orderbook.get_auction_data(batch_id_to_solve))
             .boxed()


### PR DESCRIPTION
In the contract this is a u32 so there is no reason to use U256.

### Test Plan
CI.