### PR TITLE
[Trivial] Invert priority price source

### DIFF
--- a/core/src/price_estimation.rs
+++ b/core/src/price_estimation.rs
@@ -83,8 +83,8 @@ impl PriceOracle {
             Box::new(PricegraphEstimator::new(orderbook_reader)),
         ]));
         let prioritized_source = Box::new(PriorityPriceSource::new(vec![
-            averaged_source,
             Box::new(token_data),
+            averaged_source,
         ]));
 
         Ok(PriceOracle {


### PR DESCRIPTION
Fixes #1150

We no longer override prices as a fallback. Quite to the contrary, on Saturday's token sale we were trying to use TokenData as an override to a faulty price estimation. This did however not work, because the hardcoded token data had less priority than the averaged price source.

### Test Plan
`export TOKEN_DATA='{ "T0072":{"alias":"MTA","decimals":18,"externalPrice":17} }'`

run it and see T0072 with price 17 in the instance file.