### PR TITLE
[Pricegraph] Remove unused method

### DIFF
--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -209,7 +209,6 @@ impl Orderbook {
         if !self.is_token_pair_valid(pair) {
             return Vec::new();
         }
-        self.update_projection_graph();
 
         let (sell, buy) = (node_index(pair.sell), node_index(pair.buy));
 
@@ -286,7 +285,6 @@ impl Orderbook {
         if !self.is_token_pair_valid(pair) {
             return None;
         }
-        self.update_projection_graph();
 
         let (sell, buy) = (node_index(pair.sell), node_index(pair.buy));
         let predecessors = self.reduced_shortest_paths(sell);
@@ -350,7 +348,6 @@ impl Orderbook {
         if !self.is_token_pair_valid(pair) {
             return 0.0;
         }
-        self.update_projection_graph();
 
         let (sell, buy) = (node_index(pair.sell), node_index(pair.buy));
         // NOTE: The limit price is expressed in `buy_amount / sell_amount` for
@@ -414,18 +411,6 @@ impl Orderbook {
                     });
                 }
             }
-        }
-    }
-
-    /// Updates the projection graph for every token pair.
-    fn update_projection_graph(&mut self) {
-        let pairs = self
-            .orders
-            .all_pairs()
-            .map(|(pair, _)| pair)
-            .collect::<Vec<_>>();
-        for pair in pairs {
-            self.update_projection_graph_edge(pair);
         }
     }
 


### PR DESCRIPTION
Because of how the pricegraph was previously structured, the projection graph needed to be updated before calling methods that did path searching. This has not been the case for a while now, but the method was left in.

### Test Plan

CI, and unit tests still pass. Additionally, we can test with an actual orderbook and a real price estimate:
```
$ cargo test -p pricegraph real_orderbooks -- --nocapture # before change
   Compiling pricegraph v0.1.0 (/var/home/nlordell/Developer/dex-services/pricegraph)
    Finished test [unoptimized + debuginfo] target(s) in 1.41s
     Running /var/home/nlordell/Developer/dex-services/target/debug/deps/pricegraph-397047f497bad3b3
running 1 test
#5298183: estimated price for selling 1 WETH at 194.87633796952346 DAI/WETH
test orderbook::tests::real_orderbooks ... ok
$ cargo test -p pricegraph real_orderbooks -- --nocapture # with change
   Compiling pricegraph v0.1.0 (/var/home/nlordell/Developer/dex-services/pricegraph)
    Finished test [unoptimized + debuginfo] target(s) in 0.08s
     Running /var/home/nlordell/Developer/dex-services/target/debug/deps/pricegraph-397047f497bad3b3
running 1 test
#5298183: estimated price for selling 1 WETH at 194.87633796952346 DAI/WETH
test orderbook::tests::real_orderbooks ... ok
```