### PR TITLE
Reuse compare non-NaN assertion

### DIFF
--- a/pricegraph/src/num.rs
+++ b/pricegraph/src/num.rs
@@ -52,10 +52,7 @@ pub fn u256_to_f64(u: U256) -> f64 {
 ///
 /// If any of the two floats are NaN.
 pub fn min(a: f64, b: f64) -> f64 {
-    match a
-        .partial_cmp(&b)
-        .expect("orderbooks cannot have NaN quantities")
-    {
+    match compare(a, b) {
         cmp::Ordering::Less => a,
         _ => b,
     }


### PR DESCRIPTION
Noticed this when refactoring, we repeat the non-NaN assertion in the compare method a couple lines below.

### Test Plan

Unit tests.