### PR TITLE
[TokenInfo 2] Making TokenInfoFetching async

### DIFF
--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -28,3 +28,9 @@ macro_rules! std_map {
         map
     }}
 }
+
+macro_rules! immediate {
+    ($expression:expr) => {
+        async { $expression }.boxed()
+    };
+}

--- a/core/src/price_estimation/dexag.rs
+++ b/core/src/price_estimation/dexag.rs
@@ -3,12 +3,13 @@ mod api;
 use super::PriceSource;
 use crate::http::HttpFactory;
 use crate::models::TokenId;
-use crate::token_info::TokenInfoFetching;
+use crate::token_info::{TokenBaseInfo, TokenInfoFetching};
 use anyhow::{anyhow, Context, Result};
 use api::{DexagApi, DexagHttpApi};
 use futures::{
     future::{self, BoxFuture, FutureExt as _},
     lock::Mutex,
+    stream::{self, StreamExt},
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -102,27 +103,34 @@ where
                 }
             };
 
-            let (tokens_, futures): (Vec<TokenId>, Vec<_>) = tokens
-                .iter()
-                .filter_map(|token| -> Option<(&TokenId, BoxFuture<Result<f64>>)> {
-                    // api_tokens symbols are converted to uppercase to disambiguate
-                    let symbol = self
-                        .token_info_fetcher
-                        .get_token_info(*token)
-                        .ok()?
-                        .symbol()
-                        .to_uppercase();
-                    if symbol == api_tokens.stable_coin.symbol {
-                        Some((token, async { Ok(1.0) }.boxed()))
-                    } else if let Some(api_token) = api_tokens.tokens.get(&symbol) {
-                        Some((
-                            token,
-                            self.api.get_price(api_token, &api_tokens.stable_coin),
-                        ))
-                    } else {
-                        None
-                    }
+            let token_infos: Vec<_> = stream::iter(tokens)
+                .filter_map(|token| async move {
+                    Some((
+                        *token,
+                        self.token_info_fetcher.get_token_info(*token).await.ok()?,
+                    ))
                 })
+                .collect()
+                .await;
+
+            let (tokens_, futures): (Vec<(TokenId, TokenBaseInfo)>, Vec<_>) = token_infos
+                .iter()
+                .filter_map(
+                    |(token_id, token_info)| -> Option<((TokenId, TokenBaseInfo), BoxFuture<Result<f64>>)> {
+                        // api_tokens symbols are converted to uppercase to disambiguate
+                        let symbol = token_info.symbol().to_uppercase();
+                        if symbol == api_tokens.stable_coin.symbol {
+                            Some(((*token_id, token_info.clone()), immediate!(Ok(1.0))))
+                        } else if let Some(api_token) = api_tokens.tokens.get(&symbol) {
+                            Some((
+                                (*token_id, token_info.clone()),
+                                self.api.get_price(api_token, &api_tokens.stable_coin),
+                            ))
+                        } else {
+                            None
+                        }
+                    },
+                )
                 .unzip();
 
             let joined = future::join_all(futures);
@@ -134,11 +142,8 @@ where
                 .zip(results.iter())
                 .filter_map(|(token, result)| match result {
                     Ok(price) => Some((
-                        *token,
-                        self.token_info_fetcher
-                            .get_token_info(*token)
-                            .ok()?
-                            .get_owl_price(*price),
+                        token.0,
+                        token.1.get_owl_price(*price),
                     )),
                     Err(_) => None,
                 })

--- a/core/src/price_estimation/dexag.rs
+++ b/core/src/price_estimation/dexag.rs
@@ -77,6 +77,8 @@ where
     }
 }
 
+type TokenIdAndInfo = (TokenId, TokenBaseInfo);
+
 impl<Api> PriceSource for DexagClient<Api>
 where
     Api: DexagApi + Sync + Send,
@@ -113,10 +115,10 @@ where
                 .collect()
                 .await;
 
-            let (tokens_, futures): (Vec<(TokenId, TokenBaseInfo)>, Vec<_>) = token_infos
+            let (tokens_, futures): (Vec<TokenIdAndInfo>, Vec<_>) = token_infos
                 .iter()
                 .filter_map(
-                    |(token_id, token_info)| -> Option<((TokenId, TokenBaseInfo), BoxFuture<Result<f64>>)> {
+                    |(token_id, token_info)| -> Option<(TokenIdAndInfo, BoxFuture<Result<f64>>)> {
                         // api_tokens symbols are converted to uppercase to disambiguate
                         let symbol = token_info.symbol().to_uppercase();
                         if symbol == api_tokens.stable_coin.symbol {
@@ -141,10 +143,7 @@ where
                 .iter()
                 .zip(results.iter())
                 .filter_map(|(token, result)| match result {
-                    Ok(price) => Some((
-                        token.0,
-                        token.1.get_owl_price(*price),
-                    )),
+                    Ok(price) => Some((token.0, token.1.get_owl_price(*price))),
                     Err(_) => None,
                 })
                 .collect())

--- a/core/src/price_estimation/kraken.rs
+++ b/core/src/price_estimation/kraken.rs
@@ -6,7 +6,7 @@ use self::api::{Asset, AssetPair, KrakenApi, KrakenHttpApi};
 use super::PriceSource;
 use crate::http::HttpFactory;
 use crate::models::TokenId;
-use crate::token_info::TokenInfoFetching;
+use crate::token_info::{TokenBaseInfo, TokenInfoFetching};
 use anyhow::{anyhow, Context, Result};
 use futures::future::{self, BoxFuture, FutureExt as _};
 use futures::stream::{self, StreamExt};
@@ -33,6 +33,8 @@ impl KrakenClient<KrakenHttpApi> {
     }
 }
 
+type TokenIdAndInfo = (TokenId, TokenBaseInfo);
+
 impl<Api> KrakenClient<Api>
 where
     Api: KrakenApi,
@@ -49,17 +51,10 @@ where
     /// Generates a mapping between Kraken asset pair identifiers and tokens
     /// that are used when computing the price map.
     #[allow(clippy::needless_lifetimes)]
-    async fn get_token_asset_pairs(&self, tokens: &[TokenId]) -> Result<HashMap<String, TokenId>> {
-        let token_infos: Vec<_> = stream::iter(tokens)
-            .filter_map(|token| async move {
-                Some((
-                    *token,
-                    self.token_info_fetcher.get_token_info(*token).await.ok()?,
-                ))
-            })
-            .collect()
-            .await;
-
+    async fn get_token_asset_pairs(
+        &self,
+        tokens: &[TokenIdAndInfo],
+    ) -> Result<HashMap<String, TokenIdAndInfo>> {
         // TODO(nlordell): If these calls start taking too long, we can consider
         //   caching this information somehow. The only thing that is
         //   complicated is determining when the cache needs to be invalidated
@@ -72,12 +67,12 @@ where
             .ok_or_else(|| anyhow!("unable to locate USD asset"))?
             .to_owned();
 
-        let token_assets = token_infos
+        let token_assets = tokens
             .iter()
             .filter_map(|(token_id, token_info)| {
                 let asset = find_asset(token_info.symbol(), &assets)?;
                 let pair = find_asset_pair(asset, &usd, &asset_pairs)?;
-                Some((pair.to_owned(), *token_id))
+                Some((pair.to_owned(), (*token_id, token_info.clone())))
             })
             .collect();
 
@@ -94,8 +89,18 @@ where
         tokens: &'a [TokenId],
     ) -> BoxFuture<'a, Result<HashMap<TokenId, u128>>> {
         async move {
+            let token_infos: Vec<_> = stream::iter(tokens)
+                .filter_map(|token| async move {
+                    Some((
+                        *token,
+                        self.token_info_fetcher.get_token_info(*token).await.ok()?,
+                    ))
+                })
+                .collect()
+                .await;
+
             let token_asset_pairs = self
-                .get_token_asset_pairs(tokens)
+                .get_token_asset_pairs(&token_infos)
                 .await
                 .context("failed to generate asset pairs mapping for tokens")?;
 
@@ -104,16 +109,10 @@ where
 
             let prices = stream::iter(ticker_infos)
                 .filter_map(|(pair, info)| {
-                    let token_info_fetcher = self.token_info_fetcher.clone();
-                    let token = token_asset_pairs.get(&pair);
+                    let token_id_and_pair = token_asset_pairs.get(&pair);
                     async move {
-                        let price = token_info_fetcher
-                            .get_token_info(*(token?))
-                            .await
-                            .ok()?
-                            .get_owl_price(info.p.last_24h());
-
-                        Some((*(token?), price))
+                        let price = token_id_and_pair?.1.get_owl_price(info.p.last_24h());
+                        Some((token_id_and_pair?.0, price))
                     }
                 })
                 .collect()

--- a/core/src/price_estimation/kraken.rs
+++ b/core/src/price_estimation/kraken.rs
@@ -9,6 +9,7 @@ use crate::models::TokenId;
 use crate::token_info::TokenInfoFetching;
 use anyhow::{anyhow, Context, Result};
 use futures::future::{self, BoxFuture, FutureExt as _};
+use futures::stream::{self, StreamExt};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -49,6 +50,16 @@ where
     /// that are used when computing the price map.
     #[allow(clippy::needless_lifetimes)]
     async fn get_token_asset_pairs(&self, tokens: &[TokenId]) -> Result<HashMap<String, TokenId>> {
+        let token_infos: Vec<_> = stream::iter(tokens)
+            .filter_map(|token| async move {
+                Some((
+                    *token,
+                    self.token_info_fetcher.get_token_info(*token).await.ok()?,
+                ))
+            })
+            .collect()
+            .await;
+
         // TODO(nlordell): If these calls start taking too long, we can consider
         //   caching this information somehow. The only thing that is
         //   complicated is determining when the cache needs to be invalidated
@@ -57,16 +68,16 @@ where
         let (assets, asset_pairs) =
             future::try_join(self.api.assets(), self.api.asset_pairs()).await?;
 
-        let usd =
-            find_asset("USD", &assets).ok_or_else(|| anyhow!("unable to locate USD asset"))?;
+        let usd = find_asset("USD", &assets)
+            .ok_or_else(|| anyhow!("unable to locate USD asset"))?
+            .to_owned();
 
-        let token_assets = tokens
+        let token_assets = token_infos
             .iter()
-            .flat_map(|token| {
-                let token_info = &self.token_info_fetcher.get_token_info(*token).ok()?;
+            .filter_map(|(token_id, token_info)| {
                 let asset = find_asset(token_info.symbol(), &assets)?;
-                let pair = find_asset_pair(asset, usd, &asset_pairs)?;
-                Some((pair.to_owned(), *token))
+                let pair = find_asset_pair(asset, &usd, &asset_pairs)?;
+                Some((pair.to_owned(), *token_id))
             })
             .collect();
 
@@ -91,19 +102,22 @@ where
             let asset_pairs: Vec<_> = token_asset_pairs.keys().map(String::as_str).collect();
             let ticker_infos = self.api.ticker(&asset_pairs).await?;
 
-            let prices = ticker_infos
-                .iter()
-                .flat_map(|(pair, info)| {
-                    let token = token_asset_pairs.get(pair)?;
-                    let price = self
-                        .token_info_fetcher
-                        .get_token_info(*token)
-                        .ok()?
-                        .get_owl_price(info.p.last_24h());
+            let prices = stream::iter(ticker_infos)
+                .filter_map(|(pair, info)| {
+                    let token_info_fetcher = self.token_info_fetcher.clone();
+                    let token = token_asset_pairs.get(&pair);
+                    async move {
+                        let price = token_info_fetcher
+                            .get_token_info(*(token?))
+                            .await
+                            .ok()?
+                            .get_owl_price(info.p.last_24h());
 
-                    Some((*token, price))
+                        Some((*(token?), price))
+                    }
                 })
-                .collect();
+                .collect()
+                .await;
 
             Ok(prices)
         }

--- a/core/src/price_estimation/threaded_price_source.rs
+++ b/core/src/price_estimation/threaded_price_source.rs
@@ -35,7 +35,7 @@ impl ThreadedPriceSource {
             let price_map = Arc::downgrade(&price_map);
             async move {
                 while let Some(price_map) = price_map.upgrade() {
-                    match update_prices(&price_source, &token_info_fetcher).await {
+                    match update_prices(&price_source, token_info_fetcher.as_ref()).await {
                         Ok(prices) => price_map.lock().await.extend(prices),
                         Err(err) => log::warn!("price_source::get_prices failed: {}", err),
                     }
@@ -49,7 +49,7 @@ impl ThreadedPriceSource {
 
 async fn update_prices<T: PriceSource>(
     price_source: &T,
-    token_info_fetching: &Arc<dyn TokenInfoFetching>,
+    token_info_fetching: &dyn TokenInfoFetching,
 ) -> Result<HashMap<TokenId, u128>> {
     let tokens = token_info_fetching.all_ids().await?;
     price_source.get_prices(&tokens).await

--- a/core/src/price_estimation/threaded_price_source.rs
+++ b/core/src/price_estimation/threaded_price_source.rs
@@ -1,5 +1,6 @@
 use super::price_source::PriceSource;
 use crate::models::TokenId;
+use crate::token_info::TokenInfoFetching;
 use anyhow::Result;
 use async_std::{
     sync::Mutex,
@@ -25,7 +26,7 @@ impl ThreadedPriceSource {
     /// The join handle represents the task. It can be used to verify that it exits when the struct
     /// is dropped.
     pub fn new<T: 'static + PriceSource + Send + Sync>(
-        tokens: Vec<TokenId>,
+        token_info_fetcher: Arc<dyn TokenInfoFetching>,
         price_source: T,
         update_interval: Duration,
     ) -> (Self, JoinHandle<()>) {
@@ -34,7 +35,7 @@ impl ThreadedPriceSource {
             let price_map = Arc::downgrade(&price_map);
             async move {
                 while let Some(price_map) = price_map.upgrade() {
-                    match price_source.get_prices(&tokens).await {
+                    match update_prices(&price_source, &token_info_fetcher).await {
                         Ok(prices) => price_map.lock().await.extend(prices),
                         Err(err) => log::warn!("price_source::get_prices failed: {}", err),
                     }
@@ -44,6 +45,14 @@ impl ThreadedPriceSource {
         });
         (Self { price_map }, join_handle)
     }
+}
+
+async fn update_prices<T: PriceSource>(
+    price_source: &T,
+    token_info_fetching: &Arc<dyn TokenInfoFetching>,
+) -> Result<HashMap<TokenId, u128>> {
+    let tokens = token_info_fetching.all_ids().await?;
+    price_source.get_prices(&tokens).await
 }
 
 impl PriceSource for ThreadedPriceSource {
@@ -66,6 +75,7 @@ impl PriceSource for ThreadedPriceSource {
 mod tests {
     use super::super::price_source::MockPriceSource;
     use super::*;
+    use crate::token_info::MockTokenInfoFetching;
     use crate::util::FutureWaitExt;
     use futures::future::{self, Either};
     use std::sync::atomic;
@@ -100,8 +110,15 @@ mod tests {
     fn thread_exits_when_owner_is_dropped() {
         let mut ps = MockPriceSource::new();
         ps.expect_get_prices()
-            .returning(|_| async { Ok(HashMap::new()) }.boxed());
-        let (tps, handle) = ThreadedPriceSource::new(TOKENS.to_vec(), ps, UPDATE_INTERVAL);
+            .returning(|_| immediate!(Ok(HashMap::new())));
+
+        let mut token_info_fetcher = MockTokenInfoFetching::new();
+        token_info_fetcher
+            .expect_all_ids()
+            .returning(|| immediate!(Ok(TOKENS.to_vec())));
+
+        let (tps, handle) =
+            ThreadedPriceSource::new(Arc::new(token_info_fetcher), ps, UPDATE_INTERVAL);
         join(tps, handle).wait();
     }
 
@@ -117,8 +134,13 @@ mod tests {
             }
         });
 
+        let mut token_info_fetcher = MockTokenInfoFetching::new();
+        token_info_fetcher
+            .expect_all_ids()
+            .returning(|| immediate!(Ok(TOKENS.to_vec())));
+
         let (tps, handle) =
-            ThreadedPriceSource::new(TOKENS.to_vec(), price_source, UPDATE_INTERVAL);
+            ThreadedPriceSource::new(Arc::new(token_info_fetcher), price_source, UPDATE_INTERVAL);
         let get_prices = || tps.get_prices(&TOKENS[..]).wait().unwrap();
         price.store(1, ORDERING);
         let condition = || get_prices().get(&TOKENS[0]) == Some(&1);

--- a/core/src/token_info.rs
+++ b/core/src/token_info.rs
@@ -12,10 +12,10 @@ pub mod hardcoded;
 #[cfg_attr(test, automock)]
 pub trait TokenInfoFetching: Send + Sync {
     /// Retrieves some token information from a token ID.
-    fn get_token_info<'a>(&self, id: TokenId) -> BoxFuture<'a, Result<TokenBaseInfo>>;
+    fn get_token_info<'a>(&'a self, id: TokenId) -> BoxFuture<'a, Result<TokenBaseInfo>>;
 
     /// Returns a vector with all the token IDs available
-    fn all_ids<'a>(&self) -> BoxFuture<'a, Result<Vec<TokenId>>>;
+    fn all_ids<'a>(&'a self) -> BoxFuture<'a, Result<Vec<TokenId>>>;
 }
 
 /// Base token info to use for providing token information to the solver. This

--- a/core/src/token_info.rs
+++ b/core/src/token_info.rs
@@ -1,17 +1,21 @@
 use anyhow::Result;
+use futures::future::BoxFuture;
 use lazy_static::lazy_static;
+#[cfg(test)]
+use mockall::automock;
 use serde::Deserialize;
 use std::collections::HashMap;
 
 use crate::models::{TokenId, TokenInfo};
 pub mod hardcoded;
 
+#[cfg_attr(test, automock)]
 pub trait TokenInfoFetching: Send + Sync {
     /// Retrieves some token information from a token ID.
-    fn get_token_info(&self, id: TokenId) -> Result<TokenBaseInfo>;
+    fn get_token_info<'a>(&self, id: TokenId) -> BoxFuture<'a, Result<TokenBaseInfo>>;
 
     /// Returns a vector with all the token IDs available
-    fn all_ids(&self) -> Result<Vec<TokenId>>;
+    fn all_ids<'a>(&self) -> BoxFuture<'a, Result<Vec<TokenId>>>;
 }
 
 /// Base token info to use for providing token information to the solver. This

--- a/core/src/token_info/hardcoded.rs
+++ b/core/src/token_info/hardcoded.rs
@@ -23,7 +23,7 @@ impl TokenInfoFetching for TokenData {
     fn get_token_info<'a>(&self, id: TokenId) -> BoxFuture<'a, Result<TokenBaseInfo>> {
         let info = self
             .0
-            .get(&id.into())
+            .get(&id)
             .cloned()
             .ok_or_else(|| anyhow!("Token {:?} not found in hardcoded data", id));
         immediate!(info)

--- a/core/src/token_info/hardcoded.rs
+++ b/core/src/token_info/hardcoded.rs
@@ -4,6 +4,7 @@
 use crate::models::TokenId;
 use anyhow::{anyhow, Context, Error, Result};
 
+use futures::future::{BoxFuture, FutureExt};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::iter::FromIterator;
@@ -19,15 +20,18 @@ use super::{TokenBaseInfo, TokenInfoFetching};
 pub struct TokenData(HashMap<TokenId, TokenBaseInfo>);
 
 impl TokenInfoFetching for TokenData {
-    fn get_token_info(&self, id: TokenId) -> Result<TokenBaseInfo> {
-        self.0
-            .get(&id)
+    fn get_token_info<'a>(&self, id: TokenId) -> BoxFuture<'a, Result<TokenBaseInfo>> {
+        let info = self
+            .0
+            .get(&id.into())
             .cloned()
-            .ok_or_else(|| anyhow!("Token {:?} not found in hardcoded data", id))
+            .ok_or_else(|| anyhow!("Token {:?} not found in hardcoded data", id));
+        immediate!(info)
     }
 
-    fn all_ids(&self) -> Result<Vec<TokenId>> {
-        Ok(Vec::from_iter(self.0.keys().copied()))
+    fn all_ids<'a>(&self) -> BoxFuture<'a, Result<Vec<TokenId>>> {
+        let ids = Vec::from_iter(self.0.keys().copied());
+        immediate!(Ok(ids))
     }
 }
 

--- a/core/src/token_info/hardcoded.rs
+++ b/core/src/token_info/hardcoded.rs
@@ -20,7 +20,7 @@ use super::{TokenBaseInfo, TokenInfoFetching};
 pub struct TokenData(HashMap<TokenId, TokenBaseInfo>);
 
 impl TokenInfoFetching for TokenData {
-    fn get_token_info<'a>(&self, id: TokenId) -> BoxFuture<'a, Result<TokenBaseInfo>> {
+    fn get_token_info<'a>(&'a self, id: TokenId) -> BoxFuture<'a, Result<TokenBaseInfo>> {
         let info = self
             .0
             .get(&id)
@@ -29,7 +29,7 @@ impl TokenInfoFetching for TokenData {
         immediate!(info)
     }
 
-    fn all_ids<'a>(&self) -> BoxFuture<'a, Result<Vec<TokenId>>> {
+    fn all_ids<'a>(&'a self) -> BoxFuture<'a, Result<Vec<TokenId>>> {
         let ids = Vec::from_iter(self.0.keys().copied());
         immediate!(Ok(ids))
     }


### PR DESCRIPTION
Part of #1007 

In order to fetch data from chain we need an async way of fetching token info. This PR refactors the existing trait and callsites to work with async assumptions.

### Test Plan
CI