### PR TITLE
Build price estimator image based on alpine

### DIFF
--- a/price-estimator/docker/Dockerfile
+++ b/price-estimator/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.43-stretch as builder
+FROM clux/muslrust:1.43.1-stable as builder
 WORKDIR /usr/src/app
 COPY Cargo.toml .
 COPY Cargo.lock .
@@ -10,12 +10,8 @@ COPY pricegraph pricegraph
 COPY price-estimator price-estimator
 RUN ls -l && cargo build --release -p price-estimator
 
-FROM debian:stretch-slim
-# Needed so that price-estimator works with https node urls.
-RUN apt-get update && apt-get --yes install openssl ca-certificates
-COPY --from=builder /usr/src/app/target/release/price-estimator /bin/
-ADD docker/rust/tini /tini
-RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--"]
+FROM alpine:latest
+COPY --from=builder /usr/src/app/target/x86_64-unknown-linux-musl/release/price-estimator /bin/
+RUN apk add -u tini
+ENTRYPOINT ["tini", "--"]
 CMD ["price-estimator"]
-


### PR DESCRIPTION
Fixes #1027 

This PR adds the necessary changes in order to build an alpine based image for the price estimator.

Note that the image is still fairly large (price estimator is a 20MB?! binary).
```
$ docker images
REPOSITORY                                      TAG             IMAGE ID       CREATED          SIZE
pe                                              latest          6a21ba0a7202   35 minutes ago   26.4 MB
```

This is currenty implemented by pulling a `crux/muslrust` image that is setup for cross compiling x86_64 musl targets and includes musl libraries for linking (such as openssl). 

For comparison, here is the current image, so its about 1/4 of the size (also the Rust image is 1.23GB).

```
$ docker images
REPOSITORY                                      TAG             IMAGE ID       CREATED              SIZE
pe                                              latest          6ea8d7a1e1d1   About a minute ago   101 MB
```

### Test Plan

```
$ docker build -t pe -f price-estimator/docker/Dockerfile .
...
$ docker run -it --rm -e RUST_LOG=info -e ETHEREUM_NODE_URL pe
[2020-06-19T10:25:02Z INFO  price_estimator] Starting price estimator with runtime options: Options {
```