### PR TITLE
Make sure gas station gas price does not decrease

### DIFF
--- a/core/src/solution_submission/retry.rs
+++ b/core/src/solution_submission/retry.rs
@@ -42,11 +42,8 @@ impl<'a> InfallibleGasPriceEstimator<'a> {
     async fn estimate(&mut self) -> U256 {
         match self.gas_price_estimating.estimate_gas_price().await {
             Ok(gas_estimate) => {
-                let price = gas_estimate.fast;
                 // `retry` relies on the gas price always increasing.
-                if price >= self.previous_gas_price {
-                    self.previous_gas_price = gas_estimate.fast;
-                }
+                self.previous_gas_price = self.previous_gas_price.max(gas_estimate.fast);
             }
             Err(ref err) => {
                 log::warn!(

--- a/core/src/solution_submission/retry.rs
+++ b/core/src/solution_submission/retry.rs
@@ -215,7 +215,7 @@ mod tests {
                 always(),
                 always(),
                 always(),
-                eq(U256::from(DEFAULT_GAS_PRICE * 5)),
+                eq(U256::from(DEFAULT_GAS_PRICE * 6)),
                 eq(Some(2)),
                 always(),
             )
@@ -235,7 +235,7 @@ mod tests {
                 always(),
                 always(),
                 always(),
-                eq(U256::from(DEFAULT_GAS_PRICE * 7)),
+                eq(U256::from(DEFAULT_GAS_PRICE * 9)),
                 eq(None),
                 always(),
             )
@@ -245,7 +245,7 @@ mod tests {
         gas_station.expect_estimate_gas_price().returning(|| {
             async {
                 Ok(GasPrice {
-                    fast: (DEFAULT_GAS_PRICE * 5).into(),
+                    fast: (DEFAULT_GAS_PRICE * 6).into(),
                     ..Default::default()
                 })
             }
@@ -258,7 +258,7 @@ mod tests {
             Solution::trivial(),
             1.into(),
             &gas_station,
-            (DEFAULT_GAS_PRICE * 9).into(),
+            (DEFAULT_GAS_PRICE * 10).into(),
             U256::from(0),
         )
         .now_or_never()

--- a/core/src/solution_submission/retry.rs
+++ b/core/src/solution_submission/retry.rs
@@ -10,6 +10,8 @@ use pricegraph::num;
 
 use super::MIN_GAS_PRICE_INCREASE_FACTOR;
 
+const DEFAULT_GAS_PRICE: u64 = 15_000_000_000;
+
 fn is_confirm_timeout(result: &Result<(), MethodError>) -> bool {
     matches!(
         result,
@@ -40,7 +42,11 @@ impl<'a> InfallibleGasPriceEstimator<'a> {
     async fn estimate(&mut self) -> U256 {
         match self.gas_price_estimating.estimate_gas_price().await {
             Ok(gas_estimate) => {
-                self.previous_gas_price = gas_estimate.fast;
+                let price = gas_estimate.fast;
+                // `retry` relies on the gas price always increasing.
+                if price >= self.previous_gas_price {
+                    self.previous_gas_price = gas_estimate.fast;
+                }
             }
             Err(ref err) => {
                 log::warn!(
@@ -69,7 +75,6 @@ pub async fn retry_with_gas_price_increase(
     nonce: U256,
 ) -> Result<(), MethodError> {
     const BLOCK_TIMEOUT: usize = 2;
-    const DEFAULT_GAS_PRICE: u64 = 15_000_000_000;
 
     let effective_gas_price_cap = U256::from(
         (gas_price_cap.as_u128() as f64 / MIN_GAS_PRICE_INCREASE_FACTOR).floor() as u128,
@@ -164,6 +169,33 @@ mod tests {
     }
 
     #[test]
+    fn infallible_gas_price_estimator_does_not_decrease() {
+        let mut gas_station = MockGasPriceEstimating::new();
+        gas_station
+            .expect_estimate_gas_price()
+            .times(1)
+            .return_once(|| {
+                immediate!(Ok(GasPrice {
+                    fast: 10.into(),
+                    ..Default::default()
+                }))
+            });
+        gas_station
+            .expect_estimate_gas_price()
+            .times(1)
+            .return_once(|| {
+                immediate!(Ok(GasPrice {
+                    fast: 9.into(),
+                    ..Default::default()
+                }))
+            });
+
+        let mut estimator = InfallibleGasPriceEstimator::new(&gas_station, 3.into());
+        assert_eq!(estimator.estimate().now_or_never().unwrap(), U256::from(10));
+        assert_eq!(estimator.estimate().now_or_never().unwrap(), U256::from(10));
+    }
+
+    #[test]
     fn gas_price_increases_as_expected_and_hits_limit() {
         let estimated = U256::from(5);
         let cap = U256::from(50);
@@ -186,7 +218,7 @@ mod tests {
                 always(),
                 always(),
                 always(),
-                eq(U256::from(5)),
+                eq(U256::from(DEFAULT_GAS_PRICE * 5)),
                 eq(Some(2)),
                 always(),
             )
@@ -206,7 +238,7 @@ mod tests {
                 always(),
                 always(),
                 always(),
-                eq(U256::from(7)),
+                eq(U256::from(DEFAULT_GAS_PRICE * 7)),
                 eq(None),
                 always(),
             )
@@ -216,7 +248,7 @@ mod tests {
         gas_station.expect_estimate_gas_price().returning(|| {
             async {
                 Ok(GasPrice {
-                    fast: 5.into(),
+                    fast: (DEFAULT_GAS_PRICE * 5).into(),
                     ..Default::default()
                 })
             }
@@ -229,7 +261,7 @@ mod tests {
             Solution::trivial(),
             1.into(),
             &gas_station,
-            9.into(),
+            (DEFAULT_GAS_PRICE * 9).into(),
             U256::from(0),
         )
         .now_or_never()
@@ -247,7 +279,7 @@ mod tests {
                 always(),
                 always(),
                 always(),
-                eq(U256::from(90)),
+                eq(U256::from(DEFAULT_GAS_PRICE * 90)),
                 always(),
                 always(),
             )
@@ -268,7 +300,7 @@ mod tests {
         gas_station.expect_estimate_gas_price().returning(|| {
             async {
                 Ok(GasPrice {
-                    fast: 90.into(),
+                    fast: (DEFAULT_GAS_PRICE * 90).into(),
                     ..Default::default()
                 })
             }
@@ -281,7 +313,7 @@ mod tests {
             Solution::trivial(),
             1.into(),
             &gas_station,
-            100.into(),
+            (DEFAULT_GAS_PRICE * 100).into(),
             0.into()
         )
         .now_or_never()
@@ -309,7 +341,7 @@ mod tests {
         gas_station.expect_estimate_gas_price().returning(|| {
             async {
                 Ok(GasPrice {
-                    fast: 5.into(),
+                    fast: (DEFAULT_GAS_PRICE * 5).into(),
                     ..Default::default()
                 })
             }
@@ -322,7 +354,7 @@ mod tests {
             Solution::trivial(),
             1.into(),
             &gas_station,
-            15.into(),
+            (DEFAULT_GAS_PRICE * 15).into(),
             0.into()
         )
         .now_or_never()


### PR DESCRIPTION
The solution submission logic enforces that gas prices increase by at
least 12% each resubmission. However with the current logic it is
possible that the gas station returns significantly lower prices in the
next iteration which could cause this to be violated.
This commit ensures that we only ever increase the gas price estimate.

### Test Plan
Added new test for this.