### PR TITLE
E2E historic batch analysis command helpers.

### DIFF
--- a/core/src/history.rs
+++ b/core/src/history.rs
@@ -1,8 +1,10 @@
 //! This module contains an implementation for querying historic echange data by
 //! inspecting indexed events.
 
+pub mod batches;
 pub mod events;
 
+use self::batches::Batches;
 use self::events::EventRegistry;
 use crate::contracts::stablex_contract::batch_exchange::{
     event_data::{SolutionSubmission, Trade},
@@ -34,7 +36,16 @@ impl ExchangeHistory {
 
     /// Returns the very first batch for the exchange.
     pub fn first_batch(&self) -> Option<BatchId> {
-        self.events.events().next().map(|(_, batch)| batch)
+        let (_, batch) = self.events.events().next()?;
+        Some(batch)
+    }
+
+    /// Returns an iterator over all batches until the current
+    pub fn batches_until_now(&self) -> Batches {
+        match self.first_batch() {
+            Some(start) => Batches::from_batch(start),
+            None => Batches::empty(),
+        }
     }
 
     /// Returns a collection of auction elements for the specified batch.

--- a/core/src/history/batches.rs
+++ b/core/src/history/batches.rs
@@ -1,0 +1,47 @@
+//! Module containing iterator implementation for batch IDs.
+
+use crate::models::BatchId;
+use std::{iter::FusedIterator, ops::RangeInclusive};
+
+pub struct Batches {
+    range: RangeInclusive<u64>,
+}
+
+impl Batches {
+    /// Creates a new batch iterator from a starting batch until the current
+    /// batch determined from system time.
+    pub fn from_batch(start: BatchId) -> Self {
+        Batches {
+            range: start.0..=BatchId::now().0,
+        }
+    }
+
+    /// Creates an empty batch iterator.
+    pub fn empty() -> Self {
+        #[allow(clippy::reversed_empty_ranges)]
+        Batches { range: 1..=0 }
+    }
+
+    /// Returns the number of batches in this range.
+    pub fn batch_count(&self) -> u64 {
+        self.range.end().saturating_sub(*self.range.start())
+    }
+}
+
+impl Iterator for Batches {
+    type Item = BatchId;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.range.next().map(BatchId)
+    }
+}
+
+impl DoubleEndedIterator for Batches {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.range.next_back().map(BatchId)
+    }
+}
+
+impl ExactSizeIterator for Batches {}
+
+impl FusedIterator for Batches {}

--- a/e2e/src/cmd.rs
+++ b/e2e/src/cmd.rs
@@ -1,0 +1,24 @@
+//! Module containing command line helpers for e2e scripts.
+
+use anyhow::Result;
+use core::{history::ExchangeHistory, models::BatchId};
+use pbr::ProgressBar;
+use std::{io, path::Path};
+
+/// Runs a closure for each batch for the specified event history.
+pub fn for_each_batch(
+    orderbook_file: impl AsRef<Path>,
+    mut f: impl FnMut(&ExchangeHistory, BatchId) -> Result<()>,
+) -> Result<()> {
+    let history = ExchangeHistory::from_filestore(orderbook_file)?;
+
+    let batches = history.batches_until_now();
+    let mut progress = ProgressBar::on(io::stderr(), batches.batch_count());
+
+    for batch in batches {
+        progress.inc();
+        f(&history, batch)?;
+    }
+
+    Ok(())
+}

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -6,6 +6,7 @@ ethcontract::contract!(pub "dex-contracts/build/contracts/IterableAppendOnlySet.
 ethcontract::contract!(pub "dex-contracts/build/contracts/TokenOWL.json");
 ethcontract::contract!(pub "dex-contracts/build/contracts/ERC20Mintable.json");
 
+pub mod cmd;
 pub mod common;
 pub mod docker_logs;
 pub mod stablex;


### PR DESCRIPTION
This PR just splits out some helper methods for analyzing historic batches.

### Test Plan

Rustc. `cargo run -p e2e` and see output.