### PR TITLE
Implement estimated sell amount route

### DIFF
--- a/price-estimator/README.md
+++ b/price-estimator/README.md
@@ -53,3 +53,31 @@ Example Response:
 
 * `buyAmountInBase` estimates the buy amount (in base tokens) a user can set as a limit order while still expecting to be completely matched when selling the given amount of quote token.
 * The other fields repeat the parameters in the url back.
+
+### Estimated Sell Amount
+
+`GET /api/v1/markets/:market/estimated-sell-amount/:price-in-quote`
+
+* `market` is as above
+* `price_in_quote` is a decimal number.
+
+Url query is as above.
+
+Example Request: `/api/v1/markets/1-7/estimated-sell-amount/245.5?atoms=true`
+
+Example Response:
+
+```json
+{
+    "baseTokenId": "1",
+    "quoteTokenId": "7",
+    "buyAmountInBase": "1103276584712580736",
+    "sellAmountInQuote": "271125527074012594176"
+}
+```
+
+The following result indicates that if we wanted to buy ETH (token 1) for DAI (token 7) and pay 245.5 DAI per unit of ETH, we would be able to sell an estimated maximum 271.13 DAI.
+
+* `sellAmountInBase` estimates the sell amount (in quote tokens) a user can completely fill in the following batch at the specified `price_in_quote`.
+* `buyAmountInBase` is the computed buy amount (in base tokens) for the order from the specified price and estimated sell amount.
+* The other fields repeat the parameters in the url back.

--- a/price-estimator/README.md
+++ b/price-estimator/README.md
@@ -56,14 +56,14 @@ Example Response:
 
 ### Estimated Sell Amount
 
-`GET /api/v1/markets/:market/estimated-sell-amount/:price-in-quote`
+`GET /api/v1/markets/:market/estimated-amounts-at-price/:price-in-quote`
 
 * `market` is as above
 * `price_in_quote` is a decimal number.
 
 Url query is as above.
 
-Example Request: `/api/v1/markets/1-7/estimated-sell-amount/245.5?atoms=true`
+Example Request: `/api/v1/markets/1-7/estimated-amounts-at-price/245.5?atoms=true`
 
 Example Response:
 
@@ -71,8 +71,8 @@ Example Response:
 {
     "baseTokenId": "1",
     "quoteTokenId": "7",
-    "buyAmountInBase": "1103276584712580736",
-    "sellAmountInQuote": "271125527074012594176"
+    "buyAmountInBase": "6098377078823660544",
+    "sellAmountInQuote": "1497151572851208749056"
 }
 ```
 

--- a/price-estimator/README.md
+++ b/price-estimator/README.md
@@ -54,7 +54,7 @@ Example Response:
 * `buyAmountInBase` estimates the buy amount (in base tokens) a user can set as a limit order while still expecting to be completely matched when selling the given amount of quote token.
 * The other fields repeat the parameters in the url back.
 
-### Estimated Sell Amount
+### Estimated Amounts At Price
 
 `GET /api/v1/markets/:market/estimated-amounts-at-price/:price-in-quote`
 
@@ -76,8 +76,8 @@ Example Response:
 }
 ```
 
-The following result indicates that if we wanted to buy ETH (token 1) for DAI (token 7) and pay 245.5 DAI per unit of ETH, we would be able to sell an estimated maximum 271.13 DAI.
+The following result indicates that if we wanted to buy ETH (token 2) for DAI (token 7) and pay 245.5 DAI per unit of ETH, we would be able to sell an estimated maximum 1497.15 DAI.
 
 * `sellAmountInBase` estimates the sell amount (in quote tokens) a user can completely fill in the following batch at the specified `price_in_quote`.
-* `buyAmountInBase` is the computed buy amount (in base tokens) for the order from the specified price and estimated sell amount.
+* `buyAmountInBase` is the computed buy amount (in base tokens) for the order from the specified price and estimated sell amount. Note that it might be possible to use a higher buy amount for the same returned sell amount and still likely get completely matched by the solver. This buy amount can be computed with a subsequent estimate buy amount API call using the returned sell amount in quote value.
 * The other fields repeat the parameters in the url back.

--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -117,11 +117,14 @@ async fn get_markets<T>(
 
 async fn estimate_sell_amount<T>(
     token_pair: TokenPair,
-    exchange_rate: f64,
+    price_in_quote: f64,
     _query: QueryParameters,
     price_rounding_buffer: f64,
     orderbook: Arc<Orderbook<T>>,
 ) -> Result<impl warp::Reply, Infallible> {
+    // NOTE: The price in quote is `sell_amount / buy_amount` which is the
+    // inverse of an exchange rate.
+    let exchange_rate = 1.0 / price_in_quote;
     let transitive_order = orderbook
         .get_pricegraph()
         .await

--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -92,7 +92,7 @@ async fn estimate_buy_amount<T>(
     let buy_amount_in_base = transitive_order
         .map(|order| apply_rounding_buffer(order.buy, price_rounding_buffer))
         .unwrap_or_default();
-    let result = EstimatedBuyAmountResult {
+    let result = EstimatedOrderResult {
         base_token_id: token_pair.buy_token_id,
         quote_token_id: token_pair.sell_token_id,
         sell_amount_in_quote,
@@ -134,7 +134,7 @@ async fn estimate_sell_amount<T>(
             )
         })
         .unwrap_or_default();
-    let result = EstimatedBuyAmountResult {
+    let result = EstimatedOrderResult {
         base_token_id: token_pair.buy_token_id,
         quote_token_id: token_pair.sell_token_id,
         sell_amount_in_quote,
@@ -263,5 +263,20 @@ mod tests {
                 .unwrap()
                 .is_err());
         }
+    }
+
+    #[test]
+    fn estimated_sell_amount_ok() {
+        let (token_pair, volume, query) = warp::test::request()
+            .path("/api/v1/markets/0-65535/estimated-sell-amount/0.5?atoms=true")
+            .filter(&estimated_sell_amount_filter())
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        assert_eq!(token_pair.buy_token_id, 0);
+        assert_eq!(token_pair.sell_token_id, 65535);
+        assert!((volume - 0.5).abs() < f64::EPSILON);
+        assert_eq!(query.atoms, true);
+        assert_eq!(query.hops, None);
     }
 }

--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -133,7 +133,7 @@ async fn estimate_sell_amount<T>(
         .map(|order| {
             (
                 apply_rounding_buffer(order.buy, price_rounding_buffer),
-                order.sell as u128,
+                apply_rounding_buffer(order.sell, price_rounding_buffer),
             )
         })
         .unwrap_or_default();
@@ -146,8 +146,8 @@ async fn estimate_sell_amount<T>(
     Ok(warp::reply::json(&result))
 }
 
-fn apply_rounding_buffer(buy_amount: f64, price_rounding_buffer: f64) -> u128 {
-    ((1.0 - price_rounding_buffer) * buy_amount) as _
+fn apply_rounding_buffer(amount: f64, price_rounding_buffer: f64) -> u128 {
+    ((1.0 - price_rounding_buffer) * amount) as _
 }
 
 #[cfg(test)]

--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -14,7 +14,7 @@ pub fn all<T: Send + Sync + 'static>(
             orderbook.clone(),
             price_rounding_buffer,
         ))
-        .or(estimated_sell_amount(orderbook, price_rounding_buffer))
+        .or(estimated_amounts_at_price(orderbook, price_rounding_buffer))
 }
 
 /// Validate a request of the form
@@ -44,17 +44,17 @@ pub fn markets<T: Send + Sync + 'static>(
 }
 
 /// Validate a request of the form:
-/// `/api/v1/markets/<baseTokenId>-<quoteTokenId>/estimated-sell-amount/<exchangeRate>`
+/// `/api/v1/markets/<baseTokenId>-<quoteTokenId>/estimated-amounts-at-price/<exchangeRate>`
 /// and answer it.
-pub fn estimated_sell_amount<T: Send + Sync + 'static>(
+pub fn estimated_amounts_at_price<T: Send + Sync + 'static>(
     orderbook: Arc<Orderbook<T>>,
     price_rounding_buffer: f64,
 ) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
-    estimated_sell_amount_filter()
+    estimated_amounts_at_price_filter()
         .and(warp::any().map(move || price_rounding_buffer))
         .and(warp::any().map(move || orderbook.clone()))
-        .and_then(estimate_sell_amount)
-        .with(warp::log("price_estimator::api::estimate_sell_amount"))
+        .and_then(estimate_amounts_at_price)
+        .with(warp::log("price_estimator::api::estimate_amounts_at_price"))
 }
 
 fn estimated_buy_amount_filter(
@@ -71,9 +71,9 @@ fn markets_filter() -> impl Filter<Extract = (TokenPair, QueryParameters), Error
         .and(warp::query::<QueryParameters>())
 }
 
-fn estimated_sell_amount_filter(
+fn estimated_amounts_at_price_filter(
 ) -> impl Filter<Extract = (TokenPair, f64, QueryParameters), Error = Rejection> + Copy {
-    warp::path!("api" / "v1" / "markets" / TokenPair / "estimated-sell-amount" / f64)
+    warp::path!("api" / "v1" / "markets" / TokenPair / "estimated-amounts-at-price" / f64)
         .and(warp::get())
         .and(warp::query::<QueryParameters>())
 }
@@ -115,7 +115,7 @@ async fn get_markets<T>(
     Ok(warp::reply::json(&result))
 }
 
-async fn estimate_sell_amount<T>(
+async fn estimate_amounts_at_price<T>(
     token_pair: TokenPair,
     price_in_quote: f64,
     _query: QueryParameters,
@@ -130,7 +130,7 @@ async fn estimate_sell_amount<T>(
     let transitive_order = orderbook
         .get_pricegraph()
         .await
-        .order_for_exchange_rate(token_pair.into(), exchange_rate);
+        .order_at_exchange_rate(token_pair.into(), exchange_rate);
     let (buy_amount_in_base, sell_amount_in_quote) = transitive_order
         .map(|order| {
             (
@@ -271,10 +271,10 @@ mod tests {
     }
 
     #[test]
-    fn estimated_sell_amount_ok() {
+    fn estimated_amounts_at_price_ok() {
         let (token_pair, volume, query) = warp::test::request()
-            .path("/api/v1/markets/0-65535/estimated-sell-amount/0.5?atoms=true")
-            .filter(&estimated_sell_amount_filter())
+            .path("/api/v1/markets/0-65535/estimated-amounts-at-price/0.5?atoms=true")
+            .filter(&estimated_amounts_at_price_filter())
             .now_or_never()
             .unwrap()
             .unwrap();

--- a/price-estimator/src/models.rs
+++ b/price-estimator/src/models.rs
@@ -56,7 +56,7 @@ pub struct QueryParameters {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct EstimatedBuyAmountResult {
+pub struct EstimatedOrderResult {
     #[serde(with = "display_fromstr")]
     pub base_token_id: u16,
     #[serde(with = "display_fromstr")]
@@ -95,7 +95,7 @@ mod tests {
 
     #[test]
     fn estimated_buy_amount_serialization() {
-        let original = EstimatedBuyAmountResult {
+        let original = EstimatedOrderResult {
             base_token_id: 1,
             quote_token_id: 2,
             buy_amount_in_base: 3,

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -165,10 +165,10 @@ impl Pricegraph {
             .fill_order_at_price(pair, exchange_rate)
     }
 
-    /// Returns a transitive order with a buy and sell amount computed such that
-    /// there exists overlapping transitive orders to completely fill the order
-    /// at the specified limit exchange rate. Returns `None` if no overlapping
-    /// transitive orders exist at the given exchange rate.
+    /// Returns a transitive order with the largest buy and sell amount computed
+    /// such that there exists overlapping transitive orders to completely fill
+    /// the order at the specified limit exchange rate. Returns `None` if no
+    /// overlapping transitive orders exist at the given exchange rate.
     pub fn order_for_exchange_rate(
         &self,
         pair: TokenPair,

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -158,6 +158,33 @@ impl Pricegraph {
         })
     }
 
+    /// Estimates a sell amount for the specified token pair and limit exchange
+    /// rate.
+    pub fn estimate_sell_amount(&self, pair: TokenPair, exchange_rate: f64) -> f64 {
+        self.reduced_orderbook()
+            .fill_order_at_price(pair, exchange_rate)
+    }
+
+    /// Returns a transitive order with a buy and sell amount computed such that
+    /// there exists overlapping transitive orders to completely fill the order
+    /// at the specified limit exchange rate. Returns `None` if no overlapping
+    /// transitive orders exist at the given exchange rate.
+    pub fn order_for_exchange_rate(
+        &self,
+        pair: TokenPair,
+        exchange_rate: f64,
+    ) -> Option<TransitiveOrder> {
+        let sell_amount = self.estimate_sell_amount(pair, exchange_rate);
+        if sell_amount == 0.0 {
+            return None;
+        }
+
+        Some(TransitiveOrder {
+            buy: sell_amount * exchange_rate,
+            sell: sell_amount,
+        })
+    }
+
     /// Computes a transitive orderbook for the given market specified by the
     /// base and quote tokens.
     ///

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -158,11 +158,11 @@ impl Pricegraph {
         })
     }
 
-    /// Returns a transitive order with the smallest buy amount and largest sell
-    /// amount such that its exchange rate is smaller than or equal to the
-    /// specified limit exchange rate and there exists overlapping transitive
-    /// orders to completely fill the order. Returns `None` if no overlapping
-    /// transitive orders exist at the given exchange rate.
+    /// Returns a transitive order with the largest buy and sell amounts such
+    /// that its exchange rate is greater than or equal to the specified limit
+    /// exchange rate and there exists overlapping transitive orders to
+    /// completely fill the order. Returns `None` if no overlapping transitive
+    /// orders exist at the given exchange rate.
     pub fn order_for_limit_exchange_rate(
         &self,
         pair: TokenPair,

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -1117,23 +1117,23 @@ mod tests {
             orderbook
                 .clone()
                 .fill_order_at_price(TokenPair { buy: 2, sell: 1 }, 1.0 / FEE_FACTOR.powi(2)),
-            1_000_000.0
+            1_000_000.0 * FEE_FACTOR
         );
         assert_approx_eq!(
             orderbook
                 .clone()
                 .fill_order_at_price(TokenPair { buy: 2, sell: 1 }, 0.3),
-            2_000_000.0
+            3_000_000.0 * FEE_FACTOR
         );
         assert_approx_eq!(
             orderbook
                 .clone()
                 .fill_order_at_price(TokenPair { buy: 2, sell: 1 }, 0.25 / FEE_FACTOR.powi(2)),
-            3_000_000.0
+            7_000_000.0 * FEE_FACTOR
         );
         assert_approx_eq!(
             orderbook.fill_order_at_price(TokenPair { buy: 2, sell: 1 }, 0.1),
-            3_000_000.0
+            7_000_000.0 * FEE_FACTOR
         );
     }
 
@@ -1382,7 +1382,10 @@ mod tests {
         let amount = orderbook.fill_order_at_price(TokenPair { buy: 1, sell: 0 }, 1.0);
         assert_approx_eq!(
             amount,
-            83_798_276_971_421_254_262_445_676_335_662_107_162.0,
+            (83_798_276_971_421_254_262_445_676_335_662_107_162.0
+                / 327_042_228_921_422_829_026_657_257_798_164_547_592.0)
+                * 13_294_906_614_391_990_988_372_451_468_773_477_386.0
+                * FEE_FACTOR,
             num::max_rounding_error_with_epsilon(amount)
         );
     }

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -359,7 +359,7 @@ impl Orderbook {
         Some(invert_price(last_transitive_price))
     }
 
-    /// Fill an order at a given price, returning the estimated buy amount that
+    /// Fill an order at a given price, returning the estimated sell amount that
     /// can be filled at the given price with the current existing orders.
     ///
     /// This is calculated by repeatedly finding the cheapest path between a
@@ -394,8 +394,7 @@ impl Orderbook {
             if transitive_price > max_price {
                 break;
             }
-            // NOTE: Capacity is a sell amount, so convert to a buy amount.
-            total_volume += capacity / transitive_price;
+            total_volume += capacity;
 
             self.fill_path_with_capacity(&path, capacity)
                 .unwrap_or_else(|_| {

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -359,18 +359,21 @@ impl Orderbook {
         Some(invert_price(last_transitive_price))
     }
 
-    /// Fill an order at a given price, returning the estimated sell amount that
-    /// can be filled at the given price with the current existing orders.
+    /// Fill an order at a given price, returning the estimated buy and sell
+    /// amounts that can be filled at the given limit price with the current
+    /// existing orders.
     ///
     /// This is calculated by repeatedly finding the cheapest path between a
     /// token pair that is below the specified price and adding the capacity of
     /// the path to the result.
     ///
     /// Note that the limit price is expressed as an exchange limit price, i.e.
-    /// with implicitely included fees.
-    pub fn fill_order_at_price(&mut self, pair: TokenPair, limit_price: f64) -> f64 {
+    /// with implicitely included fees. Additionally, the invariant
+    /// `buy_amount / sell_amount <= limit_price` holds, but in general the
+    /// ratio of the two amounts does not equal the limit price.
+    pub fn fill_order_at_price(&mut self, pair: TokenPair, limit_price: f64) -> (f64, f64) {
         if !self.is_token_pair_valid(pair) {
-            return 0.0;
+            return (0.0, 0.0);
         }
 
         let (sell, buy) = (node_index(pair.sell), node_index(pair.buy));
@@ -380,7 +383,8 @@ impl Orderbook {
         // price that still respects the provided limit price.
         let max_price = (1.0 / limit_price) / FEE_FACTOR;
 
-        let mut total_volume = 0.0;
+        let mut total_buy_volume = 0.0;
+        let mut total_sell_volume = 0.0;
         let mut predecessors = self.reduced_shortest_paths(sell);
         while let Some(path) = path::find_path(&predecessors, sell, buy) {
             let (capacity, transitive_price) =
@@ -394,7 +398,8 @@ impl Orderbook {
             if transitive_price > max_price {
                 break;
             }
-            total_volume += capacity;
+            total_buy_volume += capacity / transitive_price;
+            total_sell_volume += capacity;
 
             self.fill_path_with_capacity(&path, capacity)
                 .unwrap_or_else(|_| {
@@ -408,7 +413,7 @@ impl Orderbook {
                 .1;
         }
 
-        total_volume
+        (total_buy_volume, total_sell_volume)
     }
 
     /// Calculates the shortest paths from the start token to all other tokens
@@ -1105,36 +1110,35 @@ mod tests {
             }
         };
 
-        assert_approx_eq!(
-            orderbook
-                .clone()
-                // NOTE: 1 for 1.001 is not enough to match any volume because
-                // fees need to be applied twice!
-                .fill_order_at_price(TokenPair { buy: 2, sell: 1 }, 1.0 / FEE_FACTOR),
-            0.0
-        );
-        assert_approx_eq!(
-            orderbook
-                .clone()
-                .fill_order_at_price(TokenPair { buy: 2, sell: 1 }, 1.0 / FEE_FACTOR.powi(2)),
-            1_000_000.0 * FEE_FACTOR
-        );
-        assert_approx_eq!(
-            orderbook
-                .clone()
-                .fill_order_at_price(TokenPair { buy: 2, sell: 1 }, 0.3),
-            3_000_000.0 * FEE_FACTOR
-        );
-        assert_approx_eq!(
-            orderbook
-                .clone()
-                .fill_order_at_price(TokenPair { buy: 2, sell: 1 }, 0.25 / FEE_FACTOR.powi(2)),
-            7_000_000.0 * FEE_FACTOR
-        );
-        assert_approx_eq!(
-            orderbook.fill_order_at_price(TokenPair { buy: 2, sell: 1 }, 0.1),
-            7_000_000.0 * FEE_FACTOR
-        );
+        let (buy, sell) = orderbook
+            .clone()
+            // NOTE: 1 for 1.001 is not enough to match any volume because
+            // fees need to be applied twice!
+            .fill_order_at_price(TokenPair { buy: 2, sell: 1 }, 1.0 / FEE_FACTOR);
+        assert_approx_eq!(buy, 0.0);
+        assert_approx_eq!(sell, 0.0);
+
+        let (buy, sell) = orderbook
+            .clone()
+            .fill_order_at_price(TokenPair { buy: 2, sell: 1 }, 1.0 / FEE_FACTOR.powi(2));
+        assert_approx_eq!(buy, 1_000_000.0);
+        assert_approx_eq!(sell, 1_000_000.0 * FEE_FACTOR);
+
+        let (buy, sell) = orderbook
+            .clone()
+            .fill_order_at_price(TokenPair { buy: 2, sell: 1 }, 0.3);
+        assert_approx_eq!(buy, 2_000_000.0);
+        assert_approx_eq!(sell, 3_000_000.0 * FEE_FACTOR);
+
+        let (buy, sell) = orderbook
+            .clone()
+            .fill_order_at_price(TokenPair { buy: 2, sell: 1 }, 0.25 / FEE_FACTOR.powi(2));
+        assert_approx_eq!(buy, 3_000_000.0);
+        assert_approx_eq!(sell, 7_000_000.0 * FEE_FACTOR);
+
+        let (buy, sell) = orderbook.fill_order_at_price(TokenPair { buy: 2, sell: 1 }, 0.1);
+        assert_approx_eq!(buy, 3_000_000.0);
+        assert_approx_eq!(sell, 7_000_000.0 * FEE_FACTOR);
     }
 
     #[test]
@@ -1379,14 +1383,19 @@ mod tests {
             }
         };
 
-        let amount = orderbook.fill_order_at_price(TokenPair { buy: 1, sell: 0 }, 1.0);
+        let (buy, sell) = orderbook.fill_order_at_price(TokenPair { buy: 1, sell: 0 }, 1.0);
         assert_approx_eq!(
-            amount,
+            buy,
+            83_798_276_971_421_254_262_445_676_335_662_107_162.0,
+            num::max_rounding_error_with_epsilon(buy)
+        );
+        assert_approx_eq!(
+            sell,
             (83_798_276_971_421_254_262_445_676_335_662_107_162.0
                 / 327_042_228_921_422_829_026_657_257_798_164_547_592.0)
                 * 13_294_906_614_391_990_988_372_451_468_773_477_386.0
                 * FEE_FACTOR,
-            num::max_rounding_error_with_epsilon(amount)
+            num::max_rounding_error_with_epsilon(sell)
         );
     }
 }


### PR DESCRIPTION
This PR implements an estimated sell amount route for computing the and order using maximum sell amount from a given exchange rate.

This will be useful for various GP services to know about how much of a token they can sell in the next batch at an exchange rate.

If you guys think its worth it, I can split the pricegraph and price-estimator changes into two separate PRs.

### Test Plan

Added unit test to verify route parameters are correctly parsed, also, check run the price estimator and check the route:
```
$ curl -s http://localhost:8080/api/v1/markets/1-7/estimated-sell-amount/245.5\?atoms\=true | jq
{
  "baseTokenId": "1",
  "quoteTokenId": "7",
  "buyAmountInBase": "64016789977586752",
  "sellAmountInQuote": "15731853793290840064"
}
```