### PR TITLE
Cache all token infos in parallel

### DIFF
--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -31,6 +31,6 @@ macro_rules! std_map {
 
 macro_rules! immediate {
     ($expression:expr) => {
-        async { $expression }.boxed()
+        async move { $expression }.boxed()
     };
 }


### PR DESCRIPTION
and move this into TokenInfoCache. Imo this fits better into the cache
than the trait.

### Test Plan
Unit test and starting price estimator shows the output about failed tokens faster.