### PR TITLE
Use Mergify for merge-when-green

### DIFF
--- a/.github/merge-when-green.yml
+++ b/.github/merge-when-green.yml
@@ -1,1 +1,0 @@
-mergeMethod: squash

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,12 @@
+pull_request_rules:
+  - name: Merge approved and green PRs with merge-when-green label
+    conditions:
+      - "#approved-reviews-by>=1"
+      - status-success=Travis CI - Pull Request
+      - base=master
+      - label=merge-when-green
+    actions:
+      merge:
+        method: squash
+        strict: smart+fasttrack
+        commit_message: title+body

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,7 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - status-success=Travis CI - Pull Request
       - base=master
-      - label=merge-when-green
+      - label=merge when green
     actions:
       merge:
         method: squash


### PR DESCRIPTION
Merge when green does not support automatically updating the PR branch if it is out of date with master. When multiple people submit PRs at around the same time this can require multiple manual visits of the PR page to update against current master.

[Mergify](https://doc.mergify.io/index.html) seems to be a much more powerful tool that can also allow us to do things such as automatic rebases if the base branch gets merged, auto-merge dependabot changes etc.

This PR aims at just replacing the basic functionality we have today (merge when green) with mergify. This should also work on outdated branches.

### Test Plan
Wait for approval. Then push empty commit into master (to make it out of date) and attach merge-when-green label expect PR to be automatically merged after rebasing and running CI again.