### PR TITLE
Add new method for finding optimal transitive order

### DIFF
--- a/pricegraph/src/api/price_estimation.rs
+++ b/pricegraph/src/api/price_estimation.rs
@@ -27,18 +27,18 @@ impl Pricegraph {
         if max_sell_amount == 0.0 {
             // NOTE: For a 0 volume we simulate sending an tiny epsilon of value
             // through the network without actually filling any orders.
-            let mut exchange_rate = None;
-            let flow = orderbook.fill_optimal_transitive_order_if(inverse_pair, |flow| {
-                exchange_rate = Some(flow.exchange_rate);
-                false
-            });
-            debug_assert!(flow.is_none());
-
-            // NOTE: The exchange rates are for transitive orders in the inverse
-            // direction, so we need to invert the exchange rate and account for
-            // the fees so that the estimated exchange rate actually overlaps with
-            // the last counter transtive order's exchange rate.
-            return Some(exchange_rate?.inverse().price().value());
+            // Additionally, the exchange rates are for transitive orders in the
+            // inverse direction, so we need to invert the exchange rate and
+            // account for the fees so that the estimated exchange rate actually
+            // overlaps with the last counter transtive order's exchange rate.
+            return Some(
+                orderbook
+                    .find_optimal_transitive_order(inverse_pair)?
+                    .exchange_rate
+                    .inverse()
+                    .price()
+                    .value(),
+            );
         }
 
         if !num::is_strictly_positive_and_finite(max_sell_amount) {

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -213,6 +213,25 @@ impl Orderbook {
         self.fill_optimal_transitive_order_if(pair, |_| true)
     }
 
+    /// Finds and returns the optimal transitive order for the specified token
+    /// pair without filling it. Returns `None` if no such transitive order
+    /// exists.
+    ///
+    /// This method returns an error if the orderbook graph is not reduced.
+    pub fn find_optimal_transitive_order(
+        &mut self,
+        pair: TokenPair,
+    ) -> Result<Option<Flow>, OverlapError> {
+        let mut flow = None;
+        let reduced_flow = self.fill_optimal_transitive_order_if(pair, |f| {
+            flow = Some(*f);
+            false
+        })?;
+        debug_assert!(reduced_flow.is_none());
+
+        Ok(flow)
+    }
+
     /// Fills the optimal transitive order (i.e. with the lowest exchange rate)
     /// for the specified token pair by pushing flow from the buy token to the
     /// sell token, if the condition is met. The trading path through the

--- a/pricegraph/src/orderbook/reduced.rs
+++ b/pricegraph/src/orderbook/reduced.rs
@@ -22,6 +22,15 @@ impl ReducedOrderbook {
         self.fill_optimal_transitive_order_if(pair, |_| true)
     }
 
+    /// Finds and returns the optimal transitive order for the specified token
+    /// pair without filling it. Returns `None` if no such transitive order
+    /// exists.
+    pub fn find_optimal_transitive_order(&mut self, pair: TokenPair) -> Option<Flow> {
+        self.0
+            .find_optimal_transitive_order(pair)
+            .expect("negative cycle in reduced orderbook")
+    }
+
     /// Fills the optimal transitive order (i.e. with the lowest exchange rate)
     /// for the specified token pair by pushing flow from the buy token to the
     /// sell token, if the condition is met. The trading path through the


### PR DESCRIPTION
This PR adds a utility method for finding (but **not** filling) the optimal transitive order in an orderbook. This common method will be used in a future PR.

### Test Plan

Tests continue to pass.