### PR TITLE
[Trivial] Fix Node.js version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It contains two sub-projects that both implement the market mechanism described 
 ### Requirements
 
 - Rust (stable)
-- NodeJS <=11.0, starting with version 12 some deprecated APIs were removed that cause `scrypt`, `keccak`, `secp256k1`, and `sha3` packages to fail to build
+- Node.js v12 LTS
 - Docker and Docker-compose (stable)
 - libpq - the PostgreSQL library
 


### PR DESCRIPTION
Just noticed that the README still suggests using the old Node.js version despite that no longer being necessary.
