### PR TITLE
Move serialization structs into own module

### DIFF
--- a/price-estimator/src/estimate_buy_amount.rs
+++ b/price-estimator/src/estimate_buy_amount.rs
@@ -1,4 +1,4 @@
-use crate::filter::TokenPair;
+use crate::models::TokenPair;
 use pricegraph::Orderbook;
 
 pub fn estimate_buy_amount(

--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -1,8 +1,6 @@
+use crate::models::*;
 use crate::orderbook::Orderbook;
-use serde::{Deserialize, Serialize};
-use serde_with::rust::display_fromstr;
 use std::convert::Infallible;
-use std::num::ParseIntError;
 use std::sync::Arc;
 use warp::{Filter, Rejection};
 
@@ -41,7 +39,7 @@ async fn estimate_buy_amount<T>(
         orderbook.get_reduced_orderbook().await,
     )
     .unwrap_or(0.0) as u128;
-    let result = JsonResult {
+    let result = EstimatedBuyAmountResult {
         base_token_id: token_pair.buy_token_id,
         quote_token_id: token_pair.sell_token_id,
         sell_amount_in_quote,
@@ -50,75 +48,10 @@ async fn estimate_buy_amount<T>(
     Ok(warp::reply::json(&result))
 }
 
-#[derive(Debug, Copy, Clone)]
-pub struct TokenPair {
-    pub buy_token_id: u16,
-    pub sell_token_id: u16,
-}
-
-impl std::convert::Into<pricegraph::TokenPair> for TokenPair {
-    fn into(self) -> pricegraph::TokenPair {
-        pricegraph::TokenPair {
-            buy: self.buy_token_id,
-            sell: self.sell_token_id,
-        }
-    }
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum ParseTokenPairError {
-    #[error("wrong number of tokens")]
-    WrongNumberOfTokens,
-    #[error("parse int error")]
-    ParseIntError(#[from] ParseIntError),
-}
-
-impl std::str::FromStr for TokenPair {
-    type Err = ParseTokenPairError;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut split = s.split('-');
-        let mut next_token_id = || -> Result<u16, ParseTokenPairError> {
-            let token_string = split
-                .next()
-                .ok_or(ParseTokenPairError::WrongNumberOfTokens)?;
-            token_string.parse().map_err(From::from)
-        };
-        let buy_token_id = next_token_id()?;
-        let sell_token_id = next_token_id()?;
-        if split.next().is_some() {
-            return Err(ParseTokenPairError::WrongNumberOfTokens);
-        }
-        Ok(Self {
-            buy_token_id,
-            sell_token_id,
-        })
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct QueryParameters {
-    atoms: bool,
-    hops: Option<u16>,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct JsonResult {
-    #[serde(with = "display_fromstr")]
-    base_token_id: u16,
-    #[serde(with = "display_fromstr")]
-    quote_token_id: u16,
-    #[serde(with = "display_fromstr")]
-    buy_amount_in_base: u128,
-    #[serde(with = "display_fromstr")]
-    sell_amount_in_quote: u128,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use futures::future::FutureExt as _;
-    use serde_json::Value;
 
     #[test]
     fn estimated_buy_amount_ok() {
@@ -217,24 +150,5 @@ mod tests {
                 .unwrap()
                 .is_err());
         }
-    }
-
-    #[test]
-    fn serialization() {
-        let original = JsonResult {
-            base_token_id: 1,
-            quote_token_id: 2,
-            buy_amount_in_base: 3,
-            sell_amount_in_quote: 4,
-        };
-        let serialized = serde_json::to_string(&original).unwrap();
-        let json: Value = serde_json::from_str(&serialized).unwrap();
-        let expected = serde_json::json!({
-            "baseTokenId": "1",
-            "quoteTokenId": "2",
-            "buyAmountInBase": "3",
-            "sellAmountInQuote": "4",
-        });
-        assert_eq!(json, expected);
     }
 }

--- a/price-estimator/src/main.rs
+++ b/price-estimator/src/main.rs
@@ -1,5 +1,6 @@
 mod estimate_buy_amount;
 mod filter;
+mod models;
 mod orderbook;
 
 use core::{

--- a/price-estimator/src/models.rs
+++ b/price-estimator/src/models.rs
@@ -1,0 +1,93 @@
+use serde::{Deserialize, Serialize};
+use serde_with::rust::display_fromstr;
+use std::num::ParseIntError;
+
+#[derive(Debug, Copy, Clone)]
+pub struct TokenPair {
+    pub buy_token_id: u16,
+    pub sell_token_id: u16,
+}
+
+impl std::convert::Into<pricegraph::TokenPair> for TokenPair {
+    fn into(self) -> pricegraph::TokenPair {
+        pricegraph::TokenPair {
+            buy: self.buy_token_id,
+            sell: self.sell_token_id,
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ParseTokenPairError {
+    #[error("wrong number of tokens")]
+    WrongNumberOfTokens,
+    #[error("parse int error")]
+    ParseIntError(#[from] ParseIntError),
+}
+
+impl std::str::FromStr for TokenPair {
+    type Err = ParseTokenPairError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut split = s.split('-');
+        let mut next_token_id = || -> Result<u16, ParseTokenPairError> {
+            let token_string = split
+                .next()
+                .ok_or(ParseTokenPairError::WrongNumberOfTokens)?;
+            token_string.parse().map_err(From::from)
+        };
+        let buy_token_id = next_token_id()?;
+        let sell_token_id = next_token_id()?;
+        if split.next().is_some() {
+            return Err(ParseTokenPairError::WrongNumberOfTokens);
+        }
+        Ok(Self {
+            buy_token_id,
+            sell_token_id,
+        })
+    }
+}
+
+/// The query part of the url.
+#[derive(Debug, Deserialize)]
+pub struct QueryParameters {
+    pub atoms: bool,
+    pub hops: Option<u16>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EstimatedBuyAmountResult {
+    #[serde(with = "display_fromstr")]
+    pub base_token_id: u16,
+    #[serde(with = "display_fromstr")]
+    pub quote_token_id: u16,
+    #[serde(with = "display_fromstr")]
+    pub buy_amount_in_base: u128,
+    #[serde(with = "display_fromstr")]
+    pub sell_amount_in_quote: u128,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    #[test]
+    fn serialization() {
+        let original = EstimatedBuyAmountResult {
+            base_token_id: 1,
+            quote_token_id: 2,
+            buy_amount_in_base: 3,
+            sell_amount_in_quote: 4,
+        };
+        let serialized = serde_json::to_string(&original).unwrap();
+        let json: Value = serde_json::from_str(&serialized).unwrap();
+        let expected = serde_json::json!({
+            "baseTokenId": "1",
+            "quoteTokenId": "2",
+            "buyAmountInBase": "3",
+            "sellAmountInQuote": "4",
+        });
+        assert_eq!(json, expected);
+    }
+}


### PR DESCRIPTION
We are going to need more code for the transitive orderbook there which
I feel would make the filter module too big.

Also renamed `JsonResult` to `EstimatedBuyAmountResult` in preparation for the transitive orderbook.

### Test Plan
CI, no logic change.