### PR TITLE
Remove tokens from price source trait

### DIFF
--- a/core/src/price_estimation.rs
+++ b/core/src/price_estimation.rs
@@ -306,30 +306,4 @@ mod tests {
             }
         );
     }
-
-    #[test]
-    fn token_get_price() {
-        for (token, usd_price, expected) in &[
-            (Token::new(4, "USDC", 6), 0.99, 0.99 * 10f64.powi(30)),
-            (Token::new(7, "DAI", 18), 1.01, 1.01 * 10f64.powi(18)),
-            (Token::new(42, "FAKE", 32), 1.0, 10f64.powi(4)),
-            (Token::new(99, "SCAM", 42), 10f64.powi(10), 10f64.powi(4)),
-        ] {
-            let owl_price = token.get_owl_price(*usd_price);
-            assert_eq!(owl_price, *expected as u128);
-        }
-    }
-
-    #[test]
-    fn token_get_price_without_rounding_error() {
-        assert_eq!(
-            Token::new(0, "OWL", 18).get_owl_price(1.0),
-            1_000_000_000_000_000_000,
-        );
-    }
-
-    #[test]
-    fn weth_token_symbol_is_eth() {
-        assert_eq!(Token::new(1, "WETH", 18).symbol(), "ETH");
-    }
 }

--- a/core/src/price_estimation/average_price_source.rs
+++ b/core/src/price_estimation/average_price_source.rs
@@ -1,4 +1,4 @@
-use super::{PriceSource, Token};
+use super::PriceSource;
 use crate::models::TokenId;
 use anyhow::{anyhow, Result};
 use futures::future::{self, BoxFuture, FutureExt as _};
@@ -18,7 +18,7 @@ impl AveragePriceSource {
 impl PriceSource for AveragePriceSource {
     fn get_prices<'a>(
         &'a self,
-        tokens: &'a [Token],
+        tokens: &'a [TokenId],
     ) -> BoxFuture<'a, Result<HashMap<TokenId, u128>>> {
         async move {
             let price_futures =

--- a/core/src/price_estimation/data.rs
+++ b/core/src/price_estimation/data.rs
@@ -1,9 +1,9 @@
 //! This module contains fallback token data that should be used by the price
 //! estimator when prices are not available.
 
-use super::Token;
 use crate::models::{TokenId, TokenInfo};
 use anyhow::{Context, Error, Result};
+use lazy_static::lazy_static;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -42,6 +42,30 @@ impl TokenBaseInfo {
             should_estimate_price,
         }
     }
+
+    /// Retrieves the token symbol for this token.
+    ///
+    /// Note that the token info alias is first checked if it is part of a
+    /// symbol override map, and if it is, then that value is used instead. This
+    /// allows ERC20 tokens like WETH to be treated as ETH, since exchanges
+    /// generally only track prices for the latter.
+    pub fn symbol(&self) -> &str {
+        lazy_static! {
+            static ref SYMBOL_OVERRIDES: HashMap<String, String> = hash_map! {
+                "WETH" => "ETH".to_owned(),
+            };
+        }
+
+        SYMBOL_OVERRIDES.get(&self.alias).unwrap_or(&self.alias)
+    }
+
+    /// Converts the prices from USD into the unit expected by the contract.
+    /// This price is relative to the OWL token which is considered pegged at
+    /// exactly 1 USD with 18 decimals.
+    pub fn get_owl_price(&self, usd_price: f64) -> u128 {
+        let pow = 36 - (self.decimals as i32);
+        (usd_price * 10f64.powi(pow)) as _
+    }
 }
 
 impl Into<TokenInfo> for TokenBaseInfo {
@@ -74,14 +98,11 @@ impl TokenData {
 
     /// Returns a vector with all the tokens that should be priced in the token
     /// data map.
-    pub fn all_tokens_to_estimate_price(&self) -> Vec<Token> {
+    pub fn all_tokens_to_estimate_price(&self) -> Vec<TokenId> {
         self.0
             .iter()
             .filter(|&(_, info)| info.should_estimate_price)
-            .map(|(&id, info)| Token {
-                id,
-                info: info.clone().into(),
-            })
+            .map(|(&id, _)| id)
             .collect()
     }
 }

--- a/core/src/price_estimation/data.rs
+++ b/core/src/price_estimation/data.rs
@@ -150,4 +150,42 @@ mod tests {
             })
         );
     }
+
+    #[test]
+    fn token_get_price() {
+        for (token, usd_price, expected) in &[
+            (
+                TokenBaseInfo::new("USDC", 6, 0, true),
+                0.99,
+                0.99 * 10f64.powi(30),
+            ),
+            (
+                TokenBaseInfo::new("DAI", 18, 0, true),
+                1.01,
+                1.01 * 10f64.powi(18),
+            ),
+            (TokenBaseInfo::new("FAKE", 32, 0, true), 1.0, 10f64.powi(4)),
+            (
+                TokenBaseInfo::new("SCAM", 42, 0, true),
+                10f64.powi(10),
+                10f64.powi(4),
+            ),
+        ] {
+            let owl_price = token.get_owl_price(*usd_price);
+            assert_eq!(owl_price, *expected as u128);
+        }
+    }
+
+    #[test]
+    fn token_get_price_without_rounding_error() {
+        assert_eq!(
+            TokenBaseInfo::new("OWL", 18, 0, true).get_owl_price(1.0),
+            1_000_000_000_000_000_000,
+        );
+    }
+
+    #[test]
+    fn weth_token_symbol_is_eth() {
+        assert_eq!(TokenBaseInfo::new("WETH", 18, 0, true).symbol(), "ETH");
+    }
 }

--- a/core/src/price_estimation/dexag.rs
+++ b/core/src/price_estimation/dexag.rs
@@ -383,7 +383,7 @@ mod tests {
             TokenId(9) => TokenBaseInfo::new("sUSD", 18, 0, true),
             TokenId(15) => TokenBaseInfo::new("SNX", 18, 0, true)
         };
-        let ids: Vec<TokenId> = tokens.keys().map(|id| *id).collect();
+        let ids: Vec<TokenId> = tokens.keys().copied().collect();
 
         let client = DexagClient::new(&HttpFactory::default(), tokens.clone().into()).unwrap();
         let before = Instant::now();

--- a/core/src/price_estimation/dexag.rs
+++ b/core/src/price_estimation/dexag.rs
@@ -1,6 +1,6 @@
 mod api;
 
-use super::{PriceSource, Token};
+use super::{PriceSource, TokenData};
 use crate::http::HttpFactory;
 use crate::models::TokenId;
 use anyhow::{anyhow, Context, Result};
@@ -23,13 +23,14 @@ pub struct DexagClient<Api> {
     /// Lazily retrieved the first time it is needed when `get_prices` is
     /// called. We don't want to use the network in `new`.
     api_tokens: Mutex<Option<ApiTokens>>,
+    tokens: TokenData,
 }
 
 impl DexagClient<DexagHttpApi> {
     /// Create a DexagClient using DexagHttpApi as the api implementation.
-    pub fn new(http_factory: &HttpFactory) -> Result<Self> {
+    pub fn new(http_factory: &HttpFactory, tokens: TokenData) -> Result<Self> {
         let api = DexagHttpApi::new(http_factory)?;
-        Ok(Self::with_api(api))
+        Ok(Self::with_api_and_tokens(api, tokens))
     }
 }
 
@@ -37,10 +38,11 @@ impl<Api> DexagClient<Api>
 where
     Api: DexagApi,
 {
-    pub fn with_api(api: Api) -> Self {
+    pub fn with_api_and_tokens(api: Api, tokens: TokenData) -> Self {
         Self {
             api,
             api_tokens: Mutex::new(None),
+            tokens,
         }
     }
 
@@ -75,7 +77,7 @@ where
 {
     fn get_prices<'a>(
         &'a self,
-        tokens: &'a [Token],
+        tokens: &'a [TokenId],
     ) -> BoxFuture<'a, Result<HashMap<TokenId, u128>>> {
         async move {
             if tokens.is_empty() {
@@ -95,11 +97,11 @@ where
                 }
             };
 
-            let (tokens_, futures): (Vec<_>, Vec<_>) = tokens
+            let (tokens_, futures): (Vec<TokenId>, Vec<_>) = tokens
                 .iter()
-                .filter_map(|token| -> Option<(&Token, BoxFuture<Result<f64>>)> {
+                .filter_map(|token| -> Option<(&TokenId, BoxFuture<Result<f64>>)> {
                     // api_tokens symbols are converted to uppercase to disambiguate
-                    let symbol = token.symbol().to_uppercase();
+                    let symbol = self.tokens.info(*token)?.symbol().to_uppercase();
                     if symbol == api_tokens.stable_coin.symbol {
                         Some((token, async { Ok(1.0) }.boxed()))
                     } else if let Some(api_token) = api_tokens.tokens.get(&symbol) {
@@ -121,10 +123,9 @@ where
                 .iter()
                 .zip(results.iter())
                 .filter_map(|(token, result)| match result {
-                    Ok(price) => Some((token, price)),
+                    Ok(price) => Some((*token, self.tokens.info(*token)?.get_owl_price(*price))),
                     Err(_) => None,
                 })
-                .map(|(token, price)| (token.id, token.get_owl_price(*price)))
                 .collect())
         }
         .boxed()
@@ -135,6 +136,7 @@ where
 mod tests {
     use super::api::MockDexagApi;
     use super::*;
+    use crate::price_estimation::data::TokenBaseInfo;
     use crate::util::FutureWaitExt as _;
     use lazy_static::lazy_static;
     use mockall::{predicate::*, Sequence};
@@ -145,8 +147,9 @@ mod tests {
         api.expect_get_token_list()
             .returning(|| async { Ok(Vec::new()) }.boxed());
 
-        assert!(DexagClient::with_api(api)
-            .get_prices(&[Token::new(6, "DAI", 18)])
+        let tokens = hash_map! { TokenId::from(6) => TokenBaseInfo::new("DAI", 18, 0, true)};
+        assert!(DexagClient::with_api_and_tokens(api, tokens.into())
+            .get_prices(&[6.into()])
             .now_or_never()
             .unwrap()
             .is_err());
@@ -154,7 +157,7 @@ mod tests {
 
     #[test]
     fn get_token_prices_initialization_fails_then_works() {
-        let tokens = [Token::new(1, "ETH", 18)];
+        let tokens = hash_map! { TokenId::from(1) => TokenBaseInfo::new("ETH", 18, 0, true)};
         let mut api = MockDexagApi::new();
         let mut seq = Sequence::new();
 
@@ -177,22 +180,38 @@ mod tests {
                 .boxed()
             });
 
-        let client = DexagClient::with_api(api);
-        assert!(client.get_prices(&tokens).now_or_never().unwrap().is_err());
-        assert!(client.get_prices(&tokens).now_or_never().unwrap().is_err());
-        assert!(client.get_prices(&tokens).now_or_never().unwrap().is_ok());
-        assert!(client.get_prices(&tokens).now_or_never().unwrap().is_ok());
+        let client = DexagClient::with_api_and_tokens(api, tokens.into());
+        assert!(client
+            .get_prices(&[1.into()])
+            .now_or_never()
+            .unwrap()
+            .is_err());
+        assert!(client
+            .get_prices(&[1.into()])
+            .now_or_never()
+            .unwrap()
+            .is_err());
+        assert!(client
+            .get_prices(&[1.into()])
+            .now_or_never()
+            .unwrap()
+            .is_ok());
+        assert!(client
+            .get_prices(&[1.into()])
+            .now_or_never()
+            .unwrap()
+            .is_ok());
     }
 
     #[test]
     fn get_token_prices() {
         let mut api = MockDexagApi::new();
 
-        let tokens = [
-            Token::new(6, "DAI", 18),
-            Token::new(1, "ETH", 18),
-            Token::new(4, "USDC", 6),
-        ];
+        let tokens = hash_map! {
+            TokenId(6) => TokenBaseInfo::new("DAI", 18, 0, true),
+            TokenId(1) => TokenBaseInfo::new("ETH", 18, 0, true),
+            TokenId(4) => TokenBaseInfo::new("USDC", 6, 0, true),
+        };
 
         lazy_static! {
             static ref API_TOKENS: [super::api::Token; 3] = [
@@ -228,14 +247,18 @@ mod tests {
             )
             .returning(|_, _| async { Ok(1.2) }.boxed());
 
-        let client = DexagClient::with_api(api);
-        let prices = client.get_prices(&tokens).now_or_never().unwrap().unwrap();
+        let client = DexagClient::with_api_and_tokens(api, tokens.clone().into());
+        let prices = client
+            .get_prices(&[1.into(), 4.into(), 6.into()])
+            .now_or_never()
+            .unwrap()
+            .unwrap();
         assert_eq!(
             prices,
             hash_map! {
-                TokenId(1) => tokens[1].get_owl_price(0.7) as u128,
-                TokenId(4) => tokens[2].get_owl_price(1.2) as u128,
-                TokenId(6) => tokens[0].get_owl_price(1.0) as u128,
+                TokenId(1) => tokens.get(&1.into()).unwrap().get_owl_price(0.7) as u128,
+                TokenId(4) => tokens.get(&4.into()).unwrap().get_owl_price(1.2) as u128,
+                TokenId(6) => tokens.get(&6.into()).unwrap().get_owl_price(1.0) as u128
             }
         );
     }
@@ -244,7 +267,10 @@ mod tests {
     fn get_token_prices_error() {
         let mut api = MockDexagApi::new();
 
-        let tokens = [Token::new(6, "DAI", 18), Token::new(1, "ETH", 18)];
+        let tokens = hash_map! {
+            TokenId(6) => TokenBaseInfo::new("DAI", 18, 0, true),
+            TokenId(1) => TokenBaseInfo::new("ETH", 18, 0, true)
+        };
 
         lazy_static! {
             static ref API_TOKENS: [super::api::Token; 2] = [
@@ -272,13 +298,17 @@ mod tests {
             )
             .returning(|_, _| async { Err(anyhow!("")) }.boxed());
 
-        let client = DexagClient::with_api(api);
-        let prices = client.get_prices(&tokens).now_or_never().unwrap().unwrap();
+        let client = DexagClient::with_api_and_tokens(api, tokens.clone().into());
+        let prices = client
+            .get_prices(&[6.into(), 1.into()])
+            .now_or_never()
+            .unwrap()
+            .unwrap();
         assert_eq!(
             prices,
             hash_map! {
                 // No TokenId(1) because we made the price error above.
-                TokenId(6) => tokens[0].get_owl_price(1.0) as u128,
+                TokenId(6) => tokens.get(&6.into()).unwrap().get_owl_price(1.0) as u128,
             }
         );
     }
@@ -287,11 +317,11 @@ mod tests {
     fn test_case_insensitivity() {
         let mut api = MockDexagApi::new();
 
-        let tokens = [
-            Token::new(6, "dai", 18),
-            Token::new(1, "ETH", 18),
-            Token::new(4, "sUSD", 6),
-        ];
+        let tokens = hash_map! {
+            TokenId(6) => TokenBaseInfo::new("dai", 18, 0, true),
+            TokenId(1) => TokenBaseInfo::new("ETH", 18, 0, true),
+            TokenId(4) => TokenBaseInfo::new("sUSD", 6, 0, true)
+        };
 
         lazy_static! {
             static ref API_TOKENS: [super::api::Token; 3] = [
@@ -319,14 +349,18 @@ mod tests {
         api.expect_get_price()
             .returning(|_, _| async { Ok(1.0) }.boxed());
 
-        let client = DexagClient::with_api(api);
-        let prices = client.get_prices(&tokens).now_or_never().unwrap().unwrap();
+        let client = DexagClient::with_api_and_tokens(api, tokens.clone().into());
+        let prices = client
+            .get_prices(&[1.into(), 4.into(), 6.into()])
+            .now_or_never()
+            .unwrap()
+            .unwrap();
         assert_eq!(
             prices,
             hash_map! {
-                TokenId(1) => tokens[1].get_owl_price(1.0) as u128,
-                TokenId(4) => tokens[2].get_owl_price(1.0) as u128,
-                TokenId(6) => tokens[0].get_owl_price(1.0) as u128,
+                TokenId(1) => tokens.get(&1.into()).unwrap().get_owl_price(1.0) as u128,
+                TokenId(4) => tokens.get(&4.into()).unwrap().get_owl_price(1.0) as u128,
+                TokenId(6) => tokens.get(&6.into()).unwrap().get_owl_price(1.0) as u128
             }
         );
     }
@@ -337,30 +371,31 @@ mod tests {
     fn online_dexag_client() {
         use std::time::Instant;
 
-        let tokens = &[
-            Token::new(1, "WETH", 18),
-            Token::new(2, "USDT", 6),
-            Token::new(3, "TUSD", 18),
-            Token::new(4, "USDC", 6),
-            Token::new(5, "PAX", 18),
-            Token::new(6, "GUSD", 2),
-            Token::new(7, "DAI", 18),
-            Token::new(8, "sETH", 18),
-            Token::new(9, "sUSD", 18),
-            Token::new(15, "SNX", 18),
-        ];
+        let tokens = hash_map! {
+            TokenId(1) => TokenBaseInfo::new("WETH", 18, 0, true),
+            TokenId(2) => TokenBaseInfo::new("USDT", 6, 0, true),
+            TokenId(3) => TokenBaseInfo::new("TUSD", 18, 0, true),
+            TokenId(4) => TokenBaseInfo::new("USDC", 6, 0, true),
+            TokenId(5) => TokenBaseInfo::new("PAX", 18, 0, true),
+            TokenId(6) => TokenBaseInfo::new("GUSD", 2, 0, true),
+            TokenId(7) => TokenBaseInfo::new("DAI", 18, 0, true),
+            TokenId(8) => TokenBaseInfo::new("sETH", 18, 0, true),
+            TokenId(9) => TokenBaseInfo::new("sUSD", 18, 0, true),
+            TokenId(15) => TokenBaseInfo::new("SNX", 18, 0, true)
+        };
+        let ids: Vec<TokenId> = tokens.keys().map(|id| *id).collect();
 
-        let client = DexagClient::new(&HttpFactory::default()).unwrap();
+        let client = DexagClient::new(&HttpFactory::default(), tokens.clone().into()).unwrap();
         let before = Instant::now();
-        let prices = client.get_prices(tokens).wait().unwrap();
+        let prices = client.get_prices(&ids).wait().unwrap();
         let after = Instant::now();
         println!(
             "Took {} seconds to get prices.",
             (after - before).as_secs_f64()
         );
 
-        for token in tokens {
-            if let Some(price) = prices.get(&token.id) {
+        for (id, token) in tokens {
+            if let Some(price) = prices.get(&id) {
                 println!("Token {} has OWL price of {}.", token.symbol(), price);
             } else {
                 println!("Token {} price could not be determined.", token.symbol());

--- a/core/src/price_estimation/kraken.rs
+++ b/core/src/price_estimation/kraken.rs
@@ -216,7 +216,7 @@ mod tests {
             TokenId(9) => TokenBaseInfo::new("sUSD", 18, 0, true),
             TokenId(15) => TokenBaseInfo::new("SNX", 18, 0, true)
         };
-        let token_ids: Vec<TokenId> = tokens.keys().map(|id| *id).collect();
+        let token_ids: Vec<TokenId> = tokens.keys().copied().collect();
 
         let start_time = Instant::now();
         {

--- a/core/src/price_estimation/kraken.rs
+++ b/core/src/price_estimation/kraken.rs
@@ -3,7 +3,7 @@
 mod api;
 
 use self::api::{Asset, AssetPair, KrakenApi, KrakenHttpApi};
-use super::{PriceSource, Token};
+use super::{PriceSource, TokenData};
 use crate::http::HttpFactory;
 use crate::models::TokenId;
 use anyhow::{anyhow, Context, Result};
@@ -15,14 +15,15 @@ pub struct KrakenClient<Api> {
     /// A Kraken API implementation. This allows for mocked Kraken APIs to be
     /// used for testing.
     api: Api,
+    tokens: TokenData,
 }
 
 impl KrakenClient<KrakenHttpApi> {
     /// Creates a new client instance using an HTTP API instance and the default
     /// Kraken API base URL.
-    pub fn new(http_factory: &HttpFactory) -> Result<Self> {
+    pub fn new(http_factory: &HttpFactory, tokens: TokenData) -> Result<Self> {
         let api = KrakenHttpApi::new(http_factory)?;
-        Ok(KrakenClient::with_api(api))
+        Ok(KrakenClient::with_api_and_tokens(api, tokens))
     }
 }
 
@@ -31,18 +32,15 @@ where
     Api: KrakenApi,
 {
     /// Create a new client instance from an API.
-    pub fn with_api(api: Api) -> Self {
-        KrakenClient { api }
+    pub fn with_api_and_tokens(api: Api, tokens: TokenData) -> Self {
+        KrakenClient { api, tokens }
     }
 
     // Clippy complains about this but the lifetimes are needed.
     /// Generates a mapping between Kraken asset pair identifiers and tokens
     /// that are used when computing the price map.
     #[allow(clippy::needless_lifetimes)]
-    async fn get_token_asset_pairs<'a>(
-        &self,
-        tokens: &'a [Token],
-    ) -> Result<HashMap<String, &'a Token>> {
+    async fn get_token_asset_pairs(&self, tokens: &[TokenId]) -> Result<HashMap<String, TokenId>> {
         // TODO(nlordell): If these calls start taking too long, we can consider
         //   caching this information somehow. The only thing that is
         //   complicated is determining when the cache needs to be invalidated
@@ -57,9 +55,9 @@ where
         let token_assets = tokens
             .iter()
             .flat_map(|token| {
-                let asset = find_asset(token.symbol(), &assets)?;
+                let asset = find_asset(&self.tokens.info(*token)?.symbol(), &assets)?;
                 let pair = find_asset_pair(asset, usd, &asset_pairs)?;
-                Some((pair.to_owned(), token))
+                Some((pair.to_owned(), *token))
             })
             .collect();
 
@@ -73,7 +71,7 @@ where
 {
     fn get_prices<'a>(
         &'a self,
-        tokens: &'a [Token],
+        tokens: &'a [TokenId],
     ) -> BoxFuture<'a, Result<HashMap<TokenId, u128>>> {
         async move {
             let token_asset_pairs = self
@@ -88,9 +86,9 @@ where
                 .iter()
                 .flat_map(|(pair, info)| {
                     let token = token_asset_pairs.get(pair)?;
-                    let price = token.get_owl_price(info.p.last_24h());
+                    let price = self.tokens.info(*token)?.get_owl_price(info.p.last_24h());
 
-                    Some((token.id, price))
+                    Some((*token, price))
                 })
                 .collect();
 
@@ -131,17 +129,18 @@ fn find_asset_pair<'a>(
 mod tests {
     use super::api::{MockKrakenApi, TickerInfo};
     use super::*;
+    use crate::price_estimation::data::TokenBaseInfo;
     use crate::util::FutureWaitExt as _;
     use std::collections::HashSet;
     use std::time::Instant;
 
     #[test]
     fn get_token_prices() {
-        let tokens = vec![
-            Token::new(1, "ETH", 18),
-            Token::new(4, "USDC", 6),
-            Token::new(5, "PAX", 18),
-        ];
+        let tokens = hash_map! {
+            TokenId(1) => TokenBaseInfo::new("ETH", 18, 0, true),
+            TokenId(4) => TokenBaseInfo::new("USDC", 6, 0, true),
+            TokenId(5) => TokenBaseInfo::new("PAX", 18, 0, true),
+        };
 
         let mut api = MockKrakenApi::new();
         api.expect_assets().returning(|| {
@@ -178,8 +177,12 @@ mod tests {
                 .boxed()
             });
 
-        let client = KrakenClient::with_api(api);
-        let prices = client.get_prices(&tokens).now_or_never().unwrap().unwrap();
+        let client = KrakenClient::with_api_and_tokens(api, tokens.into());
+        let prices = client
+            .get_prices(&[1.into(), 4.into(), 5.into()])
+            .now_or_never()
+            .unwrap()
+            .unwrap();
 
         assert_eq!(
             prices,
@@ -201,23 +204,24 @@ mod tests {
         // cargo test online_kraken_prices -- --ignored --nocapture
         // ```
 
-        let tokens = vec![
-            Token::new(1, "WETH", 18),
-            Token::new(2, "USDT", 6),
-            Token::new(3, "TUSD", 18),
-            Token::new(4, "USDC", 6),
-            Token::new(5, "PAX", 18),
-            Token::new(6, "GUSD", 2),
-            Token::new(7, "DAI", 18),
-            Token::new(8, "sETH", 18),
-            Token::new(9, "sUSD", 18),
-            Token::new(15, "SNX", 18),
-        ];
+        let tokens = hash_map! {
+            TokenId(1) => TokenBaseInfo::new("WETH", 18, 0, true),
+            TokenId(2) => TokenBaseInfo::new("USDT", 6, 0, true),
+            TokenId(3) => TokenBaseInfo::new("TUSD", 18, 0, true),
+            TokenId(4) => TokenBaseInfo::new("USDC", 6, 0, true),
+            TokenId(5) => TokenBaseInfo::new("PAX", 18, 0, true),
+            TokenId(6) => TokenBaseInfo::new("GUSD", 2, 0, true),
+            TokenId(7) => TokenBaseInfo::new("DAI", 18, 0, true),
+            TokenId(8) => TokenBaseInfo::new("sETH", 18, 0, true),
+            TokenId(9) => TokenBaseInfo::new("sUSD", 18, 0, true),
+            TokenId(15) => TokenBaseInfo::new("SNX", 18, 0, true)
+        };
+        let token_ids: Vec<TokenId> = tokens.keys().map(|id| *id).collect();
 
         let start_time = Instant::now();
         {
-            let client = KrakenClient::new(&HttpFactory::default()).unwrap();
-            let prices = client.get_prices(&tokens).wait().unwrap();
+            let client = KrakenClient::new(&HttpFactory::default(), tokens.into()).unwrap();
+            let prices = client.get_prices(&token_ids).wait().unwrap();
 
             println!("{:#?}", prices);
             assert!(

--- a/core/src/price_estimation/price_source.rs
+++ b/core/src/price_estimation/price_source.rs
@@ -1,7 +1,6 @@
 use crate::models::{TokenId, TokenInfo};
 use anyhow::Result;
 use futures::future::{BoxFuture, FutureExt as _};
-use lazy_static::lazy_static;
 use std::collections::HashMap;
 
 /// A token representation.
@@ -13,47 +12,6 @@ pub struct Token {
     /// The token info for this token including, token symbol and number of
     /// decimals.
     pub info: TokenInfo,
-}
-
-impl Token {
-    /// Retrieves the token symbol for this token.
-    ///
-    /// Note that the token info alias is first checked if it is part of a
-    /// symbol override map, and if it is, then that value is used instead. This
-    /// allows ERC20 tokens like WETH to be treated as ETH, since exchanges
-    /// generally only track prices for the latter.
-    pub fn symbol(&self) -> &str {
-        lazy_static! {
-            static ref SYMBOL_OVERRIDES: HashMap<String, String> = hash_map! {
-                "WETH" => "ETH".to_owned(),
-            };
-        }
-
-        SYMBOL_OVERRIDES
-            .get(&self.info.alias)
-            .unwrap_or(&self.info.alias)
-    }
-
-    /// Converts the prices from USD into the unit expected by the contract.
-    /// This price is relative to the OWL token which is considered pegged at
-    /// exactly 1 USD with 18 decimals.
-    pub fn get_owl_price(&self, usd_price: f64) -> u128 {
-        let pow = 36 - (self.info.decimals as i32);
-        (usd_price * 10f64.powi(pow)) as _
-    }
-
-    /// Creates a new token from its parameters.
-    #[cfg(test)]
-    pub fn new(id: impl Into<TokenId>, symbol: impl Into<String>, decimals: u8) -> Self {
-        Token {
-            id: id.into(),
-            info: TokenInfo {
-                alias: symbol.into(),
-                decimals,
-                external_price: 0,
-            },
-        }
-    }
 }
 
 /// An abstraction around a type that retrieves price estimate from a source

--- a/core/src/price_estimation/price_source.rs
+++ b/core/src/price_estimation/price_source.rs
@@ -65,7 +65,7 @@ pub trait PriceSource {
     /// error.
     fn get_prices<'a>(
         &'a self,
-        tokens: &'a [Token],
+        tokens: &'a [TokenId],
     ) -> BoxFuture<'a, Result<HashMap<TokenId, u128>>>;
 }
 
@@ -73,7 +73,7 @@ pub trait PriceSource {
 pub struct NoopPriceSource;
 
 impl PriceSource for NoopPriceSource {
-    fn get_prices(&self, _: &[Token]) -> BoxFuture<Result<HashMap<TokenId, u128>>> {
+    fn get_prices(&self, _: &[TokenId]) -> BoxFuture<Result<HashMap<TokenId, u128>>> {
         async { Ok(HashMap::new()) }.boxed()
     }
 }
@@ -88,12 +88,12 @@ mod mock {
     pub trait PriceSource_ {
         fn get_prices<'a>(
             &'a self,
-            tokens: &[Token],
+            tokens: &[TokenId],
         ) -> BoxFuture<'a, Result<HashMap<TokenId, u128>>>;
     }
 
     impl PriceSource for MockPriceSource_ {
-        fn get_prices(&self, tokens: &[Token]) -> BoxFuture<Result<HashMap<TokenId, u128>>> {
+        fn get_prices(&self, tokens: &[TokenId]) -> BoxFuture<Result<HashMap<TokenId, u128>>> {
             PriceSource_::get_prices(self, tokens)
         }
     }

--- a/core/src/price_estimation/threaded_price_source.rs
+++ b/core/src/price_estimation/threaded_price_source.rs
@@ -108,7 +108,6 @@ impl PriceSource for ThreadedPriceSource {
 mod tests {
     use super::super::price_source::MockPriceSource;
     use super::*;
-    use crate::price_estimation::{data::TokenBaseInfo, TokenData};
     use std::sync::atomic;
     use std::time::Instant;
 


### PR DESCRIPTION
Part of #842. For this issue we need to implement a PriceSource, that is using the price graph to estimate prices. The way the PriceGraph trait is currently designed is that it passes a list of tokens that should be estimated. That list of tokens contains detailed information such as symbol name and decimals. 

This is required for our existing external data sources. However for the internal, pricegraph based estimation all we need to know about a token is its ID. Moreover, given that arbitrary tokens can be added to the exchange we are not guaranteed to have full detail information for all tokens.

This PR therefore changes the signature of the PriceSource trait to only pass the token Id. The more detailed information (required for kraken and dex.ag) is now passed as instance state via the constructor.

In a next step I want to get rid of the `shouldEstimatePrice` flag and make it so that we attempt to estimate all tokens for which there are orders.

Eventually I would like to get rid of the hardcoded TokenData altogether and fetch the information either from the graph or from the chain (the only thing we need to hardcode is a fallback estimate for our core tokens).

### Test Plan

No logic changes. Therefore:

- cargo test
- cargo test price_estimation  -- --ignored