### PR TITLE
Fix race condition when cancelling solution submission transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core"
-version = "14.1.0"
+version = "14.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25525f6002338fb4debb5167a89a0b47f727a5a48418417545ad3429758b7fec"
+checksum = "a0747307121ffb9703afd93afbd0fb4f854c38fb873f2c8b90e0e902f27c7b62"
 dependencies = [
  "futures 0.1.29",
  "log 0.4.11",


### PR DESCRIPTION
When the solution submission transaction and the cancellation
transaction execute at the same time it is possible for us to observe
the failure first.
Previously we did not detect this case and could emit an error message
when there was not actually an error.
This commit handles this situation by waiting on and returning the
result of the other transaction if the first one completes with a "nonce
already used error".

This is part #1143 . In another PR a similar case in `retry.rs` will
be handled.

### Test Plan
Unit tests for the new logic.