### PR TITLE
[Easy] Make async logger blocking

### DIFF
--- a/core/src/logging.rs
+++ b/core/src/logging.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use slog::Level;
 use slog::{o, Drain, Logger, OwnedKVList, Record};
-use slog_async::Async;
+use slog_async::{Async, OverflowStrategy};
 use slog_envlogger::LogBuilder;
 use slog_scope::GlobalLoggerGuard;
 use slog_term::{Decorator, TermDecorator};
@@ -9,9 +9,6 @@ use std::{
     panic::{self, PanicInfo},
     thread,
 };
-
-/// The channel size for async logging.
-const BUFFER_SIZE: usize = 10000;
 
 /// Initialize driver logging.
 pub fn init(filter: impl AsRef<str>) -> (Logger, GlobalLoggerGuard) {
@@ -22,7 +19,7 @@ pub fn init(filter: impl AsRef<str>) -> (Logger, GlobalLoggerGuard) {
     )
     .fuse();
     let drain = Async::new(LogBuilder::new(format).parse(filter.as_ref()).build())
-        .chan_size(BUFFER_SIZE)
+        .overflow_strategy(OverflowStrategy::Block)
         .build();
     let logger = Logger::root(drain.fuse(), o!());
 


### PR DESCRIPTION
We are still seeing logger overflows in the alert channel. Looking at the logs that actually get produced this is clearly not due to file I/O but rather due to the fact that filtering out irrelevant logs (e.g. trace) happens on the async thread which may be suspended and thus not process any logs.

I see three possible strategies:
1. Keep increasing the buffer (not a fan as this is really just the band-aid way of fixing things and we don't really have a good upper bound)
2. Make the strategy in case of overflow to [block](https://docs.rs/slog-async/2.5.0/slog_async/enum.OverflowStrategy.html#variant.Block) (I chose this as we don't really rely on our logs being async for performance reasons. It's only to have a logger that we can send across threads).
3. Lift the filter one layer up and do it before dispatching the logs down the drain (while this would be the nicest, the logic that converts the filter string into a boolean filter method inside LogBuilder is not public and would thus involve writing it manually as far as I can tell).

I also removed the custom channel size as it doesn't seem needed anymore

### Test Plan
Run locally with a fake channel size of 5. See no errors and no noticeable performance overhead.