### PR TITLE
Price Estimator: Set up orderbook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2124,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df32da11d84f3a7d70205549562966279adb900e080fad3dccd8e64afccf0ad"
+checksum = "282adbf10f2698a7a77f8e983a74b2d18176c19a7fd32a45446139ae7b02b715"
 
 [[package]]
 name = "pin-utils"
@@ -2191,6 +2191,7 @@ dependencies = [
 name = "price-estimator"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "core",
  "env_logger",
  "ethcontract",
@@ -3245,6 +3246,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "slab 0.4.2",
+ "tokio-macros",
 ]
 
 [[package]]
@@ -3328,6 +3330,17 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
  "log 0.4.8",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/price-estimator/Cargo.toml
+++ b/price-estimator/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0"
 core = { path = "../core" }
 env_logger = "0.7"
 ethcontract = "0.7"
@@ -12,6 +13,6 @@ pricegraph = { path = "../pricegraph" }
 primitive-types = "0.7"
 prometheus = "0.9"
 structopt = "0.3"
-tokio = { version = "0.2", features = ["rt-threaded"] }
+tokio = { version = "0.2", features = ["macros", "rt-threaded", "time"] }
 url = "2.1"
 warp = "0.2"

--- a/price-estimator/src/orderbook.rs
+++ b/price-estimator/src/orderbook.rs
@@ -1,0 +1,128 @@
+use core::{
+    models::{AccountState, Order},
+    orderbook::StableXOrderBookReading,
+};
+use pricegraph::{Element, Price, TokenPair, UserId, Validity};
+use primitive_types::U256;
+use std::time::{Duration, SystemTime};
+use tokio::sync::RwLock;
+
+/// Access and update the pricegraph orderbook.
+pub struct Orderbook<T> {
+    orderbook_reading: T,
+    reduced_pricegraph_orderbook: RwLock<pricegraph::Orderbook>,
+}
+
+impl<T> Orderbook<T> {
+    pub fn new(orderbook_reading: T) -> Self {
+        Self {
+            orderbook_reading,
+            reduced_pricegraph_orderbook: RwLock::new(pricegraph::Orderbook::from_elements(
+                std::iter::empty(),
+            )),
+        }
+    }
+
+    pub async fn _get_reduced_orderbook(&self) -> pricegraph::Orderbook {
+        self.reduced_pricegraph_orderbook.read().await.clone()
+    }
+}
+
+impl<T: StableXOrderBookReading> Orderbook<T> {
+    /// Recreate the pricegraph orderbook.
+    pub async fn update(&self) -> anyhow::Result<()> {
+        let (account_state, orders) = self
+            .orderbook_reading
+            .get_auction_data(current_batch_id() as u32)
+            .await?;
+
+        // TODO: Move this cpu heavy computation out of the async function using spawn_blocking.
+        let mut orderbook = pricegraph::Orderbook::from_elements(
+            orders
+                .iter()
+                .map(|order| order_to_element(order, &account_state)),
+        );
+        orderbook.reduce_overlapping_orders();
+
+        *self.reduced_pricegraph_orderbook.write().await = orderbook;
+        Ok(())
+    }
+}
+
+/// Current batch id based on system time.
+fn current_batch_id() -> u64 {
+    const BATCH_DURATION: Duration = Duration::from_secs(300);
+    let now = SystemTime::now();
+    let time_since_epoch = now
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("unix epoch is not in the past");
+    time_since_epoch.as_secs() / BATCH_DURATION.as_secs()
+}
+
+/// Convert a core Order to a pricegraph Element.
+fn order_to_element(order: &Order, account_state: &AccountState) -> Element {
+    // Some conversions are needed because the primitive types crate is on different versions in
+    // core and pricegraph.
+    Element {
+        user: UserId::from_slice(order.account_id.as_fixed_bytes()),
+        balance: U256(
+            account_state
+                .read_balance(order.sell_token, order.account_id)
+                .0,
+        ),
+        pair: TokenPair {
+            buy: order.buy_token,
+            sell: order.sell_token,
+        },
+        valid: Validity {
+            from: order.valid_from,
+            to: order.valid_until,
+        },
+        price: Price {
+            numerator: order.numerator,
+            denominator: order.denominator,
+        },
+        remaining_sell_amount: order.remaining_sell_amount,
+        id: order.id,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ethcontract::{Address, U256};
+    use std::collections::HashMap;
+
+    #[test]
+    fn order_to_element_() {
+        let order = Order {
+            id: 1,
+            account_id: Address::from_low_u64_le(2),
+            buy_token: 3,
+            sell_token: 4,
+            numerator: 5,
+            denominator: 6,
+            remaining_sell_amount: 7,
+            valid_from: 8,
+            valid_until: 9,
+        };
+        let mut account_state = AccountState(HashMap::new());
+        account_state
+            .0
+            .insert((order.account_id, order.sell_token), U256::from(10));
+        let element = order_to_element(&order, &account_state);
+        assert_eq!(
+            element.user.as_fixed_bytes(),
+            order.account_id.as_fixed_bytes()
+        );
+        assert_eq!(element.balance.0, U256::from(10).0);
+        assert_eq!(element.pair.buy, order.buy_token);
+        assert_eq!(element.pair.sell, order.sell_token);
+        assert_eq!(element.valid.from, order.valid_from);
+        assert_eq!(element.valid.to, order.valid_until);
+        assert_eq!(element.price.numerator, order.numerator);
+        assert_eq!(element.price.denominator, order.denominator);
+        assert_eq!(element.remaining_sell_amount, order.remaining_sell_amount);
+        assert_eq!(element.id, order.id);
+    }
+}


### PR DESCRIPTION
Add an Orderbook to the price estimator and set up one task to update
and another task to serve http requests.
To handle requests the get_reduced_orderbook method on Orderbook is
going to be used and the resulting pricegraph::Orderbook will be moved
into the function that handles the request.

### Test Plan
CI but not really applicable yet.