### PR TITLE
Add configurable event-based orderbook page size

### DIFF
--- a/core/src/contracts/stablex_contract.rs
+++ b/core/src/contracts/stablex_contract.rs
@@ -147,6 +147,7 @@ pub trait StableXContract {
         &'a self,
         from_block: BlockNumber,
         to_block: BlockNumber,
+        block_page_size: u64,
     ) -> BoxFuture<'a, Result<Vec<Event<batch_exchange::Event>>, ExecutionError>>;
 
     fn stream_events<'a>(
@@ -323,11 +324,13 @@ impl StableXContract for StableXContractImpl {
         &'a self,
         from_block: BlockNumber,
         to_block: BlockNumber,
+        block_page_size: u64,
     ) -> BoxFuture<'a, Result<Vec<Event<batch_exchange::Event>>, ExecutionError>> {
         self.instance
             .all_events()
             .from_block(from_block)
             .to_block(to_block)
+            .block_page_size(block_page_size)
             .query_past_events_paginated()
             .boxed()
     }

--- a/core/src/orderbook.rs
+++ b/core/src/orderbook.rs
@@ -73,9 +73,12 @@ impl OrderbookReaderKind {
                 auction_data_page_size,
                 orderbook_filter,
             )),
-            OrderbookReaderKind::EventBased => {
-                Box::new(EventBasedOrderbook::new(contract, web3, file_path))
-            }
+            OrderbookReaderKind::EventBased => Box::new(EventBasedOrderbook::new(
+                contract,
+                web3,
+                auction_data_page_size as _,
+                file_path,
+            )),
         }
     }
 }

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -110,8 +110,10 @@ struct Options {
     #[structopt(short = "k", long, env = "PRIVATE_KEY", hide_env_values = true)]
     private_key: PrivateKey,
 
-    /// The page size with which to read orders from the smart contract.
-    #[structopt(long, env = "AUCTION_DATA_PAGE_SIZE", default_value = "100")]
+    /// For storage based orderbook reading, the page size with which to read
+    /// orders from the smart contract. For event based orderbook reading, the
+    /// number of blocks to fetch events for at a time.
+    #[structopt(long, env = "AUCTION_DATA_PAGE_SIZE", default_value = "500")]
     auction_data_page_size: u16,
 
     /// The timeout in milliseconds of web3 JSON RPC calls, defaults to 10000ms

--- a/price-estimator/src/main.rs
+++ b/price-estimator/src/main.rs
@@ -62,6 +62,11 @@ struct Options {
     /// which can happen for example when tokens do not implement the standard properly.
     #[structopt(long, env = "TOKEN_DATA", default_value = "{}")]
     token_data: TokenData,
+
+    /// The number of blocks to fetch events for at a time for constructing the
+    /// orderbook.
+    #[structopt(long, env = "AUCTION_DATA_PAGE_SIZE", default_value = "500")]
+    auction_data_page_size: usize,
 }
 
 fn main() {
@@ -93,7 +98,12 @@ fn main() {
         .expect("failed to cache token infos");
     let token_info = Arc::new(token_info);
 
-    let orderbook = EventBasedOrderbook::new(contract, web3, options.orderbook_file);
+    let orderbook = EventBasedOrderbook::new(
+        contract,
+        web3,
+        options.auction_data_page_size,
+        options.orderbook_file,
+    );
     let orderbook = Arc::new(Orderbook::new(Box::new(orderbook)));
     let _ = orderbook.update().wait();
     log::info!("Orderbook initialized.");


### PR DESCRIPTION
Fixes #1203 

This PR adds block page size configuration to the streamed orderbook so that it can be used with Infura. Currently Infura cannot deal with the number of events in the default 500 block page size because of the increased recent activity on the exchange.

### Test Plan

Run the price estimator from scratch connected to an Infura node with a small-ish block size and wait a long time:
```
$ RUST_LOG=info,core::transport=info,core=debug cargo run -p price-estimator -- --node-url https://mainnet.infura.io/v3/$INFURA_PROJECT_ID --auction-data-page-size 100
# ...
[2020-07-28T07:25:27Z DEBUG core::transport] [id:1199] sending request: '{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"address":"0x6f400810b62df8e13fded51be75ff5393eaa841f","fromBlock":"0x9038e3","toBlock":"0x903946","topics":[]}],"id":1199}' # note 0x903946 - 0x9038e3 == 99
# ...
[2020-07-28T07:37:56Z INFO  core::orderbook::streamed::updating_orderbook] Finished applying events
```