### PR TITLE
Promote transitive orderbook implementation to Pricegraph

### DIFF
--- a/pricegraph/src/api.rs
+++ b/pricegraph/src/api.rs
@@ -72,4 +72,12 @@ impl Market {
             sell: self.quote,
         }
     }
+
+    /// Returns the inverse market.
+    pub fn inverse(self) -> Market {
+        Market {
+            base: self.quote,
+            quote: self.base,
+        }
+    }
 }

--- a/pricegraph/src/api/transitive_orderbook.rs
+++ b/pricegraph/src/api/transitive_orderbook.rs
@@ -70,10 +70,7 @@ impl Pricegraph {
         // negative cycles in the inverse market. However, there should be no
         // ring trades over the inverse market (if there were, then the `quote`
         // and `base` token would be part of the same subgraph), so assert it.
-        let inverse_ring = orderbook.fill_market_ring_trade(Market {
-            base: market.quote,
-            quote: market.base,
-        });
+        let inverse_ring = orderbook.fill_market_ring_trade(market.inverse());
         debug_assert_eq!(inverse_ring, None);
 
         transitive_orderbook.asks.extend(

--- a/pricegraph/src/api/transitive_orderbook.rs
+++ b/pricegraph/src/api/transitive_orderbook.rs
@@ -2,7 +2,9 @@
 //! over a market.
 
 use crate::api::{Market, TransitiveOrder};
+use crate::encoding::TokenPair;
 use crate::num;
+use crate::orderbook::{Orderbook, OverlapError, Ring};
 use crate::{Pricegraph, FEE_FACTOR};
 
 /// A struct representing a transitive orderbook for a base and quote token.
@@ -55,16 +57,31 @@ impl Pricegraph {
     pub fn transitive_orderbook(&self, market: Market, spread: Option<f64>) -> TransitiveOrderbook {
         let mut orderbook = self.full_orderbook();
 
-        let mut transitive_orderbook = orderbook.reduce_overlapping_transitive_orderbook(market);
+        let mut transitive_orderbook = TransitiveOrderbook::default();
+        while let Some(Ring { ask, bid }) = orderbook.fill_market_ring_trade(market) {
+            transitive_orderbook.asks.push(ask.as_transitive_order());
+            transitive_orderbook.bids.push(bid.as_transitive_order());
+        }
+
+        // NOTE: In the case where the market `quote` and `base` token are in
+        // different disconnected subgraphs, it is possible that the `base`
+        // token's subgraph contains negative cycles. In order to ensure that
+        // the `base` token subgraph is also reduced, fill any remaining
+        // negative cycles in the inverse market. However, there should be no
+        // ring trades over the inverse market (if there were, then the `quote`
+        // and `base` token would be part of the same subgraph), so assert it.
+        let inverse_ring = orderbook.fill_market_ring_trade(Market {
+            base: market.quote,
+            quote: market.base,
+        });
+        debug_assert_eq!(inverse_ring, None);
+
         transitive_orderbook.asks.extend(
-            orderbook
-                .clone()
-                .fill_transitive_orders(market.ask_pair(), spread)
+            fill_transitive_orders(orderbook.clone(), market.ask_pair(), spread)
                 .expect("overlapping orders in reduced orderbook"),
         );
         transitive_orderbook.bids.extend(
-            orderbook
-                .fill_transitive_orders(market.bid_pair(), spread)
+            fill_transitive_orders(orderbook, market.bid_pair(), spread)
                 .expect("overlapping orders in reduced orderbook"),
         );
 
@@ -77,6 +94,48 @@ impl Pricegraph {
 
         transitive_orderbook
     }
+}
+
+/// Fills transitive orders along a token pair, optionally specifying a
+/// maximum spread for the orders.
+///
+/// Returns a vector containing all the transitive orders that were filled.
+///
+/// Note that the spread is a decimal fraction that defines the maximum
+/// transitive order exchange rate with the equation:
+/// `first_transitive_xrate + first_transitive_xrate * spread`. This means
+/// that given a spread of `0.5` (or 50%), and if the cheapest transitive
+/// order has an exchange rate of `1.2`, then the maximum exchange rate will
+/// be `1.8`.
+///
+/// # Panics
+///
+/// This method panics if the spread is zero or negative.
+fn fill_transitive_orders(
+    mut orderbook: Orderbook,
+    pair: TokenPair,
+    spread: Option<f64>,
+) -> Result<Vec<TransitiveOrder>, OverlapError> {
+    if let Some(spread) = spread {
+        assert!(spread > 0.0, "invalid spread");
+    }
+
+    let mut orders = Vec::new();
+    let mut max_xrate = None;
+
+    while let Some(flow) = orderbook.fill_optimal_transitive_order_if(pair, |flow| {
+        if let Some(spread) = spread {
+            let max_xrate =
+                max_xrate.get_or_insert_with(|| flow.exchange_rate.value() * (1.0 + spread));
+            flow.exchange_rate <= *max_xrate
+        } else {
+            true
+        }
+    })? {
+        orders.push(flow.as_transitive_order());
+    }
+
+    Ok(orders)
 }
 
 #[cfg(test)]
@@ -167,6 +226,190 @@ mod tests {
         assert_approx_eq!(bid_prices[0].1, 1_000_000.0);
         assert_approx_eq!(bid_prices[1].0, (9.0 / 5.0) / FEE_FACTOR);
         assert_approx_eq!(bid_prices[1].1, 500_000.0);
+    }
+
+    #[test]
+    fn detects_overlapping_transitive_orders() {
+        // 0 --1.0--> 1 --0.5--> 2 --1.0--> 3 --1.0--> 4
+        //            ^---------1.0--------/^---0.5---/
+        let pricegraph = pricegraph! {
+            users {
+                @1 {
+                    token 1 => 1_000_000,
+                }
+                @2 {
+                    token 2 => 2_000_000,
+                }
+                @3 {
+                    token 3 => 1_000_000,
+                }
+
+                @4 {
+                    token 4 => 1_000_000,
+                }
+                @5 {
+                    token 3 => 2_000_000,
+                }
+            }
+            orders {
+                owner @1 buying 0 [1_000_000] selling 1 [1_000_000],
+                owner @1 buying 3 [1_000_000] selling 1 [1_000_000],
+                owner @2 buying 1 [1_000_000] selling 2 [2_000_000],
+                owner @3 buying 2 [1_000_000] selling 3 [1_000_000] (500_000),
+
+                owner @4 buying 3 [1_000_000] selling 4 [1_000_000],
+                owner @5 buying 4 [1_000_000] selling 3 [2_000_000],
+            }
+        };
+
+        let transitive_orderbook =
+            pricegraph.transitive_orderbook(Market { base: 1, quote: 2 }, None);
+
+        // Transitive order `2 -> 3 -> 1` buying 2 selling 1
+        assert_eq!(transitive_orderbook.asks.len(), 1);
+        assert_approx_eq!(transitive_orderbook.asks[0].buy, 500_000.0);
+        assert_approx_eq!(transitive_orderbook.asks[0].sell, 500_000.0 / FEE_FACTOR);
+
+        // Transitive order `1 -> 2` buying 1 selling 2
+        assert_eq!(transitive_orderbook.bids.len(), 1);
+        assert_approx_eq!(transitive_orderbook.bids[0].buy, 1_000_000.0);
+        assert_approx_eq!(transitive_orderbook.bids[0].sell, 2_000_000.0);
+    }
+
+    #[test]
+    fn includes_transitive_order_only_once() {
+        // /---0.5---v
+        // 0         1
+        // ^---1.0---/
+        // ^---1.5--/
+        let pricegraph = pricegraph! {
+            users {
+                @1 {
+                    token 1 => 100_000_000,
+                }
+                @2 {
+                    token 0 => 1_000_000,
+                }
+                @3 {
+                    token 0 => 1_000_000,
+                }
+            }
+            orders {
+                owner @1 buying 0 [50_000_000] selling 1 [100_000_000],
+                owner @2 buying 1 [1_000_000] selling 0 [1_000_000],
+                owner @3 buying 1 [1_500_000] selling 0 [1_000_000],
+            }
+        };
+
+        let transitive_orderbook =
+            pricegraph.transitive_orderbook(Market { base: 0, quote: 1 }, None);
+
+        // Transitive orders `1 -> 0` buying 1 selling 0
+        assert_eq!(transitive_orderbook.asks.len(), 2);
+        assert_approx_eq!(transitive_orderbook.asks[0].buy, 1_000_000.0);
+        assert_approx_eq!(transitive_orderbook.asks[0].sell, 1_000_000.0);
+        assert_approx_eq!(transitive_orderbook.asks[1].buy, 1_500_000.0);
+        assert_approx_eq!(transitive_orderbook.asks[1].sell, 1_000_000.0);
+
+        // Transitive order `0 -> 1` buying 0 selling 1
+        assert_eq!(transitive_orderbook.bids.len(), 1);
+        assert_approx_eq!(transitive_orderbook.bids[0].buy, 50_000_000.0);
+        assert_approx_eq!(transitive_orderbook.bids[0].sell, 100_000_000.0);
+    }
+
+    #[test]
+    fn fills_transitive_orders_with_maximum_spread() {
+        //    /--1.0--v
+        //   /        v---2.0--\
+        //  /---4.0---v         \
+        // 1          2          3
+        //  \                    ^
+        //   \--------1.0-------/
+        let pricegraph = pricegraph! {
+            users {
+                @1 {
+                    token 2 => 1_000_000,
+                    token 3 => 1_000_000,
+                }
+                @2 {
+                    token 2 => 1_000_000,
+                }
+                @3 {
+                    token 2 => 1_000_000,
+                }
+            }
+            orders {
+                owner @1 buying 1 [1_000_000] selling 2 [1_000_000],
+                owner @2 buying 3 [2_000_000] selling 2 [1_000_000],
+                owner @3 buying 1 [4_000_000] selling 2 [1_000_000],
+
+                owner @1 buying 1 [1_000_000] selling 3 [1_000_000],
+            }
+        };
+        let market = Market { base: 1, quote: 2 };
+
+        let TransitiveOrderbook { bids, .. } = pricegraph.transitive_orderbook(market, Some(0.5));
+        assert_eq!(bids.len(), 1);
+        assert_approx_eq!(bids[0].buy, 1_000_000.0);
+        assert_approx_eq!(bids[0].sell, 1_000_000.0);
+
+        let TransitiveOrderbook { bids, .. } = pricegraph.transitive_orderbook(market, Some(1.0));
+        assert_eq!(bids.len(), 1);
+
+        let TransitiveOrderbook { bids, .. } =
+            pricegraph.transitive_orderbook(market, Some((2.0 * FEE_FACTOR) - 1.0));
+        assert_eq!(bids.len(), 2);
+        assert_approx_eq!(bids[1].buy, 1_000_000.0);
+        assert_approx_eq!(bids[1].sell, 500_000.0 / FEE_FACTOR);
+
+        let TransitiveOrderbook { bids, .. } = pricegraph.transitive_orderbook(market, Some(3.0));
+        assert_eq!(bids.len(), 3);
+        assert_approx_eq!(bids[2].buy, 4_000_000.0);
+        assert_approx_eq!(bids[2].sell, 1_000_000.0);
+    }
+
+    #[test]
+    fn fills_all_transitive_orders_without_maximum_spread() {
+        //    /--1.0--v
+        //   /        v---2.0--\
+        //  /---4.0---v         \
+        // 1          2          3
+        //  \                    ^
+        //   \--------1.0-------/
+        let pricegraph = pricegraph! {
+            users {
+                @1 {
+                    token 2 => 1_000_000,
+                    token 3 => 1_000_000,
+                }
+                @2 {
+                    token 2 => 1_000_000,
+                }
+                @3 {
+                    token 2 => 1_000_000,
+                }
+            }
+            orders {
+                owner @1 buying 1 [1_000_000] selling 2 [1_000_000],
+                owner @2 buying 3 [2_000_000] selling 2 [1_000_000],
+                owner @3 buying 1 [4_000_000] selling 2 [1_000_000],
+
+                owner @1 buying 1 [1_000_000] selling 3 [1_000_000],
+            }
+        };
+        let market = Market { base: 1, quote: 2 };
+
+        let TransitiveOrderbook { bids, .. } = pricegraph.transitive_orderbook(market, None);
+        assert_eq!(bids.len(), 3);
+
+        assert_approx_eq!(bids[0].buy, 1_000_000.0);
+        assert_approx_eq!(bids[0].sell, 1_000_000.0);
+
+        assert_approx_eq!(bids[1].buy, 1_000_000.0);
+        assert_approx_eq!(bids[1].sell, 500_000.0 / FEE_FACTOR);
+
+        assert_approx_eq!(bids[2].buy, 4_000_000.0);
+        assert_approx_eq!(bids[2].sell, 1_000_000.0);
     }
 
     #[test]


### PR DESCRIPTION
This PR moves the transitive orderbook calculation to the `Pricegraph` type instead of the `Orderbook` type. This is part of the changes to make `Orderbook` only implement orderbook graph primitives (keeping the module more manageable) and have the high-level `Pricegraph` API implement actual high level operations (such as computing the transitive orderbook).

### Test Plan

Refactored unit tests to new API and they still pass.