### PR TITLE
Adding a pricegraph based price source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,8 @@ dependencies = [
  "log 0.4.8",
  "mockall",
  "num",
+ "pricegraph",
+ "primitive-types 0.7.2",
  "prometheus",
  "rouille",
  "rustc-hex",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,6 +18,8 @@ isahc = { version = "0.9.4", features = ["json"] }
 lazy_static = "1.4.0"
 log = "0.4.8"
 num = { version = "0.2", features = ["serde"] }
+pricegraph = { path = "../pricegraph" }
+primitive-types = "0.7"
 prometheus = "0.9.0"
 rouille = "3.0.0"
 rustc-hex = "2.1.0"

--- a/core/src/models/order.rs
+++ b/core/src/models/order.rs
@@ -1,5 +1,6 @@
 use crate::util::CeiledDiv;
 use ethcontract::{Address, U256};
+use pricegraph::{Element, Price, TokenPair, UserId, Validity};
 
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 pub struct Order {
@@ -39,6 +40,29 @@ impl Order {
             self.denominator,
             self.remaining_sell_amount,
         )
+    }
+
+    pub fn to_element(&self, balance: primitive_types::U256) -> Element {
+        // Some conversions are needed because the primitive types crate is on different versions in
+        // core and pricegraph.
+        Element {
+            user: UserId::from_slice(self.account_id.as_fixed_bytes()),
+            balance,
+            pair: TokenPair {
+                buy: self.buy_token,
+                sell: self.sell_token,
+            },
+            valid: Validity {
+                from: self.valid_from,
+                to: self.valid_until,
+            },
+            price: Price {
+                numerator: self.numerator,
+                denominator: self.denominator,
+            },
+            remaining_sell_amount: self.remaining_sell_amount,
+            id: self.id,
+        }
     }
 }
 

--- a/core/src/price_estimation.rs
+++ b/core/src/price_estimation.rs
@@ -5,6 +5,7 @@ mod average_price_source;
 pub mod data;
 mod dexag;
 mod kraken;
+mod orderbook_based;
 mod price_source;
 mod threaded_price_source;
 

--- a/core/src/price_estimation/price_source.rs
+++ b/core/src/price_estimation/price_source.rs
@@ -18,9 +18,9 @@ pub struct Token {
 /// such as an exchange.
 pub trait PriceSource {
     /// Retrieve current prices relative to the OWL token for the specified
-    /// tokens. The OWL token is pegged at 1 USD with 18 decimals. Returns a
-    /// sparse price array as being unable to find a price is not considered an
-    /// error.
+    /// tokens (price denominated in OWL). The OWL token is pegged at 1 USD
+    /// with 18 decimals. Returns a sparse price array as being unable to
+    /// find a price is not considered an error.
     fn get_prices<'a>(
         &'a self,
         tokens: &'a [TokenId],


### PR DESCRIPTION
Part of #842 

Introducing the price graph based price source. Uses the orderbook reader to get the right state of the orderbook and then estimates the amount of each token we'd be getting for selling one OWL. OWL itself is priced at 1 (10^18).

### Test Plan
For now added some unit test. Will wire it into our system in a separate PR and then e2e test it.