### PR TITLE
Fix not running most tests in CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,9 @@ members = [
     "pricegraph/wasm",
 ]
 default-members = [
+    "core",
     "driver",
+    "price-estimator",
     "pricegraph",
 ]
 


### PR DESCRIPTION
I remembered that Ben said in our last meeting that coverage was very
low. The reason is that we only run tests for default cargo workspace
members but when I added the core and now the price estimator crates I
did not add them there. I never noticed this because I always run tests
only for the crate I am working on like `cargo test -p price-estimator`.
Alternatively we could run all tests in CI like `cargo test --workspace`
but currently the e2e tests are rust tests too which would run and
fail because the needed docker containers haven't been started.

### Test Plan
CI, see that all tests are run, see that coverage goes up.