### PR TITLE
[Pricegraph] Calculate estimated buy amount from price

### DIFF
--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -908,8 +908,7 @@ mod tests {
             3_000_000.0
         );
         assert_approx_eq!(
-            orderbook
-                .fill_order_at_price(TokenPair { buy: 2, sell: 1 }, 10.0),
+            orderbook.fill_order_at_price(TokenPair { buy: 2, sell: 1 }, 10.0),
             3_000_000.0
         );
     }

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -276,14 +276,17 @@ impl Orderbook {
     /// This is calculated by repeatedly finding the cheapest path between a
     /// token pair that is below the specified price and adding the capacity of
     /// the path to the result.
-    pub fn fill_order_at_price(&mut self, pair: TokenPair, limit_price: f64) -> f64 {
+    ///
+    /// Note that the limit price is expressed as an exchange limit price, i.e.
+    /// with implicitely included fees.
+    pub fn fill_order_at_price(&mut self, pair: TokenPair, actual_limit_price: f64) -> f64 {
         if !self.is_token_pair_valid(pair) {
             return 0.0;
         }
         self.update_projection_graph();
 
         let (sell, buy) = (node_index(pair.sell), node_index(pair.buy));
-        let effective_limit_price = limit_price / FEE_FACTOR;
+        let effective_limit_price = actual_limit_price / FEE_FACTOR;
 
         let mut total_volume = 0.0;
         let mut predecessors = self.reduced_shortest_paths(sell);


### PR DESCRIPTION
This PR adds a new `fill_order_at_price` method for calculating the estimated buy amount for an order at a given price. This will allow market makers to estimate how much they will be able to actually sell at their preferred price given the state of the orderbook.

The code in the `orderbook.rs` file feels like it is getting a little spaghetti, so it is time for a great refactoring!

### Test Plan

New unit test :tada: 