### PR TITLE
Cached TokenInfoFetching

### DIFF
--- a/core/src/token_info.rs
+++ b/core/src/token_info.rs
@@ -6,6 +6,7 @@ use mockall::automock;
 use std::collections::HashMap;
 
 use crate::models::TokenId;
+pub mod cached;
 pub mod hardcoded;
 pub mod onchain;
 

--- a/core/src/token_info/cached.rs
+++ b/core/src/token_info/cached.rs
@@ -25,7 +25,7 @@ impl TokenInfoCache {
     }
 
     #[allow(dead_code)]
-    pub fn new_with_existing_cache(
+    pub fn new_with_cache(
         inner: Arc<dyn TokenInfoFetching>,
         cache: HashMap<TokenId, TokenBaseInfo>,
     ) -> Self {
@@ -138,7 +138,7 @@ mod tests {
             alias: "Foo".to_owned(),
             decimals: 42,
         };
-        let cache = TokenInfoCache::new_with_existing_cache(
+        let cache = TokenInfoCache::new_with_cache(
             Arc::new(inner),
             hash_map! {
                 TokenId::from(1) => hardcoded.clone()

--- a/core/src/token_info/cached.rs
+++ b/core/src/token_info/cached.rs
@@ -25,7 +25,7 @@ impl TokenInfoCache {
     }
 
     #[allow(dead_code)]
-    pub fn new_with_cache(
+    pub fn with_cache(
         inner: Arc<dyn TokenInfoFetching>,
         cache: HashMap<TokenId, TokenBaseInfo>,
     ) -> Self {
@@ -138,7 +138,7 @@ mod tests {
             alias: "Foo".to_owned(),
             decimals: 42,
         };
-        let cache = TokenInfoCache::new_with_cache(
+        let cache = TokenInfoCache::with_cache(
             Arc::new(inner),
             hash_map! {
                 TokenId::from(1) => hardcoded.clone()

--- a/core/src/token_info/cached.rs
+++ b/core/src/token_info/cached.rs
@@ -1,0 +1,126 @@
+use super::{TokenBaseInfo, TokenId, TokenInfoFetching};
+
+use anyhow::Result;
+use futures::future::{BoxFuture, FutureExt};
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+/**
+ * Implementation of TokenInfoFetching that stores previously fetched information in an in-memory cache for fast retrieval.
+ * TokenIds will always be fetched from the inner layer, as new tokens could be added at any time.
+ */
+struct TokenInfoCache {
+    cache: RwLock<HashMap<TokenId, TokenBaseInfo>>,
+    inner: Arc<dyn TokenInfoFetching>,
+}
+
+impl TokenInfoCache {
+    #[allow(dead_code)]
+    pub fn new(inner: Arc<dyn TokenInfoFetching>) -> Self {
+        Self {
+            cache: RwLock::new(HashMap::new()),
+            inner,
+        }
+    }
+}
+
+impl TokenInfoFetching for TokenInfoCache {
+    fn get_token_info<'a>(&'a self, id: TokenId) -> BoxFuture<'a, Result<TokenBaseInfo>> {
+        if let Some(info) = self
+            .cache
+            .read()
+            .ok()
+            .and_then(|cache| cache.get(&id).cloned())
+        {
+            return immediate!(Ok(info));
+        }
+        async move {
+            let info = self.inner.get_token_info(id).await;
+            if let (Ok(info), Ok(mut cache)) = (info.as_ref(), self.cache.write()) {
+                cache.insert(id, info.clone());
+            }
+            info
+        }
+        .boxed()
+    }
+
+    fn all_ids<'a>(&'a self) -> BoxFuture<'a, Result<Vec<TokenId>>> {
+        self.inner.all_ids()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::MockTokenInfoFetching;
+    use super::*;
+    use anyhow::anyhow;
+
+    #[test]
+    fn calls_inner_once_per_token_id_on_success() {
+        let mut inner = MockTokenInfoFetching::new();
+
+        inner.expect_get_token_info().times(1).returning(|_| {
+            immediate!(Ok(TokenBaseInfo {
+                alias: "Foo".to_owned(),
+                decimals: 18,
+            }))
+        });
+
+        let cache = TokenInfoCache::new(Arc::new(inner));
+        let first = cache
+            .get_token_info(1.into())
+            .now_or_never()
+            .expect("First fetch not immediate")
+            .expect("First fetch failed");
+        let second = cache
+            .get_token_info(1.into())
+            .now_or_never()
+            .expect("Second fetch not immediate")
+            .expect("Second fetch failed");
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn calls_inner_again_on_error() {
+        let mut inner = MockTokenInfoFetching::new();
+
+        inner
+            .expect_get_token_info()
+            .times(2)
+            .returning(|_| immediate!(Err(anyhow!("error"))));
+
+        let cache = TokenInfoCache::new(Arc::new(inner));
+        cache
+            .get_token_info(1.into())
+            .now_or_never()
+            .expect("First fetch not immediate")
+            .expect_err("Fetch should return error");
+        cache
+            .get_token_info(1.into())
+            .now_or_never()
+            .expect("Second fetch not immediate")
+            .expect_err("Fetch should return error");
+    }
+
+    #[test]
+    fn always_calls_all_ids_on_inner() {
+        let mut inner = MockTokenInfoFetching::new();
+
+        inner
+            .expect_all_ids()
+            .times(2)
+            .returning(|| immediate!(Ok(vec![])));
+
+        let cache = TokenInfoCache::new(Arc::new(inner));
+        cache
+            .all_ids()
+            .now_or_never()
+            .expect("Not Immediate")
+            .expect("First fetch failed");
+        cache
+            .all_ids()
+            .now_or_never()
+            .expect("Not Immediate")
+            .expect("Second fetch failed");
+    }
+}


### PR DESCRIPTION
Part of #1007 

TokenInfo is unlikely to change over time (contracts would have to do something really 🤡 like changing decimals based on block number or the like).
Hitting the chain every time we want to fetch data is costly, and can easily be cached. This PR implements an in-memory cache for fetching token Info. It still hits the chain every-time we want to fetch all token Ids, since this can theoretically happen on every block (depending on load, we might consider caching this as well with a time to live).

I had to use a thread safe, interior mutability datatype and chose a RWLock as on cache hit we only read the cache and this can happen in parallel (a Mutex does not allow parallel reads). Not that this performance difference is critical, but I didn't see a reason to use a Mutex (couldn't find clear evidence on overhead and [this post](https://www.reddit.com/r/rust/comments/5bx34b/mutex_vs_rwlock/?utm_source=share&utm_medium=web2x) suggests the main difference are trait bounds on the inner type).

### Test Plan
Unit tests