### PR TITLE
Fix coverage tests

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,8 @@
 // Mockall triggers this warning for every mocked trait. This is fixed in Mockall master but not
 // released.
 #![cfg_attr(test, allow(clippy::unused_unit))]
+// Coverage build on nightly is failing because of this
+#![allow(unused_braces)]
 
 #[macro_use]
 pub mod macros;


### PR DESCRIPTION
Our coverage builds are currently failing (e.g. https://travis-ci.com/github/gnosis/dex-services/jobs/365778356) due to having extremely long warnings around unused braces coming from ethcontracts. Quick fix is to ignore this warning (I don't understand why the `-Awarning` rustflag that we use when running the coverage test is not suppressing it).

@nlordell is this something we could fix in ethcontracts as well?

### Test Plan
Make sure coverage passes on this build.