### PR TITLE
Include 1inch exchange in price estimation

### DIFF
--- a/core/src/metrics/http_metrics.rs
+++ b/core/src/metrics/http_metrics.rs
@@ -108,6 +108,7 @@ labels! {
         EthBatchRPC => "eth_batch_rpc",
         Kraken => "kraken",
         Dexag => "dexag",
+        Oneinch => "oneinch",
         GasStation => "gas_station",
     }
 }

--- a/core/src/price_estimation.rs
+++ b/core/src/price_estimation.rs
@@ -5,6 +5,7 @@ mod average_price_source;
 pub mod data;
 mod dexag;
 mod kraken;
+mod oneinch;
 mod orderbook_based;
 mod price_source;
 mod threaded_price_source;
@@ -12,6 +13,7 @@ mod threaded_price_source;
 pub use self::data::{TokenBaseInfo, TokenData};
 use self::dexag::DexagClient;
 use self::kraken::KrakenClient;
+use self::oneinch::OneinchClient;
 use self::orderbook_based::PricegraphEstimator;
 use crate::{
     http::HttpFactory,
@@ -69,9 +71,15 @@ impl PriceOracle {
                 DexagClient::new(http_factory, tokens.clone())?,
                 update_interval,
             );
+            let (oneinch_source, _) = ThreadedPriceSource::new(
+                tokens.all_ids(),
+                OneinchClient::new(http_factory, tokens.clone())?,
+                update_interval,
+            );
             Box::new(AveragePriceSource::new(vec![
                 Box::new(kraken_source),
                 Box::new(dexag_source),
+                Box::new(oneinch_source),
                 Box::new(PricegraphEstimator::new(orderbook_reader)),
             ]))
         };

--- a/core/src/price_estimation/oneinch/api.rs
+++ b/core/src/price_estimation/oneinch/api.rs
@@ -1,0 +1,177 @@
+use crate::http::{HttpClient, HttpFactory, HttpLabel};
+use anyhow::{Context, Result};
+use ethcontract::Address;
+use futures::future::{BoxFuture, FutureExt as _};
+use serde::Deserialize;
+use std::collections::HashMap;
+use url::Url;
+
+/// 1inch API version v1.1
+/// https://1inch.exchange/#/api
+#[cfg_attr(test, mockall::automock)]
+pub trait OneinchApi {
+    fn get_token_list<'a>(&'a self) -> BoxFuture<'a, Result<Vec<Token>>>;
+    /// Returns the price of one unit of `from` expressed in `to`.
+    /// For example `get_price("ETH", "DAI")` is ~220.
+    fn get_price<'a>(&'a self, from: &Token, to: &Token) -> BoxFuture<'a, Result<f64>>;
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct Token {
+    pub name: String,
+    pub symbol: String,
+    pub address: Option<Address>,
+    pub decimals: u8,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TradedAmounts {
+    to_token_amount: String,
+    from_token_amount: String,
+}
+
+#[derive(Debug)]
+pub struct OneinchHttpApi {
+    api_url: Url,
+    client: HttpClient,
+}
+
+pub const DEFAULT_API_URL: &str = "https://api.1inch.exchange/v1.1/";
+
+impl OneinchHttpApi {
+    pub fn new(http_factory: &HttpFactory) -> Result<Self> {
+        Self::with_url(http_factory, DEFAULT_API_URL)
+    }
+
+    pub fn with_url(http_factory: &HttpFactory, api_url: &str) -> Result<Self> {
+        let client = http_factory
+            .create()
+            .context("failed to initialize HTTP client")?;
+        let api_url = api_url
+            .parse()
+            .with_context(|| format!("failed to parse url {}", api_url))?;
+        Ok(OneinchHttpApi { api_url, client })
+    }
+}
+
+impl OneinchApi for OneinchHttpApi {
+    fn get_token_list<'a>(&'a self) -> BoxFuture<'a, Result<Vec<Token>>> {
+        async move {
+            let url = self.api_url.join("tokens").unwrap();
+            let token_mapping: HashMap<String, Token> = self
+                .client
+                .get_json_async(url.to_string(), HttpLabel::Oneinch)
+                .await
+                .context("failed to parse token list json from 1inch response")?;
+            Ok(token_mapping
+                .into_iter()
+                .map(|(_token_symbol, token_data)| token_data)
+                .collect())
+        }
+        .boxed()
+    }
+
+    fn get_price<'a>(&'a self, from: &Token, to: &Token) -> BoxFuture<'a, Result<f64>> {
+        let mut url = self.api_url.join("quote").unwrap();
+        // 1inch requires the user to specify the amount traded in atoms.
+        // We compute the price when selling one full token to avoid unavoidable rounding
+        // artifacts when selling exactly one token atom.
+        // This makes the computed price less reliable for very expensive tokens like WBTC.
+        let mut one_token_from = String::from("1");
+        one_token_from.push_str(&String::from("0").repeat(from.decimals as usize));
+        {
+            // This is in its own block because we are supposed to drop `q`.
+            let mut q = url.query_pairs_mut();
+            q.append_pair("fromTokenSymbol", &from.symbol);
+            q.append_pair("toTokenSymbol", &to.symbol);
+            q.append_pair("amount", &one_token_from);
+        }
+        let decimal_correction: f64 = 10_f64.powi(from.decimals as i32 - to.decimals as i32);
+
+        async move {
+            let traded_amounts: TradedAmounts = self
+                .client
+                .get_json_async::<_, TradedAmounts>(url.as_str(), HttpLabel::Oneinch)
+                .await
+                .context("failed to parse price json from 1inch")?;
+            let num: f64 = traded_amounts.to_token_amount.parse()?;
+            let den: f64 = traded_amounts.from_token_amount.parse()?;
+            Ok(decimal_correction * num / den)
+        }
+        .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::FutureWaitExt as _;
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn deserialize_price() {
+        let json = r#"{"fromToken":{"symbol":"ETH","name":"Ethereum","decimals":18,"address":"0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"},"toToken":{"symbol":"DAI","name":"Dai Stablecoin","decimals":18,"address":"0x6b175474e89094c44da98b954eedeac495271d0f"},"toTokenAmount":"23897808590784919590159","fromTokenAmount":"100000000000000000000","exchanges":[{"name":"MultiSplit","part":100},{"name":"Mooniswap","part":0},{"name":"Oasis","part":0},{"name":"Kyber","part":0},{"name":"Uniswap","part":0},{"name":"Balancer","part":0},{"name":"PMM","part":0},{"name":"Uniswap V2","part":0},{"name":"0x Relays","part":0},{"name":"0x API","part":0},{"name":"AirSwap","part":0}]}"#;
+        let price: TradedAmounts = serde_json::from_str(json).unwrap();
+        assert_eq!(price.to_token_amount, "23897808590784919590159");
+        assert_eq!(price.from_token_amount, "100000000000000000000");
+    }
+
+    #[test]
+    fn deserialize_token() {
+        use std::str::FromStr as _;
+        let json = r#"{"symbol":"SAI","name":"Sai Stablecoin","decimals":18,"address":"0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359"}"#;
+        let token: Token = serde_json::from_str(json).unwrap();
+        assert_eq!(token.name, "Sai Stablecoin");
+        assert_eq!(token.symbol, "SAI");
+        assert_eq!(token.decimals, 18);
+        assert_eq!(
+            token.address.unwrap(),
+            Address::from_str("89d24a6b4ccb1b6faa2625fe562bdd9a23260359").unwrap()
+        );
+    }
+
+    #[test]
+    fn deserialize_token_no_address() {
+        let json = r#"{"symbol":"SAI","name":"Sai Stablecoin","decimals":18}"#;
+        let token: Token = serde_json::from_str(json).unwrap();
+        assert_eq!(token.name, "Sai Stablecoin");
+        assert_eq!(token.symbol, "SAI");
+        assert_eq!(token.decimals, 18);
+        assert!(token.address.is_none());
+    }
+
+    // Run with `cargo test online_oneinch_api -- --ignored --nocapture`.
+    #[test]
+    #[ignore]
+    fn online_oneinch_api() {
+        use crate::metrics::HttpMetrics;
+        use std::time::Duration;
+
+        let timeout = 20;
+        let api = OneinchHttpApi::new(&HttpFactory::new(
+            Duration::from_secs(timeout),
+            HttpMetrics::default(),
+        ))
+        .unwrap();
+        let tokens = api.get_token_list().wait().unwrap();
+        println!("{:#?}", tokens);
+
+        let dai_index = tokens.iter().position(|data| data.symbol == "DAI").unwrap();
+        let eth_index = tokens.iter().position(|data| data.symbol == "ETH").unwrap();
+        let usdc_index = tokens
+            .iter()
+            .position(|data| data.symbol == "USDC")
+            .unwrap();
+        let price = api
+            .get_price(&tokens[eth_index], &tokens[dai_index])
+            .wait()
+            .unwrap();
+        println!("1 ETH = {:#?} DAI", price);
+        let price = api
+            .get_price(&tokens[eth_index], &tokens[usdc_index])
+            .wait()
+            .unwrap();
+        println!("1 ETH = {:#?} USDC", price);
+    }
+}


### PR DESCRIPTION
Fixes #720. 

Adds a new price source ([1inch](https://1inch.exchange/#/)) to the price estimator.

The code is an adaptation of that used to retrieve prices from dex.ag. The file `oneinch/api.rs` has meaningful differences from `dexag/api.rs` but `oneinch.rs` is basically a one-to-one copy of `dexag.rs`.

The 1inch API is very slow and easily needs more than 10 seconds to retrieve a price, often causing timeouts.

The PR should be already working, but I didn't test it in conjunction with the price estimator. The only thing remaining to do is to avoid the many lines of repeated code between `oneinch.rs` and `dexag.rs`, I'm not sure how to do it yet.

### Test Plan
Change directory to `core/` for better output of `cargo test`:
```
cd core
```

Make real requests to 1inch and see that the output prices are reasonable:
```
cargo test online_oneinch_api -- --ignored --nocapture
```

Note that the slowness of the requests is not caused by the implementation in this PR:
```
time curl "https://api.1inch.exchange/v1.1/quote?fromTokenSymbol=USDC&toTokenSymbol=DAI&amount=1000000" --output /dev/null
```

Compare line by line the prices of 1inch to the prices of dex.ag:
```
cargo build --tests && paste -d "#" <(cargo test online_oneinch_client -- --ignored --nocapture) <(cargo test online_dexag_client -- --ignored --nocapture) | sed "s/#/ <- 1inch\n/"
```
Sample output of the last command, note the missing prices due to timeouts:
```
running 1 test <- 1inch
running 1 test
Took 10.518514885 seconds to get prices. <- 1inch
Took 2.110943505 seconds to get prices.
Token ETH has OWL price of 226470049051339030528. <- 1inch
Token ETH has OWL price of 227370694069496152064.
Token USDT has OWL price of 1005815486204136000326822002688. <- 1inch
Token USDT has OWL price of 983989709816405959978292084736.
Token TUSD has OWL price of 1004707381819122944. <- 1inch
Token TUSD has OWL price of 991025488893842176.
Token USDC price could not be determined. <- 1inch
Token USDC has OWL price of 992005456984695744951587176448.
Token PAX has OWL price of 998353906976356352. <- 1inch
Token PAX has OWL price of 986253126953412992.
Token GUSD has OWL price of 11008608923638855295817765036752896. <- 1inch
Token GUSD price could not be determined.
Token DAI has OWL price of 1000000000000000000. <- 1inch
Token DAI has OWL price of 1000000000000000000.
Token sETH has OWL price of 223512352765316071424. <- 1inch
Token sETH has OWL price of 223512352765316300800.
Token sUSD price could not be determined. <- 1inch
Token sUSD has OWL price of 981514917038773760.
Token SNX has OWL price of 1346363348924041728. <- 1inch
Token SNX has OWL price of 1345185285168334592.
test price_estimation::oneinch::tests::online_oneinch_client ... ok <- 1inch
test price_estimation::dexag::tests::online_dexag_client ... ok
```