### PR TITLE
Fix `panic` because of partially reduced orderbook graph when computing transitive orderbook

### DIFF
--- a/pricegraph/src/encoding.rs
+++ b/pricegraph/src/encoding.rs
@@ -1,7 +1,7 @@
 //! This module implements decoding for the standard `BatchExchange` contract
 //! encoded orders.
 
-use primitive_types::{H160, U256};
+pub use primitive_types::{H160, U256};
 use thiserror::Error;
 
 /// The stride of an orderbook element in bytes.

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -318,8 +318,7 @@ impl Pricegraph {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use assert_approx_eq::assert_approx_eq;
-    use primitive_types::U256;
+    use crate::test::prelude::*;
 
     #[test]
     fn transitive_orderbook_empty_same_token() {

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -286,7 +286,6 @@ impl Pricegraph {
                 .expect("overlapping orders in reduced orderbook"),
         );
 
-        /*j
         // NOTE: It is possible that there are still negative cycles when
         // searching for the inverse token pair, so reduce overlapping
         // transitive orderbook in the inverse market. However, there should be
@@ -298,7 +297,6 @@ impl Pricegraph {
             });
         debug_assert!(inverse_transitive_orderbook.asks.is_empty());
         debug_assert!(inverse_transitive_orderbook.bids.is_empty());
-        */
 
         transitive_orderbook.bids.extend(
             orderbook

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -591,68 +591,9 @@ impl From<NegativeCycle<NodeIndex>> for OverlapError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::encoding::UserId;
+    use crate::test::prelude::*;
     use crate::FEE_FACTOR;
     use assert_approx_eq::assert_approx_eq;
-
-    /// Returns a `UserId` for a test user index.
-    ///
-    /// This method is meant to be used in conjunction with orderbooks created
-    /// with the `orderbook` macro.
-    fn user_id(id: u8) -> UserId {
-        UserId::repeat_byte(id)
-    }
-
-    /// Macro for constructing an orderbook using a DSL for testing purposes.
-    macro_rules! orderbook {
-        (
-            users {$(
-                @ $user:tt {$(
-                    token $token:tt => $balance:expr,
-                )*}
-            )*}
-            orders {$(
-                owner @ $owner:tt
-                buying $buy:tt [ $buy_amount:expr ]
-                selling $sell:tt [ $sell_amount:expr ] $( ($remaining:expr) )?
-            ,)*}
-        ) => {{
-            let mut balances = std::collections::HashMap::new();
-            $($(
-                balances.insert(($user, $token), primitive_types::U256::from($balance));
-            )*)*
-            let mut users = std::collections::HashMap::new();
-            let elements = vec![$(
-                $crate::encoding::Element {
-                    user: user_id($owner),
-                    balance: balances[&($owner, $sell)],
-                    pair: $crate::encoding::TokenPair {
-                        buy: $buy,
-                        sell: $sell,
-                    },
-                    valid: $crate::encoding::Validity {
-                        from: 0,
-                        to: u32::max_value(),
-                    },
-                    price: $crate::encoding::PriceFraction {
-                        numerator: $buy_amount,
-                        denominator: $sell_amount,
-                    },
-                    remaining_sell_amount: match &[$sell_amount, $($remaining)?][..] {
-                        [_, remaining] => *remaining,
-                        _ => $sell_amount,
-                    },
-                    id: {
-                        let count = users.entry($owner).or_insert(0u16);
-                        let id = *count;
-                        *count += 1;
-                        id
-                    },
-                },
-            )*];
-            Orderbook::from_elements(elements)
-        }};
-    }
 
     impl Orderbook {
         /// Retrieve the weight of an edge in the projection graph. This is used for

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -593,7 +593,6 @@ mod tests {
     use super::*;
     use crate::test::prelude::*;
     use crate::FEE_FACTOR;
-    use assert_approx_eq::assert_approx_eq;
 
     impl Orderbook {
         /// Retrieve the weight of an edge in the projection graph. This is used for

--- a/pricegraph/src/test.rs
+++ b/pricegraph/src/test.rs
@@ -1,0 +1,79 @@
+//! Module containing test utilities and macros.
+
+use crate::encoding::UserId;
+
+/// Returns a `UserId` for a test user index.
+///
+/// This method is meant to be used in conjunction with orderbooks created
+/// with the `orderbook` macro.
+pub fn user_id(id: u8) -> UserId {
+    UserId::repeat_byte(id)
+}
+
+/// Macro for constructing an orderbook using a DSL for testing purposes.
+macro_rules! orderbook {
+    (
+        users {$(
+            @ $user:tt {$(
+                token $token:tt => $balance:expr,
+            )*}
+        )*}
+        orders {$(
+            owner @ $owner:tt
+            buying $buy:tt [ $buy_amount:expr ]
+            selling $sell:tt [ $sell_amount:expr ] $( ($remaining:expr) )?
+        ,)*}
+    ) => {{
+        #[allow(unused_mut, unused_variables)]
+        let mut balances = std::collections::HashMap::<
+            (u8, $crate::encoding::TokenId), $crate::encoding::U256,
+        >::new();
+        $($(
+            balances.insert(($user, $token), $crate::U256::from($balance));
+        )*)*
+        #[allow(unused_mut, unused_variables)]
+        let mut users = std::collections::HashMap::<
+            u8, $crate::encoding::OrderId,
+        >::new();
+        let elements = vec![$(
+            $crate::encoding::Element {
+                user: $crate::test::user_id($owner),
+                balance: balances[&($owner, $sell)],
+                pair: $crate::encoding::TokenPair {
+                    buy: $buy,
+                    sell: $sell,
+                },
+                valid: $crate::encoding::Validity {
+                    from: 0,
+                    to: u32::MAX,
+                },
+                price: $crate::encoding::PriceFraction {
+                    numerator: $buy_amount,
+                    denominator: $sell_amount,
+                },
+                remaining_sell_amount: match &[$sell_amount, $($remaining)?][..] {
+                    [_, remaining] => *remaining,
+                    _ => $sell_amount,
+                },
+                id: {
+                    let count = users.entry($owner).or_insert(0);
+                    let id = *count;
+                    *count += 1;
+                    id
+                },
+            },
+        )*];
+        Orderbook::from_elements(elements)
+    }};
+}
+
+macro_rules! pricegraph {
+    ($($arg:tt)*) => {
+        Pricegraph::from_orderbook(orderbook!($($arg)*))
+    };
+}
+
+pub mod prelude {
+    pub use super::*;
+    pub use assert_approx_eq::assert_approx_eq;
+}

--- a/pricegraph/src/test.rs
+++ b/pricegraph/src/test.rs
@@ -67,6 +67,8 @@ macro_rules! orderbook {
     }};
 }
 
+/// Macro for constructing a pricegraph API instance using a DSL for testing
+/// purposes.
 macro_rules! pricegraph {
     ($($arg:tt)*) => {
         Pricegraph::from_orderbook(orderbook!($($arg)*))


### PR DESCRIPTION
This PR fixes a panic in the `pricegraph` when calculating the transitive orderbook for separate subgraphs, where the market's base token's subgraph contained negative cycles. This would happen because only one of the subgraphs (the quote token's subgraph) would end up completely reduced after computing the overlapping transitive orderbook, while the code assumed that both were completely reduced.

This issue was discovered by the pricegraph fuzzing.

This PR also moves the `orderbook!` macro to its own module so that it can be reused from the `pricegraph/lib.rs` module for unit tests.

### Test Plan

- `git checkout 2c0dad400608e1049dedafcdb88ad16cefb7271f` to checkout the commit with the failing test and no fix.
- `cargo test -p pricegraph` and see that it fails
- `git checkout fix-fuzz-crash && cargo test -p pricegraph` and see that it was fixed