### PR TITLE
Fix overlapping transitive orderbook direction

### DIFF
--- a/core/src/price_estimation/orderbook_based.rs
+++ b/core/src/price_estimation/orderbook_based.rs
@@ -24,7 +24,7 @@ impl PriceSource for PricegraphEstimator {
             let batch = BatchId::currently_being_solved(SystemTime::now())?;
             let (account_state, orders) =
                 self.orderbook_reader.get_auction_data(batch.into()).await?;
-            let mut orderbook = Orderbook::new(orders.iter().map(|order| {
+            let mut orderbook = Orderbook::from_elements(orders.iter().map(|order| {
                 order.to_element(U256(
                     account_state
                         .read_balance(order.sell_token, order.account_id)

--- a/core/src/price_estimation/orderbook_based.rs
+++ b/core/src/price_estimation/orderbook_based.rs
@@ -24,7 +24,7 @@ impl PriceSource for PricegraphEstimator {
             let batch = BatchId::currently_being_solved(SystemTime::now())?;
             let (account_state, orders) =
                 self.orderbook_reader.get_auction_data(batch.into()).await?;
-            let mut orderbook = Orderbook::from_elements(orders.iter().map(|order| {
+            let mut orderbook = Orderbook::new(orders.iter().map(|order| {
                 order.to_element(U256(
                     account_state
                         .read_balance(order.sell_token, order.account_id)

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -180,10 +180,6 @@ impl Orderbook {
             });
         }
 
-        for orders in &mut [&mut overlap.asks, &mut overlap.bids] {
-            orders.sort_unstable_by(|a, b| num::compare(a.price(), b.price()));
-        }
-
         overlap
     }
 
@@ -837,41 +833,6 @@ mod tests {
         // Transitive order `2 -> 3 -> 1` buying 2 selling 1
         assert_approx_eq!(overlap.bids[0].buy, 500_000.0);
         assert_approx_eq!(overlap.bids[0].sell, 500_000.0 / FEE_FACTOR);
-    }
-
-    #[test]
-    fn orders_overlapping_transitive_orders_by_price() {
-        //  /---0.5---v
-        // 0          1
-        // ^---1.0---/
-        // ^---1.5--/
-        let mut orderbook = orderbook! {
-            users {
-                @1 {
-                    token 1 => 4_000_000,
-                }
-                @2 {
-                    token 0 => 2_000_000,
-                }
-                @3 {
-                    token 0 => 1_000_000,
-                }
-            }
-            orders {
-                owner @1 buying 0 [2_000_000] selling 1 [4_000_000],
-                owner @2 buying 1 [1_000_000] selling 0 [1_000_000],
-                owner @3 buying 1 [1_500_000] selling 0 [1_000_000],
-            }
-        };
-
-        let overlap = orderbook.reduce_overlapping_transitive_orderbook(0, 1);
-
-        // Transitive orders `1 -> 0` buying 1 selling 0
-        assert_eq!(overlap.asks.len(), 2);
-        assert_approx_eq!(overlap.bids[0].buy, 1_000_000.0);
-        assert_approx_eq!(overlap.bids[0].sell, 1_000_000.0);
-        assert_approx_eq!(overlap.bids[1].buy, 1_500_000.0);
-        assert_approx_eq!(overlap.bids[1].sell, 1_000_000.0);
     }
 
     #[test]


### PR DESCRIPTION
This PR fixes the direction of the ask and bid orders, as they were inverted.

### Test Plan

Fixed old unit test.