### PR TITLE
Efficient last block for batch bis

### DIFF
--- a/core/src/contracts/stablex_contract.rs
+++ b/core/src/contracts/stablex_contract.rs
@@ -4,7 +4,6 @@
 use crate::{
     contracts,
     models::{ExecutedOrder, Solution},
-    util::FutureWaitExt,
 };
 use anyhow::{anyhow, Error, Result};
 use ethcontract::{
@@ -459,7 +458,7 @@ impl<T: Sync + BatchIdGetter> IncrementalBinarySearch for T {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::util::test_util::map_from_slice;
+    use crate::util::{test_util::map_from_slice, FutureWaitExt};
 
     #[test]
     fn generic_encode_execution_test() {

--- a/core/src/contracts/stablex_contract.rs
+++ b/core/src/contracts/stablex_contract.rs
@@ -455,7 +455,7 @@ async fn get_last_block_for_batch(
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::util::{test_util::map_from_slice, FutureWaitExt};
+    use crate::util::test_util::map_from_slice;
 
     #[test]
     fn generic_encode_execution_test() {
@@ -547,46 +547,52 @@ pub mod tests {
 
         assert_eq!(
             get_last_block_for_batch(&mock_batch_id_getting, 1)
-                .wait()
+                .now_or_never()
+                .unwrap()
                 .unwrap(),
             2
         );
         assert_eq!(
             get_last_block_for_batch(&mock_batch_id_getting, 2)
-                .wait()
+                .now_or_never()
+                .unwrap()
                 .unwrap(),
             5
         );
         assert_eq!(
             get_last_block_for_batch(&mock_batch_id_getting, 3)
-                .wait()
+                .now_or_never()
+                .unwrap()
                 .unwrap(),
             7
         );
         assert_eq!(
             get_last_block_for_batch(&mock_batch_id_getting, 4)
-                .wait()
+                .now_or_never()
+                .unwrap()
                 .unwrap(),
             7
         ); // note: no error if batch does not exist
         assert_eq!(
             get_last_block_for_batch(&mock_batch_id_getting, 5)
-                .wait()
+                .now_or_never()
+                .unwrap()
                 .unwrap(),
             9
         );
         assert_eq!(
             get_last_block_for_batch(&mock_batch_id_getting, 6)
-                .wait()
+                .now_or_never()
+                .unwrap()
                 .unwrap(),
             10
         );
         assert_eq!(
             get_last_block_for_batch(&mock_batch_id_getting, 7)
-                .wait()
+                .now_or_never()
+                .unwrap()
                 .unwrap(),
             10
-        );
-        // note: returns last batch for batches in the future
+        ); // note: returns last batch for batches in the future
     }
 }

--- a/core/src/contracts/stablex_contract.rs
+++ b/core/src/contracts/stablex_contract.rs
@@ -167,18 +167,7 @@ impl StableXContract for StableXContractImpl {
     fn get_last_block_for_batch<'a>(&'a self, batch_id: u32) -> BoxFuture<'a, Result<u64>> {
         async move {
             let web3 = self.instance.raw_instance().web3();
-            let mut current_block = get_block(&web3, BlockNumber::Latest).await?;
-            let mut block_number = current_block
-                .number
-                .ok_or_else(|| {
-                    anyhow!("latest block {:?} has no block number", current_block.hash)
-                })?
-                .as_u64();
-            while batch_id < get_block_batch_id(&current_block) && block_number > 0 {
-                block_number -= 1;
-                current_block = get_block(&web3, block_number.into()).await?;
-            }
-            Ok(block_number)
+            Ok(web3.get_last_block_for_batch(batch_id).await?)
         }
         .boxed()
     }

--- a/core/src/contracts/stablex_contract.rs
+++ b/core/src/contracts/stablex_contract.rs
@@ -1,22 +1,20 @@
 // NOTE: Required for automock.
 #![cfg_attr(test, allow(clippy::ptr_arg))]
 
+mod search_batches;
+
 use crate::{
     contracts,
     models::{ExecutedOrder, Solution},
 };
-use anyhow::{anyhow, Error, Result};
+use anyhow::{Error, Result};
 use ethcontract::{
     contract::Event,
     errors::{ExecutionError, MethodError},
-    prelude::Web3,
     transaction::{confirm::ConfirmParams, GasPrice, ResolveCondition},
-    transport::DynTransport,
-    web3::types::Block,
-    Address, BlockNumber, PrivateKey, H256, U256,
+    Address, BlockNumber, PrivateKey, U256,
 };
 use futures::{
-    compat::Future01CompatExt as _,
     future::{BoxFuture, FutureExt as _},
     stream::{BoxStream, StreamExt as _},
 };
@@ -167,7 +165,7 @@ impl StableXContract for StableXContractImpl {
     fn get_last_block_for_batch<'a>(&'a self, batch_id: u32) -> BoxFuture<'a, Result<u64>> {
         async move {
             let web3 = self.instance.raw_instance().web3();
-            search_last_block_for_batch(&web3, batch_id).await
+            search_batches::search_last_block_for_batch(&web3, batch_id).await
         }
         .boxed()
     }
@@ -350,108 +348,6 @@ fn encode_execution_for_contract(
     (owners, order_ids, volumes)
 }
 
-fn get_block_batch_id<T>(block: &Block<T>) -> u32 {
-    const BATCH_DURATION: u64 = 300;
-    (block.timestamp.as_u64() / BATCH_DURATION) as _
-}
-
-async fn get_block(
-    web3: &Web3<DynTransport>,
-    block_number: BlockNumber,
-) -> Result<ethcontract::web3::types::Block<H256>> {
-    web3.eth()
-        .block(block_number.into())
-        .compat()
-        .await?
-        .ok_or_else(|| anyhow!("block {:?} is missing", block_number))
-}
-
-#[cfg_attr(test, automock)]
-trait BatchIdGetting {
-    fn batch_id_from_block<'a>(&'a self, block_number: BlockNumber) -> BoxFuture<'a, Result<u32>>;
-
-    fn current_batch_id_and_block_number<'a>(&'a self) -> BoxFuture<'a, Result<(u32, u64)>>;
-}
-
-impl BatchIdGetting for Web3<DynTransport> {
-    fn batch_id_from_block<'a>(&'a self, block_number: BlockNumber) -> BoxFuture<'a, Result<u32>> {
-        async move {
-            let current_block = get_block(&self, block_number).await?;
-            Ok(get_block_batch_id(&current_block))
-        }
-        .boxed()
-    }
-
-    fn current_batch_id_and_block_number<'a>(&'a self) -> BoxFuture<'a, Result<(u32, u64)>> {
-        async move {
-            let current_block = get_block(&self, BlockNumber::Latest).await?;
-            let batch_id = get_block_batch_id(&current_block);
-            let block_number = current_block
-                .number
-                .ok_or_else(|| {
-                    anyhow!("latest block {:?} has no block number", current_block.hash)
-                })?
-                .as_u64();
-            Ok((batch_id, block_number))
-        }
-        .boxed()
-    }
-}
-
-async fn search_last_block_for_batch(
-    batch_id_getting: &impl BatchIdGetting,
-    batch_id: u32,
-) -> Result<u64> {
-    struct Bounds {
-        lower: u64,
-        upper: u64,
-    }
-    impl Bounds {
-        fn diff(&self) -> u64 {
-            self.upper - self.lower
-        }
-        fn mid(&self) -> u64 {
-            (self.upper + self.lower) / 2
-        }
-    }
-
-    let (current_batch_id, current_block_number) =
-        batch_id_getting.current_batch_id_and_block_number().await?;
-
-    // find lower bound for binary search
-    let mut step = 1_u64;
-    let mut bounds = Bounds {
-        lower: current_block_number,
-        upper: current_block_number,
-    };
-    let mut lower_batch_id = current_batch_id;
-    while batch_id < lower_batch_id {
-        bounds.upper = bounds.lower;
-        if step >= bounds.lower {
-            bounds.lower = 0;
-            break;
-        } else {
-            bounds.lower -= step;
-            lower_batch_id = batch_id_getting
-                .batch_id_from_block(bounds.lower.into())
-                .await?;
-        }
-        step *= 2;
-    }
-
-    // find last block for batch within bounds
-    while bounds.diff() > 1 {
-        let mid = bounds.mid();
-        let mid_batch_id = batch_id_getting.batch_id_from_block(mid.into()).await?;
-        if batch_id >= mid_batch_id {
-            bounds.lower = mid;
-        } else {
-            bounds.upper = mid;
-        }
-    }
-    Ok(bounds.lower)
-}
-
 #[cfg(test)]
 pub mod tests {
     use super::*;
@@ -511,88 +407,5 @@ pub mod tests {
             encode_prices_for_contract(&unordered_price_map),
             (expected_prices, expected_token_ids)
         );
-    }
-
-    #[test]
-    fn incremental_binary_search() {
-        //                                   2        5     7     9  10
-        let batch_ids: Vec<u32> = vec![1, 1, 1, 2, 2, 2, 3, 3, 5, 5, 6];
-        let mut mock_batch_id_getting = MockBatchIdGetting::new();
-        mock_batch_id_getting
-            .expect_batch_id_from_block()
-            .withf(|block_number: &BlockNumber| match block_number {
-                BlockNumber::Number(_) => true,
-                _ => false,
-            })
-            .returning({
-                let batch_ids = batch_ids.clone();
-                move |block_number: BlockNumber| {
-                    let result = batch_ids[if let BlockNumber::Number(n) = block_number {
-                        n
-                    } else {
-                        panic!("Not implemented");
-                    }
-                    .as_u64() as usize];
-                    async move { Ok(result) }.boxed()
-                }
-            });
-
-        mock_batch_id_getting
-            .expect_current_batch_id_and_block_number()
-            .returning(move || {
-                let latest_block = batch_ids.len() as u64 - 1;
-                let latest_batch_id = batch_ids[latest_block as usize];
-                async move { Ok((latest_batch_id, latest_block)) }.boxed()
-            });
-
-        assert_eq!(
-            search_last_block_for_batch(&mock_batch_id_getting, 1)
-                .now_or_never()
-                .unwrap()
-                .unwrap(),
-            2
-        );
-        assert_eq!(
-            search_last_block_for_batch(&mock_batch_id_getting, 2)
-                .now_or_never()
-                .unwrap()
-                .unwrap(),
-            5
-        );
-        assert_eq!(
-            search_last_block_for_batch(&mock_batch_id_getting, 3)
-                .now_or_never()
-                .unwrap()
-                .unwrap(),
-            7
-        );
-        assert_eq!(
-            search_last_block_for_batch(&mock_batch_id_getting, 4)
-                .now_or_never()
-                .unwrap()
-                .unwrap(),
-            7
-        ); // note: no error if batch does not exist
-        assert_eq!(
-            search_last_block_for_batch(&mock_batch_id_getting, 5)
-                .now_or_never()
-                .unwrap()
-                .unwrap(),
-            9
-        );
-        assert_eq!(
-            search_last_block_for_batch(&mock_batch_id_getting, 6)
-                .now_or_never()
-                .unwrap()
-                .unwrap(),
-            10
-        );
-        assert_eq!(
-            search_last_block_for_batch(&mock_batch_id_getting, 7)
-                .now_or_never()
-                .unwrap()
-                .unwrap(),
-            10
-        ); // note: returns last batch for batches in the future
     }
 }

--- a/core/src/contracts/stablex_contract.rs
+++ b/core/src/contracts/stablex_contract.rs
@@ -167,7 +167,7 @@ impl StableXContract for StableXContractImpl {
     fn get_last_block_for_batch<'a>(&'a self, batch_id: u32) -> BoxFuture<'a, Result<u64>> {
         async move {
             let web3 = self.instance.raw_instance().web3();
-            get_last_block_for_batch(&web3, batch_id).await
+            search_last_block_for_batch(&web3, batch_id).await
         }
         .boxed()
     }
@@ -398,7 +398,7 @@ impl BatchIdGetting for Web3<DynTransport> {
     }
 }
 
-async fn get_last_block_for_batch(
+async fn search_last_block_for_batch(
     batch_id_getting: &impl BatchIdGetting,
     batch_id: u32,
 ) -> Result<u64> {
@@ -546,49 +546,49 @@ pub mod tests {
             });
 
         assert_eq!(
-            get_last_block_for_batch(&mock_batch_id_getting, 1)
+            search_last_block_for_batch(&mock_batch_id_getting, 1)
                 .now_or_never()
                 .unwrap()
                 .unwrap(),
             2
         );
         assert_eq!(
-            get_last_block_for_batch(&mock_batch_id_getting, 2)
+            search_last_block_for_batch(&mock_batch_id_getting, 2)
                 .now_or_never()
                 .unwrap()
                 .unwrap(),
             5
         );
         assert_eq!(
-            get_last_block_for_batch(&mock_batch_id_getting, 3)
+            search_last_block_for_batch(&mock_batch_id_getting, 3)
                 .now_or_never()
                 .unwrap()
                 .unwrap(),
             7
         );
         assert_eq!(
-            get_last_block_for_batch(&mock_batch_id_getting, 4)
+            search_last_block_for_batch(&mock_batch_id_getting, 4)
                 .now_or_never()
                 .unwrap()
                 .unwrap(),
             7
         ); // note: no error if batch does not exist
         assert_eq!(
-            get_last_block_for_batch(&mock_batch_id_getting, 5)
+            search_last_block_for_batch(&mock_batch_id_getting, 5)
                 .now_or_never()
                 .unwrap()
                 .unwrap(),
             9
         );
         assert_eq!(
-            get_last_block_for_batch(&mock_batch_id_getting, 6)
+            search_last_block_for_batch(&mock_batch_id_getting, 6)
                 .now_or_never()
                 .unwrap()
                 .unwrap(),
             10
         );
         assert_eq!(
-            get_last_block_for_batch(&mock_batch_id_getting, 7)
+            search_last_block_for_batch(&mock_batch_id_getting, 7)
                 .now_or_never()
                 .unwrap()
                 .unwrap(),

--- a/core/src/contracts/stablex_contract/search_batches.rs
+++ b/core/src/contracts/stablex_contract/search_batches.rs
@@ -26,6 +26,19 @@ async fn get_block(
         .ok_or_else(|| anyhow!("block {:?} is missing", block_number))
 }
 
+struct Bounds {
+    lower: u64,
+    upper: u64,
+}
+impl Bounds {
+    fn diff(&self) -> u64 {
+        self.upper - self.lower
+    }
+    fn mid(&self) -> u64 {
+        (self.upper + self.lower) / 2
+    }
+}
+
 #[cfg_attr(test, automock)]
 pub trait BatchIdRetrieving {
     fn batch_id_from_block<'a>(&'a self, block_number: BlockNumber) -> BoxFuture<'a, Result<u32>>;
@@ -62,19 +75,6 @@ pub async fn search_last_block_for_batch(
     batch_id_retrieving: &impl BatchIdRetrieving,
     batch_id: u32,
 ) -> Result<u64> {
-    struct Bounds {
-        lower: u64,
-        upper: u64,
-    }
-    impl Bounds {
-        fn diff(&self) -> u64 {
-            self.upper - self.lower
-        }
-        fn mid(&self) -> u64 {
-            (self.upper + self.lower) / 2
-        }
-    }
-
     let (current_batch_id, current_block_number) = batch_id_retrieving
         .current_batch_id_and_block_number()
         .await?;

--- a/core/src/contracts/stablex_contract/search_batches.rs
+++ b/core/src/contracts/stablex_contract/search_batches.rs
@@ -1,0 +1,201 @@
+// NOTE: Required for automock.
+#![cfg_attr(test, allow(clippy::ptr_arg))]
+
+use anyhow::{anyhow, Result};
+use ethcontract::{prelude::Web3, transport::DynTransport, web3::types::Block, BlockNumber, H256};
+use futures::{
+    compat::Future01CompatExt as _,
+    future::{BoxFuture, FutureExt as _},
+};
+#[cfg(test)]
+use mockall::automock;
+
+fn get_block_batch_id<T>(block: &Block<T>) -> u32 {
+    const BATCH_DURATION: u64 = 300;
+    (block.timestamp.as_u64() / BATCH_DURATION) as _
+}
+
+async fn get_block(
+    web3: &Web3<DynTransport>,
+    block_number: BlockNumber,
+) -> Result<ethcontract::web3::types::Block<H256>> {
+    web3.eth()
+        .block(block_number.into())
+        .compat()
+        .await?
+        .ok_or_else(|| anyhow!("block {:?} is missing", block_number))
+}
+
+#[cfg_attr(test, automock)]
+pub trait BatchIdGetting {
+    fn batch_id_from_block<'a>(&'a self, block_number: BlockNumber) -> BoxFuture<'a, Result<u32>>;
+
+    fn current_batch_id_and_block_number<'a>(&'a self) -> BoxFuture<'a, Result<(u32, u64)>>;
+}
+
+impl BatchIdGetting for Web3<DynTransport> {
+    fn batch_id_from_block<'a>(&'a self, block_number: BlockNumber) -> BoxFuture<'a, Result<u32>> {
+        async move {
+            let current_block = get_block(&self, block_number).await?;
+            Ok(get_block_batch_id(&current_block))
+        }
+        .boxed()
+    }
+
+    fn current_batch_id_and_block_number<'a>(&'a self) -> BoxFuture<'a, Result<(u32, u64)>> {
+        async move {
+            let current_block = get_block(&self, BlockNumber::Latest).await?;
+            let batch_id = get_block_batch_id(&current_block);
+            let block_number = current_block
+                .number
+                .ok_or_else(|| {
+                    anyhow!("latest block {:?} has no block number", current_block.hash)
+                })?
+                .as_u64();
+            Ok((batch_id, block_number))
+        }
+        .boxed()
+    }
+}
+
+pub async fn search_last_block_for_batch(
+    batch_id_getting: &impl BatchIdGetting,
+    batch_id: u32,
+) -> Result<u64> {
+    struct Bounds {
+        lower: u64,
+        upper: u64,
+    }
+    impl Bounds {
+        fn diff(&self) -> u64 {
+            self.upper - self.lower
+        }
+        fn mid(&self) -> u64 {
+            (self.upper + self.lower) / 2
+        }
+    }
+
+    let (current_batch_id, current_block_number) =
+        batch_id_getting.current_batch_id_and_block_number().await?;
+
+    // find lower bound for binary search
+    let mut step = 1_u64;
+    let mut bounds = Bounds {
+        lower: current_block_number,
+        upper: current_block_number,
+    };
+    let mut lower_batch_id = current_batch_id;
+    while batch_id < lower_batch_id {
+        bounds.upper = bounds.lower;
+        if step >= bounds.lower {
+            bounds.lower = 0;
+            break;
+        } else {
+            bounds.lower -= step;
+            lower_batch_id = batch_id_getting
+                .batch_id_from_block(bounds.lower.into())
+                .await?;
+        }
+        step *= 2;
+    }
+
+    // find last block for batch within bounds
+    while bounds.diff() > 1 {
+        let mid = bounds.mid();
+        let mid_batch_id = batch_id_getting.batch_id_from_block(mid.into()).await?;
+        if batch_id >= mid_batch_id {
+            bounds.lower = mid;
+        } else {
+            bounds.upper = mid;
+        }
+    }
+    Ok(bounds.lower)
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn incremental_binary_search() {
+        //                                   2        5     7     9  10
+        let batch_ids: Vec<u32> = vec![1, 1, 1, 2, 2, 2, 3, 3, 5, 5, 6];
+        let mut mock_batch_id_getting = MockBatchIdGetting::new();
+        mock_batch_id_getting
+            .expect_batch_id_from_block()
+            .withf(|block_number: &BlockNumber| match block_number {
+                BlockNumber::Number(_) => true,
+                _ => false,
+            })
+            .returning({
+                let batch_ids = batch_ids.clone();
+                move |block_number: BlockNumber| {
+                    let result = batch_ids[if let BlockNumber::Number(n) = block_number {
+                        n
+                    } else {
+                        panic!("Not implemented");
+                    }
+                    .as_u64() as usize];
+                    async move { Ok(result) }.boxed()
+                }
+            });
+
+        mock_batch_id_getting
+            .expect_current_batch_id_and_block_number()
+            .returning(move || {
+                let latest_block = batch_ids.len() as u64 - 1;
+                let latest_batch_id = batch_ids[latest_block as usize];
+                async move { Ok((latest_batch_id, latest_block)) }.boxed()
+            });
+
+        assert_eq!(
+            search_last_block_for_batch(&mock_batch_id_getting, 1)
+                .now_or_never()
+                .unwrap()
+                .unwrap(),
+            2
+        );
+        assert_eq!(
+            search_last_block_for_batch(&mock_batch_id_getting, 2)
+                .now_or_never()
+                .unwrap()
+                .unwrap(),
+            5
+        );
+        assert_eq!(
+            search_last_block_for_batch(&mock_batch_id_getting, 3)
+                .now_or_never()
+                .unwrap()
+                .unwrap(),
+            7
+        );
+        assert_eq!(
+            search_last_block_for_batch(&mock_batch_id_getting, 4)
+                .now_or_never()
+                .unwrap()
+                .unwrap(),
+            7
+        ); // note: no error if batch does not exist
+        assert_eq!(
+            search_last_block_for_batch(&mock_batch_id_getting, 5)
+                .now_or_never()
+                .unwrap()
+                .unwrap(),
+            9
+        );
+        assert_eq!(
+            search_last_block_for_batch(&mock_batch_id_getting, 6)
+                .now_or_never()
+                .unwrap()
+                .unwrap(),
+            10
+        );
+        assert_eq!(
+            search_last_block_for_batch(&mock_batch_id_getting, 7)
+                .now_or_never()
+                .unwrap()
+                .unwrap(),
+            10
+        ); // note: returns last batch for batches in the future
+    }
+}

--- a/core/src/contracts/stablex_contract/search_batches.rs
+++ b/core/src/contracts/stablex_contract/search_batches.rs
@@ -131,13 +131,14 @@ pub mod tests {
             .returning({
                 let batch_ids = batch_ids.clone();
                 move |block_number: BlockNumber| {
-                    let result = batch_ids[if let BlockNumber::Number(n) = block_number {
+                    let index = if let BlockNumber::Number(n) = block_number {
                         n
                     } else {
                         panic!("Not implemented");
                     }
-                    .as_u64() as usize];
-                    async move { Ok(result) }.boxed()
+                    .as_u64() as usize;
+                    let batch_id = batch_ids[index];
+                    async move { Ok(batch_id) }.boxed()
                 }
             });
 

--- a/core/src/contracts/stablex_contract/search_batches.rs
+++ b/core/src/contracts/stablex_contract/search_batches.rs
@@ -41,8 +41,10 @@ impl Bounds {
 
 #[cfg_attr(test, automock)]
 pub trait BatchIdRetrieving {
+    /// Return the id of the unique batch associated with the given block
     fn batch_id_from_block<'a>(&'a self, block_number: BlockNumber) -> BoxFuture<'a, Result<u32>>;
 
+    /// Return a pair containing the id of the batch we are currently in and the last block number, in this order
     fn current_batch_id_and_block_number<'a>(&'a self) -> BoxFuture<'a, Result<(u32, u64)>>;
 }
 


### PR DESCRIPTION
Fixes #832.

Implements a faster algorithm to determine the last block of a batch based on binary search.
This is a rewrite of PR #904. The logic is mostly unchanged but the structure, based on @fleupold's comments, is very different. There is now
- a trait `BatchIdRetrieving` implemented for `web3` that yields information on batch ids.
- a generic function implementing binary search for the last block of a batch that relies on the implementation of `BatchIdRetriever`.

`BatchIdRetriever` is not tested. The function implementing binary search is tested over a mock structure implementing `BatchIdRetriever`.

Compared to the older method, it makes more web3 calls for 2 and 4 steps back.
```
before:  1 2 3 4 5  6  7  8  9 10 11 12 13 14 15 16...
now:     1 3 3 5 5  5  5  7  7  7  7  7  7  7  7  9...
diff:    0 1 0 1 0 -1 -2 -1 -2 -3 -4 -5 -6 -7 -8 -7... 
```
Afterwards it's much better, for searching in the first `2^n` blocks it takes at most `2n+1` web3 queries.

### Test Plan
```
cd core
cargo test contracts::stablex_contract::search_batches::tests::incremental_binary_search
```