### PR TITLE
[Pricegraph] Fix fill order at price

### DIFF
--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -357,7 +357,7 @@ impl Orderbook {
         // the specified token pair, but since we are finding transitive orders
         // in the opposite direction to match this order, calculate the maximum
         // price that still respects the provided limit price.
-        let max_price = 1.0 / (limit_price * FEE_FACTOR);
+        let max_price = (1.0 / limit_price) / FEE_FACTOR;
 
         let mut total_volume = 0.0;
         let mut predecessors = self.reduced_shortest_paths(sell);


### PR DESCRIPTION
This PR fixes an issue with the `fill_order_at_price` method that I noticed when adding benchmarks. The specified limit price was actually being used as if it were `sell_amount / buy_amount`. The limit price is now correctly inverted.

:see_no_evil: 

### Test Plan

Adjusted unit test, added new benchmark:
```
Orderbook::fill_order_at_price(reduced)/200                                                                           
                        time:   [56.977 us 57.390 us 57.714 us]
Orderbook::fill_order_at_price(reduced)/190                                                                           
                        time:   [189.15 us 192.99 us 196.01 us]
Orderbook::fill_order_at_price(reduced)/180                                                                           
                        time:   [335.67 us 342.30 us 350.79 us]
Orderbook::fill_order_at_price(reduced)/150                                                                            
                        time:   [710.69 us 745.72 us 774.40 us]
Orderbook::fill_order_at_price(reduced)/100                                                                            
                        time:   [804.67 us 838.13 us 879.61 us]
```