### PR TITLE
Log price estimates

### DIFF
--- a/core/src/price_estimation/clients/generic_client.rs
+++ b/core/src/price_estimation/clients/generic_client.rs
@@ -154,10 +154,11 @@ where
                 .iter()
                 .zip(results.iter())
                 .filter_map(|((token_id, token_info), result)| match result {
-                    Ok(price) => Some((
-                        *token_id,
-                        NonZeroU128::new(token_info.get_owl_price(*price))?,
-                    )),
+                    Ok(price) => {
+                        let owl_price = token_info.get_owl_price(*price);
+                        log::info!("Fetched price for token {}: {}", token_id, owl_price);
+                        Some((*token_id, NonZeroU128::new(owl_price)?))
+                    }
                     Err(err) => {
                         log::warn!(
                             "failed to retrieve {} prices for token ID {} ({}): {:?}",

--- a/core/src/price_estimation/clients/generic_client.rs
+++ b/core/src/price_estimation/clients/generic_client.rs
@@ -156,7 +156,7 @@ where
                 .filter_map(|((token_id, token_info), result)| match result {
                     Ok(price) => {
                         let owl_price = token_info.get_owl_price(*price);
-                        log::info!("Fetched price for token {}: {}", token_id, owl_price);
+                        log::debug!("Fetched price for token {}: {}", token_id, owl_price);
                         Some((*token_id, NonZeroU128::new(owl_price)?))
                     }
                     Err(err) => {

--- a/core/src/price_estimation/clients/kraken.rs
+++ b/core/src/price_estimation/clients/kraken.rs
@@ -112,8 +112,10 @@ where
                 .filter_map(|(pair, info)| {
                     let token_id_and_pair = token_asset_pairs.get(&pair);
                     async move {
-                        let price = token_id_and_pair?.1.get_owl_price(info.p.last_24h());
-                        Some((token_id_and_pair?.0, NonZeroU128::new(price)?))
+                        let token_id_and_pair = token_id_and_pair?;
+                        let price = token_id_and_pair.1.get_owl_price(info.p.last_24h());
+                        log::debug!("Fetched price for token {}: {}", token_id_and_pair.0, price);
+                        Some((token_id_and_pair.0, NonZeroU128::new(price)?))
                     }
                 })
                 .collect()

--- a/core/src/price_estimation/orderbook_based.rs
+++ b/core/src/price_estimation/orderbook_based.rs
@@ -61,6 +61,7 @@ impl<T: LimitPriceEstimating> PriceSource for T {
                     self.estimate_limit_price(pair, ONE_OWL)?
                 };
                 let price_in_reference = 1.0 / price_in_token;
+                log::info!("Fetched price for token {}: {}", token, price_in_reference);
                 Some((
                     *token,
                     NonZeroU128::new((ONE_OWL * price_in_reference) as u128)?,

--- a/core/src/price_estimation/orderbook_based.rs
+++ b/core/src/price_estimation/orderbook_based.rs
@@ -61,7 +61,7 @@ impl<T: LimitPriceEstimating> PriceSource for T {
                     self.estimate_limit_price(pair, ONE_OWL)?
                 };
                 let price_in_reference = 1.0 / price_in_token;
-                log::info!("Fetched price for token {}: {}", token, price_in_reference);
+                log::debug!("Fetched price for token {}: {}", token, price_in_reference);
                 Some((
                     *token,
                     NonZeroU128::new((ONE_OWL * price_in_reference) as u128)?,


### PR DESCRIPTION
Fixes #1149

In order to debug issues with the price estimation it makes sense to log the individual components separately as debug prints 

### Test Plan
Run and see print statements.