### PR TITLE
Use AsyncSleep trait in solution submission

### DIFF
--- a/core/src/contracts/stablex_contract.rs
+++ b/core/src/contracts/stablex_contract.rs
@@ -85,7 +85,7 @@ pub enum NoopTransactionError {
     #[error("no account")]
     NoAccount,
     #[error("execution error: {0}")]
-    ExecutedOrder(#[from] ExecutionError),
+    ExecutionError(#[from] ExecutionError),
 }
 
 #[cfg_attr(test, automock)]


### PR DESCRIPTION
Previously we introduced a `handle_submit_result` function in order to
be able to test is separately because `submit_solution` was using
`async_std::timeout`.
Now that we have the async sleep trait we no longer need the extra
function by using `future::select` with the sleep instead of `timeout`.
This is also a step towards handling the nonce already used race
condition correctly which will be done in another PR.

### Test Plan
Unit tests adapted but this isn't change in observable behavior.