### PR TITLE
[Easy] Increase async logging channel size

### DIFF
--- a/core/src/logging.rs
+++ b/core/src/logging.rs
@@ -7,7 +7,7 @@ use slog_scope::GlobalLoggerGuard;
 use slog_term::{Decorator, TermDecorator};
 
 /// The channel size for async logging.
-const BUFFER_SIZE: usize = 1024;
+const BUFFER_SIZE: usize = 10000;
 
 /// Initialize driver logging.
 pub fn init(filter: impl AsRef<str>) -> (Logger, GlobalLoggerGuard) {


### PR DESCRIPTION
For #960 . This hopefully alleviates the problem immediately while we look into if this can be an improvement in slog-async.

### Test Plan
Does not need to be tested.