### PR TITLE
Implementing PriceSource for TokenData

### DIFF
--- a/core/src/price_estimation.rs
+++ b/core/src/price_estimation.rs
@@ -5,14 +5,14 @@ mod average_price_source;
 mod dexag;
 mod kraken;
 mod orderbook_based;
-mod price_source;
+pub mod price_source;
 mod priority_price_source;
 mod threaded_price_source;
 
 use self::dexag::DexagClient;
 use self::kraken::KrakenClient;
 use self::orderbook_based::PricegraphEstimator;
-use crate::token_info::TokenInfoFetching;
+use crate::token_info::{hardcoded::TokenData, TokenInfoFetching};
 use crate::{
     http::HttpFactory,
     models::{Order, TokenId, TokenInfo},
@@ -23,6 +23,7 @@ use average_price_source::AveragePriceSource;
 use futures::future::{BoxFuture, FutureExt as _};
 use log::warn;
 use price_source::PriceSource;
+use priority_price_source::PriorityPriceSource;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::iter;
 use std::iter::FromIterator;
@@ -53,9 +54,10 @@ impl PriceOracle {
     pub fn new(
         http_factory: &HttpFactory,
         orderbook_reader: Arc<dyn StableXOrderBookReading>,
-        token_info_fetcher: Arc<dyn TokenInfoFetching>,
+        token_data: TokenData,
         update_interval: Duration,
     ) -> Result<Self> {
+        let token_info_fetcher = Arc::new(token_data.clone());
         let (kraken_source, _) = ThreadedPriceSource::new(
             token_info_fetcher.clone(),
             KrakenClient::new(http_factory, token_info_fetcher.clone())?,
@@ -66,15 +68,19 @@ impl PriceOracle {
             DexagClient::new(http_factory, token_info_fetcher.clone())?,
             update_interval,
         );
-        let source = Box::new(AveragePriceSource::new(vec![
+        let averaged_source = Box::new(AveragePriceSource::new(vec![
             Box::new(kraken_source),
             Box::new(dexag_source),
             Box::new(PricegraphEstimator::new(orderbook_reader)),
         ]));
+        let prioritized_source = Box::new(PriorityPriceSource::new(vec![
+            Box::new(token_data),
+            averaged_source,
+        ]));
 
         Ok(PriceOracle {
             token_info_fetcher,
-            source,
+            source: prioritized_source,
         })
     }
 
@@ -123,22 +129,20 @@ impl PriceEstimating for PriceOracle {
 
             let mut tokens = Tokens::new();
             for token_id in token_ids_to_price {
-                let price = prices.get(&token_id).copied();
-                let token_info =
-                    if let Ok(base_info) = self.token_info_fetcher.get_token_info(token_id).await {
-                        Some(TokenInfo {
-                            external_price: price.unwrap_or(base_info.external_price),
-                            ..base_info.into()
-                        })
-                    } else if let Some(price) = price {
-                        Some(TokenInfo {
-                            alias: None,
-                            decimals: None,
-                            external_price: price,
-                        })
-                    } else {
-                        None
+                let token_info = if let Some(price) = prices.get(&token_id) {
+                    let mut token_info = TokenInfo {
+                        alias: None,
+                        decimals: None,
+                        external_price: *price,
                     };
+                    if let Ok(base_info) = self.token_info_fetcher.get_token_info(token_id).await {
+                        token_info.alias = Some(base_info.alias);
+                        token_info.decimals = Some(base_info.decimals);
+                    }
+                    Some(token_info)
+                } else {
+                    None
+                };
                 tokens.insert(token_id, token_info);
             }
             tokens
@@ -172,6 +176,7 @@ mod tests {
             .returning(|_| {
                 async {
                     Ok(hash_map! {
+                        TokenId(1) => 0,
                         TokenId(2) => 1_000_000_000_000_000_000,
                     })
                 }
@@ -222,7 +227,7 @@ mod tests {
             prices,
             btree_map! {
                 TokenId(0) => None,
-                TokenId(1) => Some(TokenInfo::new("WETH", 18, 0)),
+                TokenId(1) => None,
             }
         );
     }
@@ -233,31 +238,5 @@ mod tests {
         let prices = oracle.get_token_prices(&[]).now_or_never().unwrap();
 
         assert_eq!(prices, btree_map! { TokenId(0) => None });
-    }
-
-    #[test]
-    fn price_oracle_uses_uses_fallback_prices() {
-        let tokens = Arc::new(TokenData::from(hash_map! {
-            TokenId(7) => TokenBaseInfo::new("DAI", 18, 1_000_000_000_000_000_000),
-        }));
-
-        let mut source = MockPriceSource::new();
-        source
-            .expect_get_prices()
-            .returning(|_| async { Ok(HashMap::new()) }.boxed());
-
-        let oracle = PriceOracle::with_source(tokens, source);
-        let prices = oracle
-            .get_token_prices(&[Order::for_token_pair(0, 7)])
-            .now_or_never()
-            .unwrap();
-
-        assert_eq!(
-            prices,
-            btree_map! {
-                TokenId(0) => None,
-                TokenId(7) => Some(TokenInfo::new("DAI", 18, 1_000_000_000_000_000_000)),
-            }
-        );
     }
 }

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -242,7 +242,7 @@ fn main() {
     let price_oracle = PriceOracle::new(
         &http_factory,
         orderbook.clone(),
-        Arc::new(options.token_data),
+        options.token_data,
         options.price_source_update_interval,
     )
     .unwrap();


### PR DESCRIPTION
Depends on #1068

This PR implements PriceSource on TokenData and uses it in combination with the priority price source to get rid of the custom override logic in the PriceOracle. We can now rely on the PriceSource to give us a correct price estimate and can orthogonally and optionally (later we might want to do this somewhere else), fetch token information via the TokenInfoFetching trait.

### Test Plan

Unit tests as well as making sure that our instance file still has the correct metadata when running locally on mainnet.