### PR TITLE
Use types to represent prices and exchange rates

### DIFF
--- a/core/src/models/order.rs
+++ b/core/src/models/order.rs
@@ -1,7 +1,7 @@
 use super::AccountState;
 use crate::util::CeiledDiv;
 use ethcontract::{Address, U256};
-use pricegraph::{Element, Price, TokenPair, Validity};
+use pricegraph::{Element, PriceFraction, TokenPair, Validity};
 
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 pub struct Order {
@@ -55,7 +55,7 @@ impl Order {
                 from: self.valid_from,
                 to: self.valid_until,
             },
-            price: Price {
+            price: PriceFraction {
                 numerator: self.numerator,
                 denominator: self.denominator,
             },

--- a/pricegraph/src/encoding.rs
+++ b/pricegraph/src/encoding.rs
@@ -42,7 +42,7 @@ pub struct Validity {
 /// A price expressed as a fraction of buy and sell amounts.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-pub struct Price {
+pub struct PriceFraction {
     /// The price numerator, or the buy amount.
     pub numerator: u128,
     /// The price denominator, or the sell amount.
@@ -61,7 +61,7 @@ pub struct Element {
     /// The validity of the order.
     pub valid: Validity,
     /// The price fraction for the order.
-    pub price: Price,
+    pub price: PriceFraction,
     /// The remaining sell amount available to this order.
     pub remaining_sell_amount: u128,
     /// The user order id.
@@ -113,7 +113,7 @@ impl Element {
                     from: read!(u32),
                     to: read!(u32),
                 },
-                price: Price {
+                price: PriceFraction {
                     numerator: read!(u128),
                     denominator: read!(u128),
                 },
@@ -140,7 +140,7 @@ mod abitrary_impl {
         balance: [u8; 32],
         pair: TokenPair,
         valid: Validity,
-        price: Price,
+        price: PriceFraction,
         remaining_sell_amount: u128,
         id: OrderId,
     }
@@ -220,7 +220,7 @@ mod tests {
                     from: 0x38393a3b,
                     to: 0x3c3d3e3f,
                 },
-                price: Price {
+                price: PriceFraction {
                     numerator: 0x404142434445464748494a4b4c4d4e4f,
                     denominator: 0x505152535455565758595a5b5c5d5e5f,
                 },

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -228,7 +228,7 @@ impl Pricegraph {
     ) -> Option<TransitiveOrder> {
         let (buy, sell) = self
             .reduced_orderbook()
-            .fill_order_at_price(pair, Price::new(limit_exchange_rate)?)
+            .fill_order_at_price(pair, LimitPrice::new(limit_exchange_rate)?)
             .expect("overlapping orders in reduced orderbook");
         if buy == 0.0 {
             return None;

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -10,7 +10,7 @@ mod orderbook;
 mod data;
 
 pub use encoding::*;
-pub use orderbook::Orderbook;
+pub use orderbook::*;
 
 /// The fee factor that is applied to each order's buy price.
 const FEE_FACTOR: f64 = 1.0 / 0.999;
@@ -192,9 +192,12 @@ impl Pricegraph {
     /// Note that this price is in exchange format, that is, it is expressed as
     /// the ratio between buy and sell amounts, with implicit fees.
     pub fn estimate_exchange_rate(&self, pair: TokenPair, sell_amount: f64) -> Option<f64> {
-        self.reduced_orderbook()
-            .fill_market_order(pair, sell_amount as _)
-            .expect("overlapping orders in reduced orderbook")
+        Some(
+            self.reduced_orderbook()
+                .fill_market_order(pair, sell_amount as _)
+                .expect("overlapping orders in reduced orderbook")?
+                .value(),
+        )
     }
 
     /// Returns a transitive order with a buy amount calculated such that there
@@ -225,7 +228,7 @@ impl Pricegraph {
     ) -> Option<TransitiveOrder> {
         let (buy, sell) = self
             .reduced_orderbook()
-            .fill_order_at_price(pair, limit_exchange_rate)
+            .fill_order_at_price(pair, Price::new(limit_exchange_rate)?)
             .expect("overlapping orders in reduced orderbook");
         if buy == 0.0 {
             return None;
@@ -318,7 +321,7 @@ mod tests {
             balance: U256::from(2) * U256::from(base),
             pair: TokenPair { buy: 0, sell: 1 },
             valid: Validity { from: 0, to: 1 },
-            price: Price {
+            price: PriceFraction {
                 numerator: 2 * base,
                 denominator: base,
             },

--- a/pricegraph/src/orderbook/flow.rs
+++ b/pricegraph/src/orderbook/flow.rs
@@ -22,7 +22,7 @@ impl Flow {
         // - `capacity = sell_amount * price`
         // Solving for `buy_amount` and `sell_amount`, we get:
         let buy = self.capacity / FEE_FACTOR;
-        let sell = self.capacity / *self.exchange_rate;
+        let sell = self.capacity / self.exchange_rate.value();
 
         TransitiveOrder { buy, sell }
     }

--- a/pricegraph/src/orderbook/flow.rs
+++ b/pricegraph/src/orderbook/flow.rs
@@ -1,14 +1,15 @@
 //! Module containing data for representing flow through the orderbook graph.
 
+use super::ExchangeRate;
 use crate::{TransitiveOrder, FEE_FACTOR};
 
 /// A reprensentation of a flow of tokens through the orderbook graph.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Flow {
     /// The effective exchange rate for trading along a path in the graph.
-    pub exchange_rate: f64,
+    pub exchange_rate: ExchangeRate,
     /// The total capacity the path can accomodate expressed in the starting
-    /// token.
+    /// token, which is the buy token for the transitive order along a path.
     pub capacity: f64,
 }
 
@@ -21,7 +22,7 @@ impl Flow {
         // - `capacity = sell_amount * price`
         // Solving for `buy_amount` and `sell_amount`, we get:
         let buy = self.capacity / FEE_FACTOR;
-        let sell = self.capacity / self.exchange_rate;
+        let sell = self.capacity / *self.exchange_rate;
 
         TransitiveOrder { buy, sell }
     }

--- a/pricegraph/src/orderbook/order.rs
+++ b/pricegraph/src/orderbook/order.rs
@@ -1,6 +1,6 @@
 //! Data and logic related to token pair order management.
 
-use super::{ExchangeRate, Price, UserMap};
+use super::{ExchangeRate, LimitPrice, UserMap};
 use crate::encoding::{Element, OrderId, TokenId, TokenPair, UserId};
 use crate::num;
 use std::cmp::Reverse;
@@ -141,7 +141,7 @@ impl Order {
         } else {
             element.remaining_sell_amount as _
         };
-        let exchange_rate = Price::from_fraction(&element.price)?.exchange_rate();
+        let exchange_rate = LimitPrice::from_fraction(&element.price)?.exchange_rate();
 
         Some(Order {
             user: element.user,

--- a/pricegraph/src/orderbook/scalar.rs
+++ b/pricegraph/src/orderbook/scalar.rs
@@ -1,0 +1,153 @@
+//! This module contains definitions for measurement scalars used by the
+//! orderbook graph representation.
+
+use crate::encoding;
+use crate::FEE_FACTOR;
+use std::cmp;
+use std::ops;
+
+/// An exchange price. Limit prices on the exchange are represented by a
+/// fraction of two `u128`s representing a buy and sell amount. These limit
+/// prices implicitly include fees, that is they must be respected **after**
+/// fees are applied. As such, the actual exchange rate for a trade (the ratio
+/// of executed buy amount over executed sell amount) is strictly greater than
+/// and **never equal to** the limit price of an order.
+///
+/// Prices are guaranteed to be a strictly positive finite real numbers.
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+pub struct Price(f64);
+
+impl Price {
+    /// Creates a new price from a `f64` value. Returns `None` if the price
+    /// value is not valid. Specifically, it must be in the range `(0, +∞)`.
+    pub fn new(value: f64) -> Option<Self> {
+        if is_strictly_positive_and_finite(value) {
+            Some(Price(value))
+        } else {
+            None
+        }
+    }
+
+    /// Creates a new price from an exchange price fraction.
+    pub fn from_fraction(price: &encoding::Price) -> Option<Self> {
+        if price.numerator != 0 && price.denominator != 0 {
+            Some(Price(assert_strictly_positive_and_finite(
+                price.numerator as f64 / price.denominator as f64,
+            )))
+        } else {
+            None
+        }
+    }
+
+    /// Converts a price into an effective exchange rate with explicit fees.
+    pub fn exchange_rate(self) -> ExchangeRate {
+        ExchangeRate(assert_strictly_positive_and_finite(self.0 * FEE_FACTOR))
+    }
+}
+
+/// An effective exchange rate that explicitly includes fees. As such, the
+/// actual exchange rate for a trade (the ratio of executed buy amount over
+/// executed sell amount) is greater than **or equal to** the limit exchange
+/// rate for an order.
+///
+/// Exchange rates are guaranteed to be a strictly positive finite real numbers.
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+pub struct ExchangeRate(f64);
+
+impl ExchangeRate {
+    /// The 1:1 exchange rate.
+    pub const IDENTITY: ExchangeRate = ExchangeRate(1.0);
+
+    /// Converts an exchange rate into a price with implicit fees.
+    pub fn price(self) -> Price {
+        Price(assert_strictly_positive_and_finite(self.0 / FEE_FACTOR))
+    }
+
+    /// Computes the inverse exchange rate.
+    pub fn inverse(self) -> Self {
+        ExchangeRate(assert_strictly_positive_and_finite(1.0 / self.0))
+    }
+
+    /// Computes the edge weight for an exchange rate for the orderbook
+    /// projection graph.
+    ///
+    /// This is the base-2 logarithm of the exchange rate. This eanbles path
+    /// weights to be computed using addition instead of multiplication.
+    pub fn weight(self) -> f64 {
+        self.0.log2()
+    }
+}
+
+// NOTE: We can implement `Eq` for `ExchangeRate` since its value is garanteed
+// to not be `NaN`.
+impl Eq for ExchangeRate {}
+
+impl Ord for ExchangeRate {
+    fn cmp(&self, rhs: &Self) -> cmp::Ordering {
+        self.partial_cmp(rhs).expect("exchange rate cannot be NaN")
+    }
+}
+
+impl PartialEq<f64> for ExchangeRate {
+    fn eq(&self, rhs: &f64) -> bool {
+        self.0 == *rhs
+    }
+}
+
+impl PartialOrd<f64> for ExchangeRate {
+    fn partial_cmp(&self, rhs: &f64) -> Option<cmp::Ordering> {
+        self.0.partial_cmp(rhs)
+    }
+}
+
+macro_rules! impl_deref_f64 {
+    ($($t:ty),*) => {$(
+        impl ops::Deref for $t {
+            type Target = f64;
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+    )*}
+}
+
+impl_deref_f64!(Price, ExchangeRate);
+
+macro_rules! impl_binop {
+    ($(
+        $op:tt => {
+            $trait:ident :: $method:ident,
+            $trait_assign:ident :: $method_assign:ident
+        }
+    )*) => {$(
+        impl ops::$trait for ExchangeRate {
+            type Output = ExchangeRate;
+
+            fn $method(self, rhs: Self) -> Self::Output {
+                ExchangeRate(assert_strictly_positive_and_finite(self.0 $op rhs.0))
+            }
+        }
+
+        impl ops::$trait_assign for ExchangeRate {
+            fn $method_assign(&mut self, rhs: Self) {
+                self.0 = assert_strictly_positive_and_finite(self.0 $op rhs.0);
+            }
+        }
+    )*}
+}
+
+impl_binop! {
+    * => { Mul::mul, MulAssign::mul_assign }
+}
+
+fn is_strictly_positive_and_finite(value: f64) -> bool {
+    value > 0.0 && value < f64::INFINITY
+}
+
+/// Internal method for asserting values are strictly positive and finite. This
+/// is used in debug builds to ensure assumptions about price and exchange rate
+/// operations hold. In release mode, this method does nothing.
+fn assert_strictly_positive_and_finite(value: f64) -> f64 {
+    debug_assert!(is_strictly_positive_and_finite(value));
+    value
+}

--- a/pricegraph/src/orderbook/scalar.rs
+++ b/pricegraph/src/orderbook/scalar.rs
@@ -6,7 +6,7 @@ use crate::FEE_FACTOR;
 use std::cmp;
 use std::ops;
 
-/// An exchange price. Limit prices on the exchange are represented by a
+/// An exchange limit price. Limit prices on the exchange are represented by a
 /// fraction of two `u128`s representing a buy and sell amount. These limit
 /// prices implicitly include fees, that is they must be respected **after**
 /// fees are applied. As such, the actual exchange rate for a trade (the ratio
@@ -15,14 +15,14 @@ use std::ops;
 ///
 /// Prices are guaranteed to be a strictly positive finite real numbers.
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
-pub struct Price(f64);
+pub struct LimitPrice(f64);
 
-impl Price {
+impl LimitPrice {
     /// Creates a new price from a `f64` value. Returns `None` if the price
     /// value is not valid. Specifically, it must be in the range `(0, +∞)`.
     pub fn new(value: f64) -> Option<Self> {
         if is_strictly_positive_and_finite(value) {
-            Some(Price(value))
+            Some(LimitPrice(value))
         } else {
             None
         }
@@ -40,7 +40,7 @@ impl Price {
     /// Creates a new price from an exchange price fraction.
     pub fn from_fraction(price: &PriceFraction) -> Option<Self> {
         if price.numerator != 0 && price.denominator != 0 {
-            Some(Price(assert_strictly_positive_and_finite(
+            Some(LimitPrice(assert_strictly_positive_and_finite(
                 price.numerator as f64 / price.denominator as f64,
             )))
         } else {
@@ -78,8 +78,8 @@ impl ExchangeRate {
     }
 
     /// Converts an exchange rate into a price with implicit fees.
-    pub fn price(self) -> Price {
-        Price(assert_strictly_positive_and_finite(self.0 / FEE_FACTOR))
+    pub fn price(self) -> LimitPrice {
+        LimitPrice(assert_strictly_positive_and_finite(self.0 / FEE_FACTOR))
     }
 
     /// Computes the inverse exchange rate.

--- a/pricegraph/src/orderbook/scalar.rs
+++ b/pricegraph/src/orderbook/scalar.rs
@@ -97,7 +97,7 @@ impl ExchangeRate {
     }
 }
 
-// NOTE: We can implement `Eq` for `ExchangeRate` since its value is garanteed
+// NOTE: We can implement `Eq` for `ExchangeRate` since its value is guaranteed
 // to not be `NaN`.
 impl Eq for ExchangeRate {}
 


### PR DESCRIPTION
This PR introduces two new scalar types:
- `Price` to represent exchange order limit prices (with implicit fees). That is, an orders buy amount (or price numerator) divided by an order's sell amount (or price denominator).
- `ExchangeRate` to represent effective order exchange rates that include fees.

These types help us convert between prices and exchange rates in a type-safe way, preventing using a `Price` where an `ExchangeRate` is expected.

### Test Plan

Unit tests still pass with same values! :tada: 