### PR TITLE
Use two-stage model for standard solver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ language: rust
 env:
   global:
     - OPEN_SOLVER_VERSION=v0.0.10
-    - PRIVATE_SOLVER_VERSION=v0.7.6
+    - PRIVATE_SOLVER_VERSION=v0.7.7
 
 install:
   - nvm install 12 && nvm alias default 12 && npm install -g yarn@latest && yarn --version

--- a/core/src/price_finding/price_finder_interface.rs
+++ b/core/src/price_finding/price_finder_interface.rs
@@ -117,7 +117,11 @@ impl SolverType {
                 input_file,
                 time_limit,
                 min_avg_fee_per_order,
-                if self == SolverType::StandardSolver {OptModel::TwoStage} else {OptModel::Mip},
+                if self == SolverType::StandardSolver {
+                    OptModel::TwoStage
+                } else {
+                    OptModel::Mip
+                },
                 internal_optimizer,
                 self == SolverType::BestRingSolver,
             ),

--- a/core/src/price_finding/price_finder_interface.rs
+++ b/core/src/price_finding/price_finder_interface.rs
@@ -57,17 +57,6 @@ pub enum OptModel {
     TwoStage,
 }
 
-impl FromStr for OptModel {
-    type Err = Error;
-    fn from_str(string: &str) -> Result<Self> {
-        match string {
-            "mip" => Ok(Self::Mip),
-            "two_stage" => Ok(Self::TwoStage),
-            _ => Err(anyhow!("optimization model does not exit")),
-        }
-    }
-}
-
 impl OptModel {
     fn to_argument(self) -> &'static str {
         match self {

--- a/core/src/price_finding/price_finder_interface.rs
+++ b/core/src/price_finding/price_finder_interface.rs
@@ -53,14 +53,14 @@ impl InternalOptimizer {
 /// The optimization algorithm used by standard and best-ring solvers.
 #[derive(Clone, Copy, Debug)]
 pub enum OptModel {
-    Mip,
+    MixedInteger,
     TwoStage,
 }
 
 impl OptModel {
     fn to_argument(self) -> &'static str {
         match self {
-            OptModel::Mip => "mip",
+            OptModel::MixedInteger => "mip",
             OptModel::TwoStage => "two_stage",
         }
     }
@@ -109,7 +109,7 @@ impl SolverType {
                 if self == SolverType::StandardSolver {
                     OptModel::TwoStage
                 } else {
-                    OptModel::Mip
+                    OptModel::MixedInteger
                 },
                 internal_optimizer,
                 self == SolverType::BestRingSolver,


### PR DESCRIPTION
This PR:
* passes the `--optModel` parameter to the private solvers (standard and best-ring)
* uses the two-stage model for the standard solver (see https://github.com/gnosis/dex-solver/pull/296)
* updates the solver version to v0.7.7

### Test Plan
e2e tests