### PR TITLE
Bump solver version to v0.7.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ language: rust
 env:
   global:
     - OPEN_SOLVER_VERSION=v0.0.10
-    - PRIVATE_SOLVER_VERSION=v0.7.4
+    - PRIVATE_SOLVER_VERSION=v0.7.5
 
 install:
   - nvm install 12 && nvm alias default 12 && npm install -g yarn@latest && yarn --version


### PR DESCRIPTION
This version contains another speed-up PR for finding the best cycle in the best-ring-solver:
https://github.com/gnosis/dex-solver/pull/287

### Test Plan
e2e tests