### PR TITLE
Add log messages for price source API errors

### DIFF
--- a/core/src/models/tokens.rs
+++ b/core/src/models/tokens.rs
@@ -2,7 +2,10 @@
 
 use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::borrow::Cow;
+use std::{
+    borrow::Cow,
+    fmt::{self, Display, Formatter},
+};
 
 /// A token ID wrapper type that implements JSON serialization in the solver
 /// format.
@@ -49,6 +52,12 @@ impl Into<u16> for TokenId {
 impl From<u16> for TokenId {
     fn from(id: u16) -> Self {
         TokenId(id)
+    }
+}
+
+impl Display for TokenId {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(&self.0, f)
     }
 }
 

--- a/core/src/price_estimation/clients/generic_client.rs
+++ b/core/src/price_estimation/clients/generic_client.rs
@@ -8,8 +8,7 @@ use futures::{
     lock::Mutex,
     stream::{self, StreamExt},
 };
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{any, collections::HashMap, sync::Arc};
 
 /// Provides a generic interface to communicate in a standardized way
 /// with specific API token implementations
@@ -105,15 +104,14 @@ where
             }
 
             let mut api_tokens_guard = self.api_tokens.lock().await;
-            let api_tokens_option = &mut api_tokens_guard;
-            let api_tokens: &Tokens<T> = match api_tokens_option.as_ref() {
+            let api_tokens: &Tokens<T> = match api_tokens_guard.as_ref() {
                 Some(api_tokens) => api_tokens,
                 None => {
                     let initialized = self
                         .create_api_tokens()
                         .await
                         .with_context(|| anyhow!("failed to perform lazy initialization"))?;
-                    api_tokens_option.get_or_insert(initialized)
+                    api_tokens_guard.get_or_insert(initialized)
                 }
             };
 
@@ -154,9 +152,18 @@ where
             Ok(tokens_
                 .iter()
                 .zip(results.iter())
-                .filter_map(|(token, result)| match result {
-                    Ok(price) => Some((token.0, token.1.get_owl_price(*price))),
-                    Err(_) => None,
+                .filter_map(|((token_id, token_info), result)| match result {
+                    Ok(price) => Some((*token_id, token_info.get_owl_price(*price))),
+                    Err(err) => {
+                        log::warn!(
+                            "error retrieving {} prices for token ID {} ({}): {}",
+                            any::type_name::<T>(),
+                            token_id,
+                            token_info.symbol(),
+                            err,
+                        );
+                        None
+                    }
                 })
                 .collect())
         }
@@ -167,7 +174,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::TokenId;
     use crate::token_info::hardcoded::{TokenData, TokenInfoOverride};
     use anyhow::anyhow;
     use lazy_static::lazy_static;


### PR DESCRIPTION
This PR will help diagnose #1153 

This PR adds warning log messages when encountering errors retrieving price estimates from price source APIs such as DexAG and 1Inch.

### Test Plan

Just log messages, check to see if `[<unknown>] Timeout` messages are related to price estimation.