### PR TITLE
Unit test solution submission noop transaction

### DIFF
--- a/core/src/solution_submission.rs
+++ b/core/src/solution_submission.rs
@@ -1,10 +1,13 @@
 #![allow(clippy::ptr_arg)] // required for automock
 
-use crate::contracts::stablex_contract::StableXContract;
-use crate::gas_station::GasPriceEstimating;
-use crate::models::{BatchId, Solution};
+use crate::{
+    contracts::stablex_contract::StableXContract,
+    gas_station::GasPriceEstimating,
+    models::{BatchId, Solution},
+};
 
 use anyhow::{anyhow, Error, Result};
+use async_std::future::TimeoutError;
 use ethcontract::errors::{ExecutionError, MethodError};
 use ethcontract::web3::types::TransactionReceipt;
 use ethcontract::U256;
@@ -23,6 +26,7 @@ const POLL_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg(test)]
 const POLL_TIMEOUT: Duration = Duration::from_secs(0);
 
+const GAS_PRICE_CAP: u64 = 60_000_000_000;
 // openethereum requires that the gas price of the resubmitted transaction has increased by at
 // least 12.5%.
 const MIN_GAS_PRICE_INCREASE_FACTOR: f64 = 1.125 * (1.0 + f64::EPSILON);
@@ -127,6 +131,41 @@ impl<'a> StableXSolutionSubmitter<'a> {
         }
         SolutionSubmissionError::Unexpected(err.into())
     }
+
+    async fn handle_submit_solution_result(
+        &self,
+        batch_index: u32,
+        solution: Solution,
+        result: std::result::Result<Result<(), MethodError>, TimeoutError>,
+    ) -> Result<(), SolutionSubmissionError> {
+        if let Ok(submit_result) = result {
+            match submit_result {
+                Ok(()) => Ok(()),
+                Err(err) => Err(self.make_error(batch_index, solution, err).await),
+            }
+        } else {
+            let gas_price =
+                U256::from((GAS_PRICE_CAP as f64 * MIN_GAS_PRICE_INCREASE_FACTOR).ceil() as u128);
+            log::info!(
+                "cancelling transaction because it took too long, using gas price {}",
+                gas_price
+            );
+            match self.contract.send_noop_transaction(gas_price).await {
+                Ok(_) => log::info!(
+                    "cancelled solution submission of batch {} because of deadline",
+                    batch_index
+                ),
+                Err(err) => log::error!(
+                    "failed to cancel solution submission of batch {} after deadline: {:?}",
+                    batch_index,
+                    err
+                ),
+            }
+            Err(SolutionSubmissionError::Unexpected(anyhow!(
+                "solution submission transaction not confirmed in time"
+            )))
+        }
+    }
 }
 
 impl<'a> StableXSolutionSubmitting for StableXSolutionSubmitter<'a> {
@@ -159,7 +198,6 @@ impl<'a> StableXSolutionSubmitting for StableXSolutionSubmitter<'a> {
         solution: Solution,
         claimed_objective_value: U256,
     ) -> BoxFuture<Result<(), SolutionSubmissionError>> {
-        const GAS_PRICE_CAP: u64 = 60_000_000_000;
         async move {
             let submit_future = retry_with_gas_price_increase(
                 self.contract,
@@ -174,34 +212,9 @@ impl<'a> StableXSolutionSubmitting for StableXSolutionSubmitter<'a> {
             let remaining = deadline
                 .duration_since(SystemTime::now())
                 .unwrap_or(Duration::from_secs(0));
-            if let Ok(submit_result) = async_std::future::timeout(remaining, submit_future).await {
-                match submit_result {
-                    Ok(()) => Ok(()),
-                    Err(err) => Err(self.make_error(batch_index, solution, err).await),
-                }
-            } else {
-                let gas_price = U256::from(
-                    (GAS_PRICE_CAP as f64 * MIN_GAS_PRICE_INCREASE_FACTOR).ceil() as u128,
-                );
-                log::info!(
-                    "cancelling transaction because it took too long, using gas price {}",
-                    gas_price
-                );
-                match self.contract.send_noop_transaction(gas_price).await {
-                    Ok(_) => log::info!(
-                        "cancelled solution submission of batch {} because of deadline",
-                        batch_index
-                    ),
-                    Err(err) => log::error!(
-                        "failed to cancel solution submission of batch {} after deadline: {:?}",
-                        batch_index,
-                        err
-                    ),
-                }
-                Err(SolutionSubmissionError::Unexpected(anyhow!(
-                    "solution submission transaction not confirmed in time"
-                )))
-            }
+            let result = async_std::future::timeout(remaining, submit_future).await;
+            self.handle_submit_solution_result(batch_index, solution, result)
+                .await
         }
         .boxed()
     }
@@ -638,5 +651,42 @@ mod tests {
                 panic!("Expecting benign failure, but got {}", err)
             }
         };
+    }
+
+    // Silly way to create a TimeoutError because the type can't be constructed directly.
+    fn timeout_error() -> TimeoutError {
+        async_std::future::timeout(Duration::from_secs(0), futures::future::pending::<()>())
+            .now_or_never()
+            .unwrap()
+            .unwrap_err()
+    }
+
+    #[test]
+    fn handle_submit_solution_result_timeout() {
+        let mut contract = MockStableXContract::new();
+        contract
+            .expect_send_noop_transaction()
+            .with(eq(U256::from(67_500_000_001u128)))
+            .times(1)
+            .returning(|_| immediate!(Err(anyhow!(""))));
+        let gas_station = MockGasPriceEstimating::new();
+        let submitter = StableXSolutionSubmitter::new(&contract, &gas_station);
+        let result = submitter
+            .handle_submit_solution_result(0, Solution::trivial(), Err(timeout_error()))
+            .now_or_never()
+            .unwrap();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn handle_submit_solution_result_ok() {
+        let contract = MockStableXContract::new();
+        let gas_station = MockGasPriceEstimating::new();
+        let submitter = StableXSolutionSubmitter::new(&contract, &gas_station);
+        let result = submitter
+            .handle_submit_solution_result(0, Solution::trivial(), Ok(Ok(())))
+            .now_or_never()
+            .unwrap();
+        assert!(result.is_ok());
     }
 }


### PR DESCRIPTION
In #1089 we talked about testing the new functionality of sending the noop transaction. This PR adds a test by moving the logic that handles the result of deadline-solution-submission into its own function. This sidesteps having to mock `async_std::future::timeout`. Mocking this is not worth the extra code for what little benefit we get. The mocked version looks something like this

```rust
use futures::future::{BoxFuture, FutureExt as _};
use std::{error::Error, fmt, future::Future, time::Duration};

/// A mockable version of async_std::future::timeout .
#[cfg_attr(test, mockall::automock)]
pub trait Timeouting {
    // must use static because mockall limitations
    fn timeout<F, T>(dur: Duration, f: F) -> BoxFuture<'static, Result<T, TimeoutError>>
    where
        F: Future<Output = T> + Send + 'static,
        T: 'static,
    {
        async move {
            async_std::future::timeout(dur, f)
                .await
                .map_err(|_| TimeoutError {})
        }
        .boxed()
    }
}

/// An error returned when a future times out.
#[derive(Clone, Copy, Debug)]
pub struct TimeoutError {}

impl Error for TimeoutError {}

impl fmt::Display for TimeoutError {
    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
        "future has timed out".fmt(f)
    }
}
```
and in addition to that we have to store a `Timeouter` in the solution submission struct. 

It can still be argued that there is some untested code left in `submit_solution` but this function has no control flow and only trivial arithmetic that doesn't need to be tested.