### PR TITLE
[Trivial] Making the event based orderbook the default

### DIFF
--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -101,8 +101,8 @@ struct Options {
     #[structopt(long, env = "ORDERBOOK_FILTER", default_value = "{}")]
     orderbook_filter: OrderbookFilter,
 
-    /// Primary method for orderbook retrieval ("Paginated" or "OnchainFiltered")
-    #[structopt(long, env = "PRIMARY_ORDERBOOK", default_value = "paginated")]
+    /// Primary method for orderbook retrieval
+    #[structopt(long, env = "PRIMARY_ORDERBOOK", default_value = "eventbased")]
     primary_orderbook: OrderbookReaderKind,
 
     /// The private key used by the driver to sign transactions.


### PR DESCRIPTION
Anything else is taking too long at the moment.

### Test Plan
 Can cargo run without the `--primary-orderbook` argument and it loads the fast event based orderbook