### PR TITLE
Event iterators for batch ranges

### DIFF
--- a/core/src/models/batch_id.rs
+++ b/core/src/models/batch_id.rs
@@ -25,8 +25,12 @@ impl BatchId {
         Self::current(now).map(|batch_id| batch_id.prev())
     }
 
+    pub fn as_timestamp(self) -> u64 {
+        self.0 * BATCH_DURATION.as_secs()
+    }
+
     pub fn order_collection_start_time(self) -> SystemTime {
-        SystemTime::UNIX_EPOCH + Duration::from_secs(self.0 * BATCH_DURATION.as_secs())
+        SystemTime::UNIX_EPOCH + Duration::from_secs(self.as_timestamp())
     }
 
     pub fn solve_start_time(self) -> SystemTime {


### PR DESCRIPTION
Adds `EventRegstry` utility methods for getting iterators to events for batch ranges.

### Test Plan

Added unit test.