### PR TITLE
Add 1inch API

### DIFF
--- a/core/src/metrics/http_metrics.rs
+++ b/core/src/metrics/http_metrics.rs
@@ -108,6 +108,7 @@ labels! {
         EthBatchRPC => "eth_batch_rpc",
         Kraken => "kraken",
         Dexag => "dexag",
+        Oneinch => "oneinch",
         GasStation => "gas_station",
     }
 }

--- a/core/src/price_estimation.rs
+++ b/core/src/price_estimation.rs
@@ -8,7 +8,7 @@ pub mod price_source;
 mod priority_price_source;
 mod threaded_price_source;
 
-use self::clients::{DexagClient, KrakenClient};
+use self::clients::{DexagClient, KrakenClient, OneinchClient};
 use self::orderbook_based::PricegraphEstimator;
 use crate::token_info::{hardcoded::TokenData, TokenInfoFetching};
 use crate::{
@@ -66,9 +66,15 @@ impl PriceOracle {
             DexagClient::new(http_factory, token_info_fetcher.clone())?,
             update_interval,
         );
+        let (oneinch_source, _) = ThreadedPriceSource::new(
+            token_info_fetcher.clone(),
+            OneinchClient::new(http_factory, token_info_fetcher.clone())?,
+            update_interval,
+        );
         let averaged_source = Box::new(AveragePriceSource::new(vec![
             Box::new(kraken_source),
             Box::new(dexag_source),
+            Box::new(oneinch_source),
             Box::new(PricegraphEstimator::new(orderbook_reader)),
         ]));
         let prioritized_source = Box::new(PriorityPriceSource::new(vec![

--- a/core/src/price_estimation/clients.rs
+++ b/core/src/price_estimation/clients.rs
@@ -1,6 +1,8 @@
 mod dexag;
 mod generic_client;
 mod kraken;
+mod oneinch;
 
 pub use dexag::DexagClient;
 pub use kraken::KrakenClient;
+pub use oneinch::OneinchClient;

--- a/core/src/price_estimation/clients/dexag/api.rs
+++ b/core/src/price_estimation/clients/dexag/api.rs
@@ -69,14 +69,11 @@ impl Api for DexagHttpApi {
     fn get_price<'a>(&'a self, from: &Token, to: &Token) -> BoxFuture<'a, Result<f64>> {
         let mut url = self.base_url.clone();
         url.set_path("price");
-        {
-            // This is in its own block because we are supposed to drop `q`.
-            let mut q = url.query_pairs_mut();
-            q.append_pair("from", &from.symbol);
-            q.append_pair("to", &to.symbol);
-            q.append_pair("fromAmount", "1");
-            q.append_pair("dex", "ag");
-        }
+        url.query_pairs_mut()
+            .append_pair("from", &from.symbol)
+            .append_pair("to", &to.symbol)
+            .append_pair("fromAmount", "1")
+            .append_pair("dex", "ag");
 
         async move {
             Ok(self

--- a/core/src/price_estimation/clients/oneinch.rs
+++ b/core/src/price_estimation/clients/oneinch.rs
@@ -1,0 +1,61 @@
+mod api;
+
+use super::generic_client::GenericClient;
+use api::OneinchHttpApi;
+
+pub type OneinchClient = GenericClient<OneinchHttpApi>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http::HttpFactory;
+    use crate::models::TokenId;
+    use crate::price_estimation::price_source::PriceSource;
+    use crate::token_info::{hardcoded::TokenData, TokenBaseInfo};
+    use crate::util::FutureWaitExt as _;
+    use std::sync::Arc;
+
+    // Run with `cargo test online_oneinch_client -- --ignored --nocapture`.
+    #[test]
+    #[ignore]
+    fn online_oneinch_client() {
+        use std::time::Instant;
+
+        let tokens = hash_map! {
+            TokenId(1) => TokenBaseInfo::new("WETH", 18, 0),
+            TokenId(2) => TokenBaseInfo::new("USDT", 6, 0),
+            TokenId(3) => TokenBaseInfo::new("TUSD", 18, 0),
+            TokenId(4) => TokenBaseInfo::new("USDC", 6, 0),
+            TokenId(5) => TokenBaseInfo::new("PAX", 18, 0),
+            TokenId(6) => TokenBaseInfo::new("GUSD", 2, 0),
+            TokenId(7) => TokenBaseInfo::new("DAI", 18, 0),
+            TokenId(8) => TokenBaseInfo::new("sETH", 18, 0),
+            TokenId(9) => TokenBaseInfo::new("sUSD", 18, 0),
+            TokenId(15) => TokenBaseInfo::new("SNX", 18, 0)
+        };
+        let mut ids: Vec<TokenId> = tokens.keys().copied().collect();
+
+        let client = OneinchClient::new(
+            &HttpFactory::default(),
+            Arc::new(TokenData::from(tokens.clone())),
+        )
+        .unwrap();
+        let before = Instant::now();
+        let prices = client.get_prices(&ids).wait().unwrap();
+        let after = Instant::now();
+        println!(
+            "Took {} seconds to get prices.",
+            (after - before).as_secs_f64()
+        );
+
+        ids.sort();
+        for id in ids {
+            let symbol = tokens.get(&id).unwrap().symbol();
+            if let Some(price) = prices.get(&id) {
+                println!("Token {} has OWL price of {}.", symbol, price);
+            } else {
+                println!("Token {} price could not be determined.", symbol);
+            }
+        }
+    }
+}

--- a/core/src/price_estimation/clients/oneinch.rs
+++ b/core/src/price_estimation/clients/oneinch.rs
@@ -11,7 +11,7 @@ mod tests {
     use crate::http::HttpFactory;
     use crate::models::TokenId;
     use crate::price_estimation::price_source::PriceSource;
-    use crate::token_info::{hardcoded::TokenData, TokenBaseInfo};
+    use crate::token_info::hardcoded::{TokenData, TokenInfoOverride};
     use crate::util::FutureWaitExt as _;
     use std::sync::Arc;
 
@@ -22,16 +22,16 @@ mod tests {
         use std::time::Instant;
 
         let tokens = hash_map! {
-            TokenId(1) => TokenBaseInfo::new("WETH", 18, 0),
-            TokenId(2) => TokenBaseInfo::new("USDT", 6, 0),
-            TokenId(3) => TokenBaseInfo::new("TUSD", 18, 0),
-            TokenId(4) => TokenBaseInfo::new("USDC", 6, 0),
-            TokenId(5) => TokenBaseInfo::new("PAX", 18, 0),
-            TokenId(6) => TokenBaseInfo::new("GUSD", 2, 0),
-            TokenId(7) => TokenBaseInfo::new("DAI", 18, 0),
-            TokenId(8) => TokenBaseInfo::new("sETH", 18, 0),
-            TokenId(9) => TokenBaseInfo::new("sUSD", 18, 0),
-            TokenId(15) => TokenBaseInfo::new("SNX", 18, 0)
+            TokenId(1) => TokenInfoOverride::new("WETH", 18, 0),
+            TokenId(2) => TokenInfoOverride::new("USDT", 6, 0),
+            TokenId(3) => TokenInfoOverride::new("TUSD", 18, 0),
+            TokenId(4) => TokenInfoOverride::new("USDC", 6, 0),
+            TokenId(5) => TokenInfoOverride::new("PAX", 18, 0),
+            TokenId(6) => TokenInfoOverride::new("GUSD", 2, 0),
+            TokenId(7) => TokenInfoOverride::new("DAI", 18, 0),
+            TokenId(8) => TokenInfoOverride::new("sETH", 18, 0),
+            TokenId(9) => TokenInfoOverride::new("sUSD", 18, 0),
+            TokenId(15) => TokenInfoOverride::new("SNX", 18, 0)
         };
         let mut ids: Vec<TokenId> = tokens.keys().copied().collect();
 
@@ -50,7 +50,7 @@ mod tests {
 
         ids.sort();
         for id in ids {
-            let symbol = tokens.get(&id).unwrap().symbol();
+            let symbol = &tokens.get(&id).unwrap().alias;
             if let Some(price) = prices.get(&id) {
                 println!("Token {} has OWL price of {}.", symbol, price);
             } else {

--- a/core/src/price_estimation/clients/oneinch/api.rs
+++ b/core/src/price_estimation/clients/oneinch/api.rs
@@ -78,13 +78,11 @@ impl Api for OneinchHttpApi {
         // We compute the price when selling one full token to avoid unavoidable rounding
         // artifacts when selling exactly one token atom.
         let one_token_from = 10_u128.pow(from.decimals as u32).to_string();
-        {
-            // This is in its own block because we are supposed to drop `q`.
-            let mut q = url.query_pairs_mut();
-            q.append_pair("fromTokenSymbol", &from.symbol);
-            q.append_pair("toTokenSymbol", &to.symbol);
-            q.append_pair("amount", &one_token_from);
-        }
+        url.query_pairs_mut()
+            .append_pair("fromTokenSymbol", &from.symbol)
+            .append_pair("toTokenSymbol", &to.symbol)
+            .append_pair("amount", &one_token_from);
+
         let decimal_correction: f64 = 10_f64.powi(from.decimals as i32 - to.decimals as i32);
 
         async move {

--- a/core/src/price_estimation/clients/oneinch/api.rs
+++ b/core/src/price_estimation/clients/oneinch/api.rs
@@ -119,8 +119,8 @@ mod tests {
     fn deserialize_price() {
         let json = r#"{"fromToken":{"symbol":"ETH","name":"Ethereum","decimals":18,"address":"0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"},"toToken":{"symbol":"DAI","name":"Dai Stablecoin","decimals":18,"address":"0x6b175474e89094c44da98b954eedeac495271d0f"},"toTokenAmount":"23897808590784919590159","fromTokenAmount":"100000000000000000000","exchanges":[{"name":"MultiSplit","part":100},{"name":"Mooniswap","part":0},{"name":"Oasis","part":0},{"name":"Kyber","part":0},{"name":"Uniswap","part":0},{"name":"Balancer","part":0},{"name":"PMM","part":0},{"name":"Uniswap V2","part":0},{"name":"0x Relays","part":0},{"name":"0x API","part":0},{"name":"AirSwap","part":0}]}"#;
         let price: TradedAmounts = serde_json::from_str(json).unwrap();
-        assert_eq!(price.to_token_amount, 23897808590784919590159);
-        assert_eq!(price.from_token_amount, 100000000000000000000);
+        assert_eq!(price.to_token_amount, 23_897_808_590_784_919_590_159);
+        assert_eq!(price.from_token_amount, 100_000_000_000_000_000_000);
     }
 
     #[test]

--- a/core/src/price_estimation/clients/oneinch/api.rs
+++ b/core/src/price_estimation/clients/oneinch/api.rs
@@ -32,6 +32,7 @@ pub struct OneinchHttpApi {
     api_url: Url,
     client: HttpClient,
 }
+
 impl OneinchHttpApi {
     pub fn with_url(http_factory: &HttpFactory, api_url: &str) -> Result<Self> {
         let client = http_factory

--- a/core/src/price_estimation/clients/oneinch/api.rs
+++ b/core/src/price_estimation/clients/oneinch/api.rs
@@ -1,0 +1,179 @@
+use super::super::generic_client::{Api, GenericToken};
+use crate::http::{HttpClient, HttpFactory, HttpLabel};
+use anyhow::{Context, Result};
+use ethcontract::Address;
+use futures::future::{BoxFuture, FutureExt as _};
+use serde::Deserialize;
+use std::collections::HashMap;
+use url::Url;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct Token {
+    pub name: String,
+    pub symbol: String,
+    pub address: Option<Address>,
+    pub decimals: u8,
+}
+impl GenericToken for Token {
+    fn symbol(&self) -> &str {
+        &self.symbol
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TradedAmounts {
+    to_token_amount: String,
+    from_token_amount: String,
+}
+
+#[derive(Debug)]
+pub struct OneinchHttpApi {
+    api_url: Url,
+    client: HttpClient,
+}
+impl OneinchHttpApi {
+    pub fn with_url(http_factory: &HttpFactory, api_url: &str) -> Result<Self> {
+        let client = http_factory
+            .create()
+            .context("failed to initialize HTTP client")?;
+        let api_url = api_url
+            .parse()
+            .with_context(|| format!("failed to parse url {}", api_url))?;
+        Ok(OneinchHttpApi { api_url, client })
+    }
+}
+
+pub const DEFAULT_API_URL: &str = "https://api.1inch.exchange/v1.1/";
+
+/// 1inch API version v1.1
+/// https://1inch.exchange/#/api
+impl Api for OneinchHttpApi {
+    type Token = Token;
+
+    fn bind(http_factory: &HttpFactory) -> Result<Self> {
+        Self::with_url(http_factory, DEFAULT_API_URL)
+    }
+
+    fn get_token_list<'a>(&'a self) -> BoxFuture<'a, Result<Vec<Token>>> {
+        async move {
+            let url = self.api_url.join("tokens").unwrap();
+            let token_mapping: HashMap<String, Token> = self
+                .client
+                .get_json_async(url.to_string(), HttpLabel::Oneinch)
+                .await
+                .context("failed to parse token list json from 1inch response")?;
+            Ok(token_mapping
+                .into_iter()
+                .map(|(_token_symbol, token_data)| token_data)
+                .collect())
+        }
+        .boxed()
+    }
+
+    fn get_price<'a>(&'a self, from: &Token, to: &Token) -> BoxFuture<'a, Result<f64>> {
+        let mut url = self.api_url.join("quote").unwrap();
+        // 1inch requires the user to specify the amount traded in atoms.
+        // We compute the price when selling one full token to avoid unavoidable rounding
+        // artifacts when selling exactly one token atom.
+        let mut one_token_from = String::from("1");
+        one_token_from.push_str(&String::from("0").repeat(from.decimals as usize));
+        {
+            // This is in its own block because we are supposed to drop `q`.
+            let mut q = url.query_pairs_mut();
+            q.append_pair("fromTokenSymbol", &from.symbol);
+            q.append_pair("toTokenSymbol", &to.symbol);
+            q.append_pair("amount", &one_token_from);
+        }
+        let decimal_correction: f64 = 10_f64.powi(from.decimals as i32 - to.decimals as i32);
+
+        async move {
+            let traded_amounts: TradedAmounts = self
+                .client
+                .get_json_async::<_, TradedAmounts>(url.as_str(), HttpLabel::Oneinch)
+                .await
+                .context("failed to parse price json from 1inch")?;
+            let num: f64 = traded_amounts.to_token_amount.parse()?;
+            let den: f64 = traded_amounts.from_token_amount.parse()?;
+            Ok(decimal_correction * num / den)
+        }
+        .boxed()
+    }
+
+    fn reference_token_symbol() -> &'static str {
+        &"OWL"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::FutureWaitExt as _;
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn deserialize_price() {
+        let json = r#"{"fromToken":{"symbol":"ETH","name":"Ethereum","decimals":18,"address":"0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"},"toToken":{"symbol":"DAI","name":"Dai Stablecoin","decimals":18,"address":"0x6b175474e89094c44da98b954eedeac495271d0f"},"toTokenAmount":"23897808590784919590159","fromTokenAmount":"100000000000000000000","exchanges":[{"name":"MultiSplit","part":100},{"name":"Mooniswap","part":0},{"name":"Oasis","part":0},{"name":"Kyber","part":0},{"name":"Uniswap","part":0},{"name":"Balancer","part":0},{"name":"PMM","part":0},{"name":"Uniswap V2","part":0},{"name":"0x Relays","part":0},{"name":"0x API","part":0},{"name":"AirSwap","part":0}]}"#;
+        let price: TradedAmounts = serde_json::from_str(json).unwrap();
+        assert_eq!(price.to_token_amount, "23897808590784919590159");
+        assert_eq!(price.from_token_amount, "100000000000000000000");
+    }
+
+    #[test]
+    fn deserialize_token() {
+        use std::str::FromStr as _;
+        let json = r#"{"symbol":"SAI","name":"Sai Stablecoin","decimals":18,"address":"0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359"}"#;
+        let token: Token = serde_json::from_str(json).unwrap();
+        assert_eq!(token.name, "Sai Stablecoin");
+        assert_eq!(token.symbol, "SAI");
+        assert_eq!(token.decimals, 18);
+        assert_eq!(
+            token.address.unwrap(),
+            Address::from_str("89d24a6b4ccb1b6faa2625fe562bdd9a23260359").unwrap()
+        );
+    }
+
+    #[test]
+    fn deserialize_token_no_address() {
+        let json = r#"{"symbol":"SAI","name":"Sai Stablecoin","decimals":18}"#;
+        let token: Token = serde_json::from_str(json).unwrap();
+        assert_eq!(token.name, "Sai Stablecoin");
+        assert_eq!(token.symbol, "SAI");
+        assert_eq!(token.decimals, 18);
+        assert!(token.address.is_none());
+    }
+
+    // Run with `cargo test online_oneinch_api -- --ignored --nocapture`.
+    #[test]
+    #[ignore]
+    fn online_oneinch_api() {
+        use crate::metrics::HttpMetrics;
+        use std::time::Duration;
+
+        let timeout = 20;
+        let api = OneinchHttpApi::bind(&HttpFactory::new(
+            Duration::from_secs(timeout),
+            HttpMetrics::default(),
+        ))
+        .unwrap();
+        let tokens = api.get_token_list().wait().unwrap();
+        println!("{:#?}", tokens);
+
+        let dai_index = tokens.iter().position(|data| data.symbol == "DAI").unwrap();
+        let eth_index = tokens.iter().position(|data| data.symbol == "ETH").unwrap();
+        let usdc_index = tokens
+            .iter()
+            .position(|data| data.symbol == "USDC")
+            .unwrap();
+        let price = api
+            .get_price(&tokens[eth_index], &tokens[dai_index])
+            .wait()
+            .unwrap();
+        println!("1 ETH = {:#?} DAI", price);
+        let price = api
+            .get_price(&tokens[eth_index], &tokens[usdc_index])
+            .wait()
+            .unwrap();
+        println!("1 ETH = {:#?} USDC", price);
+    }
+}

--- a/core/src/price_estimation/clients/oneinch/api.rs
+++ b/core/src/price_estimation/clients/oneinch/api.rs
@@ -61,7 +61,7 @@ impl Api for OneinchHttpApi {
 
     fn get_token_list<'a>(&'a self) -> BoxFuture<'a, Result<Vec<Token>>> {
         async move {
-            let url = self.api_url.join("tokens").unwrap();
+            let url = self.api_url.join("tokens")?;
             let token_mapping: HashMap<String, Token> = self
                 .client
                 .get_json_async(url.to_string(), HttpLabel::Oneinch)

--- a/core/src/price_estimation/clients/oneinch/api.rs
+++ b/core/src/price_estimation/clients/oneinch/api.rs
@@ -76,8 +76,7 @@ impl Api for OneinchHttpApi {
         // 1inch requires the user to specify the amount traded in atoms.
         // We compute the price when selling one full token to avoid unavoidable rounding
         // artifacts when selling exactly one token atom.
-        let mut one_token_from = String::from("1");
-        one_token_from.push_str(&String::from("0").repeat(from.decimals as usize));
+        let one_token_from = 10_u128.pow(from.decimals as u32).to_string();
         {
             // This is in its own block because we are supposed to drop `q`.
             let mut q = url.query_pairs_mut();


### PR DESCRIPTION
Fixes #720. 

Adds a new price source ([1inch](https://1inch.exchange/#/)) to the price estimator.



### Test Plan

Make real requests to 1inch and see that the output prices are reasonable:
```
cd core
cargo test online_oneinch_api -- --ignored --nocapture
cargo test online_oneinch_client -- --ignored --nocapture
```

Compare line by line the prices of 1inch to the prices of dex.ag:
```
cargo build --tests && paste -d "#" <(cargo test online_oneinch_client -- --ignored --nocapture) <(cargo test online_dexag_client -- --ignored --nocapture) | sed "s/#/ <- 1inch\n/"
```

Sample output of the last command (currently 1 OWL ≈ 1 DAI):
```
Took 10.306066243 seconds to get prices. <- 1inch
Took 3.076605871 seconds to get prices.
Token ETH has OWL price of 230216987158628073472. <- 1inch
Token ETH has OWL price of 271568087876241457152.
Token USDT price could not be determined. <- 1inch
Token USDT has OWL price of 988542174834931369985118830592.
Token TUSD price could not be determined. <- 1inch
Token TUSD has OWL price of 1016945049680955520.
Token USDC has OWL price of 1084226059718864440266741252096. <- 1inch
Token USDC has OWL price of 989262897579293506779113062400.
Token PAX price could not be determined. <- 1inch
Token PAX has OWL price of 984341620006141056.
Token GUSD has OWL price of 7329162705030018616441094040190976. <- 1inch
Token GUSD price could not be determined.
Token DAI has OWL price of 1093977005319718912. <- 1inch
Token DAI has OWL price of 1000000000000000000.
Token sETH has OWL price of 230548517962684497920. <- 1inch
Token sETH has OWL price of 227093142966047801344.
Token sUSD has OWL price of 1102349188370144896. <- 1inch
Token sUSD has OWL price of 1069104617560581120.
Token SNX price could not be determined. <- 1inch
Token SNX has OWL price of 2323483974903152640.
test price_estimation::clients::oneinch::tests::online_oneinch_client ... ok <- 1inch
test price_estimation::clients::dexag::tests::online_dexag_client ... ok
```

Things to note:
1. dex.ag currently returns a wrong price for ETH/DAI. Compare to some ETH price from another source.
2. The price of USDC is quite different because the 1inch API tries to trade only 1 USDC. If it tried to use 10USDC the two prices would be similar. No plans to mitigate this issue currently.
3. 1inch is slow. I believe all missing prices are timeouts (>10s to retrieve a price).