### PR TITLE
Remove price from TokenBaseInfo

### DIFF
--- a/core/src/price_estimation.rs
+++ b/core/src/price_estimation.rs
@@ -152,15 +152,15 @@ impl PriceEstimating for PriceOracle {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::token_info::{hardcoded::TokenData, TokenBaseInfo};
+    use crate::token_info::hardcoded::{TokenData, TokenInfoOverride};
     use anyhow::anyhow;
     use price_source::{MockPriceSource, NoopPriceSource};
 
     #[test]
     fn price_oracle_fetches_token_prices() {
         let tokens = Arc::new(TokenData::from(hash_map! {
-            TokenId(1) => TokenBaseInfo::new("WETH", 18, 0),
-            TokenId(2) => TokenBaseInfo::new("USDT", 6, 0),
+            TokenId(1) => TokenInfoOverride::new("WETH", 18, 0),
+            TokenId(2) => TokenInfoOverride::new("USDT", 6, 0),
         }));
 
         let mut source = MockPriceSource::new();
@@ -207,7 +207,7 @@ mod tests {
     #[test]
     fn price_oracle_ignores_source_error() {
         let tokens = Arc::new(TokenData::from(hash_map! {
-            TokenId(1) => TokenBaseInfo::new("WETH", 18, 0),
+            TokenId(1) => TokenInfoOverride::new("WETH", 18, 0),
         }));
 
         let mut source = MockPriceSource::new();

--- a/core/src/price_estimation/clients/dexag.rs
+++ b/core/src/price_estimation/clients/dexag.rs
@@ -11,7 +11,7 @@ mod tests {
     use crate::http::HttpFactory;
     use crate::models::TokenId;
     use crate::price_estimation::price_source::PriceSource;
-    use crate::token_info::{hardcoded::TokenData, TokenBaseInfo};
+    use crate::token_info::hardcoded::{TokenData, TokenInfoOverride};
     use crate::util::FutureWaitExt as _;
     use std::sync::Arc;
 
@@ -22,16 +22,16 @@ mod tests {
         use std::time::Instant;
 
         let tokens = hash_map! {
-            TokenId(1) => TokenBaseInfo::new("WETH", 18, 0),
-            TokenId(2) => TokenBaseInfo::new("USDT", 6, 0),
-            TokenId(3) => TokenBaseInfo::new("TUSD", 18, 0),
-            TokenId(4) => TokenBaseInfo::new("USDC", 6, 0),
-            TokenId(5) => TokenBaseInfo::new("PAX", 18, 0),
-            TokenId(6) => TokenBaseInfo::new("GUSD", 2, 0),
-            TokenId(7) => TokenBaseInfo::new("DAI", 18, 0),
-            TokenId(8) => TokenBaseInfo::new("sETH", 18, 0),
-            TokenId(9) => TokenBaseInfo::new("sUSD", 18, 0),
-            TokenId(15) => TokenBaseInfo::new("SNX", 18, 0)
+            TokenId(1) => TokenInfoOverride::new("WETH", 18, 0),
+            TokenId(2) => TokenInfoOverride::new("USDT", 6, 0),
+            TokenId(3) => TokenInfoOverride::new("TUSD", 18, 0),
+            TokenId(4) => TokenInfoOverride::new("USDC", 6, 0),
+            TokenId(5) => TokenInfoOverride::new("PAX", 18, 0),
+            TokenId(6) => TokenInfoOverride::new("GUSD", 2, 0),
+            TokenId(7) => TokenInfoOverride::new("DAI", 18, 0),
+            TokenId(8) => TokenInfoOverride::new("sETH", 18, 0),
+            TokenId(9) => TokenInfoOverride::new("sUSD", 18, 0),
+            TokenId(15) => TokenInfoOverride::new("SNX", 18, 0)
         };
         let mut ids: Vec<TokenId> = tokens.keys().copied().collect();
 
@@ -50,7 +50,7 @@ mod tests {
 
         ids.sort();
         for id in ids {
-            let symbol = tokens.get(&id).unwrap().symbol();
+            let symbol = &tokens.get(&id).unwrap().alias;
             if let Some(price) = prices.get(&id) {
                 println!("Token {} has OWL price of {}.", symbol, price);
             } else {

--- a/core/src/price_estimation/clients/generic_client.rs
+++ b/core/src/price_estimation/clients/generic_client.rs
@@ -168,7 +168,7 @@ where
 mod tests {
     use super::*;
     use crate::models::TokenId;
-    use crate::token_info::{hardcoded::TokenData, TokenBaseInfo};
+    use crate::token_info::hardcoded::{TokenData, TokenInfoOverride};
     use anyhow::anyhow;
     use lazy_static::lazy_static;
     use mockall::{predicate::*, Sequence};
@@ -213,7 +213,7 @@ mod tests {
         api.expect_get_token_list()
             .returning(|| async { Ok(Vec::new()) }.boxed());
 
-        let tokens = hash_map! { TokenId::from(6) => TokenBaseInfo::new("DAI", 18, 0)};
+        let tokens = hash_map! { TokenId::from(6) => TokenInfoOverride::new("DAI", 18, 0)};
         assert!(GenericClient::<MockApi>::with_api_and_tokens(
             api,
             Arc::new(TokenData::from(tokens))
@@ -227,7 +227,7 @@ mod tests {
     #[test]
     fn get_token_prices_initialization_fails_then_works() {
         initialize_mockapi_context();
-        let tokens = hash_map! { TokenId::from(1) => TokenBaseInfo::new("ETH", 18, 0)};
+        let tokens = hash_map! { TokenId::from(1) => TokenInfoOverride::new("ETH", 18, 0)};
         let mut api = MockApi::new();
         let mut seq = Sequence::new();
 
@@ -271,9 +271,9 @@ mod tests {
         let mut api = MockApi::new();
 
         let tokens = hash_map! {
-            TokenId(6) => TokenBaseInfo::new("DAI", 18, 0),
-            TokenId(1) => TokenBaseInfo::new("ETH", 18, 0),
-            TokenId(4) => TokenBaseInfo::new("USDC", 6, 0),
+            TokenId(6) => TokenInfoOverride::new("DAI", 18, 0),
+            TokenId(1) => TokenInfoOverride::new("ETH", 18, 0),
+            TokenId(4) => TokenInfoOverride::new("USDC", 6, 0),
         };
 
         lazy_static! {
@@ -307,9 +307,9 @@ mod tests {
         assert_eq!(
             prices,
             hash_map! {
-                TokenId(1) => tokens.get(&1.into()).unwrap().get_owl_price(0.7) as u128,
-                TokenId(4) => tokens.get(&4.into()).unwrap().get_owl_price(1.2) as u128,
-                TokenId(6) => tokens.get(&6.into()).unwrap().get_owl_price(1.0) as u128
+                TokenId(1) => (0.7 * 10f64.powi(18)) as u128,
+                TokenId(4) => (1.2 * 10f64.powi(30)) as u128,
+                TokenId(6) => 10u128.pow(18)
             }
         );
     }
@@ -320,8 +320,8 @@ mod tests {
         let mut api = MockApi::new();
 
         let tokens = hash_map! {
-            TokenId(6) => TokenBaseInfo::new("DAI", 18, 0),
-            TokenId(1) => TokenBaseInfo::new("ETH", 18, 0)
+            TokenId(6) => TokenInfoOverride::new("DAI", 18, 0),
+            TokenId(1) => TokenInfoOverride::new("ETH", 18, 0)
         };
 
         lazy_static! {
@@ -352,7 +352,7 @@ mod tests {
             prices,
             hash_map! {
                 // No TokenId(1) because we made the price error above.
-                TokenId(6) => tokens.get(&6.into()).unwrap().get_owl_price(1.0) as u128,
+                TokenId(6) => 10u128.pow(18),
             }
         );
     }
@@ -363,9 +363,9 @@ mod tests {
         let mut api = MockApi::new();
 
         let tokens = hash_map! {
-            TokenId(6) => TokenBaseInfo::new("dai", 18, 0),
-            TokenId(1) => TokenBaseInfo::new("ETH", 18, 0),
-            TokenId(4) => TokenBaseInfo::new("sUSD", 6, 0)
+            TokenId(6) => TokenInfoOverride::new("dai", 18, 0),
+            TokenId(1) => TokenInfoOverride::new("ETH", 18, 0),
+            TokenId(4) => TokenInfoOverride::new("sUSD", 6, 0)
         };
 
         lazy_static! {
@@ -391,9 +391,9 @@ mod tests {
         assert_eq!(
             prices,
             hash_map! {
-                TokenId(1) => tokens.get(&1.into()).unwrap().get_owl_price(1.0) as u128,
-                TokenId(4) => tokens.get(&4.into()).unwrap().get_owl_price(1.0) as u128,
-                TokenId(6) => tokens.get(&6.into()).unwrap().get_owl_price(1.0) as u128
+                TokenId(1) => 10f64.powi(18) as u128,
+                TokenId(4) => 10f64.powi(30) as u128,
+                TokenId(6) => 10f64.powi(18) as u128,
             }
         );
     }

--- a/core/src/price_estimation/clients/generic_client.rs
+++ b/core/src/price_estimation/clients/generic_client.rs
@@ -295,10 +295,8 @@ mod tests {
             )
             .returning(|_, _| async { Ok(1.2) }.boxed());
 
-        let client = GenericClient::<MockApi>::with_api_and_tokens(
-            api,
-            Arc::new(TokenData::from(tokens.clone())),
-        );
+        let client =
+            GenericClient::<MockApi>::with_api_and_tokens(api, Arc::new(TokenData::from(tokens)));
         let prices = client
             .get_prices(&[1.into(), 4.into(), 6.into()])
             .now_or_never()
@@ -339,10 +337,8 @@ mod tests {
             )
             .returning(|_, _| async { Err(anyhow!("")) }.boxed());
 
-        let client = GenericClient::<MockApi>::with_api_and_tokens(
-            api,
-            Arc::new(TokenData::from(tokens.clone())),
-        );
+        let client =
+            GenericClient::<MockApi>::with_api_and_tokens(api, Arc::new(TokenData::from(tokens)));
         let prices = client
             .get_prices(&[6.into(), 1.into()])
             .now_or_never()
@@ -379,10 +375,8 @@ mod tests {
         api.expect_get_price()
             .returning(|_, _| async { Ok(1.0) }.boxed());
 
-        let client = GenericClient::<MockApi>::with_api_and_tokens(
-            api,
-            Arc::new(TokenData::from(tokens.clone())),
-        );
+        let client =
+            GenericClient::<MockApi>::with_api_and_tokens(api, Arc::new(TokenData::from(tokens)));
         let prices = client
             .get_prices(&[1.into(), 4.into(), 6.into()])
             .now_or_never()

--- a/core/src/price_estimation/clients/kraken.rs
+++ b/core/src/price_estimation/clients/kraken.rs
@@ -155,7 +155,7 @@ fn find_asset_pair<'a>(
 mod tests {
     use super::api::{MockKrakenApi, TickerInfo};
     use super::*;
-    use crate::token_info::{hardcoded::TokenData, TokenBaseInfo};
+    use crate::token_info::hardcoded::{TokenData, TokenInfoOverride};
     use crate::util::FutureWaitExt as _;
     use std::collections::HashSet;
     use std::time::Instant;
@@ -163,9 +163,9 @@ mod tests {
     #[test]
     fn get_token_prices() {
         let tokens = hash_map! {
-            TokenId(1) => TokenBaseInfo::new("ETH", 18, 0),
-            TokenId(4) => TokenBaseInfo::new("USDC", 6, 0),
-            TokenId(5) => TokenBaseInfo::new("PAX", 18, 0),
+            TokenId(1) => TokenInfoOverride::new("ETH", 18, 0),
+            TokenId(4) => TokenInfoOverride::new("USDC", 6, 0),
+            TokenId(5) => TokenInfoOverride::new("PAX", 18, 0),
         };
 
         let mut api = MockKrakenApi::new();
@@ -231,16 +231,16 @@ mod tests {
         // ```
 
         let tokens = hash_map! {
-            TokenId(1) => TokenBaseInfo::new("WETH", 18, 0),
-            TokenId(2) => TokenBaseInfo::new("USDT", 6, 0),
-            TokenId(3) => TokenBaseInfo::new("TUSD", 18, 0),
-            TokenId(4) => TokenBaseInfo::new("USDC", 6, 0),
-            TokenId(5) => TokenBaseInfo::new("PAX", 18, 0),
-            TokenId(6) => TokenBaseInfo::new("GUSD", 2, 0),
-            TokenId(7) => TokenBaseInfo::new("DAI", 18, 0),
-            TokenId(8) => TokenBaseInfo::new("sETH", 18, 0),
-            TokenId(9) => TokenBaseInfo::new("sUSD", 18, 0),
-            TokenId(15) => TokenBaseInfo::new("SNX", 18, 0)
+            TokenId(1) => TokenInfoOverride::new("WETH", 18, 0),
+            TokenId(2) => TokenInfoOverride::new("USDT", 6, 0),
+            TokenId(3) => TokenInfoOverride::new("TUSD", 18, 0),
+            TokenId(4) => TokenInfoOverride::new("USDC", 6, 0),
+            TokenId(5) => TokenInfoOverride::new("PAX", 18, 0),
+            TokenId(6) => TokenInfoOverride::new("GUSD", 2, 0),
+            TokenId(7) => TokenInfoOverride::new("DAI", 18, 0),
+            TokenId(8) => TokenInfoOverride::new("sETH", 18, 0),
+            TokenId(9) => TokenInfoOverride::new("sUSD", 18, 0),
+            TokenId(15) => TokenInfoOverride::new("SNX", 18, 0)
         };
         let token_ids: Vec<TokenId> = tokens.keys().copied().collect();
 

--- a/core/src/token_info.rs
+++ b/core/src/token_info.rs
@@ -3,10 +3,9 @@ use futures::future::BoxFuture;
 use lazy_static::lazy_static;
 #[cfg(test)]
 use mockall::automock;
-use serde::Deserialize;
 use std::collections::HashMap;
 
-use crate::models::{TokenId, TokenInfo};
+use crate::models::TokenId;
 pub mod hardcoded;
 
 #[cfg_attr(test, automock)]
@@ -17,31 +16,20 @@ pub trait TokenInfoFetching: Send + Sync {
     /// Returns a vector with all the token IDs available
     fn all_ids<'a>(&'a self) -> BoxFuture<'a, Result<Vec<TokenId>>>;
 }
-
-/// Base token info to use for providing token information to the solver. This
-/// differs slightly from the `TokenInfo` type in that is allows some extra
-/// parameters that are used by the `price_estimation` module but do not get
-/// passed to the solver.
 #[cfg_attr(test, derive(Eq, PartialEq))]
-#[derive(Clone, Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug)]
 pub struct TokenBaseInfo {
-    // NOTE: We have to, unfortunately duplicate fields and cannot use
-    //   `#[serde(flatten)]` as it does not interact correctly with `u128`s:
-    //   https://github.com/serde-rs/json/issues/625
     pub alias: String,
     pub decimals: u8,
-    pub external_price: u128,
 }
 
 impl TokenBaseInfo {
     /// Create new token information from its parameters.
     #[cfg(test)]
-    pub fn new(alias: impl Into<String>, decimals: u8, external_price: u128) -> Self {
+    pub fn new(alias: impl Into<String>, decimals: u8) -> Self {
         TokenBaseInfo {
             alias: alias.into(),
             decimals,
-            external_price,
         }
     }
 
@@ -70,12 +58,37 @@ impl TokenBaseInfo {
     }
 }
 
-impl Into<TokenInfo> for TokenBaseInfo {
-    fn into(self) -> TokenInfo {
-        TokenInfo {
-            alias: Some(self.alias),
-            decimals: Some(self.decimals),
-            external_price: self.external_price,
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_get_price() {
+        for (token, usd_price, expected) in &[
+            (TokenBaseInfo::new("USDC", 6), 0.99, 0.99 * 10f64.powi(30)),
+            (TokenBaseInfo::new("DAI", 18), 1.01, 1.01 * 10f64.powi(18)),
+            (TokenBaseInfo::new("FAKE", 32), 1.0, 10f64.powi(4)),
+            (
+                TokenBaseInfo::new("SCAM", 42),
+                10f64.powi(10),
+                10f64.powi(4),
+            ),
+        ] {
+            let owl_price = token.get_owl_price(*usd_price);
+            assert_eq!(owl_price, *expected as u128);
         }
+    }
+
+    #[test]
+    fn token_get_price_without_rounding_error() {
+        assert_eq!(
+            TokenBaseInfo::new("OWL", 18).get_owl_price(1.0),
+            1_000_000_000_000_000_000,
+        );
+    }
+
+    #[test]
+    fn weth_token_symbol_is_eth() {
+        assert_eq!(TokenBaseInfo::new("WETH", 18).symbol(), "ETH");
     }
 }

--- a/core/src/token_info/hardcoded.rs
+++ b/core/src/token_info/hardcoded.rs
@@ -12,13 +12,41 @@ use std::iter::FromIterator;
 use std::str::FromStr;
 
 use super::{TokenBaseInfo, TokenInfoFetching};
+#[cfg_attr(test, derive(Eq, PartialEq))]
+#[derive(Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenInfoOverride {
+    pub alias: String,
+    pub decimals: u8,
+    pub external_price: Option<u128>,
+}
+
+impl TokenInfoOverride {
+    #[cfg(test)]
+    pub fn new(alias: &str, decimals: u8, external_price: u128) -> Self {
+        Self {
+            alias: alias.to_owned(),
+            decimals,
+            external_price: Some(external_price),
+        }
+    }
+}
+
+impl Into<TokenBaseInfo> for TokenInfoOverride {
+    fn into(self) -> TokenBaseInfo {
+        TokenBaseInfo {
+            alias: self.alias,
+            decimals: self.decimals,
+        }
+    }
+}
 
 /// Token fallback data containing all fallback information for tokens that
 /// should be provided to the solver.
 #[cfg_attr(test, derive(Eq, PartialEq))]
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(transparent)]
-pub struct TokenData(HashMap<TokenId, TokenBaseInfo>);
+pub struct TokenData(HashMap<TokenId, TokenInfoOverride>);
 
 impl TokenInfoFetching for TokenData {
     fn get_token_info<'a>(&'a self, id: TokenId) -> BoxFuture<'a, Result<TokenBaseInfo>> {
@@ -27,7 +55,7 @@ impl TokenInfoFetching for TokenData {
             .get(&id)
             .cloned()
             .ok_or_else(|| anyhow!("Token {:?} not found in hardcoded data", id));
-        immediate!(info)
+        immediate!(Ok(info?.into()))
     }
 
     fn all_ids<'a>(&'a self) -> BoxFuture<'a, Result<Vec<TokenId>>> {
@@ -43,16 +71,16 @@ impl PriceSource for TokenData {
     ) -> BoxFuture<'a, Result<HashMap<TokenId, u128>>> {
         let mut result = HashMap::new();
         for token in tokens {
-            if let Some(info) = self.0.get(token) {
-                result.insert(*token, info.external_price);
+            if let Some(price) = self.0.get(token).and_then(|info| info.external_price) {
+                result.insert(*token, price);
             }
         }
         immediate!(Ok(result))
     }
 }
 
-impl From<HashMap<TokenId, TokenBaseInfo>> for TokenData {
-    fn from(tokens: HashMap<TokenId, TokenBaseInfo>) -> Self {
+impl From<HashMap<TokenId, TokenInfoOverride>> for TokenData {
+    fn from(tokens: HashMap<TokenId, TokenInfoOverride>) -> Self {
         TokenData(tokens)
     }
 }
@@ -89,47 +117,9 @@ mod tests {
         assert_eq!(
             TokenData::from_str(json).unwrap(),
             TokenData::from(hash_map! {
-                TokenId(1) => TokenBaseInfo::new("WETH", 18, 200_000_000_000_000_000_000),
-                TokenId(4) => TokenBaseInfo::new("USDC", 6, 1_000_000_000_000_000_000_000_000_000_000),
+                TokenId(1) => TokenInfoOverride::new("WETH", 18, 200_000_000_000_000_000_000),
+                TokenId(4) => TokenInfoOverride::new("USDC", 6, 1_000_000_000_000_000_000_000_000_000_000),
             })
         );
-    }
-
-    #[test]
-    fn token_get_price() {
-        for (token, usd_price, expected) in &[
-            (
-                TokenBaseInfo::new("USDC", 6, 0),
-                0.99,
-                0.99 * 10f64.powi(30),
-            ),
-            (
-                TokenBaseInfo::new("DAI", 18, 0),
-                1.01,
-                1.01 * 10f64.powi(18),
-            ),
-            (TokenBaseInfo::new("FAKE", 32, 0), 1.0, 10f64.powi(4)),
-            (
-                TokenBaseInfo::new("SCAM", 42, 0),
-                10f64.powi(10),
-                10f64.powi(4),
-            ),
-        ] {
-            let owl_price = token.get_owl_price(*usd_price);
-            assert_eq!(owl_price, *expected as u128);
-        }
-    }
-
-    #[test]
-    fn token_get_price_without_rounding_error() {
-        assert_eq!(
-            TokenBaseInfo::new("OWL", 18, 0).get_owl_price(1.0),
-            1_000_000_000_000_000_000,
-        );
-    }
-
-    #[test]
-    fn weth_token_symbol_is_eth() {
-        assert_eq!(TokenBaseInfo::new("WETH", 18, 0).symbol(), "ETH");
     }
 }


### PR DESCRIPTION
Step 4 of plan outlined in #1068

This PR introduces a new type `TokenOverrideInfo` that is  read from the config `TOKEN_DATA` for overriding token information, such as symbol or price. `TokenBaseInfo` can then only contain `symbol` and `decimals` as prices are now fetched exclusively via the `PriceSource` trait.

Originally I planned to make all fields optional, however this will create some weirdness when we override symbol but still need to go on-chain for fetching decimals (the current abstraction doesn't work as nicely and would involve introducing a lot more optionals and `if let Some(x)` logic). It seems reasonable to override symbol and decimals in any case when doing a price override (they never change and symbol will serve as documentation which token we are overriding).

### Test Plan

CI