### PR TITLE
solver bump: hotfix for faster best ring solver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ language: rust
 env:
   global:
     - OPEN_SOLVER_VERSION=v0.0.10
-    - PRIVATE_SOLVER_VERSION=v0.7.3
+    - PRIVATE_SOLVER_VERSION=v0.7.4
 
 install:
   - nvm install 12 && nvm alias default 12 && npm install -g yarn@latest && yarn --version

--- a/core/src/price_finding/price_finder_interface.rs
+++ b/core/src/price_finding/price_finder_interface.rs
@@ -138,7 +138,7 @@ pub fn execute_private_solver(
         .arg(format!("{}{}", "/app/", input_file.to_owned()))
         .arg(format!("--outputDir={}{}", "/app/", result_folder))
         .arg("--logging=WARNING")
-        .args(&["--solverTimeLimit", &time_limit])
+        .args(&["--timeLimit", &time_limit])
         .arg(format!("--minAvgFeePerOrder={}", min_avg_fee_per_order))
         .arg(format!("--solver={}", internal_optimizer.to_argument()))
         .arg(String::from("--useExternalPrices"));

--- a/core/src/price_finding/price_finder_interface.rs
+++ b/core/src/price_finding/price_finder_interface.rs
@@ -138,7 +138,7 @@ pub fn execute_private_solver(
         .arg(format!("{}{}", "/app/", input_file.to_owned()))
         .arg(format!("--outputDir={}{}", "/app/", result_folder))
         .arg("--logging=WARNING")
-        .args(&["--timeLimit", &time_limit])
+        .arg(format!("--timeLimit={}", time_limit))
         .arg(format!("--minAvgFeePerOrder={}", min_avg_fee_per_order))
         .arg(format!("--solver={}", internal_optimizer.to_argument()))
         .arg(String::from("--useExternalPrices"));


### PR DESCRIPTION
Solver bump: See https://github.com/gnosis/dex-solver/pull/277

Additionally, in a previous PR of the solver, the time constraint was changed. Now we have available:
```
 ArgHolder(
            '--timeLimit',
            type=ArgparseHelpers.nonnegative(int),
            default=180,
            help="Time limit (preprocessing + solving + postprocessing) in [s]."
        ),
        ArgHolder(
            '--solverTimeLimit',
            type=ArgparseHelpers.nonnegative(int),
            default=180,
            help="Time limit (just for solving) in [s]."
        ),
```
This PR changes the code so that we always use `timeLimit`, as the driver intended to cap the time of all procedures in the solver.

### Test Plan
e2e only