### PR TITLE
Implement atoms=false for estimated_buy_amount

### DIFF
--- a/core/src/token_info.rs
+++ b/core/src/token_info.rs
@@ -51,6 +51,11 @@ impl TokenBaseInfo {
         SYMBOL_OVERRIDES.get(&self.alias).unwrap_or(&self.alias)
     }
 
+    /// One unit of the token taking decimals into account, given in number of atoms.
+    pub fn base_unit_in_atoms(&self) -> f64 {
+        10f64.powi(self.decimals as i32)
+    }
+
     /// Converts the prices from USD into the unit expected by the contract.
     /// This price is relative to the OWL token which is considered pegged at
     /// exactly 1 USD with 18 decimals.
@@ -92,5 +97,13 @@ mod tests {
     #[test]
     fn weth_token_symbol_is_eth() {
         assert_eq!(TokenBaseInfo::new("WETH", 18).symbol(), "ETH");
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn base_unit_in_atoms() {
+        assert_eq!(TokenBaseInfo::new("", 0).base_unit_in_atoms(), 1.0);
+        assert_eq!(TokenBaseInfo::new("", 1).base_unit_in_atoms(), 10.0);
+        assert_eq!(TokenBaseInfo::new("", 2).base_unit_in_atoms(), 100.0);
     }
 }

--- a/core/src/token_info/cached.rs
+++ b/core/src/token_info/cached.rs
@@ -16,7 +16,6 @@ pub struct TokenInfoCache {
 }
 
 impl TokenInfoCache {
-    #[cfg(test)]
     pub fn new(inner: Arc<dyn TokenInfoFetching>) -> Self {
         Self {
             cache: RwLock::new(HashMap::new()),

--- a/price-estimator/README.md
+++ b/price-estimator/README.md
@@ -1,18 +1,25 @@
 ## API
 
+All endpoints use the query part of the url with these key-values:
+
+* `atoms`: Required. If set to `true` all amounts are denominated in the smallest available unit (base quantity) of the token. If `false` all amounts are denominated in the "natural" unit of the respective token given by the number of decimals specified through the ERC20 interface. TODO: `false` is currently only implemented for estimated-buy-amount .
+* `hops`: Optional. TODO: document this once it has been implemented.
+
+Example: `<path>?atoms=true`
+
+The endpoint documentation references these types:
+
+* A *token id* is a natural number >= 0 in decimal notation. It refers to the token ids in the smart contract. Example: `0`
+* A *token amount* is given as a floating point number formatted according to https://doc.rust-lang.org/std/primitive.f64.html#impl-FromStr which resembles numbers in json closely. Examples: `0`, `1.1`.
+* A *market* is of the form `<base token id>-<quote token id>`. Example: `0-1`
+
 The service exposes the following endpoints:
 
 ### Markets
 
 `GET /api/v1/markets/:market`
 
-* `market` is of the form `<base_token_id>-<quote_token_id>`. The token ids the same as in the smart contract.
-
-Url Query:
-* `atoms`: If set to `true` (for now this is the only implemented method) all amounts will be denominated in the smallest available unit (base quantity) of the token.
-* `hops`: TODO: document this once it has been implemented.
-
-Example Request: `/api/v1/markets/1-7/?atoms=true`
+Example Request: `/api/v1/markets/1-7?atoms=true`
 
 Example Response:
 
@@ -33,11 +40,6 @@ Returns the transitive orderbook (containing bids and asks) for the given base a
 
 `GET /api/v1/markets/:market/estimated-buy-amount/:sell-amount-in-quote-token`
 
-* `market` is as above
-* `sell_amount_in_quote_token` is a positive integer.
-
-Url query is as above.
-
 Example Request: `/api/v1/markets/1-7/estimated-buy-amount/20000000000000000000?atoms=true`
 
 Example Response:
@@ -57,11 +59,6 @@ Example Response:
 ### Estimated Amounts At Price
 
 `GET /api/v1/markets/:market/estimated-amounts-at-price/:price-in-quote`
-
-* `market` is as above
-* `price_in_quote` is a decimal number.
-
-Url query is as above.
 
 Example Request: `/api/v1/markets/1-7/estimated-amounts-at-price/245.5?atoms=true`
 

--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -1,27 +1,66 @@
 use crate::models::*;
 use crate::orderbook::Orderbook;
+use core::{
+    models::TokenId,
+    token_info::{TokenBaseInfo, TokenInfoFetching},
+};
 use pricegraph::TokenPair;
 use std::convert::Infallible;
 use std::sync::Arc;
-use warp::{Filter, Rejection};
+use warp::{
+    http::StatusCode,
+    reject::{self, Reject},
+    Filter, Rejection, Reply,
+};
 
 /// Handles all supported requests under a `/api/v1` root path.
 pub fn all<T: Send + Sync + 'static>(
     orderbook: Arc<Orderbook<T>>,
+    token_info: Arc<dyn TokenInfoFetching>,
     price_rounding_buffer: f64,
-) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
-    warp::path!("api" / "v1" / ..).and(
-        markets(orderbook.clone())
-            .or(estimated_buy_amount(
-                orderbook.clone(),
-                price_rounding_buffer,
-            ))
-            .or(estimated_amounts_at_price(
-                orderbook.clone(),
-                price_rounding_buffer,
-            ))
-            .or(estimated_best_ask_price(orderbook, price_rounding_buffer)),
-    )
+) -> impl Filter<Extract = impl Reply, Error = Infallible> + Clone {
+    warp::path!("api" / "v1" / ..)
+        .and(
+            markets(orderbook.clone())
+                .or(estimated_buy_amount(
+                    orderbook.clone(),
+                    token_info,
+                    price_rounding_buffer,
+                ))
+                .or(estimated_amounts_at_price(
+                    orderbook.clone(),
+                    price_rounding_buffer,
+                ))
+                .or(estimated_best_ask_price(orderbook, price_rounding_buffer)),
+        )
+        .recover(handle_rejection)
+}
+
+#[derive(Debug)]
+struct NoTokenInfo;
+impl Reject for NoTokenInfo {}
+
+async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
+    let code;
+    let message;
+
+    if err.is_not_found() {
+        code = StatusCode::NOT_FOUND;
+        message = "invalid url path";
+    } else if let Some(NoTokenInfo) = err.find() {
+        code = StatusCode::BAD_REQUEST;
+        message = "request with atoms=true for token we don't have erc20 info for";
+    } else if let Some(warp::reject::InvalidQuery { .. }) = err.find() {
+        code = StatusCode::BAD_REQUEST;
+        message = "invalid url query";
+    } else {
+        log::warn!("unhandled rejection: {:?}", err);
+        code = StatusCode::INTERNAL_SERVER_ERROR;
+        message = "unexpected internal error";
+    }
+
+    let json = warp::reply::json(&ErrorResult { message });
+    Ok(warp::reply::with_status(json, code))
 }
 
 /// Validate a request of the form
@@ -29,7 +68,7 @@ pub fn all<T: Send + Sync + 'static>(
 /// and answer it.
 fn markets<T: Send + Sync + 'static>(
     orderbook: Arc<Orderbook<T>>,
-) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     markets_filter()
         .and(warp::any().map(move || orderbook.clone()))
         .and_then(get_markets)
@@ -41,11 +80,13 @@ fn markets<T: Send + Sync + 'static>(
 /// and answer it.
 fn estimated_buy_amount<T: Send + Sync + 'static>(
     orderbook: Arc<Orderbook<T>>,
+    token_info: Arc<dyn TokenInfoFetching>,
     price_rounding_buffer: f64,
-) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     estimated_buy_amount_filter()
         .and(warp::any().map(move || price_rounding_buffer))
         .and(warp::any().map(move || orderbook.clone()))
+        .and(warp::any().map(move || token_info.clone()))
         .and_then(estimate_buy_amount)
         .with(warp::log("price_estimator::api::estimate_buy_amount"))
 }
@@ -56,7 +97,7 @@ fn estimated_buy_amount<T: Send + Sync + 'static>(
 fn estimated_amounts_at_price<T: Send + Sync + 'static>(
     orderbook: Arc<Orderbook<T>>,
     price_rounding_buffer: f64,
-) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     estimated_amounts_at_price_filter()
         .and(warp::any().map(move || price_rounding_buffer))
         .and(warp::any().map(move || orderbook.clone()))
@@ -70,7 +111,7 @@ fn estimated_amounts_at_price<T: Send + Sync + 'static>(
 fn estimated_best_ask_price<T: Send + Sync + 'static>(
     orderbook: Arc<Orderbook<T>>,
     price_rounding_buffer: f64,
-) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     estimated_best_ask_price_filter()
         .and(warp::any().map(move || price_rounding_buffer))
         .and(warp::any().map(move || orderbook.clone()))
@@ -94,9 +135,9 @@ fn markets_filter() -> impl Filter<Extract = (Market, QueryParameters), Error = 
 }
 
 fn estimated_buy_amount_filter(
-) -> impl Filter<Extract = (TokenPair, u128, QueryParameters), Error = Rejection> + Copy {
+) -> impl Filter<Extract = (TokenPair, f64, QueryParameters), Error = Rejection> + Copy {
     markets_bid_prefix()
-        .and(warp::path!("estimated-buy-amount" / u128))
+        .and(warp::path!("estimated-buy-amount" / f64))
         .and(warp::get())
         .and(warp::query::<QueryParameters>())
 }
@@ -121,7 +162,7 @@ async fn get_markets<T>(
     market: Market,
     _query: QueryParameters,
     orderbook: Arc<Orderbook<T>>,
-) -> Result<impl warp::Reply, Infallible> {
+) -> Result<impl Reply, Infallible> {
     let transitive_orderbook = orderbook
         .get_pricegraph()
         .await
@@ -130,20 +171,43 @@ async fn get_markets<T>(
     Ok(warp::reply::json(&result))
 }
 
+async fn get_token_info(
+    token_id: u16,
+    token_info_fetching: &dyn TokenInfoFetching,
+) -> Result<TokenBaseInfo, Rejection> {
+    token_info_fetching
+        .get_token_info(TokenId(token_id))
+        .await
+        .map_err(|_| reject::custom(NoTokenInfo))
+}
+
 async fn estimate_buy_amount<T>(
     token_pair: TokenPair,
-    sell_amount_in_quote: u128,
-    _query: QueryParameters,
+    sell_amount_in_quote: f64,
+    query: QueryParameters,
     price_rounding_buffer: f64,
     orderbook: Arc<Orderbook<T>>,
-) -> Result<impl warp::Reply, Infallible> {
+    token_infos: Arc<dyn TokenInfoFetching>,
+) -> Result<impl Reply, Rejection> {
+    let sell_amount_in_quote_atoms = if query.atoms {
+        sell_amount_in_quote
+    } else {
+        let token_info = get_token_info(token_pair.sell, token_infos.as_ref()).await?;
+        sell_amount_in_quote * token_info.base_unit_in_atoms()
+    };
     let transitive_order = orderbook
         .get_pricegraph()
         .await
-        .order_for_sell_amount(token_pair, sell_amount_in_quote as f64);
-    let buy_amount_in_base = transitive_order
-        .map(|order| apply_rounding_buffer(order.buy, price_rounding_buffer) as u128)
+        .order_for_sell_amount(token_pair, sell_amount_in_quote_atoms);
+    let buy_amount_in_base_atoms = transitive_order
+        .map(|order| apply_rounding_buffer(order.buy, price_rounding_buffer))
         .unwrap_or_default();
+    let buy_amount_in_base = if query.atoms {
+        buy_amount_in_base_atoms
+    } else {
+        let token_info = get_token_info(token_pair.buy, token_infos.as_ref()).await?;
+        buy_amount_in_base_atoms / token_info.base_unit_in_atoms()
+    };
     let result = EstimatedOrderResult {
         base_token_id: token_pair.buy,
         quote_token_id: token_pair.sell,
@@ -159,7 +223,7 @@ async fn estimate_amounts_at_price<T>(
     _query: QueryParameters,
     price_rounding_buffer: f64,
     orderbook: Arc<Orderbook<T>>,
-) -> Result<impl warp::Reply, Infallible> {
+) -> Result<impl Reply, Infallible> {
     // NOTE: The price in quote is `sell_amount / buy_amount` which is the
     // inverse of an exchange rate. Additionally, we need to apply the price
     // rounding buffer to the price, which will **increase** the exchange rate,
@@ -172,8 +236,8 @@ async fn estimate_amounts_at_price<T>(
     let (buy_amount_in_base, sell_amount_in_quote) = transitive_order
         .map(|order| {
             (
-                apply_rounding_buffer(order.buy, price_rounding_buffer) as u128,
-                order.sell as u128,
+                apply_rounding_buffer(order.buy, price_rounding_buffer),
+                order.sell,
             )
         })
         .unwrap_or_default();
@@ -192,7 +256,7 @@ async fn estimate_best_ask_price<T>(
     _query: QueryParameters,
     price_rounding_buffer: f64,
     orderbook: Arc<Orderbook<T>>,
-) -> Result<impl warp::Reply, Infallible> {
+) -> Result<impl Reply, Infallible> {
     let price = orderbook
         .get_pricegraph()
         .await
@@ -213,9 +277,78 @@ fn apply_rounding_buffer(amount: f64, price_rounding_buffer: f64) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::future::FutureExt as _;
+    use anyhow::{anyhow, Result};
+    use core::orderbook::StableXOrderBookReading;
+    use futures::future::{BoxFuture, FutureExt as _};
+
+    fn empty_orderbook() -> impl StableXOrderBookReading {
+        struct OrderbookReader {}
+        impl StableXOrderBookReading for OrderbookReader {
+            fn get_auction_data<'a>(
+                &'a self,
+                _: u32,
+            ) -> BoxFuture<'a, Result<(core::models::AccountState, Vec<core::models::Order>)>>
+            {
+                async { Ok(Default::default()) }.boxed()
+            }
+        }
+        OrderbookReader {}
+    }
+
+    fn empty_token_info() -> impl TokenInfoFetching {
+        struct TokenInfoFetcher {}
+        impl TokenInfoFetching for TokenInfoFetcher {
+            fn get_token_info<'a>(
+                &'a self,
+                _: TokenId,
+            ) -> BoxFuture<'a, Result<core::token_info::TokenBaseInfo>> {
+                async { Err(anyhow!("")) }.boxed()
+            }
+            fn all_ids<'a>(&'a self) -> BoxFuture<'a, Result<Vec<TokenId>>> {
+                async { Ok(Default::default()) }.boxed()
+            }
+        }
+        TokenInfoFetcher {}
+    }
+
+    fn all_filter() -> impl Filter<Extract = impl Reply, Error = Infallible> + Clone {
+        let orderbook = Arc::new(Orderbook::new(empty_orderbook()));
+        let token_info = Arc::new(empty_token_info());
+        all(orderbook, token_info, 0.0)
+    }
 
     #[test]
+    fn error_unhandled_path() {
+        let response = warp::test::request()
+            .path("/")
+            .reply(&all_filter())
+            .now_or_never()
+            .unwrap();
+        assert_eq!(response.status(), 404);
+    }
+
+    #[test]
+    fn error_no_token_info() {
+        let response = warp::test::request()
+            .path("/api/v1/markets/0-1/estimated-buy-amount/2?atoms=false&hops=3")
+            .reply(&all_filter())
+            .now_or_never()
+            .unwrap();
+        assert_eq!(response.status(), 400);
+    }
+
+    #[test]
+    fn all_filter_ok() {
+        let response = warp::test::request()
+            .path("/api/v1/markets/0-1/estimated-buy-amount/2?atoms=true&hops=3")
+            .reply(&all_filter())
+            .now_or_never()
+            .unwrap();
+        assert_eq!(response.status(), 200);
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
     fn estimated_buy_amount_ok() {
         let (token_pair, volume, query) = warp::test::request()
             .path("/markets/0-65535/estimated-buy-amount/1?atoms=true&hops=2")
@@ -225,7 +358,7 @@ mod tests {
             .unwrap();
         assert_eq!(token_pair.buy, 0);
         assert_eq!(token_pair.sell, 65535);
-        assert_eq!(volume, 1);
+        assert_eq!(volume, 1.0);
         assert_eq!(query.atoms, true);
         assert_eq!(query.hops, Some(2));
     }

--- a/price-estimator/src/models.rs
+++ b/price-estimator/src/models.rs
@@ -56,9 +56,9 @@ pub struct EstimatedOrderResult {
     #[serde(with = "display_fromstr")]
     pub quote_token_id: u16,
     #[serde(with = "display_fromstr")]
-    pub buy_amount_in_base: u128,
+    pub buy_amount_in_base: f64,
     #[serde(with = "display_fromstr")]
-    pub sell_amount_in_quote: u128,
+    pub sell_amount_in_quote: f64,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
@@ -124,6 +124,11 @@ impl From<&pricegraph::TransitiveOrderbook> for MarketsResult {
 #[serde(transparent)]
 pub struct PriceEstimateResult(pub Option<f64>);
 
+#[derive(Debug, Serialize)]
+pub struct ErrorResult {
+    pub message: &'static str,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -153,8 +158,8 @@ mod tests {
         let original = EstimatedOrderResult {
             base_token_id: 1,
             quote_token_id: 2,
-            buy_amount_in_base: 3,
-            sell_amount_in_quote: 4,
+            buy_amount_in_base: 3.0,
+            sell_amount_in_quote: 4.0,
         };
         let serialized = serde_json::to_string(&original).unwrap();
         let json: Value = serde_json::from_str(&serialized).unwrap();


### PR DESCRIPTION
and add error code handling of rejections

First step for #1082 . So far this commit only implements this for one route but not the others. If this way of implementation makes sense I will add it to the other routes (should it apply to all routes, even `/marktets`?) and update the readme. Then we probably also want the token info overrides like the driver has for tokens that don't implement ERC20 properly.

### Test Plan
Unit test for error codes and manual test:
```
$ curl "localhost:8080/api/v1/markets/4-7/estimated-buy-amount/1000000000000000000?atoms=true"
{"baseTokenId":"4","quoteTokenId":"7","buyAmountInBase":"1006194.8387101036","sellAmountInQuote":"1000000000000000000"}

$ curl "localhost:8080/api/v1/markets/4-7/estimated-buy-amount/1?atoms=false"
{"baseTokenId":"4","quoteTokenId":"7","buyAmountInBase":"1.0061948387101036","sellAmountInQuote":"1"}
```
Tested that changing the type of token amounts from u128 to f64 doesn't cause problems in frontend.