### PR TITLE
implement historic price estimates

### DIFF
--- a/price-estimator/README.md
+++ b/price-estimator/README.md
@@ -4,7 +4,7 @@ All endpoints use the query part of the url with these key-values:
 
 * `atoms`: Required. If set to `true` all amounts are denominated in the smallest available unit (base quantity) of the token. If `false` all amounts are denominated in the "natural" unit of the respective token given by the number of decimals specified through the ERC20 interface. TODO: `false` is currently only implemented for estimated-buy-amount and estimated-amounts-at-price .
 * `hops`: Optional. TODO: document this once it has been implemented.
-* `batchId`: Optional. Specify a specific batch ID to compute the estimate for, only accounting orders that are valid at the specified batch.
+* `batchId`: Optional. Specify a specific batch ID to compute the estimate for, only accounting orders that are valid at the specified batch. If no batch ID is specified, the current batch that is collecting orders will be used.
 
 Example: `<path>?atoms=true`
 

--- a/price-estimator/README.md
+++ b/price-estimator/README.md
@@ -4,6 +4,7 @@ All endpoints use the query part of the url with these key-values:
 
 * `atoms`: Required. If set to `true` all amounts are denominated in the smallest available unit (base quantity) of the token. If `false` all amounts are denominated in the "natural" unit of the respective token given by the number of decimals specified through the ERC20 interface. TODO: `false` is currently only implemented for estimated-buy-amount and estimated-amounts-at-price .
 * `hops`: Optional. TODO: document this once it has been implemented.
+* `batchId`: Optional. Specify a specific batch ID to compute the estimate for, only accounting orders that are valid at the specified batch.
 
 Example: `<path>?atoms=true`
 

--- a/price-estimator/src/error.rs
+++ b/price-estimator/src/error.rs
@@ -1,0 +1,14 @@
+//! Module implementing a custom warp rejection for internal service errors.
+
+use anyhow::Error;
+use warp::reject::{self, Reject, Rejection};
+
+#[derive(Debug)]
+pub struct InternalError(pub Error);
+
+impl Reject for InternalError {}
+
+/// Create a
+pub fn internal_server_rejection(err: Error) -> Rejection {
+    reject::custom(InternalError(err))
+}

--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -1,10 +1,9 @@
-use crate::models::*;
-use crate::orderbook::Orderbook;
+use crate::{error, models::*, orderbook::Orderbook};
 use core::{
     models::TokenId,
     token_info::{TokenBaseInfo, TokenInfoFetching},
 };
-use pricegraph::TokenPair;
+use pricegraph::{Pricegraph, TokenPair};
 use std::convert::Infallible;
 use std::sync::Arc;
 use warp::{
@@ -170,8 +169,9 @@ async fn get_markets(
         return Err(warp::reject());
     }
     let transitive_orderbook = orderbook
-        .get_pricegraph()
+        .get_pricegraph(query.batch_id)
         .await
+        .map_err(error::internal_server_rejection)?
         .transitive_orderbook(*market, None);
     let result = MarketsResult::from(&transitive_orderbook);
     Ok(warp::reply::json(&result))
@@ -202,8 +202,9 @@ async fn estimate_buy_amount(
         sell_amount_in_quote * token_info.base_unit_in_atoms()
     };
     let transitive_order = orderbook
-        .get_pricegraph()
+        .get_pricegraph(query.batch_id)
         .await
+        .map_err(error::internal_server_rejection)?
         .order_for_sell_amount(token_pair, sell_amount_in_quote_atoms);
     let buy_amount_in_base_atoms = transitive_order
         .map(|order| apply_rounding_buffer(order.buy, price_rounding_buffer))
@@ -231,14 +232,17 @@ async fn estimate_amounts_at_price(
     orderbook: Arc<Orderbook>,
     token_infos: Arc<dyn TokenInfoFetching>,
 ) -> Result<impl Reply, Rejection> {
+    let pricegraph = orderbook
+        .get_pricegraph(query.batch_id)
+        .await
+        .map_err(error::internal_server_rejection)?;
     let result = if query.atoms {
         estimate_amounts_at_price_atoms(
             token_pair,
             price_in_quote,
             price_rounding_buffer,
-            orderbook,
+            pricegraph,
         )
-        .await
     } else {
         let buy_token_info = get_token_info(token_pair.buy, token_infos.as_ref()).await?;
         let sell_token_info = get_token_info(token_pair.sell, token_infos.as_ref()).await?;
@@ -248,9 +252,8 @@ async fn estimate_amounts_at_price(
             token_pair,
             price_in_quote_atoms,
             price_rounding_buffer,
-            orderbook,
-        )
-        .await;
+            pricegraph,
+        );
         result.buy_amount_in_base /= buy_token_info.base_unit_in_atoms();
         result.sell_amount_in_quote /= sell_token_info.base_unit_in_atoms();
         result
@@ -259,21 +262,18 @@ async fn estimate_amounts_at_price(
 }
 
 /// Like `estimate_amounts_at_price` but the price is given and returned in atoms.
-async fn estimate_amounts_at_price_atoms(
+fn estimate_amounts_at_price_atoms(
     token_pair: TokenPair,
     price_in_quote: f64,
     price_rounding_buffer: f64,
-    orderbook: Arc<Orderbook>,
+    pricegraph: Pricegraph,
 ) -> EstimatedOrderResult {
     // NOTE: The price in quote is `sell_amount / buy_amount` which is the
     // inverse of an exchange rate. Additionally, we need to apply the price
     // rounding buffer to the price, which will **increase** the exchange rate,
     // making it more restrictive and the estimate more pessimistic.
     let exchange_rate = 1.0 / apply_rounding_buffer(price_in_quote, price_rounding_buffer);
-    let transitive_order = orderbook
-        .get_pricegraph()
-        .await
-        .order_at_limit_price(token_pair, exchange_rate);
+    let transitive_order = pricegraph.order_at_limit_price(token_pair, exchange_rate);
     let (buy_amount_in_base, sell_amount_in_quote) = transitive_order
         .map(|order| {
             (
@@ -300,8 +300,9 @@ async fn estimate_best_ask_price(
         return Err(warp::reject());
     }
     let price = orderbook
-        .get_pricegraph()
+        .get_pricegraph(query.batch_id)
         .await
+        .map_err(error::internal_server_rejection)?
         .estimate_limit_price(token_pair, 0.0)
         .map(|xrate| {
             // NOTE: Exchange rate is the inverse of price for an ask order.

--- a/price-estimator/src/main.rs
+++ b/price-estimator/src/main.rs
@@ -1,3 +1,4 @@
+mod error;
 mod filter;
 mod models;
 mod orderbook;

--- a/price-estimator/src/models.rs
+++ b/price-estimator/src/models.rs
@@ -1,3 +1,4 @@
+use core::models::BatchId;
 use serde::{Deserialize, Serialize};
 use serde_with::rust::display_fromstr;
 use std::{cmp::Ordering, num::ParseIntError, ops::Deref, str::FromStr};
@@ -43,9 +44,11 @@ impl FromStr for Market {
 
 /// The query part of the url.
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct QueryParameters {
     pub atoms: bool,
     pub hops: Option<u16>,
+    pub batch_id: Option<BatchId>,
 }
 
 #[derive(Serialize)]

--- a/price-estimator/src/orderbook.rs
+++ b/price-estimator/src/orderbook.rs
@@ -1,6 +1,6 @@
-use core::orderbook::StableXOrderBookReading;
+use anyhow::Result;
+use core::{models::BatchId, orderbook::StableXOrderBookReading};
 use pricegraph::Pricegraph;
-use std::time::{Duration, SystemTime};
 use tokio::sync::RwLock;
 
 /// Access and update the pricegraph orderbook.
@@ -17,17 +17,11 @@ impl Orderbook {
         }
     }
 
-    pub async fn get_pricegraph(&self) -> Pricegraph {
-        self.pricegraph.read().await.clone()
-    }
-}
-
-impl Orderbook {
-    /// Recreate the pricegraph orderbook.
-    pub async fn update(&self) -> anyhow::Result<()> {
+    /// Creates a `Pricegraph` instance at the given batch ID.
+    async fn create_pricegraph_at_batch(&self, batch_id: BatchId) -> Result<Pricegraph> {
         let (account_state, orders) = self
             .orderbook_reading
-            .get_auction_data(current_batch_id() as u32)
+            .get_auction_data(batch_id.into())
             .await?;
 
         // TODO: Move this cpu heavy computation out of the async function using spawn_blocking.
@@ -37,17 +31,20 @@ impl Orderbook {
                 .map(|order| order.to_element_with_accounts(&account_state)),
         );
 
+        Ok(pricegraph)
+    }
+
+    pub async fn get_pricegraph(&self, batch_id: Option<BatchId>) -> Result<Pricegraph> {
+        match batch_id {
+            Some(batch_id) => self.create_pricegraph_at_batch(batch_id).await,
+            None => Ok(self.pricegraph.read().await.clone()),
+        }
+    }
+
+    /// Recreate the pricegraph orderbook.
+    pub async fn update(&self) -> Result<()> {
+        let pricegraph = self.create_pricegraph_at_batch(BatchId::now()).await?;
         *self.pricegraph.write().await = pricegraph;
         Ok(())
     }
-}
-
-/// Current batch id based on system time.
-fn current_batch_id() -> u64 {
-    const BATCH_DURATION: Duration = Duration::from_secs(300);
-    let now = SystemTime::now();
-    let time_since_epoch = now
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .expect("unix epoch is not in the past");
-    time_since_epoch.as_secs() / BATCH_DURATION.as_secs()
 }

--- a/pricegraph/src/api/price_estimation.rs
+++ b/pricegraph/src/api/price_estimation.rs
@@ -33,7 +33,7 @@ impl Pricegraph {
             orderbook.fill_optimal_transitive_order_if(inverse_pair, |flow| {
                 last_exchange_rate = Some(flow.exchange_rate);
                 false
-            })?;
+            });
         }
 
         let mut remaining_volume = sell_amount;


### PR DESCRIPTION
This PR adds initial support for computing historic prices. In a follow up PR, I will ensure that the `OrderbookReading` implementation doesn't re-query the node for events if the batch ID is sufficiently in the past (to speed up the request a bit).

Closes #967 

### Test Plan

Run the price estimator and check historic prices - note that it is currently not an error checking future batches.
```
$ curl -s 'http://localhost:8080/api/v1/markets/1-7/estimated-best-ask-price?atoms=true' | jq
230.43986139024014
$ curl -s 'http://localhost:8080/api/v1/markets/1-7/estimated-best-ask-price?atoms=true&batchId=5290000' | jq
150.08262567963578
$ curl -s 'http://localhost:8080/api/v1/markets/1-7/estimated-best-ask-price?atoms=true&batchId=9999999' | jq
230.43986139024014
```