### PR TITLE
Increase gas price slower but higher

### DIFF
--- a/core/src/solution_submission.rs
+++ b/core/src/solution_submission.rs
@@ -26,7 +26,7 @@ const POLL_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg(test)]
 const POLL_TIMEOUT: Duration = Duration::from_secs(0);
 
-const GAS_PRICE_CAP: u64 = 90_000_000_000;
+const GAS_PRICE_CAP: u64 = 200_000_000_000;
 
 // openethereum requires that the gas price of the resubmitted transaction has increased by at
 // least 12.5%.
@@ -389,7 +389,7 @@ mod tests {
         let mut contract = MockStableXContract::new();
         contract
             .expect_send_noop_transaction()
-            .with(eq(U256::from(101_250_000_001u128)), eq(U256::from(0)))
+            .with(eq(U256::from(225_000_000_001u128)), eq(U256::from(0)))
             .times(1)
             .returning(|_, _| immediate!(Err(anyhow!(""))));
         let gas_station = MockGasPriceEstimating::new();

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -7,7 +7,7 @@ mod test;
 mod api;
 mod encoding;
 mod graph;
-mod num;
+pub mod num;
 mod orderbook;
 
 pub use self::api::*;


### PR DESCRIPTION
We missed our 50k ETH/DAI auction today because the gas price was too high. This PR increases the cap to 200GWEI but makes it so that we only increase in 50% increments (doubling 90 GWEI on first attempt seems a bit harsh).

Going forward, we should not only implement #1099 but also make it that gas cap depends on the total fee that can be gained by the solver. In the example today we could have made $50 in fees. This should make us be willing to pay at least $50 in gas to get our tx mined.

### Test Plan
Unit tests