### PR TITLE
Make pricegraph price source threaded

### DIFF
--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -247,6 +247,7 @@ fn main() {
         options.price_source_update_interval,
     )
     .unwrap();
+    price_oracle.initialize().wait();
 
     // Setup price.
     let price_finder = price_finding::create_price_finder(


### PR DESCRIPTION
This is nice to have for the price estimator. It also makes sense here
as the calculation can be expensive. It does mean that its prices could
be slightly out of date compared to before this commit but considering
that we didn't have this price source at all previously this should be
fine.
While doing this I noticed a problem that we already had when all price
sources are threaded: technically we could start the solver without
having fetched prices at least once. The threaded price source updates
itself immediately but it is still possible this could take longer than
the code path that runs the solver in the first batch that we handle
after startup.


### Test Plan
CI, new tests for the wait function.