### PR TITLE
Implement atoms=false for estimated_amounts_at_price

### DIFF
--- a/price-estimator/README.md
+++ b/price-estimator/README.md
@@ -2,7 +2,7 @@
 
 All endpoints use the query part of the url with these key-values:
 
-* `atoms`: Required. If set to `true` all amounts are denominated in the smallest available unit (base quantity) of the token. If `false` all amounts are denominated in the "natural" unit of the respective token given by the number of decimals specified through the ERC20 interface. TODO: `false` is currently only implemented for estimated-buy-amount .
+* `atoms`: Required. If set to `true` all amounts are denominated in the smallest available unit (base quantity) of the token. If `false` all amounts are denominated in the "natural" unit of the respective token given by the number of decimals specified through the ERC20 interface. TODO: `false` is currently only implemented for estimated-buy-amount and estimated-amounts-at-price .
 * `hops`: Optional. TODO: document this once it has been implemented.
 
 Example: `<path>?atoms=true`


### PR DESCRIPTION
Part of #1082 

### Test Plan
Manual test:

token id 2 is usdt has 6 decimals
token id 7 is  dai has 18 decimals

in their base units (atoms=false) their price is close to 1
thus with atoms=true the price in dai for usdt is 1e(18-6) = 1e12

```
$ curl "localhost:8080/api/v1/markets/2-7/estimated-amounts-at-price/1?atoms=false"
{"baseTokenId":"2","quoteTokenId":"7","buyAmountInBase":"14211.716260852729","sellAmountInQuote":"14211.716260852727"}
```

Above amounts are in the base unit because atoms=false.

```
$ curl "localhost:8080/api/v1/markets/2-7/estimated-amounts-at-price/1e12?atoms=true"
{"baseTokenId":"2","quoteTokenId":"7","buyAmountInBase":"14211716260.852728","sellAmountInQuote":"14211716260852727000000"}
```

Above amounts are in atoms because atoms=true.
14211716260 / 1e6 is approximately 14211 which matches the atoms=false query for the same amount.
likewise 4211716260852727000000 / 1e18 matches 4211 .