### PR TITLE
Fix limit price estimation regression

### DIFF
--- a/pricegraph/src/api/price_estimation.rs
+++ b/pricegraph/src/api/price_estimation.rs
@@ -30,10 +30,11 @@ impl Pricegraph {
         if sell_amount <= 0.0 {
             // NOTE: For a 0 volume we simulate sending an tiny epsilon of value
             // through the network without actually filling any orders.
-            orderbook.fill_optimal_transitive_order_if(inverse_pair, |flow| {
+            let flow = orderbook.fill_optimal_transitive_order_if(inverse_pair, |flow| {
                 last_exchange_rate = Some(flow.exchange_rate);
                 false
             });
+            debug_assert!(flow.is_none());
         }
 
         let mut remaining_volume = sell_amount;


### PR DESCRIPTION
This PR fixes a limit price estimation regression introduced in the recent refactoring. This is because we were `?`-short circuiting on an `Option` that was always `None` (since we don't fill transitive orders when volume is `0.0`).

### Test Plan

New unit test introduced to catch similar regressions.