### PR TITLE
higher gas_cap limit

### DIFF
--- a/core/src/solution_submission.rs
+++ b/core/src/solution_submission.rs
@@ -26,7 +26,7 @@ const POLL_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg(test)]
 const POLL_TIMEOUT: Duration = Duration::from_secs(0);
 
-const GAS_PRICE_CAP: u64 = 60_000_000_000;
+const GAS_PRICE_CAP: u64 = 90_000_000_000;
 
 // openethereum requires that the gas price of the resubmitted transaction has increased by at
 // least 12.5%.

--- a/core/src/solution_submission.rs
+++ b/core/src/solution_submission.rs
@@ -667,7 +667,7 @@ mod tests {
         let mut contract = MockStableXContract::new();
         contract
             .expect_send_noop_transaction()
-            .with(eq(U256::from(67_500_000_001u128)))
+            .with(eq(U256::from(101_250_000_001u128)))
             .times(1)
             .returning(|_| immediate!(Err(anyhow!(""))));
         let gas_station = MockGasPriceEstimating::new();


### PR DESCRIPTION
For the ETH-DAI auctions it is important that we are getting our transactions into the batches, as the orders have only validity of 1 batch. With the current prevailing gas prices, this is not given with our current gas_cap.

Longterm solution is described here:https://github.com/gnosis/dex-services/issues/1099
### Test Plan
non