### PR TITLE
Use solver based rounding buffer

### DIFF
--- a/price-estimator/src/orderbook.rs
+++ b/price-estimator/src/orderbook.rs
@@ -1,34 +1,82 @@
-use core::orderbook::StableXOrderBookReading;
-use pricegraph::Pricegraph;
-use std::time::{Duration, SystemTime};
+use crate::solver_rounding_buffer;
+use core::{
+    models::TokenId, orderbook::StableXOrderBookReading,
+    price_estimation::price_source::PriceSource,
+};
+use pricegraph::{Pricegraph, TokenPair};
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
 use tokio::sync::RwLock;
 
+pub type DynPriceSource = Box<dyn PriceSource + Send + Sync>;
+
 /// Access and update the pricegraph orderbook.
-pub struct Orderbook<T> {
-    orderbook_reading: T,
+pub struct Orderbook {
+    orderbook_reading: Arc<dyn StableXOrderBookReading>,
+    price_source: DynPriceSource,
+    all_tokens: Vec<TokenId>,
     pricegraph: RwLock<Pricegraph>,
+    rounding_buffer_factor: f64,
 }
 
-impl<T> Orderbook<T> {
-    pub fn new(orderbook_reading: T) -> Self {
+impl Orderbook {
+    pub fn new(
+        orderbook_reading: Arc<dyn StableXOrderBookReading>,
+        price_source: DynPriceSource,
+        all_tokens: Vec<TokenId>,
+        rounding_buffer_factor: f64,
+    ) -> Self {
+        assert!(rounding_buffer_factor.is_finite());
+        assert!(rounding_buffer_factor >= 0.0);
         Self {
             orderbook_reading,
+            price_source,
+            all_tokens,
             pricegraph: RwLock::new(Pricegraph::new(std::iter::empty())),
+            rounding_buffer_factor,
         }
     }
 
-    pub async fn get_pricegraph(&self) -> Pricegraph {
+    pub async fn pricegraph(&self) -> Pricegraph {
         self.pricegraph.read().await.clone()
     }
-}
 
-impl<T: StableXOrderBookReading> Orderbook<T> {
+    /// See solver_rounding_buffer::rounding_buffer. This is used to adjust amounts in api queries
+    /// to adapt to how the solver sees them.
+    /// If any price is not available `1` is used as a fallback.
+    pub async fn rounding_buffer(&self, token_pair: TokenPair) -> f64 {
+        let fee_token = TokenId(0);
+        let sell_token = TokenId(token_pair.sell);
+        let buy_token = TokenId(token_pair.buy);
+        let prices = self
+            .price_source
+            .get_prices(&[fee_token, sell_token, buy_token])
+            .await
+            .unwrap_or_default();
+        let get_price = |token_id| prices.get(&token_id).copied().unwrap_or(1) as f64;
+        solver_rounding_buffer::rounding_buffer(
+            get_price(fee_token),
+            get_price(sell_token),
+            get_price(buy_token),
+        ) * self.rounding_buffer_factor
+    }
+
     /// Recreate the pricegraph orderbook.
     pub async fn update(&self) -> anyhow::Result<()> {
-        let (account_state, orders) = self
+        let (mut account_state, mut orders) = self
             .orderbook_reading
             .get_auction_data(current_batch_id() as u32)
             .await?;
+
+        let token_prices = self.price_source.get_prices(&self.all_tokens).await?;
+        solver_rounding_buffer::apply_rounding_buffer(
+            &token_prices,
+            &mut orders,
+            &mut account_state,
+            self.rounding_buffer_factor,
+        );
 
         // TODO: Move this cpu heavy computation out of the async function using spawn_blocking.
         let pricegraph = Pricegraph::new(

--- a/price-estimator/src/solver_rounding_buffer.rs
+++ b/price-estimator/src/solver_rounding_buffer.rs
@@ -1,11 +1,11 @@
-use core::models::{AccountState, Order, TokenId, TokenInfo};
+use core::models::{AccountState, Order, TokenId};
 use ethcontract::{Address, U256};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
 // This code is closely related to dex-solver/src/opt/process/Rounding.py .
 // Discussion of motivation happened in https://github.com/gnosis/dex-services/issues/970 .
 
-type Tokens = BTreeMap<TokenId, TokenInfo>;
+type TokenPrices = HashMap<TokenId, u128>;
 
 const MAX_ROUNDING_VOLUME: f64 = 100_000_000_000.0;
 const PRICE_ESTIMATION_ERROR: f64 = 10.0;
@@ -16,45 +16,49 @@ fn max_rounding_amount(token_price: f64, fee_token_price: f64) -> f64 {
     max_rounding_amount.max(1.0)
 }
 
+/// Calculate a single rounding buffer like the solver does. This amount is subtracted from the
+/// denominator of orders selling the sell token and buying the buy token.
+pub fn rounding_buffer(fee_token_price: f64, sell_token_price: f64, buy_token_price: f64) -> f64 {
+    let estimated_xrate = buy_token_price / sell_token_price;
+    max_rounding_amount(buy_token_price, fee_token_price)
+        * estimated_xrate
+        * PRICE_ESTIMATION_ERROR.powi(2)
+}
+
 /// Perform the same rounding buffer calculation as our solvers in order to increase the correctness
 /// of our estimates.
 /// All token prices must be nonzero.
-#[allow(dead_code)]
 pub fn apply_rounding_buffer(
-    tokens: &Tokens,
+    token_prices: &TokenPrices,
     orders: &mut Vec<Order>,
     account_state: &mut AccountState,
-    pessimistic_factor: f64,
+    extra_factor: f64,
 ) {
-    let fee_token_price = tokens
+    let fee_token_price = *token_prices
         .get(&TokenId(0))
-        .expect("fee token does not have price")
-        .external_price as f64;
+        .expect("fee token does not have price") as f64;
     assert!(fee_token_price > 0.0, "fee token price is 0");
 
     // The maximum rounding buffer over all orders from this address selling this token.
     let mut account_balance_buffers = HashMap::<(Address, TokenId), u128>::new();
     // Apply rounding buffer to account balances and order sell amounts.
     for order in orders.iter_mut() {
-        // Compute rounding buffer.
         // If a token doesn't have a price it means it isn't connected to the fee. In this case we
         // use a price of 1 to get some reasonable default rounding buffer.
         let (sell_token, buy_token) = (TokenId(order.sell_token), TokenId(order.buy_token));
-        let estimated_buy_token_price = match tokens.get(&buy_token) {
-            Some(TokenInfo { external_price, .. }) if *external_price > 0 => *external_price as f64,
+        let buy_token_price = match token_prices.get(&buy_token) {
+            Some(price) if *price > 0 => *price as f64,
             _ => 1.0,
         };
-        let estimated_sell_token_price = match tokens.get(&sell_token) {
-            Some(TokenInfo { external_price, .. }) if *external_price > 0 => *external_price as f64,
+        let sell_token_price = match token_prices.get(&sell_token) {
+            Some(price) if *price > 0 => *price as f64,
             _ => 1.0,
         };
-        let estimated_xrate = estimated_buy_token_price / estimated_sell_token_price;
-        let rounding_buffer = max_rounding_amount(estimated_buy_token_price, fee_token_price)
-            * estimated_xrate
-            * PRICE_ESTIMATION_ERROR.powi(2);
+
         // Multiply by an extra factor which the solver doesn't do, as added safety in case the
         // prices move.
-        let rounding_buffer = (pessimistic_factor * rounding_buffer) as u128;
+        let rounding_buffer = (rounding_buffer(fee_token_price, sell_token_price, buy_token_price)
+            * extra_factor) as u128;
 
         // Update rounding buffer for account balances;
         let entry = account_balance_buffers
@@ -88,14 +92,6 @@ mod tests {
         ((address(address_), token), U256::from(balance))
     }
 
-    fn token_info(external_price: u128) -> TokenInfo {
-        TokenInfo {
-            alias: None,
-            decimals: None,
-            external_price,
-        }
-    }
-
     fn order(
         id: u16,
         address_: u64,
@@ -119,10 +115,10 @@ mod tests {
 
     #[test]
     fn apply_rounding_buffer_ok() {
-        let mut tokens = Tokens::new();
-        tokens.insert(TokenId(0), token_info(1));
-        tokens.insert(TokenId(1), token_info(2));
-        tokens.insert(TokenId(2), token_info(10));
+        let mut tokens = TokenPrices::new();
+        tokens.insert(TokenId(0), 1);
+        tokens.insert(TokenId(1), 2);
+        tokens.insert(TokenId(2), 10);
 
         let accounts = vec![
             account(0, 0, 100_000_000_000_000_000),


### PR DESCRIPTION
and removed the generics from the orderbook struct in price estimator because this is easier to read.

The rounding buffer has been properly implemented for `estimate_buy_amount` but it's not clear what correct means in other cases (see the TODO comments in filter.rs).

### Test Plan
Run the price estimator from master, the price estimator from this PR and the price estimator from this PR with rounding-buffer-factor set to 0.0. Compare results. We see that in the estimate-buy-amount route the buy amount is the lowest for the master price estimator which is lower than the this PR's default price estimator which is lower than this PR's price estimator with no rounding buffer. Example:

```
curl "localhost:8080/api/v1/markets/4-7/estimated-buy-amount/1?atoms=false"
{"baseTokenId":4,"quoteTokenId":7,"buyAmountInBase":"1.0080441574595185","sellAmountInQuote":"1"}
curl "localhost:8081/api/v1/markets/4-7/estimated-buy-amount/1?atoms=false"
{"baseTokenId":4,"quoteTokenId":7,"buyAmountInBase":"1.008854374703835","sellAmountInQuote":"1"}
curl "localhost:8082/api/v1/markets/4-7/estimated-buy-amount/1?atoms=false"
{"baseTokenId":4,"quoteTokenId":7,"buyAmountInBase":"1.0090532106701886","sellAmountInQuote":"1"}
```