### PR TITLE
Cache token infos at startup to prevent double fetch

### DIFF
--- a/core/src/price_estimation.rs
+++ b/core/src/price_estimation.rs
@@ -50,7 +50,7 @@ pub struct PriceOracle {
 
 impl PriceOracle {
     /// Creates a new price oracle from a token whitelist data.
-    pub fn new(
+    pub async fn new(
         http_factory: &HttpFactory,
         orderbook_reader: Arc<dyn StableXOrderBookReading>,
         contract: Arc<StableXContractImpl>,
@@ -61,6 +61,7 @@ impl PriceOracle {
             contract,
             token_data.clone().into(),
         ));
+        token_info_fetcher.cache_all(10).await?;
         let (kraken_source, _) = ThreadedPriceSource::new(
             token_info_fetcher.clone(),
             KrakenClient::new(http_factory, token_info_fetcher.clone())?,

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -252,6 +252,7 @@ fn main() {
         options.token_data,
         options.price_source_update_interval,
     )
+    .wait()
     .unwrap();
 
     // Setup price.


### PR DESCRIPTION
When the cached token info fetcher does not yet contain a token it must
fetch it. If multiple calls `get_token_info` happen in parallel then we
likely make multiple requests to retrieve token info from the node
because of the way the code around the mutex works out.
This happens when the PriceOracle is created because we have multiple
price sources using the token info cache, and performing their initial
update at the same time.
This commit explicitly caches all tokens before the cache is passed to
the price sources.

Fixes #1155 

### Test Plan
CI