### PR TITLE
Rename methods for more consistent language

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![Build Status](https://travis-ci.com/gnosis/dex-services.svg?branch=master)](https://travis-ci.com/gnosis/dex-services)
 [![Coverage Status](https://coveralls.io/repos/github/gnosis/dex-services/badge.svg?branch=master)](https://coveralls.io/github/gnosis/dex-services)
 
-
 # Contents
 1. [Introduction](#introduction)
 2. [Getting Started](#getting-started)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Build Status](https://travis-ci.com/gnosis/dex-services.svg?branch=master)](https://travis-ci.com/gnosis/dex-services)
 [![Coverage Status](https://coveralls.io/repos/github/gnosis/dex-services/badge.svg?branch=master)](https://coveralls.io/github/gnosis/dex-services)
 
+
 # Contents
 1. [Introduction](#introduction)
 2. [Getting Started](#getting-started)

--- a/core/src/price_estimation/orderbook_based.rs
+++ b/core/src/price_estimation/orderbook_based.rs
@@ -40,8 +40,7 @@ trait PriceEstimating {
 
 impl PriceEstimating for Pricegraph {
     fn estimate_price(&self, pair: TokenPair, volume: f64) -> Option<f64> {
-        // Clone the pricegraph so that each estimation is independent of one another.
-        self.estimate_exchange_rate(pair, volume)
+        self.estimate_limit_price(pair, volume)
     }
 }
 

--- a/e2e/src/bin/historic_prices.rs
+++ b/e2e/src/bin/historic_prices.rs
@@ -76,7 +76,7 @@ fn check_batch_spread(
         let (buy_token, sell_token) = (token_ids[i], token_ids[j]);
 
         let best_bid = pricegraph
-            .estimate_exchange_rate(
+            .estimate_limit_price(
                 TokenPair {
                     buy: sell_token,
                     sell: buy_token,
@@ -86,7 +86,7 @@ fn check_batch_spread(
             .unwrap_or(0.0);
         let price = prices[i] as f64 / prices[j] as f64;
         let best_ask = pricegraph
-            .estimate_exchange_rate(
+            .estimate_limit_price(
                 TokenPair {
                     buy: buy_token,
                     sell: sell_token,

--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -270,7 +270,7 @@ async fn estimate_amounts_at_price_atoms<T>(
     let transitive_order = orderbook
         .get_pricegraph()
         .await
-        .order_at_exchange_rate(token_pair, exchange_rate);
+        .order_at_limit_price(token_pair, exchange_rate);
     let (buy_amount_in_base, sell_amount_in_quote) = transitive_order
         .map(|order| {
             (
@@ -296,7 +296,7 @@ async fn estimate_best_ask_price<T>(
     let price = orderbook
         .get_pricegraph()
         .await
-        .estimate_exchange_rate(token_pair, 0.0)
+        .estimate_limit_price(token_pair, 0.0)
         .map(|xrate| {
             // NOTE: Exchange rate is the inverse of price for an ask order.
             1.0 / apply_rounding_buffer(xrate, price_rounding_buffer)

--- a/pricegraph/benches/pricegraph.rs
+++ b/pricegraph/benches/pricegraph.rs
@@ -23,37 +23,37 @@ pub fn transitive_orderbook(c: &mut Criterion) {
     );
 }
 
-pub fn estimate_exchange_rate(c: &mut Criterion) {
+pub fn estimate_limit_price(c: &mut Criterion) {
     let pricegraph = read_default_pricegraph();
     let dai_weth = TokenPair { buy: 7, sell: 1 };
     let eth = 10.0f64.powi(18);
     let volumes = &[0.1 * eth, eth, 10.0 * eth, 100.0 * eth, 1000.0 * eth];
 
-    let mut group = c.benchmark_group("Pricegraph::estimate_exchange_rate");
+    let mut group = c.benchmark_group("Pricegraph::estimate_limit_price");
     for volume in volumes {
         group.bench_with_input(
             BenchmarkId::from_parameter(volume),
             &(&pricegraph, dai_weth, *volume),
             |b, &(pricegraph, pair, volume)| {
-                b.iter(|| pricegraph.estimate_exchange_rate(pair, volume))
+                b.iter(|| pricegraph.estimate_limit_price(pair, volume))
             },
         );
     }
     group.finish();
 }
 
-pub fn order_for_limit_exchange_rate(c: &mut Criterion) {
+pub fn order_for_limit_price(c: &mut Criterion) {
     let pricegraph = read_default_pricegraph();
     let dai_weth = TokenPair { buy: 7, sell: 1 };
     let prices = &[200.0, 190.0, 180.0, 150.0, 100.0];
 
-    let mut group = c.benchmark_group("Pricegraph::order_for_limit_exchange_rate");
+    let mut group = c.benchmark_group("Pricegraph::order_for_limit_price");
     for price in prices {
         group.bench_with_input(
             BenchmarkId::from_parameter(price),
             &(&pricegraph, dai_weth, *price),
             |b, &(pricegraph, pair, price)| {
-                b.iter(|| pricegraph.order_for_limit_exchange_rate(pair, price))
+                b.iter(|| pricegraph.order_for_limit_price(pair, price))
             },
         );
     }
@@ -63,6 +63,6 @@ pub fn order_for_limit_exchange_rate(c: &mut Criterion) {
 criterion_group!(
     name = benches;
     config = Criterion::default().sample_size(50);
-    targets = read, transitive_orderbook, estimate_exchange_rate, order_for_limit_exchange_rate
+    targets = read, transitive_orderbook, estimate_limit_price, order_for_limit_price
 );
 criterion_main!(benches);

--- a/pricegraph/src/api/price_estimation.rs
+++ b/pricegraph/src/api/price_estimation.rs
@@ -15,7 +15,7 @@ impl Pricegraph {
     ///
     /// Note that this price is in exchange format, that is, it is expressed as
     /// the ratio between buy and sell amounts, with implicit fees.
-    pub fn estimate_exchange_rate(&self, pair: TokenPair, sell_amount: f64) -> Option<f64> {
+    pub fn estimate_limit_price(&self, pair: TokenPair, sell_amount: f64) -> Option<f64> {
         let mut orderbook = self.reduced_orderbook();
 
         // NOTE: This method works by searching for the "best" counter
@@ -60,7 +60,7 @@ impl Pricegraph {
         pair: TokenPair,
         sell_amount: f64,
     ) -> Option<TransitiveOrder> {
-        let price = self.estimate_exchange_rate(pair, sell_amount)?;
+        let price = self.estimate_limit_price(pair, sell_amount)?;
         Some(TransitiveOrder {
             buy: sell_amount * price,
             sell: sell_amount,
@@ -72,7 +72,7 @@ impl Pricegraph {
     /// price and there exists overlapping transitive orders to completely fill
     /// the order. Returns `None` if no overlapping transitive orders exist at
     /// the given limit price.
-    pub fn order_for_limit_exchange_rate(
+    pub fn order_for_limit_price(
         &self,
         pair: TokenPair,
         limit_price: f64,
@@ -111,14 +111,14 @@ impl Pricegraph {
     /// orders exist for the given limit price.
     ///
     /// Note that this method is subtly different to
-    /// `Pricegraph::order_for_limit_exchange_rate` in that the limit price for the
+    /// `Pricegraph::order_for_limit_price` in that the limit price for the
     /// resulting order is always equal to the specified price.
-    pub fn order_at_exchange_rate(
+    pub fn order_at_limit_price(
         &self,
         pair: TokenPair,
         limit_price: f64,
     ) -> Option<TransitiveOrder> {
-        let order = self.order_for_limit_exchange_rate(pair, limit_price)?;
+        let order = self.order_for_limit_price(pair, limit_price)?;
         Some(TransitiveOrder {
             buy: order.sell * limit_price,
             sell: order.sell,
@@ -170,53 +170,52 @@ mod tests {
 
         assert_approx_eq!(
             pricegraph
-                .estimate_exchange_rate(TokenPair { buy: 2, sell: 1 }, 500_000.0)
+                .estimate_limit_price(TokenPair { buy: 2, sell: 1 }, 500_000.0)
                 .unwrap(),
             99.0 / FEE_FACTOR.powi(2)
         );
         assert_approx_eq!(
             pricegraph
-                .estimate_exchange_rate(TokenPair { buy: 1, sell: 2 }, 50_000_000.0)
+                .estimate_limit_price(TokenPair { buy: 1, sell: 2 }, 50_000_000.0)
                 .unwrap(),
             1.0 / (101.0 * FEE_FACTOR.powi(2))
         );
 
         assert_approx_eq!(
             pricegraph
-                .estimate_exchange_rate(TokenPair { buy: 2, sell: 1 }, 1_500_000.0)
+                .estimate_limit_price(TokenPair { buy: 2, sell: 1 }, 1_500_000.0)
                 .unwrap(),
             95.0 / FEE_FACTOR.powi(2)
         );
         assert_approx_eq!(
             pricegraph
-                .estimate_exchange_rate(TokenPair { buy: 1, sell: 2 }, 150_000_000.0)
+                .estimate_limit_price(TokenPair { buy: 1, sell: 2 }, 150_000_000.0)
                 .unwrap(),
             1.0 / (105.0 * FEE_FACTOR.powi(2))
         );
 
         assert_approx_eq!(
             pricegraph
-                .estimate_exchange_rate(TokenPair { buy: 2, sell: 1 }, 2_500_000.0)
+                .estimate_limit_price(TokenPair { buy: 2, sell: 1 }, 2_500_000.0)
                 .unwrap(),
             90.0 / FEE_FACTOR.powi(2)
         );
         assert_approx_eq!(
             pricegraph
-                .estimate_exchange_rate(TokenPair { buy: 1, sell: 2 }, 250_000_000.0)
+                .estimate_limit_price(TokenPair { buy: 1, sell: 2 }, 250_000_000.0)
                 .unwrap(),
             1.0 / (110.0 * FEE_FACTOR.powi(2))
         );
 
-        let price = pricegraph.estimate_exchange_rate(TokenPair { buy: 2, sell: 1 }, 10_000_000.0);
+        let price = pricegraph.estimate_limit_price(TokenPair { buy: 2, sell: 1 }, 10_000_000.0);
         assert!(price.is_none());
 
-        let price =
-            pricegraph.estimate_exchange_rate(TokenPair { buy: 1, sell: 2 }, 1_000_000_000.0);
+        let price = pricegraph.estimate_limit_price(TokenPair { buy: 1, sell: 2 }, 1_000_000_000.0);
         assert!(price.is_none());
     }
 
     #[test]
-    fn order_for_limit_exchange_rate_has_correct_amounts() {
+    fn order_for_limit_price_has_correct_amounts() {
         //    /-1.0---v
         //   /--2.0---v
         //  /---4.0---v
@@ -243,31 +242,31 @@ mod tests {
         let TransitiveOrder { buy, sell } = pricegraph
             // NOTE: 1 for 1.001 is not enough to match any volume because
             // fees need to be applied twice!
-            .order_for_limit_exchange_rate(TokenPair { buy: 2, sell: 1 }, 1.0 / FEE_FACTOR)
+            .order_for_limit_price(TokenPair { buy: 2, sell: 1 }, 1.0 / FEE_FACTOR)
             .unwrap();
         assert_approx_eq!(buy, 0.0);
         assert_approx_eq!(sell, 0.0);
 
         let TransitiveOrder { buy, sell } = pricegraph
-            .order_for_limit_exchange_rate(TokenPair { buy: 2, sell: 1 }, 1.0 / FEE_FACTOR.powi(2))
+            .order_for_limit_price(TokenPair { buy: 2, sell: 1 }, 1.0 / FEE_FACTOR.powi(2))
             .unwrap();
         assert_approx_eq!(buy, 1_000_000.0);
         assert_approx_eq!(sell, 1_000_000.0 * FEE_FACTOR);
 
         let TransitiveOrder { buy, sell } = pricegraph
-            .order_for_limit_exchange_rate(TokenPair { buy: 2, sell: 1 }, 0.3)
+            .order_for_limit_price(TokenPair { buy: 2, sell: 1 }, 0.3)
             .unwrap();
         assert_approx_eq!(buy, 2_000_000.0);
         assert_approx_eq!(sell, 3_000_000.0 * FEE_FACTOR);
 
         let TransitiveOrder { buy, sell } = pricegraph
-            .order_for_limit_exchange_rate(TokenPair { buy: 2, sell: 1 }, 0.25 / FEE_FACTOR.powi(2))
+            .order_for_limit_price(TokenPair { buy: 2, sell: 1 }, 0.25 / FEE_FACTOR.powi(2))
             .unwrap();
         assert_approx_eq!(buy, 3_000_000.0);
         assert_approx_eq!(sell, 7_000_000.0 * FEE_FACTOR);
 
         let TransitiveOrder { buy, sell } = pricegraph
-            .order_for_limit_exchange_rate(TokenPair { buy: 2, sell: 1 }, 0.1)
+            .order_for_limit_price(TokenPair { buy: 2, sell: 1 }, 0.1)
             .unwrap();
         assert_approx_eq!(buy, 3_000_000.0);
         assert_approx_eq!(sell, 7_000_000.0 * FEE_FACTOR);
@@ -289,20 +288,20 @@ mod tests {
         };
 
         let TransitiveOrder { buy, sell } = pricegraph
-            .order_for_limit_exchange_rate(TokenPair { buy: 2, sell: 1 }, 0.5)
+            .order_for_limit_price(TokenPair { buy: 2, sell: 1 }, 0.5)
             .unwrap();
         assert_approx_eq!(buy, 1_000_000.0);
         assert_approx_eq!(sell, 1_000_000.0 * FEE_FACTOR);
 
         let TransitiveOrder { buy, sell } = pricegraph
-            .order_at_exchange_rate(TokenPair { buy: 2, sell: 1 }, 0.5)
+            .order_at_limit_price(TokenPair { buy: 2, sell: 1 }, 0.5)
             .unwrap();
         assert_approx_eq!(buy, 500_000.0 * FEE_FACTOR);
         assert_approx_eq!(sell, 1_000_000.0 * FEE_FACTOR);
     }
 
     #[test]
-    fn estimate_exchange_rate_returns_none_for_invalid_token_pairs() {
+    fn estimate_limit_price_returns_none_for_invalid_token_pairs() {
         //   /---1.0---v
         //  0          1          2 --0.5--> 4
         //  ^---1.0---/
@@ -327,21 +326,21 @@ mod tests {
 
         // Token 3 is not part of the orderbook.
         assert_eq!(
-            pricegraph.estimate_exchange_rate(TokenPair { buy: 1, sell: 3 }, 500_000.0),
+            pricegraph.estimate_limit_price(TokenPair { buy: 1, sell: 3 }, 500_000.0),
             None,
         );
         // Tokens 4 and 1 are not connected.
         assert_eq!(
-            pricegraph.estimate_exchange_rate(TokenPair { buy: 4, sell: 1 }, 500_000.0),
+            pricegraph.estimate_limit_price(TokenPair { buy: 4, sell: 1 }, 500_000.0),
             None,
         );
         // Tokens 5 and 42 are out of bounds.
         assert_eq!(
-            pricegraph.estimate_exchange_rate(TokenPair { buy: 5, sell: 1 }, 500_000.0),
+            pricegraph.estimate_limit_price(TokenPair { buy: 5, sell: 1 }, 500_000.0),
             None,
         );
         assert_eq!(
-            pricegraph.estimate_exchange_rate(TokenPair { buy: 2, sell: 42 }, 500_000.0),
+            pricegraph.estimate_limit_price(TokenPair { buy: 2, sell: 42 }, 500_000.0),
             None,
         );
     }
@@ -366,7 +365,7 @@ mod tests {
         };
 
         let TransitiveOrder { buy, sell } = pricegraph
-            .order_for_limit_exchange_rate(TokenPair { buy: 1, sell: 0 }, 1.0)
+            .order_for_limit_price(TokenPair { buy: 1, sell: 0 }, 1.0)
             .unwrap();
         assert_approx_eq!(
             buy,

--- a/pricegraph/wasm/src/lib.rs
+++ b/pricegraph/wasm/src/lib.rs
@@ -42,6 +42,6 @@ impl PriceEstimator {
     #[wasm_bindgen(js_name = "estimatePrice")]
     pub fn estimate_price(&self, buy: TokenId, sell: TokenId, volume: f64) -> Option<f64> {
         self.pricegraph
-            .estimate_exchange_rate(TokenPair { buy, sell }, volume)
+            .estimate_limit_price(TokenPair { buy, sell }, volume)
     }
 }


### PR DESCRIPTION
This PR renames some methods to have more consistent language. Specifically, in `pricegraph` there is the concept of a "limit price" which is a ratio of an order's buy amount over its sell amount. This is part of the order representation in the `BatchExchange` smart contract. These values implicitly include fees and are modeled internally by the `LimitPrice` type. Conversely, there is also the concept of an "exchange rate" which is an internal exchange rate that is used in the orderbook graph calculations for computing flow though the projection graph, these are modeled internally by the `ExchangeRate` type. However, the `Pricegraph` API only deals with `BatchExchange` "limit prices", so fix the method names to reflect this.

### Test Plan

Just method renames, so `rustc` is the test plan!