### PR TITLE
Implement token price estimation in pricegraph

### DIFF
--- a/core/src/price_estimation/orderbook_based.rs
+++ b/core/src/price_estimation/orderbook_based.rs
@@ -125,17 +125,4 @@ mod tests {
         let expected = hash_map! { TokenId(1) => nonzero!(500_000_000_000_000_000) };
         assert_eq!(result, expected);
     }
-
-    #[test]
-    fn returns_one_owl_for_estimating_owl() {
-        let pricegraph = MockTokenPriceEstimating::new();
-
-        let result = pricegraph
-            .get_prices(&[0.into()])
-            .now_or_never()
-            .unwrap()
-            .unwrap();
-        let expected = hash_map! { TokenId(0) => nonzero!(1_000_000_000_000_000_000) };
-        assert_eq!(result, expected);
-    }
 }

--- a/e2e/src/bin/historic_prices.rs
+++ b/e2e/src/bin/historic_prices.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use core::{history::Settlement, models::BatchId};
 use e2e::cmd;
-use pricegraph::{Element, Pricegraph, TokenPair};
+use pricegraph::{Element, Pricegraph};
 use std::{fs::File, io::Write, path::PathBuf};
 use structopt::StructOpt;
 
@@ -26,7 +26,7 @@ fn main() -> Result<()> {
     let options = Options::from_args();
 
     let mut spreads = File::create(&options.output_dir.join("spreads.csv"))?;
-    writeln!(&mut spreads, "batch,market,best_bid,price,best_ask")?;
+    writeln!(&mut spreads, "batch,token,price,estimate")?;
 
     cmd::for_each_batch(&options.orderbook_file, |history, batch| {
         let settlement = match history.settlement_for_batch(batch) {
@@ -35,13 +35,13 @@ fn main() -> Result<()> {
         };
 
         let auction_elements = history.auction_elements_for_batch(batch)?;
-        check_batch_spread(batch, &auction_elements, &settlement, &mut spreads)?;
+        check_batch_prices(batch, &auction_elements, &settlement, &mut spreads)?;
 
         Ok(())
     })
 }
 
-fn check_batch_spread(
+fn check_batch_prices(
     batch: BatchId,
     auction_elements: &[Element],
     settlement: &Settlement,
@@ -56,40 +56,17 @@ fn check_batch_spread(
     );
 
     let pricegraph = Pricegraph::new(auction_elements.iter().cloned());
-    for (i, j) in unique_pairs(token_ids.len()) {
-        let (buy_token, sell_token) = (token_ids[i], token_ids[j]);
+    for (token_index, token) in token_ids
+        .iter()
+        .copied()
+        .enumerate()
+        .filter(|(_, token)| *token != 0)
+    {
+        let price = prices[token_index];
+        let estimate = pricegraph.estimate_token_price(token).unwrap_or(0.0) as u128;
 
-        let best_bid = pricegraph
-            .estimate_limit_price(
-                TokenPair {
-                    buy: sell_token,
-                    sell: buy_token,
-                },
-                0.0,
-            )
-            .unwrap_or(0.0);
-        let price = prices[i] as f64 / prices[j] as f64;
-        let best_ask = pricegraph
-            .estimate_limit_price(
-                TokenPair {
-                    buy: buy_token,
-                    sell: sell_token,
-                },
-                0.0,
-            )
-            .map(|xrate| 1.0 / xrate)
-            .unwrap_or(f64::INFINITY);
-
-        writeln!(
-            &mut output,
-            "{},{}-{},{},{},{}",
-            batch, buy_token, sell_token, best_bid, price, best_ask
-        )?;
+        writeln!(&mut output, "{},{},{},{}", batch, token, price, estimate)?;
     }
 
     Ok(())
-}
-
-fn unique_pairs(len: usize) -> impl Iterator<Item = (usize, usize)> {
-    (0..len - 1).flat_map(move |i| (i + 1..len).map(move |j| (i, j)))
 }

--- a/pricegraph/src/api.rs
+++ b/pricegraph/src/api.rs
@@ -1,6 +1,7 @@
 //! Module containing the high-level `Pricegraph` API operation implementations.
 
 mod price_estimation;
+mod price_source;
 mod transitive_orderbook;
 
 pub use self::transitive_orderbook::TransitiveOrderbook;

--- a/pricegraph/src/api/price_source.rs
+++ b/pricegraph/src/api/price_source.rs
@@ -11,8 +11,8 @@ impl Pricegraph {
     /// Specifically, this price repesents the number of OWL atoms required to
     /// buy 1e18 atoms of the specified token.
     ///
-    /// Returns `None` if there token is not connected to the fee token (that
-    /// is, there is no transitive order buying the fee token for the specified
+    /// Returns `None` if the token is not connected to the fee token (that is,
+    /// there is no transitive order buying the fee token for the specified
     /// token).
     ///
     /// The fee token is defined as the token with ID 0.

--- a/pricegraph/src/api/price_source.rs
+++ b/pricegraph/src/api/price_source.rs
@@ -9,7 +9,7 @@ const OWL_BASE_UNIT: f64 = 1_000_000_000_000_000_000.0;
 impl Pricegraph {
     /// Estimates the fee token price in atoms for the specified token.
     /// Specifically, this price repesents the number of OWL atoms required to
-    /// buy 10e18 atoms of the specified token.
+    /// buy 1e18 atoms of the specified token.
     ///
     /// Returns `None` if there token is not connected to the fee token (that
     /// is, there is no transitive order buying the fee token for the specified

--- a/pricegraph/src/api/price_source.rs
+++ b/pricegraph/src/api/price_source.rs
@@ -1,0 +1,89 @@
+//! This module implements price source methods for the `Pricegraph` API so that
+//! it can be used for OWL price estimates to the solver.
+
+use crate::encoding::{TokenId, TokenPair};
+use crate::{Pricegraph, FEE_TOKEN};
+
+const OWL_BASE_UNIT: f64 = 1_000_000_000_000_000_000.0;
+
+impl Pricegraph {
+    /// Estimates the fee token price in WEI for the specified token. Returns
+    /// `None` if there token is not connected to the fee token (that is, there
+    /// is no transitive order buying the fee token for the specified token).
+    ///
+    /// The fee token is defined as the token with ID 0.
+    pub fn estimate_token_price(&self, token: TokenId) -> Option<f64> {
+        if token == FEE_TOKEN {
+            return Some(OWL_BASE_UNIT);
+        }
+
+        // Estimate price of selling 1 unit of the reference token for each
+        // token. We sell rather than buy the reference token because volume is
+        // denominated in the sell token, for which we know the number of
+        // decimals.
+        let pair = TokenPair {
+            buy: token,
+            sell: FEE_TOKEN,
+        };
+
+        let price_in_token = self.estimate_limit_price(pair, OWL_BASE_UNIT)?;
+        let price_in_reference = 1.0 / price_in_token;
+
+        Some(OWL_BASE_UNIT * price_in_reference)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::num;
+    use crate::test::prelude::*;
+    use crate::FEE_FACTOR;
+
+    #[test]
+    fn fee_token_is_one_base_unit() {
+        let pricegraph = pricegraph! {
+            users {}
+            orders {}
+        };
+
+        assert_approx_eq!(pricegraph.estimate_token_price(0).unwrap(), OWL_BASE_UNIT);
+    }
+
+    #[test]
+    fn estimates_correct_token_price() {
+        const LOTS: u128 = 100 * OWL_BASE_UNIT as u128;
+
+        //   /-------0.5--------\
+        //  /                    v
+        // 0 --1.0--> 1 <--1.0-- 2
+        let pricegraph = pricegraph! {
+            users {
+                @1 {
+                    token 1 => LOTS,
+                    token 2 => LOTS,
+                }
+                @2 {
+                    token 1 => LOTS,
+                }
+            }
+            orders {
+                owner @1 buying 0 [LOTS    ] selling 1 [LOTS],
+                owner @1 buying 0 [LOTS / 2] selling 2 [LOTS],
+                owner @2 buying 2 [LOTS    ] selling 1 [LOTS],
+            }
+        };
+        let rounding_error = num::max_rounding_error_with_epsilon(OWL_BASE_UNIT);
+
+        assert_approx_eq!(
+            pricegraph.estimate_token_price(1).unwrap(),
+            (OWL_BASE_UNIT / 2.0) * FEE_FACTOR.powi(3),
+            rounding_error
+        );
+        assert_approx_eq!(
+            pricegraph.estimate_token_price(2).unwrap(),
+            (OWL_BASE_UNIT / 2.0) * FEE_FACTOR.powi(2),
+            rounding_error
+        );
+    }
+}

--- a/pricegraph/src/api/price_source.rs
+++ b/pricegraph/src/api/price_source.rs
@@ -7,9 +7,13 @@ use crate::{Pricegraph, FEE_TOKEN};
 const OWL_BASE_UNIT: f64 = 1_000_000_000_000_000_000.0;
 
 impl Pricegraph {
-    /// Estimates the fee token price in WEI for the specified token. Returns
-    /// `None` if there token is not connected to the fee token (that is, there
-    /// is no transitive order buying the fee token for the specified token).
+    /// Estimates the fee token price in atoms for the specified token.
+    /// Specifically, this price repesents the number of OWL atoms required to
+    /// buy 10e18 atoms of the specified token.
+    ///
+    /// Returns `None` if there token is not connected to the fee token (that
+    /// is, there is no transitive order buying the fee token for the specified
+    /// token).
     ///
     /// The fee token is defined as the token with ID 0.
     pub fn estimate_token_price(&self, token: TokenId) -> Option<f64> {
@@ -17,10 +21,10 @@ impl Pricegraph {
             return Some(OWL_BASE_UNIT);
         }
 
-        // Estimate price of selling 1 unit of the reference token for each
-        // token. We sell rather than buy the reference token because volume is
-        // denominated in the sell token, for which we know the number of
-        // decimals.
+        // NOTE: Estimate price of selling 1 unit of the reference token for the
+        // specified token. We sell rather than buy the reference token because
+        // volume is denominated in the sell token, for which we know the number
+        // of decimals.
         let pair = TokenPair {
             buy: token,
             sell: FEE_TOKEN,

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -17,6 +17,9 @@ pub use self::orderbook::*;
 /// The fee factor that is applied to each order's buy price.
 const FEE_FACTOR: f64 = 1.0 / 0.999;
 
+/// The fee token ID.
+const FEE_TOKEN: TokenId = 0;
+
 /// The minimum amount that must be traded for an order to be valid within a
 /// solution. Orders with effective sell amounts smaller than this amount can
 /// safely be ignored, and transitive orders with flows that trade amounts


### PR DESCRIPTION
This PR implements token price estimation in `pricegraph`. Additionally this PR modifies the `historic_prices` E2E script to use this method instead of the bid ask spread. This significantly modifies what the E2E script was testing, so a new E2E script has been introduced in #1218 to produce a more valuable metric to the one that previously existed.

Regarding the imprecision, the average error of the price estimate is 28000x :warning: (mostly because of some large outliers and non-liquid tokens). In recent batches for a token like WETH this is down to around 4% since the orderbook is more dense and therefore the estimates are much more accurate. Note that the previous promising analysis on price accuracy was using a different mechanism to estimate **exchange rates** between tokens and not token prices (in OWL reference token). 

### Test Plan

New unit tests in `pricegraph`, e2e historic prices now uses the new estimation API:
```
cargo run --release -p e2e --bin historic_prices -- --orderbook-file target/orderbook-file-mainnet
   Compiling e2e v1.0.0 (/var/home/nlordell/Developer/dex-services/e2e)
    Finished release [optimized] target(s) in 2.82s
     Running `target/release/historic_prices --orderbook-file target/orderbook-file-mainnet`
54285 / 54285 [===============================================] 100.00 % 222.25/s
Processed 13200 token prices: bad estimates 46.73%, average error 28770.95%.
```