### PR TITLE
Price Estimator scaffolding for pricegraph with rounding buffer applied

### DIFF
--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -1,4 +1,8 @@
-use crate::{error, models::*, orderbook::Orderbook};
+use crate::{
+    error,
+    models::*,
+    orderbook::{Orderbook, PricegraphType},
+};
 use core::{
     models::TokenId,
     token_info::{TokenBaseInfo, TokenInfoFetching},
@@ -169,7 +173,7 @@ async fn get_markets(
         return Err(warp::reject());
     }
     let transitive_orderbook = orderbook
-        .get_pricegraph(query.batch_id)
+        .pricegraph(query.batch_id, PricegraphType::Raw)
         .await
         .map_err(error::internal_server_rejection)?
         .transitive_orderbook(*market, None);
@@ -202,7 +206,7 @@ async fn estimate_buy_amount(
         sell_amount_in_quote * token_info.base_unit_in_atoms()
     };
     let transitive_order = orderbook
-        .get_pricegraph(query.batch_id)
+        .pricegraph(query.batch_id, PricegraphType::Raw)
         .await
         .map_err(error::internal_server_rejection)?
         .order_for_sell_amount(token_pair, sell_amount_in_quote_atoms);
@@ -233,7 +237,7 @@ async fn estimate_amounts_at_price(
     token_infos: Arc<dyn TokenInfoFetching>,
 ) -> Result<impl Reply, Rejection> {
     let pricegraph = orderbook
-        .get_pricegraph(query.batch_id)
+        .pricegraph(query.batch_id, PricegraphType::Raw)
         .await
         .map_err(error::internal_server_rejection)?;
     let result = if query.atoms {
@@ -300,7 +304,7 @@ async fn estimate_best_ask_price(
         return Err(warp::reject());
     }
     let price = orderbook
-        .get_pricegraph(query.batch_id)
+        .pricegraph(query.batch_id, PricegraphType::Raw)
         .await
         .map_err(error::internal_server_rejection)?
         .estimate_limit_price(token_pair, 0.0)

--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -1,7 +1,7 @@
 use crate::{
     error,
     models::*,
-    orderbook::{Orderbook, PricegraphType},
+    orderbook::{Orderbook, PricegraphKind},
 };
 use core::{
     models::TokenId,
@@ -173,7 +173,7 @@ async fn get_markets(
         return Err(warp::reject());
     }
     let transitive_orderbook = orderbook
-        .pricegraph(query.batch_id, PricegraphType::Raw)
+        .pricegraph(query.batch_id, PricegraphKind::Raw)
         .await
         .map_err(error::internal_server_rejection)?
         .transitive_orderbook(*market, None);
@@ -206,7 +206,7 @@ async fn estimate_buy_amount(
         sell_amount_in_quote * token_info.base_unit_in_atoms()
     };
     let transitive_order = orderbook
-        .pricegraph(query.batch_id, PricegraphType::Raw)
+        .pricegraph(query.batch_id, PricegraphKind::Raw)
         .await
         .map_err(error::internal_server_rejection)?
         .order_for_sell_amount(token_pair, sell_amount_in_quote_atoms);
@@ -237,7 +237,7 @@ async fn estimate_amounts_at_price(
     token_infos: Arc<dyn TokenInfoFetching>,
 ) -> Result<impl Reply, Rejection> {
     let pricegraph = orderbook
-        .pricegraph(query.batch_id, PricegraphType::Raw)
+        .pricegraph(query.batch_id, PricegraphKind::Raw)
         .await
         .map_err(error::internal_server_rejection)?;
     let result = if query.atoms {
@@ -304,7 +304,7 @@ async fn estimate_best_ask_price(
         return Err(warp::reject());
     }
     let price = orderbook
-        .pricegraph(query.batch_id, PricegraphType::Raw)
+        .pricegraph(query.batch_id, PricegraphKind::Raw)
         .await
         .map_err(error::internal_server_rejection)?
         .estimate_limit_price(token_pair, 0.0)

--- a/price-estimator/src/orderbook.rs
+++ b/price-estimator/src/orderbook.rs
@@ -1,50 +1,98 @@
 use anyhow::Result;
-use core::{models::BatchId, orderbook::StableXOrderBookReading};
+use core::{
+    models::{AccountState, BatchId, Order},
+    orderbook::StableXOrderBookReading,
+};
 use pricegraph::Pricegraph;
 use tokio::sync::RwLock;
+
+#[derive(Debug)]
+pub enum PricegraphType {
+    // pricegraph instance with the original orders from the orderbook
+    Raw,
+    // pricegraph instance with the orders to which the rounding buffer has been applied
+    #[allow(dead_code)]
+    WithRoundingBuffer,
+}
 
 /// Access and update the pricegraph orderbook.
 pub struct Orderbook {
     orderbook_reading: Box<dyn StableXOrderBookReading>,
-    pricegraph: RwLock<Pricegraph>,
+    pricegraph_raw: RwLock<Pricegraph>,
+    pricegraph_with_rounding_buffer: RwLock<Pricegraph>,
 }
 
 impl Orderbook {
     pub fn new(orderbook_reading: Box<dyn StableXOrderBookReading>) -> Self {
         Self {
             orderbook_reading,
-            pricegraph: RwLock::new(Pricegraph::new(std::iter::empty())),
+            pricegraph_raw: RwLock::new(Pricegraph::new(std::iter::empty())),
+            pricegraph_with_rounding_buffer: RwLock::new(Pricegraph::new(std::iter::empty())),
         }
     }
 
-    /// Creates a `Pricegraph` instance at the given batch ID.
-    async fn create_pricegraph_at_batch(&self, batch_id: BatchId) -> Result<Pricegraph> {
-        let (account_state, orders) = self
-            .orderbook_reading
-            .get_auction_data(batch_id.into())
-            .await?;
-
-        // TODO: Move this cpu heavy computation out of the async function using spawn_blocking.
-        let pricegraph = Pricegraph::new(
-            orders
-                .iter()
-                .map(|order| order.to_element_with_accounts(&account_state)),
-        );
-
-        Ok(pricegraph)
-    }
-
-    pub async fn get_pricegraph(&self, batch_id: Option<BatchId>) -> Result<Pricegraph> {
+    pub async fn pricegraph(
+        &self,
+        batch_id: Option<BatchId>,
+        pricegraph_type: PricegraphType,
+    ) -> Result<Pricegraph> {
         match batch_id {
-            Some(batch_id) => self.create_pricegraph_at_batch(batch_id).await,
-            None => Ok(self.pricegraph.read().await.clone()),
+            Some(batch_id) => {
+                let mut auction_data = self.auction_data(batch_id).await?;
+                if matches!(pricegraph_type, PricegraphType::WithRoundingBuffer) {
+                    self.apply_rounding_buffer_to_auction_data(&mut auction_data)
+                        .await;
+                }
+                Ok(pricegraph_from_auction_data(&auction_data))
+            }
+            None => Ok(self.cached_pricegraph(pricegraph_type).await),
         }
     }
 
     /// Recreate the pricegraph orderbook.
     pub async fn update(&self) -> Result<()> {
-        let pricegraph = self.create_pricegraph_at_batch(BatchId::now()).await?;
-        *self.pricegraph.write().await = pricegraph;
+        let mut auction_data = self.auction_data(BatchId::now()).await?;
+
+        // TODO: Move this cpu heavy computation out of the async function using spawn_blocking.
+        let pricegraph = pricegraph_from_auction_data(&auction_data);
+        *self.pricegraph_raw.write().await = pricegraph;
+
+        self.apply_rounding_buffer_to_auction_data(&mut auction_data)
+            .await;
+        let pricegraph = pricegraph_from_auction_data(&auction_data);
+        *self.pricegraph_with_rounding_buffer.write().await = pricegraph;
+
         Ok(())
     }
+
+    async fn auction_data(&self, batch_id: BatchId) -> Result<AuctionData> {
+        self.orderbook_reading
+            .get_auction_data(batch_id.into())
+            .await
+    }
+
+    async fn apply_rounding_buffer_to_auction_data(&self, _auction_data: &mut AuctionData) {
+        // TODO
+    }
+
+    async fn cached_pricegraph(&self, pricegraph_type: PricegraphType) -> Pricegraph {
+        match pricegraph_type {
+            PricegraphType::Raw => &self.pricegraph_raw,
+            PricegraphType::WithRoundingBuffer => &self.pricegraph_with_rounding_buffer,
+        }
+        .read()
+        .await
+        .clone()
+    }
+}
+
+type AuctionData = (AccountState, Vec<Order>);
+
+fn pricegraph_from_auction_data(auction_data: &AuctionData) -> Pricegraph {
+    Pricegraph::new(
+        auction_data
+            .1
+            .iter()
+            .map(|order| order.to_element_with_accounts(&auction_data.0)),
+    )
 }

--- a/price-estimator/src/orderbook.rs
+++ b/price-estimator/src/orderbook.rs
@@ -7,7 +7,7 @@ use pricegraph::Pricegraph;
 use tokio::sync::RwLock;
 
 #[derive(Debug)]
-pub enum PricegraphType {
+pub enum PricegraphKind {
     // pricegraph instance with the original orders from the orderbook
     Raw,
     // pricegraph instance with the orders to which the rounding buffer has been applied
@@ -15,31 +15,37 @@ pub enum PricegraphType {
     WithRoundingBuffer,
 }
 
+struct PricegraphCache {
+    pricegraph_raw: Pricegraph,
+    pricegraph_with_rounding_buffer: Pricegraph,
+}
+
 /// Access and update the pricegraph orderbook.
 pub struct Orderbook {
     orderbook_reading: Box<dyn StableXOrderBookReading>,
-    pricegraph_raw: RwLock<Pricegraph>,
-    pricegraph_with_rounding_buffer: RwLock<Pricegraph>,
+    pricegraph_cache: RwLock<PricegraphCache>,
 }
 
 impl Orderbook {
     pub fn new(orderbook_reading: Box<dyn StableXOrderBookReading>) -> Self {
         Self {
             orderbook_reading,
-            pricegraph_raw: RwLock::new(Pricegraph::new(std::iter::empty())),
-            pricegraph_with_rounding_buffer: RwLock::new(Pricegraph::new(std::iter::empty())),
+            pricegraph_cache: RwLock::new(PricegraphCache {
+                pricegraph_raw: Pricegraph::new(std::iter::empty()),
+                pricegraph_with_rounding_buffer: Pricegraph::new(std::iter::empty()),
+            }),
         }
     }
 
     pub async fn pricegraph(
         &self,
         batch_id: Option<BatchId>,
-        pricegraph_type: PricegraphType,
+        pricegraph_type: PricegraphKind,
     ) -> Result<Pricegraph> {
         match batch_id {
             Some(batch_id) => {
                 let mut auction_data = self.auction_data(batch_id).await?;
-                if matches!(pricegraph_type, PricegraphType::WithRoundingBuffer) {
+                if matches!(pricegraph_type, PricegraphKind::WithRoundingBuffer) {
                     self.apply_rounding_buffer_to_auction_data(&mut auction_data)
                         .await;
                 }
@@ -55,12 +61,18 @@ impl Orderbook {
 
         // TODO: Move this cpu heavy computation out of the async function using spawn_blocking.
         let pricegraph = pricegraph_from_auction_data(&auction_data);
-        *self.pricegraph_raw.write().await = pricegraph;
+        self.pricegraph_cache
+            .write()
+            .await
+            .pricegraph_with_rounding_buffer = pricegraph;
 
         self.apply_rounding_buffer_to_auction_data(&mut auction_data)
             .await;
         let pricegraph = pricegraph_from_auction_data(&auction_data);
-        *self.pricegraph_with_rounding_buffer.write().await = pricegraph;
+        self.pricegraph_cache
+            .write()
+            .await
+            .pricegraph_with_rounding_buffer = pricegraph;
 
         Ok(())
     }
@@ -75,13 +87,12 @@ impl Orderbook {
         // TODO
     }
 
-    async fn cached_pricegraph(&self, pricegraph_type: PricegraphType) -> Pricegraph {
+    async fn cached_pricegraph(&self, pricegraph_type: PricegraphKind) -> Pricegraph {
+        let cache = self.pricegraph_cache.read().await;
         match pricegraph_type {
-            PricegraphType::Raw => &self.pricegraph_raw,
-            PricegraphType::WithRoundingBuffer => &self.pricegraph_with_rounding_buffer,
+            PricegraphKind::Raw => &cache.pricegraph_raw,
+            PricegraphKind::WithRoundingBuffer => &cache.pricegraph_with_rounding_buffer,
         }
-        .read()
-        .await
         .clone()
     }
 }


### PR DESCRIPTION
Some routes will make use of the pricegraph with the rounding buffer
applied and some without it. To facilitate this we store another
pricegraph instance and keep it up to date.
In a future PR `apply_rounding_buffer_to_auction_data` will be
implemented and routes will moved to the new pricegraph where
appropriate.

Also turned `fn get_pricegraph` into `fn pricegraph` because that is the norm in Rust and I had to touch all calls to this function anyway.


### Test Plan
The new pricegraph with rounding buffer applied isn't used anywhere yet. Tested that price estimator still works by running it and curling.