### PR TITLE
Refactor TransitiveOrder to include price and capacity

### DIFF
--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -10,6 +10,9 @@ mod data;
 pub use encoding::*;
 pub use orderbook::Orderbook;
 
+/// The fee factor that is applied to each order's buy price.
+pub const FEE_FACTOR: f64 = 1.0 / 0.999;
+
 /// A struct representing a transitive orderbook for a base and quote token.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct TransitiveOrderbook {
@@ -36,8 +39,34 @@ pub struct TransitiveOrderbook {
 /// Additionally, a transitive order over a single order is equal to that order.
 #[derive(Clone, Debug, PartialEq)]
 pub struct TransitiveOrder {
+    price: f64,
+    capacity: f64,
+}
+
+impl TransitiveOrder {
+    /// ?
+    pub fn price(&self) -> f64 {
+        self.price
+    }
+
+    /// ?
+    pub fn capacity(&self) -> f64 {
+        self.capacity
+    }
+
+    // NOTE: We have the capacity and price for this transitive order which
+    // needs to be converted to a buy and sell amount. We have:
+    // - `price = FEE_FACTOR * buy_amount / sell_amount`
+    // - `capacity = sell_amount * price`
+    // Solving for `buy_amount` and `sell_amount`, we get:
+
     /// The effective buy amount for this transient order.
-    pub buy: f64,
+    pub fn buy(&self) -> f64 {
+        self.capacity / FEE_FACTOR
+    }
+
     /// The effective sell amount for this transient order.
-    pub sell: f64,
+    pub fn sell(&self) -> f64 {
+        self.capacity / self.price
+    }
 }

--- a/pricegraph/src/orderbook/order.rs
+++ b/pricegraph/src/orderbook/order.rs
@@ -195,10 +195,7 @@ fn is_unbounded(element: &Element) -> bool {
     element.price.numerator == UNBOUNDED_AMOUNT || element.price.denominator == UNBOUNDED_AMOUNT
 }
 
-/// The fee factor that is applied to each order's buy price.
-pub const FEE_FACTOR: f64 = 1.0 / 0.999;
-
 /// Calculates an effective price as a `f64` from a price fraction.
 fn as_effective_sell_price(price: &Price) -> f64 {
-    FEE_FACTOR * (price.numerator as f64) / (price.denominator as f64)
+    crate::FEE_FACTOR * (price.numerator as f64) / (price.denominator as f64)
 }


### PR DESCRIPTION
The transitive orderbook as returned from price estimator is supposed to
return price and volume. Pricegrpah has this internally but converts it
into buy and sell amount instead.
By expressing this in terms of methods we can pick the internal
representation as we like while making use of the struct more
convenient.

@nlordell What do you think of this?

### Test Plan
CI