### PR TITLE
Add JSON body to error context when failing to parse HTTP response

### DIFF
--- a/core/src/http.rs
+++ b/core/src/http.rs
@@ -3,7 +3,7 @@
 
 pub use crate::metrics::HttpLabel;
 use crate::metrics::HttpMetrics;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use isahc::http::{Error as HttpError, Uri};
 use isahc::prelude::{Configurable, Request};
 use isahc::{HttpClientBuilder, ResponseExt};
@@ -104,7 +104,8 @@ impl HttpClient {
         let size = json.len();
         self.metrics.request(label, start.elapsed(), size);
 
-        let result = serde_json::from_str(&json)?;
+        let result = serde_json::from_str(&json)
+            .with_context(|| format!("failed to parse JSON '{}'", json))?;
         Ok(result)
     }
 }


### PR DESCRIPTION
This PR adds HTTP response body to the error context when failing to parse HTTP responses to make it easier to diagnose JSON parse issues.

### Test Plan

Rustc.