### PR TITLE
Update infallible price source with prices

### DIFF
--- a/core/src/orderbook.rs
+++ b/core/src/orderbook.rs
@@ -41,6 +41,15 @@ pub trait StableXOrderBookReading: Send + Sync {
     }
 }
 
+/// Always suceeds with empty orderbook.
+pub struct NoopOrderbook {}
+
+impl StableXOrderBookReading for NoopOrderbook {
+    fn get_auction_data<'a>(&'a self, _: u32) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>> {
+        immediate!(Ok(Default::default()))
+    }
+}
+
 /// The different kinds of orderbook readers.
 #[derive(Clone, Debug)]
 pub enum OrderbookReaderKind {

--- a/core/src/price_estimation.rs
+++ b/core/src/price_estimation.rs
@@ -1,7 +1,7 @@
 //! Module responsible for aggregating price estimates from various sources to
 //! give good price estimates to the solver for better results.
 
-mod average_price_source;
+pub mod average_price_source;
 mod clients;
 mod orderbook_based;
 pub mod price_source;

--- a/core/src/price_estimation/average_price_source.rs
+++ b/core/src/price_estimation/average_price_source.rs
@@ -34,8 +34,8 @@ impl PriceSource for AveragePriceSource {
 /// Get the price from each price source and apply `average_prices` to them.
 /// Errors if all price sources fail. If some but not all fail then the failure is logged and the
 /// failures are not part of the average but no error is returned.
-pub async fn average_price_sources(
-    sources: impl Iterator<Item = &dyn PriceSource>,
+pub async fn average_price_sources<'a>(
+    sources: impl Iterator<Item = &'a (impl PriceSource + 'a + ?Sized)>,
     tokens: &[TokenId],
 ) -> Result<HashMap<TokenId, NonZeroU128>> {
     let futures = future::join_all(sources.map(|s| s.get_prices(tokens))).await;

--- a/core/src/token_info.rs
+++ b/core/src/token_info.rs
@@ -3,7 +3,7 @@ use futures::future::BoxFuture;
 use lazy_static::lazy_static;
 #[cfg(test)]
 use mockall::automock;
-use std::collections::HashMap;
+use std::{collections::HashMap, num::NonZeroU128};
 
 use crate::models::TokenId;
 pub mod cached;
@@ -52,8 +52,8 @@ impl TokenBaseInfo {
     }
 
     /// One unit of the token taking decimals into account, given in number of atoms.
-    pub fn base_unit_in_atoms(&self) -> u128 {
-        10u128.pow(self.decimals as u32)
+    pub fn base_unit_in_atoms(&self) -> NonZeroU128 {
+        NonZeroU128::new(10u128.pow(self.decimals as u32)).unwrap()
     }
 
     /// Converts the prices from USD into the unit expected by the contract.
@@ -98,8 +98,8 @@ mod tests {
     #[test]
     #[allow(clippy::float_cmp)]
     fn base_unit_in_atoms() {
-        assert_eq!(TokenBaseInfo::new("", 0).base_unit_in_atoms(), 1);
-        assert_eq!(TokenBaseInfo::new("", 1).base_unit_in_atoms(), 10);
-        assert_eq!(TokenBaseInfo::new("", 2).base_unit_in_atoms(), 100);
+        assert_eq!(TokenBaseInfo::new("", 0).base_unit_in_atoms().get(), 1);
+        assert_eq!(TokenBaseInfo::new("", 1).base_unit_in_atoms().get(), 10);
+        assert_eq!(TokenBaseInfo::new("", 2).base_unit_in_atoms().get(), 100);
     }
 }

--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -334,22 +334,8 @@ fn apply_rounding_buffer(amount: f64, price_rounding_buffer: f64) -> f64 {
 mod tests {
     use super::*;
     use anyhow::{anyhow, Result};
-    use core::orderbook::StableXOrderBookReading;
+    use core::orderbook::NoopOrderbook;
     use futures::future::{BoxFuture, FutureExt as _};
-
-    fn empty_orderbook() -> impl StableXOrderBookReading {
-        struct OrderbookReader {}
-        impl StableXOrderBookReading for OrderbookReader {
-            fn get_auction_data<'a>(
-                &'a self,
-                _: u32,
-            ) -> BoxFuture<'a, Result<(core::models::AccountState, Vec<core::models::Order>)>>
-            {
-                async { Ok(Default::default()) }.boxed()
-            }
-        }
-        OrderbookReader {}
-    }
 
     fn empty_token_info() -> impl TokenInfoFetching {
         struct TokenInfoFetcher {}
@@ -369,7 +355,7 @@ mod tests {
 
     fn all_filter() -> impl Filter<Extract = impl Reply, Error = Infallible> + Clone {
         let orderbook = Arc::new(Orderbook::new(
-            Box::new(empty_orderbook()),
+            Box::new(NoopOrderbook {}),
             Default::default(),
         ));
         let token_info = Arc::new(empty_token_info());

--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -368,7 +368,10 @@ mod tests {
     }
 
     fn all_filter() -> impl Filter<Extract = impl Reply, Error = Infallible> + Clone {
-        let orderbook = Arc::new(Orderbook::new(Box::new(empty_orderbook())));
+        let orderbook = Arc::new(Orderbook::new(
+            Box::new(empty_orderbook()),
+            Default::default(),
+        ));
         let token_info = Arc::new(empty_token_info());
         all(orderbook, token_info, 0.0)
     }

--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -257,8 +257,8 @@ async fn estimate_amounts_at_price(
         let buy_token_info = get_token_info(token_pair.buy, token_infos.as_ref()).await?;
         let sell_token_info = get_token_info(token_pair.sell, token_infos.as_ref()).await?;
         let price_in_quote_atoms = price_in_quote
-            * (sell_token_info.base_unit_in_atoms() as f64
-                / buy_token_info.base_unit_in_atoms() as f64);
+            * (sell_token_info.base_unit_in_atoms().get() as f64
+                / buy_token_info.base_unit_in_atoms().get() as f64);
         let mut result = estimate_amounts_at_price_atoms(
             token_pair,
             price_in_quote_atoms,

--- a/price-estimator/src/infallible_price_source.rs
+++ b/price-estimator/src/infallible_price_source.rs
@@ -1,11 +1,11 @@
 use core::{models::TokenId, token_info::TokenBaseInfo};
-use std::collections::HashMap;
+use std::{collections::HashMap, num::NonZeroU128};
 
 /// Roughly like `PriceSource` but is updated externally and cannot fail.
 #[derive(Debug, Default)]
 pub struct InfalliblePriceSource {
     token_infos: HashMap<TokenId, TokenBaseInfo>,
-    prices: HashMap<TokenId, u128>,
+    prices: HashMap<TokenId, NonZeroU128>,
 }
 
 impl InfalliblePriceSource {
@@ -16,14 +16,14 @@ impl InfalliblePriceSource {
         }
     }
 
-    pub fn _update(&mut self, prices: &HashMap<TokenId, u128>) {
+    pub fn update(&mut self, prices: &HashMap<TokenId, NonZeroU128>) {
         self.prices.extend(prices.iter());
     }
 
     /// Tries to use the current price from the first source, if that fails one base unit of the
     /// token is used (based on decimals) and if that also fails the fee price is used. If we do not
     /// not have the fee price 10e18 is used.
-    pub fn price(&self, token_id: TokenId) -> u128 {
+    pub fn price(&self, token_id: TokenId) -> NonZeroU128 {
         match self.prices.get(&token_id) {
             Some(price) => *price,
             None => match self.token_infos.get(&token_id) {
@@ -32,7 +32,7 @@ impl InfalliblePriceSource {
                     .prices
                     .get(&TokenId(0))
                     .copied()
-                    .unwrap_or_else(|| 10u128.pow(18)),
+                    .unwrap_or_else(|| NonZeroU128::new(10u128.pow(18)).unwrap()),
             },
         }
     }
@@ -45,9 +45,9 @@ mod tests {
     #[test]
     fn use_existing_price() {
         let token = TokenId(1);
-        let price = 1u128;
+        let price = NonZeroU128::new(1).unwrap();
         let mut ips = InfalliblePriceSource::default();
-        ips._update(&[(token, price)].iter().copied().collect());
+        ips.update(&[(token, price)].iter().copied().collect());
         assert_eq!(ips.price(token), price);
     }
 
@@ -59,14 +59,19 @@ mod tests {
             decimals: 1,
         };
         let ips = InfalliblePriceSource::new([(token, token_info)].iter().cloned().collect());
-        assert_eq!(ips.price(token), 10);
+        assert_eq!(ips.price(token).get(), 10);
     }
 
     #[test]
     fn fallback_to_fee() {
         let token = TokenId(1);
         let mut ips = InfalliblePriceSource::default();
-        ips._update(&[(TokenId(0), 1u128)].iter().copied().collect());
-        assert_eq!(ips.price(token), 1);
+        ips.update(
+            &[(TokenId(0), NonZeroU128::new(1).unwrap())]
+                .iter()
+                .copied()
+                .collect(),
+        );
+        assert_eq!(ips.price(token).get(), 1);
     }
 }

--- a/price-estimator/src/main.rs
+++ b/price-estimator/src/main.rs
@@ -105,7 +105,8 @@ fn main() {
         options.auction_data_page_size,
         options.orderbook_file,
     );
-    let orderbook = Arc::new(Orderbook::new(Box::new(orderbook)));
+    // TODO: Use real price source instead of default.
+    let orderbook = Arc::new(Orderbook::new(Box::new(orderbook), Default::default()));
     let _ = orderbook.update().wait();
     log::info!("Orderbook initialized.");
 

--- a/price-estimator/src/models.rs
+++ b/price-estimator/src/models.rs
@@ -80,7 +80,7 @@ impl Amount {
     pub fn into_base_units(self, token: &TokenBaseInfo) -> Self {
         match self {
             Amount::Atoms(atoms) => {
-                Amount::BaseUnits(atoms as f64 / token.base_unit_in_atoms() as f64)
+                Amount::BaseUnits(atoms as f64 / token.base_unit_in_atoms().get() as f64)
             }
             base_units => base_units,
         }
@@ -90,7 +90,7 @@ impl Amount {
     pub fn into_atoms(self, token: &TokenBaseInfo) -> Self {
         match self {
             Amount::BaseUnits(units) => {
-                Amount::Atoms((units * token.base_unit_in_atoms() as f64) as _)
+                Amount::Atoms((units * token.base_unit_in_atoms().get() as f64) as _)
             }
             atoms => atoms,
         }

--- a/price-estimator/src/orderbook.rs
+++ b/price-estimator/src/orderbook.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 use core::{
     models::{AccountState, BatchId, Order, TokenId},
     orderbook::StableXOrderBookReading,
+    price_estimation::{average_price_source, price_source::PriceSource},
 };
 use pricegraph::{Pricegraph, TokenPair};
 use std::collections::HashMap;
@@ -27,7 +28,9 @@ pub struct Orderbook {
     orderbook_reading: Box<dyn StableXOrderBookReading>,
     pricegraph_cache: RwLock<PricegraphCache>,
     extra_rounding_buffer_factor: f64,
-    infallible_price_source: InfalliblePriceSource,
+    infallible_price_source: RwLock<InfalliblePriceSource>,
+    external_price_sources: Vec<Box<dyn PriceSource + Send + Sync>>,
+    all_tokens: Vec<TokenId>,
 }
 
 impl Orderbook {
@@ -40,8 +43,12 @@ impl Orderbook {
             }),
             // TODO: pass this from command line argument
             extra_rounding_buffer_factor: 2.0,
-            // TODO: pass real token infos, and update it with a real price source in a future PR
-            infallible_price_source: InfalliblePriceSource::new(HashMap::new()),
+            // TODO: pass real token infos
+            infallible_price_source: RwLock::new(InfalliblePriceSource::new(HashMap::new())),
+            // TODO: use real external price sources
+            external_price_sources: Vec::new(),
+            // TODO: use real token ids
+            all_tokens: Vec::new(),
         }
     }
 
@@ -63,12 +70,15 @@ impl Orderbook {
         }
     }
 
-    /// Recreate the pricegraph orderbook.
+    /// Recreate the pricegraph orderbook and update the infallible price source.
     pub async fn update(&self) -> Result<()> {
         let mut auction_data = self.auction_data(BatchId::now()).await?;
 
         // TODO: Move this cpu heavy computation out of the async function using spawn_blocking.
         let pricegraph = pricegraph_from_auction_data(&auction_data);
+        if let Err(err) = self.update_infallible_price_source(&pricegraph).await {
+            log::warn!("failed to update price source: {:?}", err)
+        }
         self.pricegraph_cache.write().await.pricegraph_raw = pricegraph;
 
         self.apply_rounding_buffer_to_auction_data(&mut auction_data)
@@ -83,12 +93,30 @@ impl Orderbook {
 
     // TODO: this function is going to be used in some routes
     pub async fn _rounding_buffer(&self, token_pair: TokenPair) -> Result<f64> {
+        let price_source = self.infallible_price_source.read().await;
         Ok(solver_rounding_buffer::rounding_buffer(
-            self.infallible_price_source.price(TokenId(0)) as f64,
-            self.infallible_price_source.price(TokenId(token_pair.sell)) as f64,
-            self.infallible_price_source.price(TokenId(token_pair.buy)) as f64,
+            price_source.price(TokenId(0)).get() as f64,
+            price_source.price(TokenId(token_pair.sell)).get() as f64,
+            price_source.price(TokenId(token_pair.buy)).get() as f64,
             self.extra_rounding_buffer_factor,
         ))
+    }
+
+    /// Update the infallible price source with the averaged prices of the external price sources
+    /// and the pricegraph prices.
+    async fn update_infallible_price_source(&self, pricegraph: &Pricegraph) -> Result<()> {
+        let prices = average_price_source::average_price_sources(
+            self.external_price_sources
+                .iter()
+                .map(|source| source.as_ref() as &(dyn PriceSource + Send + Sync))
+                .chain(std::iter::once(
+                    pricegraph as &(dyn PriceSource + Send + Sync),
+                )),
+            &self.all_tokens,
+        )
+        .await?;
+        self.infallible_price_source.write().await.update(&prices);
+        Ok(())
     }
 
     async fn auction_data(&self, batch_id: BatchId) -> Result<AuctionData> {
@@ -110,7 +138,8 @@ impl Orderbook {
         &self,
         auction_data: &mut AuctionData,
     ) -> Result<()> {
-        let prices = |token_id| self.infallible_price_source.price(token_id);
+        let price_source = self.infallible_price_source.read().await;
+        let prices = |token_id| price_source.price(token_id);
         solver_rounding_buffer::apply_rounding_buffer(
             prices,
             &mut auction_data.1,


### PR DESCRIPTION
In the main orderbook update loop also update the infallible price source.
Routes are not yet using the rounding buffer.

### Test Plan
Tested that price estimator still works.