### PR TITLE
Write to pricegraph without rounding buffer on update

### DIFF
--- a/price-estimator/src/orderbook.rs
+++ b/price-estimator/src/orderbook.rs
@@ -61,10 +61,7 @@ impl Orderbook {
 
         // TODO: Move this cpu heavy computation out of the async function using spawn_blocking.
         let pricegraph = pricegraph_from_auction_data(&auction_data);
-        self.pricegraph_cache
-            .write()
-            .await
-            .pricegraph_with_rounding_buffer = pricegraph;
+        self.pricegraph_cache.write().await.pricegraph_raw = pricegraph;
 
         self.apply_rounding_buffer_to_auction_data(&mut auction_data)
             .await;


### PR DESCRIPTION
This PR fixes an issue with the `Pricegraph` instance without the rounding buffer applied was not being updated with exchange events.

### Test Plan

Run the price estimator and get a price estimate:
```
$ curl -s 'http://localhost:8080/api/v1/markets/1-7/estimated-best-ask-price?atoms=true' | jq                
235.51801773466883
```