### PR TITLE
[Easy] Add log filter to price estimation API

### DIFF
--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -17,6 +17,7 @@ pub fn estimated_buy_amount<T: Send + Sync + 'static>(
         .and(warp::any().map(move || price_rounding_buffer))
         .and(warp::any().map(move || orderbook.clone()))
         .and_then(estimate_buy_amount)
+        .with(warp::log("price_estimator::api::estimate_buy_amount"))
 }
 
 fn estimated_buy_amount_filter(


### PR DESCRIPTION
This PR adds logging to the price estimator API.

### Test Plan

Run the price estimator and make a request:
```sh
RUST_LOG=price_estimator=info cargo run -p price-estimator
# in a separate terminal window:
curl 'http://localhost:8080/markets/7-1/estimated-buy-amount/1000000000000000000?atoms=true'
```

```
[2020-06-11T07:19:40Z INFO  price_estimator] Starting price estimator with runtime options: Options {
        node_url: "https://mainnet.infura.io/v3/3cfbd84f2f8347519b21958b2fe78b04",
        timeout: 10s,
        orderbook_file: Some(
            "/var/home/nlordell/Developer/dex-services/target/orderbook-file-mainnet",
        ),
        orderbook_update_interval: 10s,
        price_rounding_buffer: 0.001,
    }
[2020-06-11T07:19:46Z INFO  price_estimator] Orderbook initialized.
[2020-06-11T07:19:46Z INFO  price_estimator] Server ready.
[2020-06-11T07:20:07Z INFO  warp::filters::log] 127.0.0.1:50528 "GET /markets/7-1/estimated-buy-amount/1000000000000000000 HTTP/1.1" 200 "-" "curl/7.69.1" 3.047754ms
```