### PR TITLE
Separate API operations into modules

### DIFF
--- a/pricegraph/src/api.rs
+++ b/pricegraph/src/api.rs
@@ -1,0 +1,75 @@
+//! Module containing the high-level `Pricegraph` API operation implementations.
+
+mod price_estimation;
+mod transitive_orderbook;
+
+pub use self::transitive_orderbook::TransitiveOrderbook;
+use crate::encoding::{TokenId, TokenPair};
+use crate::FEE_FACTOR;
+
+/// A struct representing a transitive order for trading between two tokens.
+///
+/// A transitive order is defined as the transitive combination of multiple
+/// orders into a single equivalent order. For example consider the following
+/// two orders:
+/// - *A*: buying 1.0 token 1 selling 2.0 token 2
+/// - *B*: buying 4.0 token 2 selling 1.0 token 3
+///
+/// We can define a transitive order *C* buying 1.0 token 1 selling 0.5 token 3
+/// by combining *A* and *B*. Note that the sell amount of token 3 is limited by
+/// the token 2 capacity for this transitive order.
+///
+/// Additionally, a transitive order over a single order is equal to that order.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TransitiveOrder {
+    /// The effective buy amount for this transitive order.
+    pub buy: f64,
+    /// The effective sell amount for this transitive order.
+    pub sell: f64,
+}
+
+impl TransitiveOrder {
+    /// Retrieves the exchange rate for this order.
+    pub fn exchange_rate(&self) -> f64 {
+        self.buy / self.sell
+    }
+
+    /// Retrieves the effective exchange rate for this order after fees are
+    /// condidered.
+    ///
+    /// Note that `effective_exchange_rate > exchange_rate`.
+    pub fn effective_exchange_rate(&self) -> f64 {
+        self.exchange_rate() * FEE_FACTOR
+    }
+}
+
+/// A struct representing a market.
+///
+/// This is used for computing transitive orderbooks.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct Market {
+    /// The base or transaction token.
+    pub base: TokenId,
+    /// The quote or counter token to be used as the reference token in the
+    /// market. Prices in a market are always expressed in the quote token.
+    pub quote: TokenId,
+}
+
+impl Market {
+    /// Returns the token pair for ask orders.
+    pub fn ask_pair(self) -> TokenPair {
+        TokenPair {
+            buy: self.quote,
+            sell: self.base,
+        }
+    }
+
+    /// Returns the token pair for bid orders.
+    pub fn bid_pair(self) -> TokenPair {
+        TokenPair {
+            buy: self.base,
+            sell: self.quote,
+        }
+    }
+}

--- a/pricegraph/src/api/price_estimation.rs
+++ b/pricegraph/src/api/price_estimation.rs
@@ -1,0 +1,84 @@
+//! Module containing limit price estimation implementation.
+
+use crate::api::TransitiveOrder;
+use crate::encoding::TokenPair;
+use crate::orderbook::LimitPrice;
+use crate::Pricegraph;
+
+impl Pricegraph {
+    /// Estimates an exchange rate for the specified token pair and sell volume.
+    /// Returns `None` if no combination of orders is able to trade this amount
+    /// of the sell token into the buy token. This usually occurs if there is
+    /// not enough buy token liquidity in the exchange or if there is no inverse
+    /// transitive orders buying the specified sell token for the specified buy
+    /// token.
+    ///
+    /// Note that this price is in exchange format, that is, it is expressed as
+    /// the ratio between buy and sell amounts, with implicit fees.
+    pub fn estimate_exchange_rate(&self, pair: TokenPair, sell_amount: f64) -> Option<f64> {
+        Some(
+            self.reduced_orderbook()
+                .fill_market_order(pair, sell_amount as _)
+                .expect("overlapping orders in reduced orderbook")?
+                .value(),
+        )
+    }
+
+    /// Returns a transitive order with a buy amount calculated such that there
+    /// exists overlapping transitive orders to completely fill the specified
+    /// `sell_amount`. As such, this is an estimated order that is *likely* to
+    /// be matched given the **current** state of the batch.
+    pub fn order_for_sell_amount(
+        &self,
+        pair: TokenPair,
+        sell_amount: f64,
+    ) -> Option<TransitiveOrder> {
+        let price = self.estimate_exchange_rate(pair, sell_amount)?;
+        Some(TransitiveOrder {
+            buy: sell_amount * price,
+            sell: sell_amount,
+        })
+    }
+
+    /// Returns a transitive order with the largest buy and sell amounts such
+    /// that its exchange rate is greater than or equal to the specified limit
+    /// exchange rate and there exists overlapping transitive orders to
+    /// completely fill the order. Returns `None` if no overlapping transitive
+    /// orders exist at the given exchange rate.
+    pub fn order_for_limit_exchange_rate(
+        &self,
+        pair: TokenPair,
+        limit_exchange_rate: f64,
+    ) -> Option<TransitiveOrder> {
+        let (buy, sell) = self
+            .reduced_orderbook()
+            .fill_order_at_price(pair, LimitPrice::new(limit_exchange_rate)?)
+            .expect("overlapping orders in reduced orderbook");
+        if buy == 0.0 {
+            return None;
+        }
+        debug_assert!(sell > 0.0, "zero sell amount for non-zero buy amount");
+
+        Some(TransitiveOrder { buy, sell })
+    }
+
+    /// Returns a transitive order with the largest sell amount such that there
+    /// exists overlapping transitive orders to completely fill the order at the
+    /// specified exchange rate. Returns `None` if no overlapping transitive
+    /// orders exist at the given exchange rate.
+    ///
+    /// Note that this method is subtly different to
+    /// `Pricegraph::order_for_limit_exchange_rate` in that the exchange rate
+    /// for the resulting order is equal to the specified exchange rate.
+    pub fn order_at_exchange_rate(
+        &self,
+        pair: TokenPair,
+        exchange_rate: f64,
+    ) -> Option<TransitiveOrder> {
+        let order = self.order_for_limit_exchange_rate(pair, exchange_rate)?;
+        Some(TransitiveOrder {
+            buy: order.sell * exchange_rate,
+            sell: order.sell,
+        })
+    }
+}

--- a/pricegraph/src/api/transitive_orderbook.rs
+++ b/pricegraph/src/api/transitive_orderbook.rs
@@ -1,0 +1,200 @@
+//! This module contains the implementation for computing a transitive orderbook
+//! over a market.
+
+use crate::api::{Market, TransitiveOrder};
+use crate::num;
+use crate::{Pricegraph, FEE_FACTOR};
+
+/// A struct representing a transitive orderbook for a base and quote token.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct TransitiveOrderbook {
+    /// Transitive "ask" orders, i.e. transitive orders buying the quote token
+    /// and selling the base token.
+    pub asks: Vec<TransitiveOrder>,
+    /// Transitive "bid" orders, i.e. transitive orders buying the base token
+    /// and selling the quote token.
+    pub bids: Vec<TransitiveOrder>,
+}
+
+impl TransitiveOrderbook {
+    /// Returns an iterator with ask prices (expressed in the quote token) and
+    /// corresponding volumes.
+    ///
+    /// Note that the prices are effective prices and include fees.
+    pub fn ask_prices(&self) -> impl DoubleEndedIterator<Item = (f64, f64)> + '_ {
+        self.asks
+            .iter()
+            .map(|order| ((order.buy / order.sell) * FEE_FACTOR, order.sell))
+    }
+
+    /// Returns an iterator with bid prices (expressed in the quote token) and
+    /// corresponding volumes.
+    ///
+    /// Note that the prices are effective prices and include fees.
+    pub fn bid_prices(&self) -> impl DoubleEndedIterator<Item = (f64, f64)> + '_ {
+        self.bids
+            .iter()
+            .map(|order| ((order.sell / order.buy) / FEE_FACTOR, order.buy))
+    }
+}
+
+impl Pricegraph {
+    /// Computes a transitive orderbook for the given market.
+    ///
+    /// This method optionally accepts a spread that is a decimal fraction that
+    /// defines the maximume transitive order price with the equation:
+    /// `first_transitive_price + first_transitive_price * spread`. This means
+    /// that given a spread of 0.5 (or 50%), and if the cheapest transitive
+    /// order has a price of 1.2, then the maximum price will be `1.8`.
+    ///
+    /// The spread applies to both `asks` and `bids` transitive orders.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the spread is zero or negative.
+    pub fn transitive_orderbook(&self, market: Market, spread: Option<f64>) -> TransitiveOrderbook {
+        let mut orderbook = self.full_orderbook();
+
+        let mut transitive_orderbook = orderbook.reduce_overlapping_transitive_orderbook(market);
+        transitive_orderbook.asks.extend(
+            orderbook
+                .clone()
+                .fill_transitive_orders(market.ask_pair(), spread)
+                .expect("overlapping orders in reduced orderbook"),
+        );
+        transitive_orderbook.bids.extend(
+            orderbook
+                .fill_transitive_orders(market.bid_pair(), spread)
+                .expect("overlapping orders in reduced orderbook"),
+        );
+
+        for orders in &mut [
+            &mut transitive_orderbook.asks,
+            &mut transitive_orderbook.bids,
+        ] {
+            orders.sort_unstable_by(|a, b| num::compare(a.exchange_rate(), b.exchange_rate()));
+        }
+
+        transitive_orderbook
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::prelude::*;
+
+    #[test]
+    fn transitive_orderbook_empty_same_token() {
+        let pricegraph = Pricegraph::new(std::iter::empty());
+        let orderbook = pricegraph.transitive_orderbook(Market { base: 0, quote: 0 }, None);
+        assert!(orderbook.asks.is_empty());
+        assert!(orderbook.bids.is_empty());
+    }
+
+    #[test]
+    fn transitive_orderbook_simple() {
+        let base: u128 = 1_000_000_000_000;
+        let pricegraph = pricegraph! {
+            users {
+                @0 {
+                    token 1 => 2 * base,
+                }
+            }
+            orders {
+                owner @0 buying 0 [2 * base] selling 1 [base],
+            }
+        };
+
+        let orderbook = pricegraph.transitive_orderbook(Market { base: 0, quote: 1 }, None);
+        assert_eq!(orderbook.asks, vec![]);
+        assert_eq!(
+            orderbook.bids,
+            vec![TransitiveOrder {
+                buy: 2.0 * base as f64,
+                sell: base as f64,
+            }]
+        );
+        let bid_price = orderbook.bid_prices().next().unwrap();
+        assert_approx_eq!(bid_price.0, 0.5 / FEE_FACTOR);
+
+        let orderbook = pricegraph.transitive_orderbook(Market { base: 1, quote: 0 }, None);
+        assert_eq!(
+            orderbook.asks,
+            vec![TransitiveOrder {
+                buy: 2.0 * base as f64,
+                sell: base as f64,
+            }]
+        );
+        let ask_price = orderbook.ask_prices().next().unwrap();
+        assert_approx_eq!(ask_price.0, 2.0 * FEE_FACTOR);
+        assert_eq!(orderbook.bids, vec![]);
+    }
+
+    #[test]
+    fn transitive_orderbook_prices() {
+        let transitive_orderbook = TransitiveOrderbook {
+            asks: vec![
+                TransitiveOrder {
+                    buy: 20_000_000.0,
+                    sell: 10_000_000.0,
+                },
+                TransitiveOrder {
+                    buy: 1_500_000.0,
+                    sell: 900_000.0,
+                },
+            ],
+            bids: vec![
+                TransitiveOrder {
+                    buy: 1_000_000.0,
+                    sell: 2_000_000.0,
+                },
+                TransitiveOrder {
+                    buy: 500_000.0,
+                    sell: 900_000.0,
+                },
+            ],
+        };
+
+        let ask_prices = transitive_orderbook.ask_prices().collect::<Vec<_>>();
+        assert_approx_eq!(ask_prices[0].0, 2.0 * FEE_FACTOR);
+        assert_approx_eq!(ask_prices[0].1, 10_000_000.0);
+        assert_approx_eq!(ask_prices[1].0, (1.5 / 0.9) * FEE_FACTOR);
+        assert_approx_eq!(ask_prices[1].1, 900_000.0);
+
+        let bid_prices = transitive_orderbook.bid_prices().collect::<Vec<_>>();
+        assert_approx_eq!(bid_prices[0].0, 2.0 / FEE_FACTOR);
+        assert_approx_eq!(bid_prices[0].1, 1_000_000.0);
+        assert_approx_eq!(bid_prices[1].0, (9.0 / 5.0) / FEE_FACTOR);
+        assert_approx_eq!(bid_prices[1].1, 500_000.0);
+    }
+
+    #[test]
+    fn transitive_orderbook_reduces_remaining_negative_cycles_in_inverse_market() {
+        //   /--------------1.0------------\
+        //  /---0.5---v                     v
+        // 0          1          2          3
+        // ^---0.5---/
+        let pricegraph = pricegraph! {
+            users {
+                @0 {
+                    token 0 => 1_000_000,
+                }
+                @1 {
+                    token 0 => 1_000_000,
+                }
+                @2 {
+                    token 1 => 1_000_000,
+                }
+            }
+            orders {
+                owner @0 buying 3 [1_000_000] selling 0 [1_000_000],
+                owner @1 buying 1 [500_000] selling 0 [1_000_000],
+                owner @2 buying 0 [500_000] selling 1 [1_000_000],
+            }
+        };
+        let transitive_orderbook =
+            pricegraph.transitive_orderbook(Market { base: 3, quote: 2 }, None);
+        assert!(transitive_orderbook.asks.is_empty() && transitive_orderbook.bids.is_empty());
+    }
+}

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -1,122 +1,21 @@
 #![deny(clippy::unreadable_literal)]
 
 #[cfg(test)]
-#[path = "../data/mod.rs"]
-mod data;
-#[cfg(test)]
 #[macro_use]
 mod test;
 
+mod api;
 mod encoding;
 mod graph;
 mod num;
 mod orderbook;
 
+pub use self::api::*;
 pub use self::encoding::*;
 pub use self::orderbook::*;
 
 /// The fee factor that is applied to each order's buy price.
 const FEE_FACTOR: f64 = 1.0 / 0.999;
-
-/// A struct representing a transitive orderbook for a base and quote token.
-#[derive(Clone, Debug, Default, PartialEq)]
-pub struct TransitiveOrderbook {
-    /// Transitive "ask" orders, i.e. transitive orders buying the quote token
-    /// and selling the base token.
-    pub asks: Vec<TransitiveOrder>,
-    /// Transitive "bid" orders, i.e. transitive orders buying the base token
-    /// and selling the quote token.
-    pub bids: Vec<TransitiveOrder>,
-}
-
-impl TransitiveOrderbook {
-    /// Returns an iterator with ask prices (expressed in the quote token) and
-    /// corresponding volumes.
-    ///
-    /// Note that the prices are effective prices and include fees.
-    pub fn ask_prices(&self) -> impl DoubleEndedIterator<Item = (f64, f64)> + '_ {
-        self.asks
-            .iter()
-            .map(|order| ((order.buy / order.sell) * FEE_FACTOR, order.sell))
-    }
-
-    /// Returns an iterator with bid prices (expressed in the quote token) and
-    /// corresponding volumes.
-    ///
-    /// Note that the prices are effective prices and include fees.
-    pub fn bid_prices(&self) -> impl DoubleEndedIterator<Item = (f64, f64)> + '_ {
-        self.bids
-            .iter()
-            .map(|order| ((order.sell / order.buy) / FEE_FACTOR, order.buy))
-    }
-}
-
-/// A struct representing a transitive order for trading between two tokens.
-///
-/// A transitive order is defined as the transitive combination of multiple
-/// orders into a single equivalent order. For example consider the following
-/// two orders:
-/// - *A*: buying 1.0 token 1 selling 2.0 token 2
-/// - *B*: buying 4.0 token 2 selling 1.0 token 3
-///
-/// We can define a transitive order *C* buying 1.0 token 1 selling 0.5 token 3
-/// by combining *A* and *B*. Note that the sell amount of token 3 is limited by
-/// the token 2 capacity for this transitive order.
-///
-/// Additionally, a transitive order over a single order is equal to that order.
-#[derive(Clone, Debug, PartialEq)]
-pub struct TransitiveOrder {
-    /// The effective buy amount for this transitive order.
-    pub buy: f64,
-    /// The effective sell amount for this transitive order.
-    pub sell: f64,
-}
-
-impl TransitiveOrder {
-    /// Retrieves the exchange rate for this order.
-    pub fn exchange_rate(&self) -> f64 {
-        self.buy / self.sell
-    }
-
-    /// Retrieves the effective exchange rate for this order after fees are
-    /// condidered.
-    ///
-    /// Note that `effective_exchange_rate > exchange_rate`.
-    pub fn effective_exchange_rate(&self) -> f64 {
-        self.exchange_rate() * FEE_FACTOR
-    }
-}
-
-/// A struct representing a market.
-///
-/// This is used for computing transitive orderbooks.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-pub struct Market {
-    /// The base or transaction token.
-    pub base: TokenId,
-    /// The quote or counter token to be used as the reference token in the
-    /// market. Prices in a market are always expressed in the quote token.
-    pub quote: TokenId,
-}
-
-impl Market {
-    /// Returns the token pair for ask orders.
-    pub fn ask_pair(self) -> TokenPair {
-        TokenPair {
-            buy: self.quote,
-            sell: self.base,
-        }
-    }
-
-    /// Returns the token pair for bid orders.
-    pub fn bid_pair(self) -> TokenPair {
-        TokenPair {
-            buy: self.base,
-            sell: self.quote,
-        }
-    }
-}
 
 /// API entry point for computing price estimates and transitive orderbooks for
 /// a give auction.
@@ -184,212 +83,12 @@ impl Pricegraph {
     pub fn reduced_orderbook(&self) -> Orderbook {
         self.reduced_orderbook.clone()
     }
-
-    /// Estimates an exchange rate for the specified token pair and sell volume.
-    /// Returns `None` if no combination of orders is able to trade this amount
-    /// of the sell token into the buy token. This usually occurs if there is
-    /// not enough buy token liquidity in the exchange or if there is no inverse
-    /// transitive orders buying the specified sell token for the specified buy
-    /// token.
-    ///
-    /// Note that this price is in exchange format, that is, it is expressed as
-    /// the ratio between buy and sell amounts, with implicit fees.
-    pub fn estimate_exchange_rate(&self, pair: TokenPair, sell_amount: f64) -> Option<f64> {
-        Some(
-            self.reduced_orderbook()
-                .fill_market_order(pair, sell_amount as _)
-                .expect("overlapping orders in reduced orderbook")?
-                .value(),
-        )
-    }
-
-    /// Returns a transitive order with a buy amount calculated such that there
-    /// exists overlapping transitive orders to completely fill the specified
-    /// `sell_amount`. As such, this is an estimated order that is *likely* to
-    /// be matched given the **current** state of the batch.
-    pub fn order_for_sell_amount(
-        &self,
-        pair: TokenPair,
-        sell_amount: f64,
-    ) -> Option<TransitiveOrder> {
-        let price = self.estimate_exchange_rate(pair, sell_amount)?;
-        Some(TransitiveOrder {
-            buy: sell_amount * price,
-            sell: sell_amount,
-        })
-    }
-
-    /// Returns a transitive order with the largest buy and sell amounts such
-    /// that its exchange rate is greater than or equal to the specified limit
-    /// exchange rate and there exists overlapping transitive orders to
-    /// completely fill the order. Returns `None` if no overlapping transitive
-    /// orders exist at the given exchange rate.
-    pub fn order_for_limit_exchange_rate(
-        &self,
-        pair: TokenPair,
-        limit_exchange_rate: f64,
-    ) -> Option<TransitiveOrder> {
-        let (buy, sell) = self
-            .reduced_orderbook()
-            .fill_order_at_price(pair, LimitPrice::new(limit_exchange_rate)?)
-            .expect("overlapping orders in reduced orderbook");
-        if buy == 0.0 {
-            return None;
-        }
-        debug_assert!(sell > 0.0, "zero sell amount for non-zero buy amount");
-
-        Some(TransitiveOrder { buy, sell })
-    }
-
-    /// Returns a transitive order with the largest sell amount such that there
-    /// exists overlapping transitive orders to completely fill the order at the
-    /// specified exchange rate. Returns `None` if no overlapping transitive
-    /// orders exist at the given exchange rate.
-    ///
-    /// Note that this method is subtly different to
-    /// `Pricegraph::order_for_limit_exchange_rate` in that the exchange rate
-    /// for the resulting order is equal to the specified exchange rate.
-    pub fn order_at_exchange_rate(
-        &self,
-        pair: TokenPair,
-        exchange_rate: f64,
-    ) -> Option<TransitiveOrder> {
-        let order = self.order_for_limit_exchange_rate(pair, exchange_rate)?;
-        Some(TransitiveOrder {
-            buy: order.sell * exchange_rate,
-            sell: order.sell,
-        })
-    }
-
-    /// Computes a transitive orderbook for the given market.
-    ///
-    /// This method optionally accepts a spread that is a decimal fraction that
-    /// defines the maximume transitive order price with the equation:
-    /// `first_transitive_price + first_transitive_price * spread`. This means
-    /// that given a spread of 0.5 (or 50%), and if the cheapest transitive
-    /// order has a price of 1.2, then the maximum price will be `1.8`.
-    ///
-    /// The spread applies to both `asks` and `bids` transitive orders.
-    ///
-    /// # Panics
-    ///
-    /// This method panics if the spread is zero or negative.
-    pub fn transitive_orderbook(&self, market: Market, spread: Option<f64>) -> TransitiveOrderbook {
-        let mut orderbook = self.full_orderbook();
-
-        let mut transitive_orderbook = orderbook.reduce_overlapping_transitive_orderbook(market);
-        transitive_orderbook.asks.extend(
-            orderbook
-                .clone()
-                .fill_transitive_orders(market.ask_pair(), spread)
-                .expect("overlapping orders in reduced orderbook"),
-        );
-        transitive_orderbook.bids.extend(
-            orderbook
-                .fill_transitive_orders(market.bid_pair(), spread)
-                .expect("overlapping orders in reduced orderbook"),
-        );
-
-        for orders in &mut [
-            &mut transitive_orderbook.asks,
-            &mut transitive_orderbook.bids,
-        ] {
-            orders.sort_unstable_by(|a, b| num::compare(a.exchange_rate(), b.exchange_rate()));
-        }
-
-        transitive_orderbook
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::test::prelude::*;
-
-    #[test]
-    fn transitive_orderbook_empty_same_token() {
-        let pricegraph = Pricegraph::new(std::iter::empty());
-        let orderbook = pricegraph.transitive_orderbook(Market { base: 0, quote: 0 }, None);
-        assert!(orderbook.asks.is_empty());
-        assert!(orderbook.bids.is_empty());
-    }
-
-    #[test]
-    fn transitive_orderbook_simple() {
-        let base: u128 = 1_000_000_000_000;
-        let pricegraph = pricegraph! {
-            users {
-                @0 {
-                    token 1 => 2 * base,
-                }
-            }
-            orders {
-                owner @0 buying 0 [2 * base] selling 1 [base],
-            }
-        };
-
-        let orderbook = pricegraph.transitive_orderbook(Market { base: 0, quote: 1 }, None);
-        assert_eq!(orderbook.asks, vec![]);
-        assert_eq!(
-            orderbook.bids,
-            vec![TransitiveOrder {
-                buy: 2.0 * base as f64,
-                sell: base as f64,
-            }]
-        );
-        let bid_price = orderbook.bid_prices().next().unwrap();
-        assert_approx_eq!(bid_price.0, 0.5 / FEE_FACTOR);
-
-        let orderbook = pricegraph.transitive_orderbook(Market { base: 1, quote: 0 }, None);
-        assert_eq!(
-            orderbook.asks,
-            vec![TransitiveOrder {
-                buy: 2.0 * base as f64,
-                sell: base as f64,
-            }]
-        );
-        let ask_price = orderbook.ask_prices().next().unwrap();
-        assert_approx_eq!(ask_price.0, 2.0 * FEE_FACTOR);
-        assert_eq!(orderbook.bids, vec![]);
-    }
-
-    #[test]
-    fn transitive_orderbook_prices() {
-        let transitive_orderbook = TransitiveOrderbook {
-            asks: vec![
-                TransitiveOrder {
-                    buy: 20_000_000.0,
-                    sell: 10_000_000.0,
-                },
-                TransitiveOrder {
-                    buy: 1_500_000.0,
-                    sell: 900_000.0,
-                },
-            ],
-            bids: vec![
-                TransitiveOrder {
-                    buy: 1_000_000.0,
-                    sell: 2_000_000.0,
-                },
-                TransitiveOrder {
-                    buy: 500_000.0,
-                    sell: 900_000.0,
-                },
-            ],
-        };
-
-        let ask_prices = transitive_orderbook.ask_prices().collect::<Vec<_>>();
-        assert_approx_eq!(ask_prices[0].0, 2.0 * FEE_FACTOR);
-        assert_approx_eq!(ask_prices[0].1, 10_000_000.0);
-        assert_approx_eq!(ask_prices[1].0, (1.5 / 0.9) * FEE_FACTOR);
-        assert_approx_eq!(ask_prices[1].1, 900_000.0);
-
-        let bid_prices = transitive_orderbook.bid_prices().collect::<Vec<_>>();
-        assert_approx_eq!(bid_prices[0].0, 2.0 / FEE_FACTOR);
-        assert_approx_eq!(bid_prices[0].1, 1_000_000.0);
-        assert_approx_eq!(bid_prices[1].0, (9.0 / 5.0) / FEE_FACTOR);
-        assert_approx_eq!(bid_prices[1].1, 500_000.0);
-    }
 
     #[test]
     fn real_orderbooks() {
@@ -447,35 +146,5 @@ mod tests {
                 }
             }
         }
-    }
-
-    #[test]
-    #[allow(clippy::unreadable_literal)]
-    fn transitive_orderbook_reduces_remaining_negative_cycles_in_inverse_market() {
-        //   /--------------1.0------------\
-        //  /---0.5---v                     v
-        // 0          1          2          3
-        // ^---0.5---/
-        let pricegraph = pricegraph! {
-            users {
-                @0 {
-                    token 0 => 1_000_000,
-                }
-                @1 {
-                    token 0 => 1_000_000,
-                }
-                @2 {
-                    token 1 => 1_000_000,
-                }
-            }
-            orders {
-                owner @0 buying 3 [1_000_000] selling 0 [1_000_000],
-                owner @1 buying 1 [500_000] selling 0 [1_000_000],
-                owner @2 buying 0 [500_000] selling 1 [1_000_000],
-            }
-        };
-        let transitive_orderbook =
-            pricegraph.transitive_orderbook(Market { base: 3, quote: 2 }, None);
-        assert!(transitive_orderbook.asks.is_empty() && transitive_orderbook.bids.is_empty());
     }
 }

--- a/pricegraph/src/num.rs
+++ b/pricegraph/src/num.rs
@@ -52,7 +52,10 @@ pub fn u256_to_f64(u: U256) -> f64 {
 ///
 /// If any of the two floats are NaN.
 pub fn min(a: f64, b: f64) -> f64 {
-    match compare(a, b) {
+    match a
+        .partial_cmp(&b)
+        .expect("orderbooks cannot have NaN quantities")
+    {
         cmp::Ordering::Less => a,
         _ => b,
     }

--- a/pricegraph/src/test.rs
+++ b/pricegraph/src/test.rs
@@ -1,5 +1,8 @@
 //! Module containing test utilities and macros.
 
+#[path = "../data/mod.rs"]
+pub mod data;
+
 use crate::encoding::UserId;
 
 /// Returns a `UserId` for a test user index.
@@ -63,7 +66,7 @@ macro_rules! orderbook {
                 },
             },
         )*];
-        Orderbook::from_elements(elements)
+        $crate::orderbook::Orderbook::from_elements(elements)
     }};
 }
 


### PR DESCRIPTION
This PR just splits the `Pricegraph` `impl` blocks into multiple submodules. The ultimate plan is to lift `Orderbook` methods into the `Pricegraph` type (for computing transitive orderbooks and price estimates) so that the `Orderbook` type only contains primitives for manipulating the orderbook graph while the `Pricegraph` type actually computes things by combining these primitives.

This is in an effort to reduce the size of `orderbook.rs` which is currently >1000L long :disappointed:. The motivation for splitting operations into their own modules is to allow the `Pricegraph` API surface to grow without creating another run-away module with way too much code that becomes hard to navigate.

In the following PRs, I plan on:
- move `Orderbook::{reduce_overlapping_transitive_orderbook, fill_transitive_orders}` to `src/api/transitive_orderbook.rs`, implemented with the new `Orderbook::{fill_optimal_transitive_order_if, fill_market_ring_trade}` primitive operations
- move `Orderbook::{fill_market_order, fill_order_at_price}` to `src/api/price_estimation.rs` module implemented with the `Orderbook::fill_optimal_transitive_order_if` primitive.

This has the added benefit that each module will contain unit tests specific to the operation, so hopefully the code will be easier to test and develop for.

One thing I don't 100% like about the structure is that `Pricegraph` methods are split into multiple files, which might be a bit counter-intuitive and make methods harder to find. Another option here would be to implement "helper" functions for each operations in these modules and have `Pricegraph` methods wrap them in `src/lib.rs`. However, this feels like extra work (double method signature for each operation) so I'm not sure if its worth it. Yet another option would be to implement operations as traits. This would be nice since the traits and implementations could live in the same file, and make `Pricegraph` more easily mockable, but with the downside that traits need to be `use`-ed in order to call the methods. I'm open to suggestions.

### Test Plan

Just moved code around, no substantial changes.