### PR TITLE
[Easy] Fix PriceSource priority order

### DIFF
--- a/core/src/price_estimation.rs
+++ b/core/src/price_estimation.rs
@@ -72,8 +72,8 @@ impl PriceOracle {
             Box::new(PricegraphEstimator::new(orderbook_reader)),
         ]));
         let prioritized_source = Box::new(PriorityPriceSource::new(vec![
-            Box::new(token_data),
             averaged_source,
+            Box::new(token_data),
         ]));
 
         Ok(PriceOracle {


### PR DESCRIPTION
https://github.com/gnosis/dex-services/pull/1070 made the price estimation use the PriorityPrice source with TokenData being the primary source and the average source being the secondary.

However, this was an undesired change in logic. I misread in particular this part of the code https://github.com/gnosis/dex-services/pull/1070/files#r449536863

This PR reverts the change, making the average source primary and the overrides secondary.

### Test Plan
Run driver locally and see price for WETH is no longer hardcoded at $250 but instead around $247.