### PR TITLE
Cancel transaction when solution submission time expires

### DIFF
--- a/core/src/driver/scheduler.rs
+++ b/core/src/driver/scheduler.rs
@@ -5,12 +5,10 @@ use self::evm::EvmScheduler;
 use self::system::SystemScheduler;
 use crate::contracts::stablex_contract::StableXContract;
 use crate::driver::stablex_driver::StableXDriver;
+use crate::models::batch_id::SOLVING_WINDOW;
 use anyhow::{anyhow, Error, Result};
 use std::str::FromStr;
 use std::time::Duration;
-
-/// The time in a batch where a solution may be submitted.
-const SOLVING_WINDOW: Duration = Duration::from_secs(240);
 
 /// A scheduler that can be started in order to run the driver for each batch.
 pub trait Scheduler {

--- a/core/src/models/batch_id.rs
+++ b/core/src/models/batch_id.rs
@@ -4,6 +4,8 @@ use std::time::{Duration, SystemTime, SystemTimeError};
 
 /// The total time in a batch.
 pub const BATCH_DURATION: Duration = Duration::from_secs(300);
+/// The time in a batch where a solution may be submitted.
+pub const SOLVING_WINDOW: Duration = Duration::from_secs(240);
 
 /// Wraps a batch id as in the smart contract to add functionality related to
 /// the current time.
@@ -44,6 +46,10 @@ impl BatchId {
 
     pub fn solve_start_time(self) -> SystemTime {
         self.order_collection_start_time() + BATCH_DURATION
+    }
+
+    pub fn solve_end_time(self) -> SystemTime {
+        self.solve_start_time() + SOLVING_WINDOW
     }
 
     pub fn next(self) -> BatchId {


### PR DESCRIPTION
There is no reason to continue to try submitting the solution with
higher gas prices when the deadline is already over.
With this commit we cancel the transaction and exit when this happens.

Fixes #825 
Fixes #821 

### Test Plan
Added unit test for this. Wasn't able to test the full behavior with ganache but I did test that sending the noop transaction works in ganache.