### PR TITLE
Use two-stage model in BestRingSolver.

### DIFF
--- a/core/src/price_finding/price_finder_interface.rs
+++ b/core/src/price_finding/price_finder_interface.rs
@@ -106,11 +106,7 @@ impl SolverType {
                 input_file,
                 time_limit,
                 min_avg_fee_per_order,
-                if self == SolverType::StandardSolver {
-                    OptModel::TwoStage
-                } else {
-                    OptModel::MixedInteger
-                },
+                OptModel::TwoStage,
                 internal_optimizer,
                 self == SolverType::BestRingSolver,
             ),


### PR DESCRIPTION
This PR changes the optimization model used in the best-ring-solver from MIP to two-stage. The two-stage model seems to be numerically more stable, which will hopefully avoid many of the `invalid execution request` errors (while returning the same solutions in almost all cases).

### Test Plan
e2e tests 