### PR TITLE
Onchain token fetching integration

### DIFF
--- a/core/src/orderbook/streamed.rs
+++ b/core/src/orderbook/streamed.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 mod balance;
 mod bigint_u256;
 mod block_timestamp_reading;

--- a/core/src/price_estimation.rs
+++ b/core/src/price_estimation.rs
@@ -57,7 +57,7 @@ impl PriceOracle {
         token_data: TokenData,
         update_interval: Duration,
     ) -> Result<Self> {
-        let token_info_fetcher = Arc::new(TokenInfoCache::new_with_cache(
+        let token_info_fetcher = Arc::new(TokenInfoCache::with_cache(
             contract,
             token_data.clone().into(),
         ));

--- a/core/src/price_estimation/orderbook_based.rs
+++ b/core/src/price_estimation/orderbook_based.rs
@@ -47,7 +47,6 @@ impl Pricegraph for Orderbook {
 }
 
 impl PricegraphEstimator {
-    #[allow(dead_code)]
     pub fn new(orderbook_reader: Arc<dyn StableXOrderBookReading>) -> Self {
         Self { orderbook_reader }
     }

--- a/core/src/price_estimation/priority_price_source.rs
+++ b/core/src/price_estimation/priority_price_source.rs
@@ -13,7 +13,6 @@ pub struct PriorityPriceSource {
 }
 
 impl PriorityPriceSource {
-    #[allow(dead_code)]
     pub fn new(sources: Vec<Box<dyn PriceSource + Send + Sync>>) -> Self {
         Self { sources }
     }

--- a/core/src/token_info/cached.rs
+++ b/core/src/token_info/cached.rs
@@ -10,13 +10,13 @@ use std::sync::Arc;
  * Implementation of TokenInfoFetching that stores previously fetched information in an in-memory cache for fast retrieval.
  * TokenIds will always be fetched from the inner layer, as new tokens could be added at any time.
  */
-struct TokenInfoCache {
+pub struct TokenInfoCache {
     cache: RwLock<HashMap<TokenId, TokenBaseInfo>>,
     inner: Arc<dyn TokenInfoFetching>,
 }
 
 impl TokenInfoCache {
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn new(inner: Arc<dyn TokenInfoFetching>) -> Self {
         Self {
             cache: RwLock::new(HashMap::new()),

--- a/core/src/token_info/hardcoded.rs
+++ b/core/src/token_info/hardcoded.rs
@@ -85,6 +85,23 @@ impl From<HashMap<TokenId, TokenInfoOverride>> for TokenData {
     }
 }
 
+impl Into<HashMap<TokenId, TokenBaseInfo>> for TokenData {
+    fn into(self) -> HashMap<TokenId, TokenBaseInfo> {
+        self.0
+            .into_iter()
+            .map(|(id, info)| {
+                (
+                    id,
+                    TokenBaseInfo {
+                        alias: info.alias,
+                        decimals: info.decimals,
+                    },
+                )
+            })
+            .collect()
+    }
+}
+
 impl FromStr for TokenData {
     type Err = Error;
 

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -242,6 +242,7 @@ fn main() {
     let price_oracle = PriceOracle::new(
         &http_factory,
         orderbook.clone(),
+        contract.clone(),
         options.token_data,
         options.price_source_update_interval,
     )


### PR DESCRIPTION
Depends on #1074 and will finally close #1007 

In this PR we wire together all the tokenInfoFetchers we have built over the last couple of PRs. The tip of the chain is the cached TokenInfoFetcher that is seeded with the hardcoded `TokenData` that comes from the config. It hits the on-chain fetcher for all tokens it doesn't know.

### Test Plan
Running the code before and after and inspecting the token information in the instance filees:

<details>
  <summary>Before:</summary>

```json
{
  "tokens": {
    "T0000": {
      "alias": "OWL",
      "decimals": 18,
      "externalPrice": 1000000000000000000
    },
    "T0001": {
      "alias": "WETH",
      "decimals": 18,
      "externalPrice": 250000000000000000000
    },
    "T0002": {
      "alias": "USDT",
      "decimals": 6,
      "externalPrice": 1e+30
    },
    "T0003": {
      "alias": "TUSD",
      "decimals": 18,
      "externalPrice": 1000000000000000000
    },
    "T0004": {
      "alias": "USDC",
      "decimals": 6,
      "externalPrice": 1e+30
    },
    "T0005": {
      "alias": "PAX",
      "decimals": 18,
      "externalPrice": 1000000000000000000
    },
    "T0006": {
      "alias": "GUSD",
      "decimals": 2,
      "externalPrice": 1e+34
    },
    "T0007": {
      "alias": "DAI",
      "decimals": 18,
      "externalPrice": 1000000000000000000
    },
    "T0008": {
      "alias": "SETH",
      "decimals": 18,
      "externalPrice": 250000000000000000000
    },
    "T0009": {
      "alias": "SUSD",
      "decimals": 18,
      "externalPrice": 1000000000000000000
    },
    "T0010": {
      "alias": "SBTC",
      "decimals": 18,
      "externalPrice": 8e+21
    },
    "T0011": {
      "alias": "WBTC",
      "decimals": 8,
      "externalPrice": 8e+31
    },
    "T0013": {
      "alias": "CDAI",
      "decimals": 8,
      "externalPrice": 4.8e+29
    },
    "T0014": {
      "alias": "ADAI",
      "decimals": 18,
      "externalPrice": 1000000000000000000
    },
    "T0015": {
      "alias": "SNX",
      "decimals": 18,
      "externalPrice": 900000000000000000
    },
    "T0016": {
      "alias": "CHAI",
      "decimals": 18,
      "externalPrice": 1000000000000000000
    },
    "T0017": {
      "alias": "PAXG",
      "decimals": 18,
      "externalPrice": 1.64e+21
    },
    "T0018": {
      "alias": "GNO",
      "decimals": 18,
      "externalPrice": 17000000000000000000
    },
    "T0019": null,
    "T0020": null,
    "T0021": null,
    "T0022": {
      "alias": null,
      "decimals": null,
      "externalPrice": 7.215130353025456e+22
    },
    "T0024": null,
    "T0025": null,
    "T0026": null,
    "T0027": {
      "alias": null,
      "decimals": null,
      "externalPrice": 5.56988795553895e+28
    },
    "T0028": null,
    "T0029": null,
    "T0030": {
      "alias": null,
      "decimals": null,
      "externalPrice": 1.0515946792721197e+21
    },
    "T0031": null,
    "T0032": null,
    "T0033": null,
    "T0034": null,
    "T0035": null,
    "T0036": null,
    "T0037": null,
    "T0038": null,
    "T0039": null,
    "T0040": null,
    "T0041": null,
    "T0042": null,
    "T0043": null,
    "T0046": {
      "alias": null,
      "decimals": null,
      "externalPrice": 1502213232026877200
    },
    "T0048": {
      "alias": null,
      "decimals": null,
      "externalPrice": 2169261001394773800
    },
    "T0051": {
      "alias": null,
      "decimals": null,
      "externalPrice": 111283140086949070000
    },
    "T0052": null,
    "T0053": null,
    "T0057": {
      "alias": null,
      "decimals": null,
      "externalPrice": 33703266509852344
    },
    "T0058": {
      "alias": null,
      "decimals": null,
      "externalPrice": 3.887548462747825e+32
    },
    "T0059": {
      "alias": null,
      "decimals": null,
      "externalPrice": 1910975211108639500
    },
    "T0064": {
      "alias": null,
      "decimals": null,
      "externalPrice": 223137271748327150000
    }
  }
}
```
</details>

<details>
  <summary>After:</summary>

```json
{
  "tokens": {
    "T0000": {
      "alias": "OWL",
      "decimals": 18,
      "externalPrice": 1000000000000000000
    },
    "T0001": {
      "alias": "WETH",
      "decimals": 18,
      "externalPrice": 250000000000000000000
    },
    "T0002": {
      "alias": "USDT",
      "decimals": 6,
      "externalPrice": 1e+30
    },
    "T0003": {
      "alias": "TUSD",
      "decimals": 18,
      "externalPrice": 1000000000000000000
    },
    "T0004": {
      "alias": "USDC",
      "decimals": 6,
      "externalPrice": 1e+30
    },
    "T0005": {
      "alias": "PAX",
      "decimals": 18,
      "externalPrice": 1000000000000000000
    },
    "T0006": {
      "alias": "GUSD",
      "decimals": 2,
      "externalPrice": 1e+34
    },
    "T0007": {
      "alias": "DAI",
      "decimals": 18,
      "externalPrice": 1000000000000000000
    },
    "T0008": {
      "alias": "SETH",
      "decimals": 18,
      "externalPrice": 250000000000000000000
    },
    "T0009": {
      "alias": "SUSD",
      "decimals": 18,
      "externalPrice": 1000000000000000000
    },
    "T0010": {
      "alias": "SBTC",
      "decimals": 18,
      "externalPrice": 8e+21
    },
    "T0011": {
      "alias": "WBTC",
      "decimals": 8,
      "externalPrice": 8e+31
    },
    "T0013": {
      "alias": "CDAI",
      "decimals": 8,
      "externalPrice": 4.8e+29
    },
    "T0014": {
      "alias": "ADAI",
      "decimals": 18,
      "externalPrice": 1000000000000000000
    },
    "T0015": {
      "alias": "SNX",
      "decimals": 18,
      "externalPrice": 900000000000000000
    },
    "T0016": {
      "alias": "CHAI",
      "decimals": 18,
      "externalPrice": 1000000000000000000
    },
    "T0017": {
      "alias": "PAXG",
      "decimals": 18,
      "externalPrice": 1.64e+21
    },
    "T0018": {
      "alias": "GNO",
      "decimals": 18,
      "externalPrice": 17000000000000000000
    },
    "T0019": {
      "alias": "PAN",
      "decimals": 18,
      "externalPrice": 39508497011427630
    },
    "T0020": {
      "alias": "GEN",
      "decimals": 18,
      "externalPrice": 101799533187883090
    },
    "T0021": null,
    "T0022": {
      "alias": "GRID",
      "decimals": 12,
      "externalPrice": 6.7829215534990146e+22
    },
    "T0024": {
      "alias": "LINK",
      "decimals": 18,
      "externalPrice": 4740031564326792000
    },
    "T0025": null,
    "T0026": null,
    "T0027": {
      "alias": "DZAR",
      "decimals": 6,
      "externalPrice": 5.56988795553895e+28
    },
    "T0028": null,
    "T0029": {
      "alias": "RPL",
      "decimals": 18,
      "externalPrice": 1821943168028524500
    },
    "T0030": {
      "alias": "PARETO",
      "decimals": 18,
      "externalPrice": 1.0515946792721197e+21
    },
    "T0031": null,
    "T0032": null,
    "T0033": null,
    "T0034": null,
    "T0035": null,
    "T0036": null,
    "T0037": null,
    "T0038": null,
    "T0039": null,
    "T0040": null,
    "T0041": null,
    "T0042": null,
    "T0043": {
      "alias": "BAT",
      "decimals": 18,
      "externalPrice": 281192767843870400
    },
    "T0046": {
      "alias": "ANT",
      "decimals": 18,
      "externalPrice": 1437339253175828500
    },
    "T0048": {
      "alias": "UMA",
      "decimals": 18,
      "externalPrice": 2169261001394773800
    },
    "T0051": {
      "alias": "DXD",
      "decimals": 18,
      "externalPrice": 111097315403613010000
    },
    "T0052": null,
    "T0053": null,
    "T0057": {
      "alias": "TLN",
      "decimals": 18,
      "externalPrice": 28578391824642030
    },
    "T0058": {
      "alias": "UAX",
      "decimals": 2,
      "externalPrice": 3.887548462747825e+32
    },
    "T0059": {
      "alias": "DMG",
      "decimals": 18,
      "externalPrice": 1910975211108639500
    },
    "T0064": {
      "alias": "COMP",
      "decimals": 18,
      "externalPrice": 202934076971030220000
    }
  }
}
```
</details>

Note, that e.g. for token 19 and 20 info is now available. Tokens for which there is no info at all (null) means there is no price information available (not listed on kraken/1inch/dex.ag **and** no connection to the fee token). Those token could likely be omitted, but that not in the scope of this PR.