### PR TITLE
Turn threaded price source background thread into async task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c07dab4369547dbe5114677b33fbbf724971019f3818172d59a97a61c774ffd"
 
 [[package]]
+name = "async-std"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00d68a33ebc8b57800847d00787307f84a562224a14db069b0acefe4c2abbf5d"
+dependencies = [
+ "async-task",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "kv-log-macro",
+ "log 0.4.8",
+ "memchr",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab 0.4.2",
+ "smol",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +314,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 
 [[package]]
+name = "cache-padded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24508e28c677875c380c20f4d28124fab6f8ed4ef929a1397d7b1a31e92f1005"
+
+[[package]]
 name = "cast"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +382,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83c06aff61f2d899eb87c379df3cbf7876f14471dcab474e0b6dc90ab96c080"
+dependencies = [
+ "cache-padded",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +411,7 @@ name = "core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-std",
  "bincode",
  "blocking",
  "byteorder",
@@ -914,6 +959,12 @@ name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "fastrand"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64b0126b293b050395b37b10489951590ed024c03d7df4f249d219c8ded7cbf"
 
 [[package]]
 name = "filetime"
@@ -1553,6 +1604,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ff57d6d215f7ca7eb35a9a64d656ba4d9d2bef114d741dc08048e75e2f5d418"
+dependencies = [
+ "log 0.4.8",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,9 +1626,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.69"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
+checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2969,6 +3029,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05720e22615919e4734f6a99ceae50d00226c3c5aca406e102ebc33298214e0a"
 
 [[package]]
+name = "smol"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "620cbb3c6e34da57d3a248cda0cd01cd5848164dc062e764e65d06fe3ea7aed5"
+dependencies = [
+ "async-task",
+ "blocking",
+ "concurrent-queue",
+ "fastrand",
+ "futures-io",
+ "futures-util",
+ "libc",
+ "once_cell",
+ "scoped-tls 1.0.0",
+ "slab 0.4.2",
+ "socket2",
+ "wepoll-sys-stjepang",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "socket2"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3968,6 +4049,15 @@ dependencies = [
  "tokio-tls",
  "unicase 1.4.2",
  "url 1.7.2",
+]
+
+[[package]]
+name = "wepoll-sys-stjepang"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fd319e971980166b53e17b1026812ad66c6b54063be879eb182342b55284694"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
+async-std = "1.6"
 bincode = "1.2.1"
 blocking = "0.4.6"
 byteorder = "1.3.4"

--- a/core/src/price_estimation/threaded_price_source.rs
+++ b/core/src/price_estimation/threaded_price_source.rs
@@ -1,90 +1,48 @@
 use super::price_source::PriceSource;
-use crate::{models::TokenId, util::FutureWaitExt as _};
+use crate::models::TokenId;
 use anyhow::Result;
-use futures::{
-    future::{BoxFuture, FutureExt as _},
-    lock::Mutex,
+use async_std::{
+    sync::Mutex,
+    task::{self, JoinHandle},
 };
+use futures::future::{BoxFuture, FutureExt as _};
 use std::collections::HashMap;
-#[cfg(test)]
-use std::sync::mpsc::Receiver;
-use std::sync::{
-    mpsc::{self, RecvTimeoutError, Sender},
-    Arc,
-};
-use std::thread::{self, JoinHandle};
+use std::sync::Arc;
 use std::time::Duration;
 
-/// Implements `PriceSource` in a non blocking way by updating prices in a
-/// thread and reusing previous results.
+/// Implements a `PriceSource` that is always immediately ready by updating itself in a background
+/// task and using the most recent update.
 pub struct ThreadedPriceSource {
-    // Shared between this struct and the thread. The background thread writes
-    // the prices, the thread calling `get_prices` reads them.
+    // Shared between this struct and the task. The task writes the prices and `get_prices` reads
+    // them.
     price_map: Arc<Mutex<HashMap<TokenId, u128>>>,
-    // Allows the thread to notice when the owning struct is dropped.
-    // Mutex is not needed because we don't access the sender at all but we need
-    // this struct to be sync and this makes the compiler happy.
-    _channel_to_thread: Mutex<Sender<()>>,
-
-    // To make testing easier we use another channel to which the thread sends
-    // a message whenever it completes one update loop.
-    #[cfg(test)]
-    test_receiver: Mutex<Receiver<()>>,
 }
 
 impl ThreadedPriceSource {
     /// All token prices will be updated every `update_interval`. Prices for
     /// other tokens will not be returned in `get_prices`.
     ///
-    /// The join handle represents the background thread. It can be used to
-    /// verify that it exits when the created struct is dropped.
-    pub fn new<T: 'static + PriceSource + Send>(
+    /// The join handle represents the task. It can be used to verify that it exits when the struct
+    /// is dropped.
+    pub fn new<T: 'static + PriceSource + Send + Sync>(
         tokens: Vec<TokenId>,
         price_source: T,
         update_interval: Duration,
     ) -> (Self, JoinHandle<()>) {
         let price_map = Arc::new(Mutex::new(HashMap::new()));
-        let (sender, receiver) = mpsc::channel::<()>();
-
-        #[cfg(test)]
-        let (test_sender, test_receiver) = mpsc::channel::<()>();
-
-        let join_handle = thread::spawn({
-            let price_map = price_map.clone();
-
-            // vk: Clippy notes that the following loop and match can be written
-            // as a `while let` loop but I find it clearer to make all cases
-            // explicit.
-            #[allow(clippy::while_let_loop)]
-            move || loop {
-                match receiver.recv_timeout(update_interval) {
-                    Ok(()) | Err(RecvTimeoutError::Timeout) => {
-                        // Make sure we don't hold the mutex while this blocking call happens.
-                        match price_source.get_prices(&tokens).wait() {
-                            Ok(prices) => price_map.lock().wait().extend(prices),
-                            Err(err) => log::warn!("price_source::get_prices failed: {}", err),
-                        }
+        let join_handle = task::spawn({
+            let price_map = Arc::downgrade(&price_map);
+            async move {
+                while let Some(price_map) = price_map.upgrade() {
+                    match price_source.get_prices(&tokens).await {
+                        Ok(prices) => price_map.lock().await.extend(prices),
+                        Err(err) => log::warn!("price_source::get_prices failed: {}", err),
                     }
-                    // The owning struct has been dropped.
-                    Err(RecvTimeoutError::Disconnected) => break,
+                    task::sleep(update_interval).await;
                 }
-
-                #[cfg(test)]
-                let _ = test_sender.send(());
             }
         });
-
-        // Update the prices immediately.
-        sender.send(()).unwrap();
-        (
-            Self {
-                price_map,
-                _channel_to_thread: Mutex::new(sender),
-                #[cfg(test)]
-                test_receiver: Mutex::new(test_receiver),
-            },
-            join_handle,
-        )
+        (Self { price_map }, join_handle)
     }
 }
 
@@ -108,61 +66,34 @@ impl PriceSource for ThreadedPriceSource {
 mod tests {
     use super::super::price_source::MockPriceSource;
     use super::*;
+    use crate::util::FutureWaitExt;
+    use futures::future::{self, Either};
     use std::sync::atomic;
     use std::time::Instant;
 
     const ORDERING: atomic::Ordering = atomic::Ordering::SeqCst;
     const THREAD_TIMEOUT: Duration = Duration::from_secs(1);
-
-    lazy_static::lazy_static! {
-        static ref TOKENS: [TokenId; 3] = [
-            TokenId(0),
-            TokenId(1),
-            TokenId(2),
-        ];
-    }
+    const UPDATE_INTERVAL: Duration = Duration::from_millis(1);
+    const TOKENS: [TokenId; 1] = [TokenId(0)];
 
     /// Drops tps and joins the handle which ensures that the thread exits and
     /// hasn't panicked. This is important because the mockall expectation
     /// panics happen in the thread which would otherwise let the tests pass
     /// when an expectation is violated.
-    fn join(tps: ThreadedPriceSource, handle: JoinHandle<()>) {
-        fn extract_test_receiver(tps: ThreadedPriceSource) -> Receiver<()> {
-            tps.test_receiver.into_inner()
+    async fn join(tps: ThreadedPriceSource, handle: JoinHandle<()>) {
+        std::mem::drop(tps);
+        let timeout = task::sleep(THREAD_TIMEOUT);
+        futures::pin_mut!(timeout);
+        if let Either::Right(_) = future::select(handle, timeout).await {
+            panic!("Background task of ThreadedPriceSource did not exit in time after owner was dropped.");
         }
-        let test_receiver = extract_test_receiver(tps);
-        let deadline = Instant::now() + THREAD_TIMEOUT;
-        loop {
-            match test_receiver.recv_timeout(THREAD_TIMEOUT) {
-                // The sender side of `test_receiver` has been dropped which
-                // only happens when the thread exits.
-                Err(RecvTimeoutError::Disconnected) => break,
-                // There is still a queued messages on the channel.
-                Ok(_) if Instant::now() <= deadline => continue,
-                Ok(_) | Err(RecvTimeoutError::Timeout) =>
-                    panic!("Background thread of ThreadedPriceSource did not exit in time after owner was dropped."),
-            }
-        }
-        // Propagate any panic.
-        // Does not block because we know the thread has exited.
-        handle.join().unwrap();
     }
 
-    fn wait_for_thread_to_loop(tps: &ThreadedPriceSource) {
-        // Clear previous messages.
-        let deadline = Instant::now() + THREAD_TIMEOUT;
-        for _ in tps.test_receiver.lock().now_or_never().unwrap().try_iter() {
-            if Instant::now() >= deadline {
-                panic!("Background thread of ThreadedPriceSource ran too many loops.");
-            }
+    fn wait_for_condition(mut condition: impl FnMut() -> bool, deadline: Instant) {
+        while !condition() {
+            assert!(Instant::now() <= deadline, "condition not true in time");
+            std::thread::sleep(UPDATE_INTERVAL);
         }
-        // Wait for one new message.
-        tps.test_receiver
-            .lock()
-            .now_or_never()
-            .unwrap()
-            .recv_timeout(THREAD_TIMEOUT)
-            .unwrap();
     }
 
     #[test]
@@ -170,43 +101,31 @@ mod tests {
         let mut ps = MockPriceSource::new();
         ps.expect_get_prices()
             .returning(|_| async { Ok(HashMap::new()) }.boxed());
-        let (tps, handle) =
-            ThreadedPriceSource::new(TOKENS.to_vec(), ps, Duration::from_secs(std::u64::MAX));
-        join(tps, handle);
+        let (tps, handle) = ThreadedPriceSource::new(TOKENS.to_vec(), ps, UPDATE_INTERVAL);
+        join(tps, handle).wait();
     }
 
     #[test]
     fn update_triggered_by_interval() {
         let mut price_source = MockPriceSource::new();
-        let start_returning = Arc::new(atomic::AtomicBool::new(false));
+        let price = Arc::new(atomic::AtomicU8::new(0));
         price_source.expect_get_prices().returning({
-            let start_returning = start_returning.clone();
+            let price = price.clone();
             move |_| {
-                let start_returning_ = start_returning.clone();
-                async move {
-                    Ok(if start_returning_.load(ORDERING) {
-                        hash_map! {TOKENS[0] => 1}
-                    } else {
-                        hash_map! {}
-                    })
-                }
-                .boxed()
+                let price_ = price.clone();
+                async move { Ok(hash_map! { TOKENS[0] => price_.load(ORDERING) as u128 }) }.boxed()
             }
         });
 
         let (tps, handle) =
-            ThreadedPriceSource::new(TOKENS.to_vec(), price_source, Duration::from_millis(1));
-        assert_eq!(
-            tps.get_prices(&TOKENS[..]).now_or_never().unwrap().unwrap(),
-            hash_map! {}
-        );
-        wait_for_thread_to_loop(&tps);
-        start_returning.store(true, ORDERING);
-        wait_for_thread_to_loop(&tps);
-        assert_eq!(
-            tps.get_prices(&TOKENS[..]).now_or_never().unwrap().unwrap(),
-            hash_map! {TOKENS[0] => 1}
-        );
-        join(tps, handle);
+            ThreadedPriceSource::new(TOKENS.to_vec(), price_source, UPDATE_INTERVAL);
+        let get_prices = || tps.get_prices(&TOKENS[..]).wait().unwrap();
+        price.store(1, ORDERING);
+        let condition = || get_prices().get(&TOKENS[0]) == Some(&1);
+        wait_for_condition(condition, Instant::now() + THREAD_TIMEOUT);
+        price.store(2, ORDERING);
+        let condition = || get_prices().get(&TOKENS[0]) == Some(&2);
+        wait_for_condition(condition, Instant::now() + THREAD_TIMEOUT);
+        join(tps, handle).wait();
     }
 }


### PR DESCRIPTION
using async-std.
Simplified the threaded price source in several places:
* get rid of code only compiled for tests
* use weak ptr to observe dropping of parent struct

Now that we have async_std I turned futures::Mutex into async_std::Mutex
and futures_timer::sleep into async_std::sleep. If this gets merged we
can do the same changes in other places and remove the futures-timer
dependency.

### Test Plan
CI