### PR TITLE
Fix warnings from new rust version

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,4 +1,6 @@
-#![recursion_limit = "256"]
+// Mockall triggers this warning for every mocked trait. This is fixed in Mockall master but not
+// released.
+#![cfg_attr(test, allow(clippy::unused_unit))]
 
 #[macro_use]
 pub mod macros;

--- a/core/src/price_estimation/clients/oneinch/api.rs
+++ b/core/src/price_estimation/clients/oneinch/api.rs
@@ -81,12 +81,12 @@ impl Api for OneinchHttpApi {
         // artifacts when selling exactly one token atom.
         let one_token_from = 10_u128.pow(from.decimals as u32).to_string();
 
-        let url = self.api_url.join("quote").and_then(move |mut url| {
+        let url = self.api_url.join("quote").map(move |mut url| {
             url.query_pairs_mut()
                 .append_pair("fromTokenSymbol", &from.symbol)
                 .append_pair("toTokenSymbol", &to.symbol)
                 .append_pair("amount", &one_token_from);
-            Ok(url)
+            url
         });
 
         let decimal_correction = 10_f64.powi(from.decimals as i32 - to.decimals as i32);


### PR DESCRIPTION
and removed the recursion limit that isn't needed. Iirc we introduced
this for a select! macro usage that is no longer there.

Note that CI doesn't trigger these because it is still at a previous rust version because of #958 but it is helpful for local development anyway.

### Test Plan
CI