### PR TITLE
Add transititive orderbook request scaffolding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2193,6 +2193,7 @@ name = "price-estimator"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_approx_eq",
  "core",
  "env_logger",
  "ethcontract",

--- a/price-estimator/Cargo.toml
+++ b/price-estimator/Cargo.toml
@@ -21,3 +21,6 @@ thiserror = "1.0"
 tokio = { version = "0.2", features = ["macros", "rt-threaded", "time"] }
 url = "2.1"
 warp = "0.2"
+
+[dev-dependencies]
+assert_approx_eq = "1.1"

--- a/price-estimator/README.md
+++ b/price-estimator/README.md
@@ -2,18 +2,43 @@
 
 The service exposes the following endpoints:
 
-### estimated buy amount
+### Markets
 
-`GET /markets/:market/estimated-buy-amount/:sell-amount-in-quote-token`
+`GET /markets/:market`
 
 * `market` is of the form `<base_token_id>-<quote_token_id>`. The token ids the same as in the smart contract.
-* `sell_amount_in_quote_token` is a positive integer.
 
 Url Query:
 * `atoms`: If set to `true` (for now this is the only implemented method) all amounts will be denominated in the smallest available unit (base quantity) of the token.
 * `hops`: TODO: document this once it has been implemented.
 
-Example Request: `markets/1-7/estimated-buy-amount/20000000000000000000?atoms=true`
+Example Request: `/markets/1-7/?atoms=true`
+
+Example Response:
+
+```json
+{
+    "asks": [
+        { "price": 407.6755405630054, "volume": 9.389082650375993 }
+    ],
+    "bids": [
+        { "price": 5508028446685.359, "volume": 3.2264600472733105 }
+    ],
+}
+```
+
+Returns the transitive orderbook (containing bids and asks) for the given base and quote token.
+
+### Estimated Buy Amount
+
+`GET /markets/:market/estimated-buy-amount/:sell-amount-in-quote-token`
+
+* `market` is as above
+* `sell_amount_in_quote_token` is a positive integer.
+
+Url query is as above.
+
+Example Request: `/markets/1-7/estimated-buy-amount/20000000000000000000?atoms=true`
 
 Example Response:
 

--- a/price-estimator/src/main.rs
+++ b/price-estimator/src/main.rs
@@ -91,7 +91,7 @@ fn main() {
         options.orderbook_update_interval,
     ));
 
-    let filter = filter::estimated_buy_amount(orderbook, price_rounding_buffer);
+    let filter = filter::all(orderbook, price_rounding_buffer);
     let serve_task = runtime.spawn(warp::serve(filter).run(([127, 0, 0, 1], 8080)));
 
     log::info!("Server ready.");


### PR DESCRIPTION
This includes everything except the actual functionality of computing
the transitive orderbook.

### Test Plan
Some unit tests. Can really test when fully implemented by comparing to old price estimator.