### PR TITLE
Refactor BatchID in its own module

### DIFF
--- a/core/src/driver/scheduler.rs
+++ b/core/src/driver/scheduler.rs
@@ -9,9 +9,6 @@ use anyhow::{anyhow, Error, Result};
 use std::str::FromStr;
 use std::time::Duration;
 
-/// The total time in a batch.
-const BATCH_DURATION: Duration = Duration::from_secs(300);
-
 /// The time in a batch where a solution may be submitted.
 const SOLVING_WINDOW: Duration = Duration::from_secs(240);
 

--- a/core/src/driver/scheduler/evm.rs
+++ b/core/src/driver/scheduler/evm.rs
@@ -1,9 +1,10 @@
 //! Implementation of an EVM-based scheduler that retrieves current batch and
 //! batch duration information directly from the EVM instead of system time.
 
-use super::{AuctionTimingConfiguration, Scheduler, BATCH_DURATION};
+use super::{AuctionTimingConfiguration, Scheduler};
 use crate::contracts::stablex_contract::StableXContract;
 use crate::driver::stablex_driver::{DriverResult, StableXDriver};
+use crate::models::batch_id::BATCH_DURATION;
 use crate::util::FutureWaitExt as _;
 use anyhow::Result;
 use log::{debug, error, info, warn};

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -1,9 +1,11 @@
 pub mod account_state;
+pub mod batch_id;
 pub mod order;
 pub mod solution;
 pub mod tokens;
 
 pub use self::account_state::AccountState;
+pub use self::batch_id::BatchId;
 pub use self::order::Order;
 pub use self::solution::ExecutedOrder;
 pub use self::solution::Solution;

--- a/core/src/models/batch_id.rs
+++ b/core/src/models/batch_id.rs
@@ -1,0 +1,76 @@
+use std::fmt;
+use std::time::{Duration, SystemTime, SystemTimeError};
+
+/// The total time in a batch.
+pub const BATCH_DURATION: Duration = Duration::from_secs(300);
+
+/// Wraps a batch id as in the smart contract to add functionality related to
+/// the current time.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct BatchId(pub u64);
+
+impl BatchId {
+    pub fn current(now: SystemTime) -> std::result::Result<Self, SystemTimeError> {
+        let time_since_epoch = now.duration_since(SystemTime::UNIX_EPOCH)?;
+        Ok(Self(time_since_epoch.as_secs() / BATCH_DURATION.as_secs()))
+    }
+
+    pub fn currently_being_solved(now: SystemTime) -> std::result::Result<Self, SystemTimeError> {
+        Self::current(now).map(|batch_id| batch_id.prev())
+    }
+
+    pub fn order_collection_start_time(self) -> SystemTime {
+        SystemTime::UNIX_EPOCH + Duration::from_secs(self.0 * BATCH_DURATION.as_secs())
+    }
+
+    pub fn solve_start_time(self) -> SystemTime {
+        self.order_collection_start_time() + BATCH_DURATION
+    }
+
+    pub fn next(self) -> BatchId {
+        self.0.checked_add(1).map(BatchId).unwrap()
+    }
+
+    fn prev(self) -> BatchId {
+        self.0.checked_sub(1).map(BatchId).unwrap()
+    }
+}
+
+impl Into<u32> for BatchId {
+    fn into(self) -> u32 {
+        self.0 as u32
+    }
+}
+
+impl fmt::Display for BatchId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn batch_id_current() {
+        let start_time = SystemTime::UNIX_EPOCH;
+        let batch_id = BatchId::current(start_time).unwrap();
+        assert_eq!(batch_id.0, 0);
+        assert_eq!(batch_id.order_collection_start_time(), start_time);
+
+        let start_time = SystemTime::UNIX_EPOCH;
+        let batch_id = BatchId::current(start_time + Duration::from_secs(299)).unwrap();
+        assert_eq!(batch_id.0, 0);
+        assert_eq!(batch_id.order_collection_start_time(), start_time);
+
+        let start_time = SystemTime::UNIX_EPOCH + Duration::from_secs(300);
+        let batch_id = BatchId::current(start_time).unwrap();
+        assert_eq!(batch_id.0, 1);
+        assert_eq!(batch_id.order_collection_start_time(), start_time);
+
+        let start_time = SystemTime::UNIX_EPOCH + Duration::from_secs(300);
+        let batch_id = BatchId::current(start_time + Duration::from_secs(299)).unwrap();
+        assert_eq!(batch_id.0, 1);
+        assert_eq!(batch_id.order_collection_start_time(), start_time);
+    }
+}


### PR DESCRIPTION
Part of #842 

Pricegraph requires to be initialized with a BatchID. We already have an abstraction for this type in the scheduler. This PR moves this abstraction in the model module for reuse.

### Test Plan

CI