### PR TITLE
PriorityPriceSource

### DIFF
--- a/core/src/orderbook/streamed/block_timestamp_reading.rs
+++ b/core/src/orderbook/streamed/block_timestamp_reading.rs
@@ -44,7 +44,7 @@ impl BlockTimestampBatchReading for Web3 {
         let batched_web3 = ethcontract::web3::Web3::new(Batch::new(self.transport().clone()));
         async move {
             let mut result = Vec::with_capacity(block_hashes.len());
-            for chunk in Vec::from_iter(block_hashes.into_iter()).chunks(500) {
+            for chunk in Vec::from_iter(block_hashes.into_iter()).chunks(1000) {
                 let partial_result = query_block_timestamps_batched(&batched_web3, chunk).await?;
                 result.extend(partial_result);
             }

--- a/core/src/orderbook/streamed/block_timestamp_reading.rs
+++ b/core/src/orderbook/streamed/block_timestamp_reading.rs
@@ -44,7 +44,7 @@ impl BlockTimestampBatchReading for Web3 {
         let batched_web3 = ethcontract::web3::Web3::new(Batch::new(self.transport().clone()));
         async move {
             let mut result = Vec::with_capacity(block_hashes.len());
-            for chunk in Vec::from_iter(block_hashes.into_iter()).chunks(1000) {
+            for chunk in Vec::from_iter(block_hashes.into_iter()).chunks(500) {
                 let partial_result = query_block_timestamps_batched(&batched_web3, chunk).await?;
                 result.extend(partial_result);
             }

--- a/core/src/price_estimation.rs
+++ b/core/src/price_estimation.rs
@@ -6,6 +6,7 @@ mod dexag;
 mod kraken;
 mod orderbook_based;
 mod price_source;
+mod priority_price_source;
 mod threaded_price_source;
 
 use self::dexag::DexagClient;

--- a/core/src/price_estimation/priority_price_source.rs
+++ b/core/src/price_estimation/priority_price_source.rs
@@ -30,10 +30,7 @@ impl PriceSource for PriorityPriceSource {
             for source in &self.sources {
                 match source.get_prices(&remaining_tokens).await {
                     Ok(partial_result) => {
-                        remaining_tokens = remaining_tokens
-                            .into_iter()
-                            .filter(|token| !partial_result.contains_key(token))
-                            .collect();
+                        remaining_tokens.retain(|token| !partial_result.contains_key(token));
                         result.extend(partial_result);
                     }
                     Err(err) => log::warn!("Price Source failed: {:?}", err),

--- a/core/src/price_estimation/priority_price_source.rs
+++ b/core/src/price_estimation/priority_price_source.rs
@@ -2,7 +2,6 @@ use super::PriceSource;
 use crate::models::TokenId;
 use anyhow::Result;
 use futures::future::{BoxFuture, FutureExt as _};
-use std::collections::hash_map::RandomState;
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
 
@@ -27,8 +26,7 @@ impl PriceSource for PriorityPriceSource {
         tokens: &'a [TokenId],
     ) -> BoxFuture<'a, Result<HashMap<TokenId, u128>>> {
         async move {
-            let mut remaining_tokens: HashSet<TokenId, RandomState> =
-                HashSet::from_iter(tokens.iter().cloned());
+            let mut remaining_tokens: HashSet<_> = HashSet::from_iter(tokens.iter().cloned());
             let mut result = HashMap::new();
             for source in &self.sources {
                 let remaining_token_vec = Vec::from_iter(remaining_tokens.iter().cloned());

--- a/core/src/price_estimation/priority_price_source.rs
+++ b/core/src/price_estimation/priority_price_source.rs
@@ -1,0 +1,143 @@
+use super::PriceSource;
+use crate::models::TokenId;
+use anyhow::Result;
+use futures::future::{BoxFuture, FutureExt as _};
+use std::collections::hash_map::RandomState;
+use std::collections::{HashMap, HashSet};
+use std::iter::FromIterator;
+
+/**
+ * A price source that sequentially queries its inner sources in order and returns the
+ * first price found.
+ */
+pub struct PriorityPriceSource {
+    sources: Vec<Box<dyn PriceSource + Send + Sync>>,
+}
+
+impl PriorityPriceSource {
+    #[allow(dead_code)]
+    pub fn new(sources: Vec<Box<dyn PriceSource + Send + Sync>>) -> Self {
+        Self { sources }
+    }
+}
+
+impl PriceSource for PriorityPriceSource {
+    fn get_prices<'a>(
+        &'a self,
+        tokens: &'a [TokenId],
+    ) -> BoxFuture<'a, Result<HashMap<TokenId, u128>>> {
+        async move {
+            let mut remaining_tokens: HashSet<TokenId, RandomState> =
+                HashSet::from_iter(tokens.iter().cloned());
+            let mut result = HashMap::new();
+            for source in &self.sources {
+                let remaining_token_vec = Vec::from_iter(remaining_tokens.iter().cloned());
+                match source.get_prices(&remaining_token_vec).await {
+                    Ok(partial_result) => {
+                        remaining_tokens = remaining_tokens
+                            .into_iter()
+                            .filter(|token| !partial_result.contains_key(token))
+                            .collect();
+                        result.extend(partial_result);
+                    }
+                    Err(err) => log::warn!("Price Source failed: {:?}", err),
+                };
+                if remaining_tokens.is_empty() {
+                    break;
+                }
+            }
+            Ok(result)
+        }
+        .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::price_estimation::price_source::MockPriceSource;
+    use anyhow::anyhow;
+
+    #[test]
+    fn returns_price_from_first_available_source() {
+        let mut first_source = MockPriceSource::new();
+        let mut second_source = MockPriceSource::new();
+
+        first_source
+            .expect_get_prices()
+            .times(1)
+            .withf(|token| token == &[TokenId::from(1), TokenId::from(2)][..])
+            .returning(|_| {
+                immediate!(Ok(hash_map! {
+                        TokenId::from(1) => 100
+                }))
+            });
+        // Expect second source to be called with missing tokens
+        second_source
+            .expect_get_prices()
+            .times(1)
+            .withf(|token| token == &[TokenId::from(2)][..])
+            .returning(|_| {
+                immediate!(Ok(hash_map! {
+                    TokenId::from(2) => 50
+                }))
+            });
+
+        let priority_source =
+            PriorityPriceSource::new(vec![Box::new(first_source), Box::new(second_source)]);
+        priority_source
+            .get_prices(&[1.into(), 2.into()])
+            .now_or_never();
+    }
+
+    #[test]
+    fn skips_failing_sources() {
+        let mut first_source = MockPriceSource::new();
+        let mut second_source = MockPriceSource::new();
+
+        first_source
+            .expect_get_prices()
+            .returning(|_| immediate!(Err(anyhow!("Error"))));
+        second_source.expect_get_prices().returning(|_| {
+            immediate!(Ok(hash_map! {
+                TokenId::from(1) => 50
+            }))
+        });
+
+        let priority_source =
+            PriorityPriceSource::new(vec![Box::new(first_source), Box::new(second_source)]);
+        assert_eq!(
+            priority_source
+                .get_prices(&[1.into()])
+                .now_or_never()
+                .unwrap()
+                .unwrap(),
+            hash_map! {
+                TokenId::from(1) => 50
+            }
+        );
+    }
+
+    #[test]
+    fn omits_tokens_for_which_no_prices_exist() {
+        let mut source = MockPriceSource::new();
+
+        source.expect_get_prices().returning(|_| {
+            immediate!(Ok(hash_map! {
+                TokenId::from(2) => 50
+            }))
+        });
+
+        let priority_source = PriorityPriceSource::new(vec![Box::new(source)]);
+        assert_eq!(
+            priority_source
+                .get_prices(&[1.into(), 2.into()])
+                .now_or_never()
+                .unwrap()
+                .unwrap(),
+            hash_map! {
+                TokenId::from(2) => 50
+            }
+        );
+    }
+}

--- a/core/src/price_estimation/priority_price_source.rs
+++ b/core/src/price_estimation/priority_price_source.rs
@@ -2,8 +2,7 @@ use super::PriceSource;
 use crate::models::TokenId;
 use anyhow::Result;
 use futures::future::{BoxFuture, FutureExt as _};
-use std::collections::{HashMap, HashSet};
-use std::iter::FromIterator;
+use std::collections::HashMap;
 
 /**
  * A price source that sequentially queries its inner sources in order and returns the
@@ -26,11 +25,10 @@ impl PriceSource for PriorityPriceSource {
         tokens: &'a [TokenId],
     ) -> BoxFuture<'a, Result<HashMap<TokenId, u128>>> {
         async move {
-            let mut remaining_tokens: HashSet<_> = HashSet::from_iter(tokens.iter().cloned());
+            let mut remaining_tokens = tokens.to_vec();
             let mut result = HashMap::new();
             for source in &self.sources {
-                let remaining_token_vec = Vec::from_iter(remaining_tokens.iter().cloned());
-                match source.get_prices(&remaining_token_vec).await {
+                match source.get_prices(&remaining_tokens).await {
                     Ok(partial_result) => {
                         remaining_tokens = remaining_tokens
                             .into_iter()


### PR DESCRIPTION
Partially related to #1007. While trying to read `TokenBaseInformation` from chain I noticed that this struct also contains the external price which is not part of the data we fetch from chain (we only fetch symbol and decimals). 

I therefore started looking at what it takes to separate the price information from the token base info (in line with @e00E's suggestion to make the token base info a separate piece of metadata that the solver does not need to care about).

My suggestion for separating the two is as follows:

1. Have the hardcoded TokenData contain a struct that can have any of the three pieces of information: decimals, symbol, external price (this will allow us to override any and all aspects of a token). This struct will be read from the config like today.
2. Implement `PriceSource` on the hardcoded `TokenData` (on top of `TokenInfoFetching`)
3. Use the abstract `PriceSource` trait to fetch the final price (instead of having custom override logic in `PriceOracle`)
4. Make the TokenInfoFetching return a struct that only contains `symbol` and `decimals`. This can then be implemented by the hardcoded TokenData as well as the Onchain TokenInfoFetching.
5. Use a similar override chain for `TokenInfo` (first looking at TokenData then in the cache, then onchain) as for the different price sources

This PR specifically is part of step 3 and will allow the PriceOracle to get rid of custom override logic and instead rely on its price source hierarchy to chose the right price. Hardcoded TokenData will become the highest priority source (overriding all other sources) followed by the current AveragePriceSource.

This will allow us to get rid of some logic in PriceOracle

### Test Plan
Unit tests