### PR TITLE
Finish implementing transitive orderbook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2192,7 +2192,6 @@ name = "price-estimator"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "assert_approx_eq",
  "core",
  "env_logger",
  "ethcontract",
@@ -3124,18 +3123,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.20"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+checksum = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.20"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+checksum = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/price-estimator/Cargo.toml
+++ b/price-estimator/Cargo.toml
@@ -21,6 +21,3 @@ thiserror = "1.0"
 tokio = { version = "0.2", features = ["macros", "rt-threaded", "time"] }
 url = "2.1"
 warp = "0.2"
-
-[dev-dependencies]
-assert_approx_eq = "1.1"

--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -78,15 +78,17 @@ async fn estimate_buy_amount<T>(
 }
 
 async fn get_markets<T>(
-    _token_pair: TokenPair,
+    token_pair: TokenPair,
     _query: QueryParameters,
-    _orderbook: Arc<Orderbook<T>>,
+    orderbook: Arc<Orderbook<T>>,
 ) -> Result<impl warp::Reply, Infallible> {
-    // TODO: implement
-    Ok(warp::reply::json(&MarketsResult {
-        asks: Vec::new(),
-        bids: Vec::new(),
-    }))
+    let transitive_orderbook = orderbook.get_pricegraph().await.transitive_orderbook(
+        token_pair.sell_token_id,
+        token_pair.buy_token_id,
+        None,
+    );
+    let result = MarketsResult::from(&transitive_orderbook);
+    Ok(warp::reply::json(&result))
 }
 
 #[cfg(test)]

--- a/price-estimator/src/models.rs
+++ b/price-estimator/src/models.rs
@@ -73,12 +73,6 @@ pub struct TransitiveOrder {
     pub volume: f64,
 }
 
-impl From<&pricegraph::TransitiveOrder> for TransitiveOrder {
-    fn from(_order: &pricegraph::TransitiveOrder) -> Self {
-        unimplemented!()
-    }
-}
-
 #[derive(Debug, Serialize)]
 pub struct MarketsResult {
     pub asks: Vec<TransitiveOrder>,
@@ -87,18 +81,16 @@ pub struct MarketsResult {
 
 impl From<&pricegraph::TransitiveOrderbook> for MarketsResult {
     fn from(orderbook: &pricegraph::TransitiveOrderbook) -> Self {
-        let convert = |orders: &Vec<_>| orders.iter().map(From::from).collect();
-        Self {
-            asks: convert(&orderbook.asks),
-            bids: convert(&orderbook.bids),
-        }
+        let to_order = |(price, volume)| TransitiveOrder { price, volume };
+        let asks = orderbook.ask_prices().map(to_order).collect();
+        let bids = orderbook.bid_prices().map(to_order).collect();
+        Self { asks, bids }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    // use assert_approx_eq::assert_approx_eq;
     use serde_json::Value;
 
     #[test]
@@ -140,17 +132,4 @@ mod tests {
         });
         assert_eq!(json, expected);
     }
-
-    /*
-    #[test]
-    fn transitive_order_conversion() {
-        let pricegraph_order = pricegraph::TransitiveOrder {
-            buy: 0.5,
-            sell: 2.0,
-        };
-        let converted = TransitiveOrder::from(&pricegraph_order);
-        assert_approx_eq!(converted.price, 0.25);
-        assert_approx_eq!(converted.volume, 2.0);
-    }
-    */
 }


### PR DESCRIPTION
Thanks to Nick's helper method this is very easy now.

### Test Plan
Run locally and compare to nodejs price estimator. There are a lot of differences so it's hard to tell which side is more correct but I do see rough correspondences. It's easier to tell for token pairs that have less transitive orders like `1-10`.