### PR TITLE
fix transitive orderbook ask/bid direction

### DIFF
--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -83,8 +83,8 @@ async fn get_markets<T>(
     orderbook: Arc<Orderbook<T>>,
 ) -> Result<impl warp::Reply, Infallible> {
     let transitive_orderbook = orderbook.get_pricegraph().await.transitive_orderbook(
-        token_pair.sell_token_id,
         token_pair.buy_token_id,
+        token_pair.sell_token_id,
         None,
     );
     let result = MarketsResult::from(&transitive_orderbook);

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -16,11 +16,11 @@ const FEE_FACTOR: f64 = 1.0 / 0.999;
 /// A struct representing a transitive orderbook for a base and quote token.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct TransitiveOrderbook {
-    /// Transitive "ask" orders, i.e. transitive orders buying the base token
-    /// and selling the quote token.
-    pub asks: Vec<TransitiveOrder>,
-    /// Transitive "bid" orders, i.e. transitive orders buying the quote token
+    /// Transitive "ask" orders, i.e. transitive orders buying the quote token
     /// and selling the base token.
+    pub asks: Vec<TransitiveOrder>,
+    /// Transitive "bid" orders, i.e. transitive orders buying the base token
+    /// and selling the quote token.
     pub bids: Vec<TransitiveOrder>,
 }
 
@@ -32,7 +32,7 @@ impl TransitiveOrderbook {
     pub fn ask_prices(&self) -> impl DoubleEndedIterator<Item = (f64, f64)> + '_ {
         self.asks
             .iter()
-            .map(|order| ((order.buy / order.sell) * FEE_FACTOR, order.sell))
+            .map(|order| ((order.sell / order.buy) / FEE_FACTOR, order.buy))
     }
 
     /// Returns an iterator with bid prices (expressed in the quote token) and
@@ -42,7 +42,7 @@ impl TransitiveOrderbook {
     pub fn bid_prices(&self) -> impl DoubleEndedIterator<Item = (f64, f64)> + '_ {
         self.bids
             .iter()
-            .map(|order| ((order.sell / order.buy) / FEE_FACTOR, order.buy))
+            .map(|order| ((order.buy / order.sell) * FEE_FACTOR, order.sell))
     }
 }
 
@@ -186,8 +186,8 @@ impl Pricegraph {
             .asks
             .extend(orderbook.clone().fill_transitive_orders(
                 TokenPair {
-                    buy: base,
-                    sell: quote,
+                    buy: quote,
+                    sell: base,
                 },
                 spread,
             ));
@@ -195,8 +195,8 @@ impl Pricegraph {
             .bids
             .extend(orderbook.fill_transitive_orders(
                 TokenPair {
-                    buy: quote,
-                    sell: base,
+                    buy: base,
+                    sell: quote,
                 },
                 spread,
             ));
@@ -229,16 +229,6 @@ mod tests {
         let transitive_orderbook = TransitiveOrderbook {
             asks: vec![
                 TransitiveOrder {
-                    buy: 1_000_000.0,
-                    sell: 2_000_000.0,
-                },
-                TransitiveOrder {
-                    buy: 500_000.0,
-                    sell: 900_000.0,
-                },
-            ],
-            bids: vec![
-                TransitiveOrder {
                     buy: 20_000_000.0,
                     sell: 10_000_000.0,
                 },
@@ -247,20 +237,30 @@ mod tests {
                     sell: 900_000.0,
                 },
             ],
+            bids: vec![
+                TransitiveOrder {
+                    buy: 1_000_000.0,
+                    sell: 2_000_000.0,
+                },
+                TransitiveOrder {
+                    buy: 500_000.0,
+                    sell: 900_000.0,
+                },
+            ],
         };
 
         assert_eq!(
             transitive_orderbook.ask_prices().collect::<Vec<_>>(),
             vec![
-                (0.5 * FEE_FACTOR, 2_000_000.0),
-                ((1.0 / 1.8) * FEE_FACTOR, 900_000.0)
+                (0.5 / FEE_FACTOR, 20_000_000.0),
+                ((0.9 / 1.5) / FEE_FACTOR, 1_500_000.0)
             ]
         );
         assert_eq!(
             transitive_orderbook.bid_prices().collect::<Vec<_>>(),
             vec![
-                (0.5 / FEE_FACTOR, 20_000_000.0),
-                ((0.9 / 1.5) / FEE_FACTOR, 1_500_000.0)
+                (0.5 * FEE_FACTOR, 2_000_000.0),
+                ((1.0 / 1.8) * FEE_FACTOR, 900_000.0)
             ]
         );
     }

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -184,7 +184,7 @@ impl Orderbook {
 
             if path.first() == Some(&quote) {
                 if let Some(base_index) = path.iter().position(|node| *node == base) {
-                    let (bid, ask) = (&path[0..base_index + 1], &path[base_index..]);
+                    let (ask, bid) = (&path[0..base_index + 1], &path[base_index..]);
 
                     let (capacity, transitive_price) = self
                         .fill_path(ask)
@@ -833,15 +833,15 @@ mod tests {
 
         let overlap = orderbook.reduce_overlapping_transitive_orderbook(1, 2);
 
-        // Transitive order `1 -> 2` buying 1 selling 2
-        assert_eq!(overlap.asks.len(), 1);
-        assert_approx_eq!(overlap.asks[0].buy, 1_000_000.0);
-        assert_approx_eq!(overlap.asks[0].sell, 2_000_000.0);
-
         // Transitive order `2 -> 3 -> 1` buying 2 selling 1
+        assert_eq!(overlap.asks.len(), 1);
+        assert_approx_eq!(overlap.asks[0].buy, 500_000.0);
+        assert_approx_eq!(overlap.asks[0].sell, 500_000.0 / FEE_FACTOR);
+
+        // Transitive order `1 -> 2` buying 1 selling 2
         assert_eq!(overlap.bids.len(), 1);
-        assert_approx_eq!(overlap.bids[0].buy, 500_000.0);
-        assert_approx_eq!(overlap.bids[0].sell, 500_000.0 / FEE_FACTOR);
+        assert_approx_eq!(overlap.bids[0].buy, 1_000_000.0);
+        assert_approx_eq!(overlap.bids[0].sell, 2_000_000.0);
     }
 
     #[test]
@@ -871,15 +871,15 @@ mod tests {
 
         let overlap = orderbook.reduce_overlapping_transitive_orderbook(0, 1);
 
-        // Transitive order `0 -> 1` buying 0 selling 1
-        assert_eq!(overlap.asks.len(), 1);
-        assert_approx_eq!(overlap.asks[0].buy, 50_000_000.0);
-        assert_approx_eq!(overlap.asks[0].sell, 100_000_000.0);
-
         // Transitive order `1 -> 0` buying 1 selling 0
+        assert_eq!(overlap.asks.len(), 1);
+        assert_approx_eq!(overlap.asks[0].buy, 1_000_000.0);
+        assert_approx_eq!(overlap.asks[0].sell, 1_000_000.0);
+
+        // Transitive order `0 -> 1` buying 0 selling 1
         assert_eq!(overlap.bids.len(), 1);
-        assert_approx_eq!(overlap.bids[0].buy, 1_000_000.0);
-        assert_approx_eq!(overlap.bids[0].sell, 1_000_000.0);
+        assert_approx_eq!(overlap.bids[0].buy, 50_000_000.0);
+        assert_approx_eq!(overlap.bids[0].sell, 100_000_000.0);
 
         // NOTE: This is counter-intuitive, but there should only be one
         // transitive order from `1 -> 0` even if there are two orders that


### PR DESCRIPTION
Fixes the direction of ask/bid orders (again :rofl:).

:warning: Please review with caution! :warning: 

### Test Plan

Updated unit tests by flipping ask and bid orders without changing values. They seem to pass!