### PR TITLE
[Mergify] auto merge dependabot PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,3 +10,14 @@ pull_request_rules:
         method: squash
         strict: smart+fasttrack
         commit_message: title+body
+  - name: automatic merge for Dependabot pull requests
+    conditions:
+      - author~=^dependabot(|-preview)\[bot\]$
+      - status-success=Travis CI - Pull Request
+      - base=master
+    actions:
+      merge:
+        method: squash
+        strict: smart+fasttrack
+        commit_message: title+body
+    


### PR DESCRIPTION
This PR creates a rule to automatically merge passing dependabot updates (instead of having to do so manually every morning). 

Looking forward to hearing security concerns if there are any. The regex exact matches for dependabot and depenabot-preview bots (but usernames already taken by the real bot). Therefore I think in order to automerge using this rule, it would require to capture the original dependabot account in which case it would be simpler to hide malicious code in a benign looking update.

The rule has been taken from the [mergify docs](https://doc.mergify.io/examples.html#dependabot) and adjusted to the squash based merge we normally do in this repo.

### Test Plan

See dependabot PRs being auto-merged in the future.