### PR TITLE
Compute auction state for historic batches

### DIFF
--- a/core/src/orderbook/streamed/state.rs
+++ b/core/src/orderbook/streamed/state.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::contracts::stablex_contract::batch_exchange::{event_data::*, Event};
-use crate::models::Order as ModelOrder;
+use crate::models::{AccountState, Order as ModelOrder};
+use crate::orderbook::util;
 use anyhow::{anyhow, bail, ensure, Result};
 use balance::Balance;
 use order::Order;
@@ -37,6 +38,15 @@ struct LastSolution {
 }
 
 impl State {
+    /// Creates a new state from an iterator of events with corresponding batch IDs.
+    pub fn from_events<'a>(events: impl IntoIterator<Item = (&'a Event, u32)>) -> Result<Self> {
+        events
+            .into_iter()
+            .try_fold(State::default(), |state, (event, batch_id)| {
+                state.apply_event(event, batch_id)
+            })
+    }
+
     /// Returns the orderbook when the requested batch started collecting orders given all events received so far.
     ///
     /// Errors if State has only received a partial solution which would make the result
@@ -61,6 +71,20 @@ impl State {
             "retrieved orderbook with a partially applied solution",
         );
         Ok((self.account_state(batch_id), self.orders(batch_id)))
+    }
+
+    /// Returns the normalized auction when the requested batch started collecting orders given all
+    /// events received so far.
+    ///
+    /// See `State::orderbook_at_beginning_of_batch` for more details on possible errors.
+    pub fn normalized_auction_state_at_beginning_of_batch(
+        &self,
+        batch_id: BatchId,
+    ) -> Result<(AccountState, Vec<ModelOrder>)> {
+        let (account_state, orders) = self.orderbook_at_beginning_of_batch(batch_id)?;
+        let (account_state, orders) = util::normalize_auction_data(account_state, orders);
+
+        Ok((account_state, orders))
     }
 
     fn account_state(

--- a/core/src/orderbook/streamed/state.rs
+++ b/core/src/orderbook/streamed/state.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::contracts::stablex_contract::batch_exchange::{event_data::*, Event};
-use crate::models::{AccountState, Order as ModelOrder};
-use crate::orderbook::util;
+use crate::models::Order as ModelOrder;
 use anyhow::{anyhow, bail, ensure, Result};
 use balance::Balance;
 use order::Order;
@@ -71,20 +70,6 @@ impl State {
             "retrieved orderbook with a partially applied solution",
         );
         Ok((self.account_state(batch_id), self.orders(batch_id)))
-    }
-
-    /// Returns the normalized auction when the requested batch started collecting orders given all
-    /// events received so far.
-    ///
-    /// See `State::orderbook_at_beginning_of_batch` for more details on possible errors.
-    pub fn normalized_auction_state_at_beginning_of_batch(
-        &self,
-        batch_id: BatchId,
-    ) -> Result<(AccountState, Vec<ModelOrder>)> {
-        let (account_state, orders) = self.orderbook_at_beginning_of_batch(batch_id)?;
-        let (account_state, orders) = util::normalize_auction_data(account_state, orders);
-
-        Ok((account_state, orders))
     }
 
     fn account_state(


### PR DESCRIPTION
This PR adds the ability to `streamed::Orderbook` to retrieve auction states for historic batch IDs.

### Test Plan

New unit test :tada: 