### PR TITLE
Use `node_bound` to check for invalid tokens.

### DIFF
--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -17,6 +17,7 @@ use crate::graph::subgraph::{ControlFlow, Subgraphs};
 use crate::num;
 use crate::{TransitiveOrder, TransitiveOrderbook, FEE_FACTOR};
 use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
+use petgraph::visit::NodeIndexable;
 use primitive_types::U256;
 use std::cmp;
 use std::f64;
@@ -572,10 +573,10 @@ impl Orderbook {
     /// A token pair is considered valid if both the buy and sell token
     /// exist in the current orderbook and are unequal.
     fn is_token_pair_valid(&self, pair: TokenPair) -> bool {
-        let node_count = self.projection.node_count();
+        let node_bound = self.projection.node_bound();
         pair.buy != pair.sell
-            && (pair.buy as usize) < node_count
-            && (pair.sell as usize) < node_count
+            && (pair.buy as usize) < node_bound
+            && (pair.sell as usize) < node_bound
     }
 }
 

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -1305,7 +1305,7 @@ mod tests {
     #[test]
     fn fill_market_order_returns_none_for_invalid_token_pairs() {
         //   /---1.0---v
-        //  0          1          2 --0.5--> 3
+        //  0          1          2 --0.5--> 4
         //  ^---1.0---/
         let mut orderbook = orderbook! {
             users {
@@ -1316,28 +1316,33 @@ mod tests {
                     token 0 => 1_000_000,
                 }
                 @3 {
-                    token 3 => 1_000_000,
+                    token 4 => 1_000_000,
                 }
             }
             orders {
                 owner @1 buying 0 [1_000_000] selling 1 [1_000_000],
                 owner @2 buying 1 [1_000_000] selling 0 [1_000_000],
-                owner @3 buying 2 [1_000_000] selling 3 [1_000_000],
+                owner @3 buying 2 [1_000_000] selling 4 [1_000_000],
             }
         };
 
-        // Token 2 and 1 are not connected.
+        // Token 3 is not part of the orderbook.
         assert_eq!(
-            orderbook.fill_market_order(TokenPair { buy: 2, sell: 1 }, 500_000.0),
+            orderbook.fill_market_order(TokenPair { buy: 1, sell: 3 }, 500_000.0),
             None,
         );
-        // Token 42 does not exist.
+        // Tokens 4 and 1 are not connected.
         assert_eq!(
-            orderbook.fill_market_order(TokenPair { buy: 42, sell: 1 }, 500_000.0),
+            orderbook.fill_market_order(TokenPair { buy: 4, sell: 1 }, 500_000.0),
+            None,
+        );
+        // Tokens 5 and 42 are out of bounds.
+        assert_eq!(
+            orderbook.fill_market_order(TokenPair { buy: 5, sell: 1 }, 500_000.0),
             None,
         );
         assert_eq!(
-            orderbook.fill_market_order(TokenPair { buy: 1, sell: 42 }, 500_000.0),
+            orderbook.fill_market_order(TokenPair { buy: 2, sell: 42 }, 500_000.0),
             None,
         );
     }


### PR DESCRIPTION
@fedgiac recently brought to my attention that there exists a `node_count` and `node_bound` which are slightly different. Specifically, the `node_count` is the total number of nodes, while the `node_bound` is the maximum node index. While in the `pricegraph` these two are the same, when checking whether or not a token can index into the graph's search results, `node_bound` is more correct. This could happen if the projection graph added token ID x, then an x+1 and then removed x. In this case, the node count would be x, but the node bound would be x+1. If we used the node count, then we would not be able work with the valid token x+1.

### Test Plan

More comprehensive unit test for out of bounds tokens.