### PR TITLE
Deploy price estimator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ jobs:
         - ./grcov --branch --ignore-not-existing --llvm --excl-start "mod test" --excl-line "#\[cfg_attr\(test, mockall::automock\)\]|#\[derive" --ignore "/*" --ignore "target/debug/build/**" target/debug/ --output-path coveralls.json --output-type "coveralls+" --source-dir . --service-name travis-pro --service-job-id $TRAVIS_JOB_ID
         - curl --form json_file=@coveralls.json https://coveralls.io/api/v1/jobs
 
-    - name: Deploy
+    - name: "Deploy Driver"
       if: (type != pull_request) AND (tag is present OR branch = master)
       rust: 1.43.0
       before_install:
@@ -99,5 +99,22 @@ jobs:
             branch: master
         - provider: script
           script: ./docker/deploy.sh $TRAVIS_TAG
+          on:
+            tags: true
+    - name: "Deploy Price Estimator"
+      if: (type != pull_request) AND (tag is present OR branch = master)
+      rust: 1.43.0
+      before_script:
+        - ./scripts/setup_contracts.sh
+      script:
+        - true
+      deploy:
+        - script:
+        - provider: script
+          script: ./price-estimator/docker/deploy.sh $TRAVIS_BRANCH
+          on:
+            branch: master
+        - provider: script
+          script: ./price-estimator/docker/deploy.sh $TRAVIS_TAG
           on:
             tags: true

--- a/price-estimator/README.md
+++ b/price-estimator/README.md
@@ -4,7 +4,7 @@ The service exposes the following endpoints:
 
 ### Markets
 
-`GET /markets/:market`
+`GET /api/v1/markets/:market`
 
 * `market` is of the form `<base_token_id>-<quote_token_id>`. The token ids the same as in the smart contract.
 
@@ -12,7 +12,7 @@ Url Query:
 * `atoms`: If set to `true` (for now this is the only implemented method) all amounts will be denominated in the smallest available unit (base quantity) of the token.
 * `hops`: TODO: document this once it has been implemented.
 
-Example Request: `/markets/1-7/?atoms=true`
+Example Request: `/api/v1/markets/1-7/?atoms=true`
 
 Example Response:
 
@@ -31,14 +31,14 @@ Returns the transitive orderbook (containing bids and asks) for the given base a
 
 ### Estimated Buy Amount
 
-`GET /markets/:market/estimated-buy-amount/:sell-amount-in-quote-token`
+`GET /api/v1/markets/:market/estimated-buy-amount/:sell-amount-in-quote-token`
 
 * `market` is as above
 * `sell_amount_in_quote_token` is a positive integer.
 
 Url query is as above.
 
-Example Request: `/markets/1-7/estimated-buy-amount/20000000000000000000?atoms=true`
+Example Request: `/api/v1/markets/1-7/estimated-buy-amount/20000000000000000000?atoms=true`
 
 Example Response:
 

--- a/price-estimator/docker/Dockerfile
+++ b/price-estimator/docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM rust:1.43-stretch as builder
+WORKDIR /usr/src/app
+COPY Cargo.toml .
+COPY Cargo.lock .
+COPY core core
+COPY driver driver
+COPY dex-contracts dex-contracts
+COPY e2e e2e
+COPY pricegraph pricegraph
+COPY price-estimator price-estimator
+RUN ls -l && cargo build --release -p price-estimator
+
+FROM debian:stretch-slim
+# Needed so that price-estimator works with https node urls.
+RUN apt-get update && apt-get --yes install openssl ca-certificates
+COPY --from=builder /usr/src/app/target/release/price-estimator /bin/
+ADD docker/rust/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--"]
+CMD ["price-estimator"]
+

--- a/price-estimator/docker/deploy.sh
+++ b/price-estimator/docker/deploy.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+image_tag=$1
+
+echo "Docker login"
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin;
+
+echo "Building price estimator docker";
+docker build --tag gnosispm/dex-price-estimator-rust:$image_tag -f price-estimator/docker/Dockerfile .
+
+echo "Pushing price estimator docker"
+docker push gnosispm/dex-price-estimator-rust:$image_tag;
+
+echo "done"
+
+if [ "$image_tag" == "master" ] && [ -n "$AUTODEPLOY_URL_PRICE_ESTIMATOR" ]; then
+    # Notifying webhook
+    curl -s  \
+      --output /dev/null \
+      --write-out "%{http_code}" \
+      -H "Content-Type: application/json" \
+      -X POST \
+      -d '{"push_data": {"tag": "'$AUTODEPLOY_TAG_PRICE_ESTIMATOR'" }}' \
+      $AUTODEPLOY_URL_PRICE_ESTIMATOR
+fi
+

--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -13,7 +13,7 @@ pub fn all<T: Send + Sync + 'static>(
 }
 
 /// Validate a request of the form
-/// `/markets/<baseTokenId>-<quoteTokenId>/estimated-buy-amount/<sellAmountInQuoteToken>`
+/// `/api/v1/markets/<baseTokenId>-<quoteTokenId>/estimated-buy-amount/<sellAmountInQuoteToken>`
 /// and answer it.
 pub fn estimated_buy_amount<T: Send + Sync + 'static>(
     orderbook: Arc<Orderbook<T>>,
@@ -27,7 +27,7 @@ pub fn estimated_buy_amount<T: Send + Sync + 'static>(
 }
 
 /// Validate a request of the form
-/// `/markets/<baseTokenId>-<quoteTokenId>`
+/// `/api/v1/markets/<baseTokenId>-<quoteTokenId>`
 /// and answer it.
 pub fn markets<T: Send + Sync + 'static>(
     orderbook: Arc<Orderbook<T>>,
@@ -40,14 +40,14 @@ pub fn markets<T: Send + Sync + 'static>(
 
 fn estimated_buy_amount_filter(
 ) -> impl Filter<Extract = (TokenPair, u128, QueryParameters), Error = Rejection> + Copy {
-    warp::path!("markets" / TokenPair / "estimated-buy-amount" / u128)
+    warp::path!("api" / "v1" / "markets" / TokenPair / "estimated-buy-amount" / u128)
         .and(warp::get())
         .and(warp::query::<QueryParameters>())
 }
 
 fn markets_filter() -> impl Filter<Extract = (TokenPair, QueryParameters), Error = Rejection> + Copy
 {
-    warp::path!("markets" / TokenPair)
+    warp::path!("api" / "v1" / "markets" / TokenPair)
         .and(warp::get())
         .and(warp::query::<QueryParameters>())
 }
@@ -99,7 +99,7 @@ mod tests {
     #[test]
     fn estimated_buy_amount_ok() {
         let (token_pair, volume, query) = warp::test::request()
-            .path("/markets/0-65535/estimated-buy-amount/1?atoms=true&hops=2")
+            .path("/api/v1/markets/0-65535/estimated-buy-amount/1?atoms=true&hops=2")
             .filter(&estimated_buy_amount_filter())
             .now_or_never()
             .unwrap()
@@ -114,7 +114,7 @@ mod tests {
     #[test]
     fn markets_ok() {
         let (token_pair, query) = warp::test::request()
-            .path("/markets/1-2?atoms=true&hops=3")
+            .path("/api/v1/markets/1-2?atoms=true&hops=3")
             .filter(&markets_filter())
             .now_or_never()
             .unwrap()
@@ -128,7 +128,7 @@ mod tests {
     #[test]
     fn missing_hops_ok() {
         let (_, _, query) = warp::test::request()
-            .path("/markets/0-65535/estimated-buy-amount/1?atoms=true")
+            .path("/api/v1/markets/0-65535/estimated-buy-amount/1?atoms=true")
             .filter(&estimated_buy_amount_filter())
             .now_or_never()
             .unwrap()
@@ -139,7 +139,7 @@ mod tests {
     #[test]
     fn missing_query() {
         assert!(warp::test::request()
-            .path("/markets/0-0/estimated-buy-amount/0")
+            .path("/api/v1/markets/0-0/estimated-buy-amount/0")
             .filter(&estimated_buy_amount_filter())
             .now_or_never()
             .unwrap()
@@ -149,8 +149,8 @@ mod tests {
     #[test]
     fn estimated_buy_amount_too_few_tokens() {
         for path in &[
-            "/markets//estimated-buy-amount/1",
-            "/markets/0/estimated-buy-amount/1",
+            "/api/v1/markets//estimated-buy-amount/1",
+            "/api/v1/markets/0/estimated-buy-amount/1",
         ] {
             assert!(warp::test::request()
                 .path(path)
@@ -164,10 +164,10 @@ mod tests {
     #[test]
     fn estimated_buy_amount_too_many_tokens() {
         for path in &[
-            "/markets/0-1-2/estimated-buy-amount/1",
-            "/markets/0-1-asdf/estimated-buy-amount/1",
-            "/markets/0-1-2-3/estimated-buy-amount/1",
-            "/markets/0-1-/estimated-buy-amount/1",
+            "/api/v1/markets/0-1-2/estimated-buy-amount/1",
+            "/api/v1/markets/0-1-asdf/estimated-buy-amount/1",
+            "/api/v1/markets/0-1-2-3/estimated-buy-amount/1",
+            "/api/v1/markets/0-1-/estimated-buy-amount/1",
         ] {
             assert!(warp::test::request()
                 .path(path)
@@ -181,8 +181,8 @@ mod tests {
     #[test]
     fn estimated_buy_amount_no_sell_amount() {
         for path in &[
-            "/markets/0-1/estimated-buy-amount/",
-            "/markets/0-1/estimated-buy-amount/asdf",
+            "/api/v1/markets/0-1/estimated-buy-amount/",
+            "/api/v1/markets/0-1/estimated-buy-amount/asdf",
         ] {
             assert!(warp::test::request()
                 .path(path)
@@ -196,9 +196,9 @@ mod tests {
     #[test]
     fn estimated_buy_amount_no_float_volume() {
         for path in &[
-            "/markets/0-1/estimated-buy-amount/0.0",
-            "/markets/0-1/estimated-buy-amount/1.0",
-            "/markets/0-1/estimated-buy-amount/0.5",
+            "/api/v1/markets/0-1/estimated-buy-amount/0.0",
+            "/api/v1/markets/0-1/estimated-buy-amount/1.0",
+            "/api/v1/markets/0-1/estimated-buy-amount/0.5",
         ] {
             assert!(warp::test::request()
                 .path(path)


### PR DESCRIPTION
And a couple of small changes needed for our staging environment:
* fix urls to start with /api/v1
* allow choosing bind address

Corresponding staging PR: https://gitlab.gnosisdev.com/devops/gnosis-staging/merge_requests/288

## Test Plan
I have tested that this is compatible with the frontend. This is possible with https://pr1019--dexreact.review.gnosisdev.com/ which points to our staging price estimator which I have updated with this docker image.
Alternatively the real frontend https://mesa.eth.link/ can be adapted to use a localhost price estimator by running `dexPriceEstimatorApi.urlsByNetwork[1] = "http://localhost:8080/api/v1/"` in the browser console. For this to work "cors" has to be disabled which I only managed to do with `chromium --disable-web-security --user-data-dir=temp`.
We can see that prices are the same and that the orderbook visualization loads much faster. The visuals are not the same as the old price estimator especially at the edges of the graph but they are similar.