### PR TITLE
Fix pricegraph edge cases

### DIFF
--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -217,6 +217,14 @@ mod tests {
     use super::*;
 
     #[test]
+    fn transitive_orderbook_empty_same_token() {
+        let pricegraph = Pricegraph::new(std::iter::empty());
+        let orderbook = pricegraph.transitive_orderbook(0, 0, None);
+        assert!(orderbook.asks.is_empty());
+        assert!(orderbook.bids.is_empty());
+    }
+
+    #[test]
     fn transitive_orderbook_prices() {
         let transitive_orderbook = TransitiveOrderbook {
             asks: vec![

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -166,6 +166,13 @@ impl Orderbook {
         base: TokenId,
         quote: TokenId,
     ) -> TransitiveOrderbook {
+        if !self.is_token_pair_valid(TokenPair {
+            buy: base,
+            sell: quote,
+        }) {
+            return Default::default();
+        }
+
         let (base, quote) = (node_index(base), node_index(quote));
 
         let mut overlap = TransitiveOrderbook::default();
@@ -578,11 +585,15 @@ impl Orderbook {
         Some((order, user))
     }
 
-    /// Returns `true` if the specified token pair is valid, and `false`
-    /// otherwise.
+    /// Returns whether the specified token pair is valid.
+    ///
+    /// A token pair is considered valid if both the buy and sell token
+    /// exist in the current orderbook and are unequal.
     fn is_token_pair_valid(&self, pair: TokenPair) -> bool {
-        let max_token = (self.projection.node_count() - 1) as u16;
-        pair.buy <= max_token && pair.sell <= max_token
+        let node_count = self.projection.node_count();
+        pair.buy != pair.sell
+            && (pair.buy as usize) < node_count
+            && (pair.sell as usize) < node_count
     }
 }
 


### PR DESCRIPTION
`reduce_overlapping_transitive_orderbook` was missing a check for the
token pair validity which would cause a panic in bellman_ford::search
when the quote token didn't exist.

`fill_transitive_orders` had an infinite loop with an empty orderbook
and the token pair buying and selling the fee token. `path::find_path`
would in this case keep returning `Some`.

### Test Plan
Added unit test and noticed originally in #923  .