### PR TITLE
Don't consider dust trades when enumerating transitive orders

### DIFF
--- a/pricegraph/src/api/price_estimation.rs
+++ b/pricegraph/src/api/price_estimation.rs
@@ -678,25 +678,25 @@ mod tests {
 
         // NOTE: This would trade ~10_000 -> ~1_000 -> ~100_000 -> ~1_000_000
         assert_eq!(
-            pricegraph.estimate_limit_price(TokenPair { buy: 0, sell: 3 }, 10_000.0),
+            pricegraph.estimate_limit_price(TokenPair { buy: 0, sell: 3 }, 10_001.0),
             None,
         );
 
         // NOTE: This would trade ~1_000 -> ~100_000 -> ~1_000_000
         assert_eq!(
-            pricegraph.estimate_limit_price(TokenPair { buy: 1, sell: 3 }, 10_000.0),
+            pricegraph.estimate_limit_price(TokenPair { buy: 1, sell: 3 }, 10_001.0),
             None,
         );
 
         // NOTE: This would trade ~9_000 -> ~90_000
         assert_eq!(
-            pricegraph.estimate_limit_price(TokenPair { buy: 0, sell: 4 }, 10_000.0),
+            pricegraph.estimate_limit_price(TokenPair { buy: 0, sell: 4 }, 10_001.0),
             None,
         );
 
         // NOTE: This would trade ~10_000 -> ~10_000 -> ~100
         assert_eq!(
-            pricegraph.estimate_limit_price(TokenPair { buy: 5, sell: 7 }, 10_000.0),
+            pricegraph.estimate_limit_price(TokenPair { buy: 5, sell: 7 }, 10_001.0),
             None,
         );
     }

--- a/pricegraph/src/api/price_estimation.rs
+++ b/pricegraph/src/api/price_estimation.rs
@@ -65,6 +65,10 @@ impl Pricegraph {
             // liquidity from this transitive order.
             current_exchange_rate < flow.exchange_rate.inverse()
         }) {
+            if flow.is_dust_trade() {
+                continue;
+            }
+
             cumulative_buy_volume += flow.capacity / flow.exchange_rate.value();
             cumulative_sell_volume = cumulative_buy_volume * flow.exchange_rate.value();
 
@@ -125,6 +129,10 @@ impl Pricegraph {
         while let Some(flow) = orderbook
             .fill_optimal_transitive_order_if(inverse_pair, |flow| flow.exchange_rate <= max_xrate)
         {
+            if flow.is_dust_trade() {
+                continue;
+            }
+
             // NOTE: The transitive orders being filled are **counter orders**
             // with inverted token pairs.
             total_buy_volume += flow.capacity / flow.exchange_rate.value();
@@ -627,6 +635,69 @@ mod tests {
                 * 13_294_906_614_391_990_988_372_451_468_773_477_386.0
                 * FEE_FACTOR,
             num::max_rounding_error_with_epsilon(sell)
+        );
+    }
+
+    #[test]
+    fn skips_dust_trades() {
+        //  0 --10.0-> 1 --0.01-> 2 --0.1--> 3
+        //   \
+        //    \-0.1--> 4
+        //
+        //             5 --1.0--> 6 -100.0-> 7
+        let pricegraph = pricegraph! {
+            users {
+                @1 {
+                    token 1 => 10_000_000,
+                    token 2 => 10_000_000,
+                    token 3 => 10_000_000,
+                }
+                @2 {
+                    token 4 => 10_000_000,
+                }
+                @3 {
+                    token 6 => 10_000_000,
+                    token 7 => 10_000_000,
+                }
+            }
+            orders {
+                owner @1 buying 0 [100_010] selling 1 [   10_001],
+                owner @1 buying 1 [ 10_001] selling 2 [  100_010],
+                owner @1 buying 2 [ 10_001] selling 3 [1_000_100],
+
+                owner @2 buying 0 [9000] selling 4 [90_000],
+
+                owner @3 buying 5 [   10_001] selling 6 [10_001],
+                owner @3 buying 6 [1_000_100] selling 7 [10_001],
+            }
+        };
+
+        // NOTE: There should be no valid transitive orders for the following
+        // token pairs, since the transitive orders require trades with amounts
+        // below the minimum:
+
+        // NOTE: This would trade ~10_000 -> ~1_000 -> ~100_000 -> ~1_000_000
+        assert_eq!(
+            pricegraph.estimate_limit_price(TokenPair { buy: 0, sell: 3 }, 10_000.0),
+            None,
+        );
+
+        // NOTE: This would trade ~1_000 -> ~100_000 -> ~1_000_000
+        assert_eq!(
+            pricegraph.estimate_limit_price(TokenPair { buy: 1, sell: 3 }, 10_000.0),
+            None,
+        );
+
+        // NOTE: This would trade ~9_000 -> ~90_000
+        assert_eq!(
+            pricegraph.estimate_limit_price(TokenPair { buy: 0, sell: 4 }, 10_000.0),
+            None,
+        );
+
+        // NOTE: This would trade ~10_000 -> ~10_000 -> ~100
+        assert_eq!(
+            pricegraph.estimate_limit_price(TokenPair { buy: 5, sell: 7 }, 10_000.0),
+            None,
         );
     }
 }

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -17,8 +17,10 @@ pub use self::orderbook::*;
 /// The fee factor that is applied to each order's buy price.
 const FEE_FACTOR: f64 = 1.0 / 0.999;
 
-/// The minimum amount where an order is considered a dust order and cannot be
-/// traded.
+/// The minimum amount that must be traded for an order to be valid within a
+/// solution. Orders with effective sell amounts smaller than this amount can
+/// safely be ignored, and transitive orders with flows that trade amounts
+/// smaller than this are not considered for price estimates.
 const MIN_AMOUNT: f64 = 10_000.0;
 
 /// API entry point for computing price estimates and transitive orderbooks for

--- a/pricegraph/src/num.rs
+++ b/pricegraph/src/num.rs
@@ -1,5 +1,6 @@
 //! Module implementing floating point arithmetic for the price graph.
 
+use crate::MIN_AMOUNT;
 use primitive_types::U256;
 use std::cmp;
 use std::f64;
@@ -75,6 +76,12 @@ pub fn compare(a: f64, b: f64) -> cmp::Ordering {
 /// Returns true if the specified number is within the range `(0.0, +Inf)`.
 pub fn is_strictly_positive_and_finite(value: f64) -> bool {
     value > 0.0 && value < f64::INFINITY
+}
+
+/// Returns true if an amount is considered a dust amount. See `MIN_AMOUNT`
+/// documentation for more details.
+pub fn is_dust_amount(amount: f64) -> bool {
+    amount < MIN_AMOUNT
 }
 
 #[cfg(test)]

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -22,7 +22,6 @@ use crate::graph::bellman_ford::{self, NegativeCycle};
 use crate::graph::path;
 use crate::graph::subgraph::{ControlFlow, Subgraphs};
 use crate::num;
-use crate::MIN_AMOUNT;
 use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
 use petgraph::visit::NodeIndexable;
 use std::cmp;

--- a/pricegraph/src/orderbook/flow.rs
+++ b/pricegraph/src/orderbook/flow.rs
@@ -31,7 +31,7 @@ impl Flow {
     }
 
     /// Returns true if this flow is a dust trade.
-    pub(super) fn is_dust_trade(&self) -> bool {
+    pub fn is_dust_trade(&self) -> bool {
         num::is_dust_amount(self.min_trade)
     }
 }

--- a/pricegraph/src/orderbook/flow.rs
+++ b/pricegraph/src/orderbook/flow.rs
@@ -1,6 +1,7 @@
 //! Module containing data for representing flow through the orderbook graph.
 
 use super::ExchangeRate;
+use crate::num;
 use crate::{TransitiveOrder, FEE_FACTOR};
 
 /// A reprensentation of a flow of tokens through the orderbook graph.
@@ -11,6 +12,8 @@ pub struct Flow {
     /// The total capacity the path can accomodate expressed in the starting
     /// token, which is the buy token for the transitive order along a path.
     pub capacity: f64,
+    /// The minimum traded amount along a path.
+    pub min_trade: f64,
 }
 
 impl Flow {
@@ -25,6 +28,11 @@ impl Flow {
         let sell = self.capacity / self.exchange_rate.value();
 
         TransitiveOrder { buy, sell }
+    }
+
+    /// Returns true if this flow is a dust trade.
+    pub(super) fn is_dust_trade(&self) -> bool {
+        num::is_dust_amount(self.min_trade)
     }
 }
 


### PR DESCRIPTION
Fixes #1000 

This PR fills flows for "dust" trades (that trade an amount below the minimum amount) so that they are not considered in price estimates. Note that they are still considered for the transitive orderbook computation as traded amounts depend on closing prices.

### Test Plan

New unit test.