### PR TITLE
Use more explicit return type for noop transaction

### DIFF
--- a/core/src/contracts/stablex_contract.rs
+++ b/core/src/contracts/stablex_contract.rs
@@ -84,8 +84,8 @@ pub struct FilteredOrderPage {
 pub enum NoopTransactionError {
     #[error("no account")]
     NoAccount,
-    #[error("execution error")]
-    ExecutedOrder(ExecutionError),
+    #[error("execution error: {0}")]
+    ExecutedOrder(#[from] ExecutionError),
 }
 
 #[cfg_attr(test, automock)]
@@ -359,10 +359,7 @@ impl StableXContract for StableXContractImpl {
                 .nonce(nonce)
                 .value(U256::zero())
                 .resolve(ResolveCondition::Confirmed(ConfirmParams::mined()));
-            transaction
-                .send()
-                .await
-                .map_err(NoopTransactionError::ExecutedOrder)
+            transaction.send().await.map_err(From::from)
         }
         .boxed()
     }

--- a/core/src/contracts/stablex_contract.rs
+++ b/core/src/contracts/stablex_contract.rs
@@ -7,7 +7,7 @@ use crate::{
     contracts,
     models::{ExecutedOrder, Solution},
 };
-use anyhow::{anyhow, Context as _, Error, Result};
+use anyhow::{anyhow, Error, Result};
 use ethcontract::{
     contract::Event,
     errors::{ExecutionError, MethodError},
@@ -151,7 +151,7 @@ pub trait StableXContract {
         &'a self,
         gas_price: U256,
         nonce: U256,
-    ) -> BoxFuture<'a, Result<TransactionResult>>;
+    ) -> BoxFuture<'a, Result<TransactionResult, ExecutionError>>;
 
     /// The current nonce aka transaction_count.
     fn get_transaction_count<'a>(&'a self) -> BoxFuture<'a, Result<U256>>;
@@ -338,10 +338,10 @@ impl StableXContract for StableXContractImpl {
         &'a self,
         gas_price: U256,
         nonce: U256,
-    ) -> BoxFuture<'a, Result<TransactionResult>> {
+    ) -> BoxFuture<'a, Result<TransactionResult, ExecutionError>> {
         async move {
             let web3 = self.instance.raw_instance().web3();
-            let account = self.account().ok_or_else(|| anyhow!("no account"))?;
+            let account = self.account().ok_or(ExecutionError::NoLocalAccounts)?;
             let address = account.address();
             let transaction = ethcontract::transaction::TransactionBuilder::new(web3)
                 .from(account)
@@ -351,11 +351,7 @@ impl StableXContract for StableXContractImpl {
                 .nonce(nonce)
                 .value(U256::zero())
                 .resolve(ResolveCondition::Confirmed(ConfirmParams::mined()));
-            let transaction_result = transaction
-                .send()
-                .await
-                .context("failed to send noop transaction")?;
-            Ok(transaction_result)
+            transaction.send().await
         }
         .boxed()
     }

--- a/core/src/solution_submission.rs
+++ b/core/src/solution_submission.rs
@@ -337,7 +337,7 @@ fn extract_transaction_receipt(err: &MethodError) -> Option<&TransactionReceipt>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::contracts::stablex_contract::MockStableXContract;
+    use crate::contracts::stablex_contract::{MockStableXContract, NoopTransactionError};
     use crate::gas_station::{GasPrice, MockGasPriceEstimating};
 
     use anyhow::anyhow;
@@ -702,7 +702,7 @@ mod tests {
             .with(eq(U256::from(101_250_000_001u128)), eq(U256::from(0)))
             .times(1)
             // The specific error doesn't matter.
-            .returning(|_, _| immediate!(Err(ExecutionError::InvalidOpcode)));
+            .returning(|_, _| immediate!(Err(NoopTransactionError::NoAccount)));
         let gas_station = MockGasPriceEstimating::new();
         let submitter = StableXSolutionSubmitter::new(&contract, &gas_station);
         let result = submitter

--- a/core/src/solution_submission.rs
+++ b/core/src/solution_submission.rs
@@ -701,7 +701,8 @@ mod tests {
             .expect_send_noop_transaction()
             .with(eq(U256::from(101_250_000_001u128)), eq(U256::from(0)))
             .times(1)
-            .returning(|_, _| immediate!(Err(anyhow!(""))));
+            // The specific error doesn't matter.
+            .returning(|_, _| immediate!(Err(ExecutionError::InvalidOpcode)));
         let gas_station = MockGasPriceEstimating::new();
         let submitter = StableXSolutionSubmitter::new(&contract, &gas_station);
         let result = submitter


### PR DESCRIPTION
This allows inspecting the error in more detail with going through
downcasting which will be useful in a future PR.

### Test Plan
No test needed.