### PR TITLE
use `timeLimit` instead of `solverTimeLimit`

### DIFF
--- a/core/src/price_finding/price_finder_interface.rs
+++ b/core/src/price_finding/price_finder_interface.rs
@@ -138,10 +138,10 @@ pub fn execute_private_solver(
         .arg(format!("{}{}", "/app/", input_file.to_owned()))
         .arg(format!("--outputDir={}{}", "/app/", result_folder))
         .arg("--logging=WARNING")
-        .args(&["--timeLimit", &time_limit])
+        .arg(format!("--timeLimit={}", time_limit))
         .arg(format!("--minAvgFeePerOrder={}", min_avg_fee_per_order))
         .arg(format!("--solver={}", internal_optimizer.to_argument()))
-        .arg(String::from("--useExternalPrices"));
+        .arg("--useExternalPrices");
     if search_only_for_best_ring_solution {
         private_solver_command = private_solver_command.arg(String::from("--solveBestCycle"));
     }

--- a/core/src/price_finding/price_finder_interface.rs
+++ b/core/src/price_finding/price_finder_interface.rs
@@ -138,7 +138,7 @@ pub fn execute_private_solver(
         .arg(format!("{}{}", "/app/", input_file.to_owned()))
         .arg(format!("--outputDir={}{}", "/app/", result_folder))
         .arg("--logging=WARNING")
-        .args(&["--solverTimeLimit", &time_limit])
+        .args(&["--timeLimit", &time_limit])
         .arg(format!("--minAvgFeePerOrder={}", min_avg_fee_per_order))
         .arg(format!("--solver={}", internal_optimizer.to_argument()))
         .arg(String::from("--useExternalPrices"));


### PR DESCRIPTION
I noticed that a new `timeLimit` parameter to constrain the total time (processing + solving) of the solver. I imagine that this should be used instead of the `solverTimeLimit` parameter, since the latter does not take processing time into account.

Maybe @josojo and @marcovc can confirm that this time limit is indeed what we should be using in this case.

### Test Plan

CI, solvers should accept new `timeLimit` parameter.