### PR TITLE
Use common `Order` to `Element` conversion

### DIFF
--- a/core/src/history.rs
+++ b/core/src/history.rs
@@ -42,9 +42,7 @@ impl ExchangeHistory {
         let (accounts, orders) = self.events.auction_state_for_batch(batch)?;
         Ok(orders
             .into_iter()
-            .map(|order| {
-                order.to_element(accounts.read_balance(order.sell_token, order.account_id))
-            })
+            .map(|order| order.to_element_with_accounts(&accounts))
             .collect())
     }
 

--- a/core/src/models/order.rs
+++ b/core/src/models/order.rs
@@ -1,3 +1,4 @@
+use super::AccountState;
 use crate::util::CeiledDiv;
 use ethcontract::{Address, U256};
 use pricegraph::{Element, Price, TokenPair, Validity};
@@ -61,6 +62,10 @@ impl Order {
             remaining_sell_amount: self.remaining_sell_amount,
             id: self.id,
         }
+    }
+
+    pub fn to_element_with_accounts(&self, accounts: &AccountState) -> Element {
+        self.to_element(accounts.read_balance(self.sell_token, self.account_id))
     }
 }
 

--- a/price-estimator/src/orderbook.rs
+++ b/price-estimator/src/orderbook.rs
@@ -1,8 +1,5 @@
-use core::{
-    models::{AccountState, Order},
-    orderbook::StableXOrderBookReading,
-};
-use pricegraph::{Element, Price, Pricegraph, TokenPair, Validity};
+use core::orderbook::StableXOrderBookReading;
+use pricegraph::Pricegraph;
 use std::time::{Duration, SystemTime};
 use tokio::sync::RwLock;
 
@@ -37,7 +34,7 @@ impl<T: StableXOrderBookReading> Orderbook<T> {
         let pricegraph = Pricegraph::new(
             orders
                 .iter()
-                .map(|order| order_to_element(order, &account_state)),
+                .map(|order| order.to_element_with_accounts(&account_state)),
         );
 
         *self.pricegraph.write().await = pricegraph;
@@ -53,68 +50,4 @@ fn current_batch_id() -> u64 {
         .duration_since(SystemTime::UNIX_EPOCH)
         .expect("unix epoch is not in the past");
     time_since_epoch.as_secs() / BATCH_DURATION.as_secs()
-}
-
-/// Convert a core Order to a pricegraph Element.
-fn order_to_element(order: &Order, account_state: &AccountState) -> Element {
-    // Some conversions are needed because the primitive types crate is on different versions in
-    // core and pricegraph.
-    Element {
-        user: order.account_id,
-        balance: account_state.read_balance(order.sell_token, order.account_id),
-        pair: TokenPair {
-            buy: order.buy_token,
-            sell: order.sell_token,
-        },
-        valid: Validity {
-            from: order.valid_from,
-            to: order.valid_until,
-        },
-        price: Price {
-            numerator: order.numerator,
-            denominator: order.denominator,
-        },
-        remaining_sell_amount: order.remaining_sell_amount,
-        id: order.id,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use ethcontract::{Address, U256};
-    use std::collections::HashMap;
-
-    #[test]
-    fn order_to_element_() {
-        let order = Order {
-            id: 1,
-            account_id: Address::from_low_u64_le(2),
-            buy_token: 3,
-            sell_token: 4,
-            numerator: 5,
-            denominator: 6,
-            remaining_sell_amount: 7,
-            valid_from: 8,
-            valid_until: 9,
-        };
-        let mut account_state = AccountState(HashMap::new());
-        account_state
-            .0
-            .insert((order.account_id, order.sell_token), U256::from(10));
-        let element = order_to_element(&order, &account_state);
-        assert_eq!(
-            element.user.as_fixed_bytes(),
-            order.account_id.as_fixed_bytes()
-        );
-        assert_eq!(element.balance.0, U256::from(10).0);
-        assert_eq!(element.pair.buy, order.buy_token);
-        assert_eq!(element.pair.sell, order.sell_token);
-        assert_eq!(element.valid.from, order.valid_from);
-        assert_eq!(element.valid.to, order.valid_until);
-        assert_eq!(element.price.numerator, order.numerator);
-        assert_eq!(element.price.denominator, order.denominator);
-        assert_eq!(element.remaining_sell_amount, order.remaining_sell_amount);
-        assert_eq!(element.id, order.id);
-    }
 }


### PR DESCRIPTION
I noticed when refactoring that we have multiple `core::models::Order` to `pricegraph::Element` conversion methods. This PR just removes one and uses the common implementation in `core` crate.
 
### Test Plan

Unit tests + compiler should find any issues :smile: 