### PR TITLE
Revert "fix transitive orderbook ask/bid direction (#1029)"

### DIFF
--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -83,8 +83,8 @@ async fn get_markets<T>(
     orderbook: Arc<Orderbook<T>>,
 ) -> Result<impl warp::Reply, Infallible> {
     let transitive_orderbook = orderbook.get_pricegraph().await.transitive_orderbook(
-        token_pair.buy_token_id,
         token_pair.sell_token_id,
+        token_pair.buy_token_id,
         None,
     );
     let result = MarketsResult::from(&transitive_orderbook);

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -215,6 +215,7 @@ impl Pricegraph {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use primitive_types::U256;
 
     #[test]
     fn transitive_orderbook_empty_same_token() {
@@ -222,6 +223,42 @@ mod tests {
         let orderbook = pricegraph.transitive_orderbook(0, 0, None);
         assert!(orderbook.asks.is_empty());
         assert!(orderbook.bids.is_empty());
+    }
+
+    #[test]
+    fn transitive_orderbook_simple() {
+        let user0 = UserId::from_low_u64_le(0);
+        let base: u128 = 1_000_000_000_000;
+        let pricegraph = Pricegraph::new(vec![Element {
+            user: user0,
+            balance: U256::from(2) * U256::from(base),
+            pair: TokenPair { buy: 0, sell: 1 },
+            valid: Validity { from: 0, to: 1 },
+            price: Price {
+                numerator: 2 * base,
+                denominator: base,
+            },
+            remaining_sell_amount: base,
+            id: 0,
+        }]);
+        let orderbook = pricegraph.transitive_orderbook(0, 1, None);
+        assert_eq!(
+            orderbook.asks,
+            vec![TransitiveOrder {
+                buy: 2.0 * base as f64,
+                sell: base as f64,
+            }]
+        );
+        assert_eq!(orderbook.bids, vec![]);
+        let orderbook = pricegraph.transitive_orderbook(1, 0, None);
+        assert_eq!(orderbook.asks, vec![]);
+        assert_eq!(
+            orderbook.bids,
+            vec![TransitiveOrder {
+                buy: 2.0 * base as f64,
+                sell: base as f64,
+            }]
+        );
     }
 
     #[test]

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -184,7 +184,7 @@ impl Orderbook {
 
             if path.first() == Some(&quote) {
                 if let Some(base_index) = path.iter().position(|node| *node == base) {
-                    let (ask, bid) = (&path[0..base_index + 1], &path[base_index..]);
+                    let (bid, ask) = (&path[0..base_index + 1], &path[base_index..]);
 
                     let (capacity, transitive_price) = self
                         .fill_path(ask)
@@ -833,15 +833,15 @@ mod tests {
 
         let overlap = orderbook.reduce_overlapping_transitive_orderbook(1, 2);
 
-        // Transitive order `2 -> 3 -> 1` buying 2 selling 1
-        assert_eq!(overlap.asks.len(), 1);
-        assert_approx_eq!(overlap.asks[0].buy, 500_000.0);
-        assert_approx_eq!(overlap.asks[0].sell, 500_000.0 / FEE_FACTOR);
-
         // Transitive order `1 -> 2` buying 1 selling 2
+        assert_eq!(overlap.asks.len(), 1);
+        assert_approx_eq!(overlap.asks[0].buy, 1_000_000.0);
+        assert_approx_eq!(overlap.asks[0].sell, 2_000_000.0);
+
+        // Transitive order `2 -> 3 -> 1` buying 2 selling 1
         assert_eq!(overlap.bids.len(), 1);
-        assert_approx_eq!(overlap.bids[0].buy, 1_000_000.0);
-        assert_approx_eq!(overlap.bids[0].sell, 2_000_000.0);
+        assert_approx_eq!(overlap.bids[0].buy, 500_000.0);
+        assert_approx_eq!(overlap.bids[0].sell, 500_000.0 / FEE_FACTOR);
     }
 
     #[test]
@@ -871,15 +871,15 @@ mod tests {
 
         let overlap = orderbook.reduce_overlapping_transitive_orderbook(0, 1);
 
-        // Transitive order `1 -> 0` buying 1 selling 0
-        assert_eq!(overlap.asks.len(), 1);
-        assert_approx_eq!(overlap.asks[0].buy, 1_000_000.0);
-        assert_approx_eq!(overlap.asks[0].sell, 1_000_000.0);
-
         // Transitive order `0 -> 1` buying 0 selling 1
+        assert_eq!(overlap.asks.len(), 1);
+        assert_approx_eq!(overlap.asks[0].buy, 50_000_000.0);
+        assert_approx_eq!(overlap.asks[0].sell, 100_000_000.0);
+
+        // Transitive order `1 -> 0` buying 1 selling 0
         assert_eq!(overlap.bids.len(), 1);
-        assert_approx_eq!(overlap.bids[0].buy, 50_000_000.0);
-        assert_approx_eq!(overlap.bids[0].sell, 100_000_000.0);
+        assert_approx_eq!(overlap.bids[0].buy, 1_000_000.0);
+        assert_approx_eq!(overlap.bids[0].sell, 1_000_000.0);
 
         // NOTE: This is counter-intuitive, but there should only be one
         // transitive order from `1 -> 0` even if there are two orders that


### PR DESCRIPTION
This reverts commit f9abf3ea0b4c31724874d63a04de5a85c0ebeed8.

The reason for this is that when I tested the rust price estimator
against the node price estimator again just now I noticed that the asks
and bids are reverted: visualizing the orderbook for pair A-B in the
node price estimator is the same as pair B-A in the rust price
estimator.
The reason we made the PR I am reverting here is given in https://github.com/gnosis/dex-services/pull/1021#discussion_r441311440 .

I am not yet sure where the bug is but until we find it we should
revert.

### Test Plan
Visually comparing both price estimators through the front end.