### PR TITLE
Add enum for modeling amounts so that atoms are never fractional

### DIFF
--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -214,18 +214,17 @@ async fn estimate_buy_amount(
         .await
         .map_err(error::internal_server_rejection)?
         .order_for_sell_amount(token_pair, sell_amount_in_quote_atoms);
-    let buy_amount_in_base_atoms = Amount::Atoms(
+
+    let mut buy_amount_in_base = Amount::Atoms(
         transitive_order
             .map(|order| apply_rounding_buffer(order.buy, price_rounding_buffer))
             .unwrap_or_default() as _,
     );
-
-    let buy_amount_in_base = if query.atoms {
-        buy_amount_in_base_atoms
-    } else {
+    if !query.atoms {
         let token_info = get_token_info(token_pair.buy, token_infos.as_ref()).await?;
-        buy_amount_in_base_atoms.into_base_units(&token_info)
+        buy_amount_in_base = buy_amount_in_base.into_base_units(&token_info)
     };
+
     let result = EstimatedOrderResult {
         base_token_id: token_pair.buy,
         quote_token_id: token_pair.sell,

--- a/price-estimator/src/models.rs
+++ b/price-estimator/src/models.rs
@@ -1,4 +1,4 @@
-use core::models::BatchId;
+use core::{models::BatchId, token_info::TokenBaseInfo};
 use serde::{Deserialize, Serialize};
 use serde_with::rust::display_fromstr;
 use std::{cmp::Ordering, num::ParseIntError, ops::Deref, str::FromStr};
@@ -56,16 +56,49 @@ pub struct QueryParameters {
 pub struct EstimatedOrderResult {
     pub base_token_id: u16,
     pub quote_token_id: u16,
-    #[serde(with = "display_fromstr")]
-    pub buy_amount_in_base: f64,
-    #[serde(with = "display_fromstr")]
-    pub sell_amount_in_quote: f64,
+    pub buy_amount_in_base: Amount,
+    pub sell_amount_in_quote: Amount,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct TransitiveOrder {
     pub price: f64,
     pub volume: f64,
+}
+
+/// Type used for modeling token amounts in either fractional base units or
+/// whole atoms.
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(untagged)]
+pub enum Amount {
+    Atoms(#[serde(with = "display_fromstr")] u128),
+    BaseUnits(#[serde(with = "display_fromstr")] f64),
+}
+
+impl Amount {
+    /// Converts an amount into base units for the specified token.
+    pub fn into_base_units(self, token: &TokenBaseInfo) -> Self {
+        match self {
+            Amount::Atoms(atoms) => Amount::BaseUnits(atoms as f64 / token.base_unit_in_atoms()),
+            base_units => base_units,
+        }
+    }
+
+    /// Converts an amount into atoms for the specified token.
+    pub fn into_atoms(self, token: &TokenBaseInfo) -> Self {
+        match self {
+            Amount::BaseUnits(units) => Amount::Atoms((units * token.base_unit_in_atoms()) as _),
+            atoms => atoms,
+        }
+    }
+
+    /// Returns the amount in atoms.
+    pub fn as_atoms(self, token: &TokenBaseInfo) -> u128 {
+        match self.into_atoms(token) {
+            Amount::Atoms(atoms) => atoms,
+            _ => unreachable!("amount converted into atoms"),
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -159,8 +192,8 @@ mod tests {
         let original = EstimatedOrderResult {
             base_token_id: 1,
             quote_token_id: 2,
-            buy_amount_in_base: 3.0,
-            sell_amount_in_quote: 4.0,
+            buy_amount_in_base: Amount::Atoms(3),
+            sell_amount_in_quote: Amount::BaseUnits(4.2),
         };
         let serialized = serde_json::to_string(&original).unwrap();
         let json: Value = serde_json::from_str(&serialized).unwrap();
@@ -168,7 +201,7 @@ mod tests {
             "baseTokenId": 1,
             "quoteTokenId": 2,
             "buyAmountInBase": "3",
-            "sellAmountInQuote": "4",
+            "sellAmountInQuote": "4.2",
         });
         assert_eq!(json, expected);
     }

--- a/price-estimator/src/models.rs
+++ b/price-estimator/src/models.rs
@@ -68,7 +68,7 @@ pub struct TransitiveOrder {
 
 /// Type used for modeling token amounts in either fractional base units or
 /// whole atoms.
-#[derive(Clone, Copy, Debug, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum Amount {
     Atoms(#[serde(with = "display_fromstr")] u128),
@@ -288,5 +288,28 @@ mod tests {
             ),
             expected
         );
+    }
+
+    #[test]
+    fn amount_unit_conversion() {
+        let owl = TokenBaseInfo {
+            alias: "OWL".into(),
+            decimals: 18,
+        };
+        let usdc = TokenBaseInfo {
+            alias: "USDC".into(),
+            decimals: 6,
+        };
+
+        let amount = Amount::BaseUnits(4.2);
+
+        assert_eq!(
+            amount.into_atoms(&owl),
+            Amount::Atoms(4_200_000_000_000_000_000)
+        );
+        assert_eq!(amount.into_atoms(&usdc), Amount::Atoms(4_200_000));
+
+        assert_eq!(amount.into_atoms(&owl).into_base_units(&owl), amount);
+        assert_eq!(amount.into_atoms(&usdc).into_base_units(&usdc), amount);
     }
 }


### PR DESCRIPTION
Related to #1111 

This PR defines a new `Amount` enum for representing token amounts in either atoms or base units. This has the effect of guaranteeing that atom amounts are never fractional. Note that the format is otherwise unchanged and base units are serialized as strings ("4.2" for example - see unit test) as there is still some discussion about how this should be done in the above mentioned issue.

Note that the transitive orderbook route does not use this type as it would be a "breaking" API change and we would need to evaluate with the FE team whether or not this can be changed. This should be easy to change in a follow up PR.

### Test Plan

Updated unit test and added new one. Additionally, run the price estimator and check that the results are in sync:
```
$ curl -s 'http://localhost:8080/api/v1/markets/7-1/estimated-buy-amount/1000000000000000000?atoms=true' | jq
{
  "baseTokenId": 7,
  "quoteTokenId": 1,
  "buyAmountInBase": "296069471770719551488",
  "sellAmountInQuote": "1000000000000000000"
}
$ curl -s 'http://localhost:8080/api/v1/markets/7-1/estimated-buy-amount/1?atoms=false' | jq                 
{
  "baseTokenId": 7,
  "quoteTokenId": 1,
  "buyAmountInBase": "296.06947177071953",
  "sellAmountInQuote": "1"
}
```