### PR TITLE
Set rust version to 1.43.0 temporarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
   include:
     - name: "Build and Local Testing"
       if: type = pull_request
-      rust: stable
+      rust: 1.43.0
       cache:
         directories:
           - $HOME/.cache/yarn
@@ -84,6 +84,7 @@ jobs:
 
     - name: Deploy
       if: (type != pull_request) AND (tag is present OR branch = master)
+      rust: 1.43.0
       before_install:
         - sudo apt-get update && sudo apt-get install -y python3-pip python3-setuptools && pip3 install --upgrade --user awscli
         - $(aws ecr get-login --no-include-email --region $AWS_REGION)


### PR DESCRIPTION
The new rust version introduced more warnings or lints that make master
fail in the ethcontract generated code. https://travis-ci.com/github/gnosis/dex-services/jobs/343998701
Let's temporarily use the previous version.

Btw even though master failed I didn't get an email.

### Test Plan
CI