### PR TITLE
Implement price estimates for tokens that account for overlapping orders.

### DIFF
--- a/pricegraph/src/api.rs
+++ b/pricegraph/src/api.rs
@@ -1,6 +1,7 @@
 //! Module containing the high-level `Pricegraph` API operation implementations.
 
 mod price_estimation;
+mod price_source;
 mod transitive_orderbook;
 
 pub use self::transitive_orderbook::TransitiveOrderbook;

--- a/pricegraph/src/api/price_estimation.rs
+++ b/pricegraph/src/api/price_estimation.rs
@@ -27,18 +27,18 @@ impl Pricegraph {
         if sell_amount == 0.0 {
             // NOTE: For a 0 volume we simulate sending an tiny epsilon of value
             // through the network without actually filling any orders.
-            let mut exchange_rate = None;
-            let flow = orderbook.fill_optimal_transitive_order_if(inverse_pair, |flow| {
-                exchange_rate = Some(flow.exchange_rate);
-                false
-            });
-            debug_assert!(flow.is_none());
-
-            // NOTE: The exchange rates are for transitive orders in the inverse
-            // direction, so we need to invert the exchange rate and account for
-            // the fees so that the estimated exchange rate actually overlaps with
-            // the last counter transtive order's exchange rate.
-            return Some(exchange_rate?.inverse().price().value());
+            // Additionally, the exchange rates are for transitive orders in the
+            // inverse direction, so we need to invert the exchange rate and
+            // account for the fees so that the estimated exchange rate actually
+            // overlaps with the last counter transtive order's exchange rate.
+            return Some(
+                orderbook
+                    .find_optimal_transitive_order(inverse_pair)?
+                    .exchange_rate
+                    .inverse()
+                    .price()
+                    .value(),
+            );
         }
 
         if !num::is_strictly_positive_and_finite(sell_amount) {

--- a/pricegraph/src/api/price_source.rs
+++ b/pricegraph/src/api/price_source.rs
@@ -1,0 +1,15 @@
+//! This module implements price source methods for the `Pricegraph` API so that
+//! it can be used for OWL price estimates to the solver.
+
+use crate::encoding::TokenPair;
+use crate::Pricegraph;
+
+impl Pricegraph {
+    /// Estimates the fee token price in WEI for the specified token. Returns
+    /// `None` if the token is not connected to the fee token.
+    ///
+    /// The fee token is defined as the token with ID 0.
+    pub fn token_price(&self, token: TokenId) -> Option<f64> {
+        todo!()
+    }
+}

--- a/pricegraph/src/api/price_source.rs
+++ b/pricegraph/src/api/price_source.rs
@@ -1,15 +1,123 @@
 //! This module implements price source methods for the `Pricegraph` API so that
 //! it can be used for OWL price estimates to the solver.
 
-use crate::encoding::TokenPair;
+use crate::encoding::{TokenId, TokenPair};
 use crate::Pricegraph;
+use std::cmp;
 
 impl Pricegraph {
     /// Estimates the fee token price in WEI for the specified token. Returns
     /// `None` if the token is not connected to the fee token.
     ///
     /// The fee token is defined as the token with ID 0.
-    pub fn token_price(&self, token: TokenId) -> Option<f64> {
-        todo!()
+    pub fn token_price_spread(&self, token: TokenId) -> Option<(f64, f64)> {
+        if token == 0 {
+            return Some((1.0, 1.0));
+        }
+
+        let mut orderbook = self.full_orderbook();
+
+        let mut bounds = None;
+        while let Some((min, max)) = orderbook.fill_ring_trade_around_token(token) {
+            let (current_min, current_max) = *bounds.get_or_insert((min, max));
+            bounds = Some((cmp::min(current_min, min), cmp::max(current_max, max)));
+        }
+
+        let (min, max) = bounds.or_else(|| {
+            // NOTE: If the graph is fully reduced, then just take the inverse
+            // exchange rate for selling an epsilon of reference token. Note
+            // that we sell instead of buy as the solver just requires an order
+            // selling the fee token in order to balance the fees.
+            let fee_price = orderbook
+                .find_optimal_transitive_order(TokenPair {
+                    buy: token,
+                    sell: 0,
+                })
+                .expect("negative cycle in reduced orderbook")?
+                .exchange_rate
+                .price()
+                .inverse();
+
+            Some((fee_price, fee_price))
+        })?;
+
+        debug_assert!(min <= max);
+        Some((min.value(), max.value()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::prelude::*;
+    use crate::FEE_FACTOR;
+
+    #[test]
+    fn estimates_prices_for_tokens_in_negative_cycles() {
+        //             v---0.5---\
+        //  0 <-10.0-- 1          2
+        //              \--1.25---^
+        let pricegraph = pricegraph! {
+            users {
+                @0 {
+                    token 0 => 1_000_000,
+                }
+                @1 {
+                    token 1 => 1_000_000,
+                }
+                @2 {
+                    token 2 => 1_000_000,
+                }
+            }
+            orders {
+                owner @0 buying 1 [10_000_000] selling 0 [1_000_000],
+
+                owner @1 buying 2 [  500_000] selling 1 [1_000_000],
+                owner @2 buying 1 [1_250_000] selling 2 [1_000_000],
+            }
+        };
+
+        let (min, max) = pricegraph.token_price_spread(1).unwrap();
+        assert_approx_eq!(min, 0.1);
+        assert_approx_eq!(max, 0.1);
+
+        let (min, max) = pricegraph.token_price_spread(2).unwrap();
+        assert_approx_eq!(1.0 / min, 10.0 / (1.25 * FEE_FACTOR));
+        assert_approx_eq!(1.0 / max, 10.0 * (0.5 * FEE_FACTOR));
+    }
+
+    #[test]
+    fn price_is_one_for_fee_token() {
+        //  0 <-0.42-- 1
+        let pricegraph = pricegraph! {
+            users {
+                @0 {
+                    token 0 => 100_000,
+                }
+            }
+            orders {
+                owner @0 buying 1 [42_000] selling 0 [100_000],
+            }
+        };
+
+        assert_eq!(pricegraph.token_price_spread(0), Some((1.0, 1.0)));
+    }
+
+    #[test]
+    fn estimates_prices_for_reduced_orderbooks() {
+        //  0 <-0.42-- 1
+        let pricegraph = pricegraph! {
+            users {
+                @0 {
+                    token 0 => 100_000,
+                }
+            }
+            orders {
+                owner @0 buying 1 [42_000] selling 0 [100_000],
+            }
+        };
+
+        let (min, max) = pricegraph.token_price_spread(1).unwrap();
+        assert_approx_eq!(min, 1.0 / 0.42);
+        assert_approx_eq!(max, 1.0 / 0.42);
     }
 }

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -143,8 +143,11 @@ impl Orderbook {
     /// the fee token (i.e. token ID 0).
     ///
     /// Returns `None` if the subgraph containing `token` is already reduced or
-    /// none of the ring trades are connected to the fee token.
-    pub fn fill_ring_trade_around_token(&mut self, token: TokenId) -> Option<(f64, f64)> {
+    /// none of the ring trades connect the specified token to the fee token.
+    pub fn fill_ring_trade_around_token(
+        &mut self,
+        token: TokenId,
+    ) -> Option<(LimitPrice, LimitPrice)> {
         if !self.is_token_pair_valid(fee_pair(token)) {
             return None;
         }
@@ -157,35 +160,70 @@ impl Orderbook {
             let path = path::find_cycle(&predecessors, node, Some(token))
                 .expect("negative cycle not found after being detected");
 
-            if path.first() != Some(&token) {
-                continue;
+            let mut min_inverted_price = None;
+            let mut max_inverted_price = None;
+
+            if path.first() == Some(&token) {
+                min_inverted_price = self.direct_fee_token_price(token);
+                max_inverted_price = min_inverted_price;
+
+                for mid in 1..path.len() - 1 {
+                    let mid_fee_price = if path[mid] == fee_token {
+                        ExchangeRate::IDENTITY
+                    } else {
+                        match self.direct_fee_token_price(path[mid]) {
+                            Some(value) => value,
+                            None => continue,
+                        }
+                    };
+
+                    let to_mid = &path[..mid + 1];
+                    let to_mid_xrate = self
+                        .find_path_flow(to_mid)
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "failed to find flow along detected negative cycle sub-path {}",
+                                format_path(&to_mid),
+                            )
+                        })
+                        .exchange_rate;
+                    let to_mid_fee_price = to_mid_xrate * mid_fee_price;
+
+                    let from_mid = &path[mid..];
+                    let from_mid_xrate = self
+                        .find_path_flow(from_mid)
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "failed to find flow along detected negative cycle sub-path {}",
+                                format_path(&from_mid),
+                            )
+                        })
+                        .exchange_rate;
+                    let from_mid_fee_price = from_mid_xrate.inverse() * mid_fee_price;
+
+                    // NOTE: This holds true because negative cycles ensure that
+                    // `to * from < 1.0`.
+                    debug_assert!(to_mid_fee_price < from_mid_fee_price);
+
+                    let min = min_inverted_price.get_or_insert(to_mid_fee_price);
+                    *min = cmp::min(*min, to_mid_fee_price);
+
+                    let max = max_inverted_price.get_or_insert(from_mid_fee_price);
+                    *max = cmp::max(*max, from_mid_fee_price);
+
+                    dbg!((min_inverted_price, max_inverted_price));
+                }
             }
 
-            let min_price = self.direct_fee_token_price(token);
-            let max_price = min_price;
+            self.fill_path(&path).unwrap_or_else(|| {
+                panic!(
+                    "failed to fill path along detected negative cycle {}",
+                    format_path(&path),
+                )
+            });
 
-            for i in 1..=path.len() {
-                let sub_path = &path[..i + 1];
-                let transitive_xrate = self
-                    .find_path_flow(&path[..i])
-                    .unwrap_or_else(|| {
-                        panic!(
-                            "failed to find flow along detected negative cycle sub-path {}",
-                            format_path(&sub_path),
-                        )
-                    })
-                    .exchange_rate;
-
-                let price_in_fee = if sub_path[i] == fee_token {
-                    Some(transitive_xrate)
-                } else {
-                    self.direct_fee_token_price(sub_path[i])
-                        .map(|fee_price| transitive_xrate * fee_price)
-                };
-            }
-
-            if let (Some(min), Some(max)) = (min_price, max_price) {
-                return Some((min.value(), max.value()));
+            if let (Some(min), Some(max)) = (min_inverted_price, max_inverted_price) {
+                return Some((max.price().inverse(), min.price().inverse()));
             }
         }
 
@@ -262,6 +300,25 @@ impl Orderbook {
         pair: TokenPair,
     ) -> Result<Option<Flow>, OverlapError> {
         self.fill_optimal_transitive_order_if(pair, |_| true)
+    }
+
+    /// Finds and returns the optimal transitive order for the specified token
+    /// pair without filling it. Returns `None` if no such transitive order
+    /// exists.
+    ///
+    /// This method returns an error if the orderbook graph is not reduced.
+    pub fn find_optimal_transitive_order(
+        &mut self,
+        pair: TokenPair,
+    ) -> Result<Option<Flow>, OverlapError> {
+        let mut flow = None;
+        let reduced_flow = self.fill_optimal_transitive_order_if(pair, |f| {
+            flow = Some(*f);
+            false
+        })?;
+        debug_assert!(reduced_flow.is_none());
+
+        Ok(flow)
     }
 
     /// Fills the optimal transitive order (i.e. with the lowest exchange rate)

--- a/pricegraph/src/orderbook/reduced.rs
+++ b/pricegraph/src/orderbook/reduced.rs
@@ -22,6 +22,15 @@ impl ReducedOrderbook {
         self.fill_optimal_transitive_order_if(pair, |_| true)
     }
 
+    /// Finds and returns the optimal transitive order for the specified token
+    /// pair without filling it. Returns `None` if no such transitive order
+    /// exists.
+    pub fn find_optimal_transitive_order(&mut self, pair: TokenPair) -> Option<Flow> {
+        self.0
+            .find_optimal_transitive_order(pair)
+            .expect("negative cycle in reduced orderbook")
+    }
+
     /// Fills the optimal transitive order (i.e. with the lowest exchange rate)
     /// for the specified token pair by pushing flow from the buy token to the
     /// sell token, if the condition is met. The trading path through the


### PR DESCRIPTION
Fixes #1148 

This PR introduces a new method for estimating a price spread for a given token. This is intended to be used by `PriceSource` implementation for providing price estimates to the solver.

This PR is a draft as I plan on providing a more detailed description on how the algorithm works in the issue.

### Test Plan

New unit tests!