### PR TITLE
Retry submitting solution during network congestion

### DIFF
--- a/core/src/solution_submission.rs
+++ b/core/src/solution_submission.rs
@@ -254,7 +254,7 @@ impl<'a> StableXSolutionSubmitting for StableXSolutionSubmitter<'a> {
             futures::pin_mut!(cancel_future);
             match future::select(submit_future, cancel_future).await {
                 Either::Left((submit_result, cancel_future)) => {
-                    if submit_result.is_nonce_error() {
+                    if submit_result.is_transaction_error() {
                         log::info!("solution submission transaction is nonce error");
                         Err(convert_cancel_result(cancel_future.await))
                     } else {
@@ -264,7 +264,7 @@ impl<'a> StableXSolutionSubmitting for StableXSolutionSubmitter<'a> {
                     }
                 }
                 Either::Right((cancel_result, submit_future)) => {
-                    if cancel_result.is_nonce_error() {
+                    if cancel_result.is_transaction_error() {
                         log::info!("cancel transaction is nonce error");
                         self.convert_submit_result(batch_index, solution, submit_future.await)
                             .await
@@ -297,40 +297,34 @@ fn convert_cancel_result(result: Result<(), NoopTransactionError>) -> SolutionSu
     }
 }
 
-trait IsNonceError {
-    fn is_nonce_error(&self) -> bool;
+trait IsOpenEthereumTransactionError {
+    /// Is this an error with the transaction itself instead of an evm related error.
+    fn is_transaction_error(&self) -> bool;
 }
 
-impl IsNonceError for ExecutionError {
-    fn is_nonce_error(&self) -> bool {
-        // This is the error as we've seen it on openethereum nodes.
+impl IsOpenEthereumTransactionError for ExecutionError {
+    fn is_transaction_error(&self) -> bool {
+        // This is the error as we've seen it on openethereum nodes. The code and error messages can
+        // be found in openethereum's source code in `rpc/src/v1/helpers/errors.rs`.
         // TODO: check how this looks on geth and infura. Not recognizing the error is not a serious
         // problem but it will make us sometimes log an error when there actually was no problem.
-        match self {
-            ExecutionError::Web3(Web3Error::Rpc(RpcError { code, message, .. }))
-                if code.code() == -32010
-                    && message.find("Transaction nonce is too low.").is_some() =>
-            {
-                true
-            }
-            _ => false,
-        }
+        matches!(self, ExecutionError::Web3(Web3Error::Rpc(RpcError { code, .. })) if code.code() == -32010)
     }
 }
 
-impl IsNonceError for Result<(), MethodError> {
-    fn is_nonce_error(&self) -> bool {
+impl IsOpenEthereumTransactionError for Result<(), MethodError> {
+    fn is_transaction_error(&self) -> bool {
         match self {
             Ok(()) => false,
-            Err(MethodError { inner, .. }) => inner.is_nonce_error(),
+            Err(MethodError { inner, .. }) => inner.is_transaction_error(),
         }
     }
 }
 
-impl IsNonceError for Result<(), NoopTransactionError> {
-    fn is_nonce_error(&self) -> bool {
+impl IsOpenEthereumTransactionError for Result<(), NoopTransactionError> {
+    fn is_transaction_error(&self) -> bool {
         match self {
-            Err(NoopTransactionError::ExecutionError(err)) => err.is_nonce_error(),
+            Err(NoopTransactionError::ExecutionError(err)) => err.is_transaction_error(),
             _ => false,
         }
     }

--- a/core/src/solution_submission/retry.rs
+++ b/core/src/solution_submission/retry.rs
@@ -1,4 +1,4 @@
-use super::IsNonceError as _;
+use super::IsOpenEthereumTransactionError as _;
 use crate::util::AsyncSleeping;
 use crate::{
     contracts::stablex_contract::StableXContract, gas_station::GasPriceEstimating, models::Solution,
@@ -170,7 +170,7 @@ async fn retry(
         // Unwrap because we always add the solution future above and every iteration here checks
         // that there are still futures left.
         while let FutureOutput::SolutionSubmission(result) = futures.next().await.unwrap() {
-            if !result.is_nonce_error() || futures.is_empty() {
+            if !result.is_transaction_error() || futures.is_empty() {
                 return result;
             }
         }


### PR DESCRIPTION
Currently we only check for "nonce already used" errors specifically to
determine when we should retry sending a transaction with a higher gas
price and when we should cancel a solution submission transaction.
This commit changes this to include all what openethereum calls
transaction errors. These errors indicate that the transaction did not
execute which can happen for several reasons.
This makes us more flexible with regards to the exact error string. It
has the side effect that we will try to resubmit the transaction with a
higher gas price in cases where this won't help but it also will not
hurt as we will still end up with the same error eventually.
openethereum transaction errors that share this error code (-32010):

```rust
AlreadyImported => "Transaction with the same hash was already imported.".into(),
Old => "Transaction nonce is too low. Try incrementing the nonce.".into(),
TooCheapToReplace { prev, new } => {
        format!("Transaction gas price {} is too low. There is another transaction with same nonce in the queue{}. Try increasing the gas price or incrementing the nonce.",
                        new.map(|gas| format!("{}wei", gas)).unwrap_or("supplied".into()),
                        prev.map(|gas| format!(" with gas price: {}wei", gas)).unwrap_or("".into())
        )
}
LimitReached => {
        "There are too many transactions in the queue. Your transaction was dropped due to limit. Try increasing the fee.".into()
}
InsufficientGas { minimal, got } => {
        format!("Transaction gas is too low. There is not enough gas to cover minimal cost of the transaction (minimal: {}, got: {}). Try increasing supplied gas.", minimal, got)
}
InsufficientGasPrice { minimal, got } => {
        format!("Transaction gas price is too low. It does not satisfy your node's minimal gas price (minimal: {}, got: {}). Try increasing the gas price.", minimal, got)
}
InsufficientBalance { balance, cost } => {
        format!("Insufficient funds. The account you tried to send transaction from does not have enough funds. Required {} and got: {}.", cost, balance)
}
GasLimitExceeded { limit, got } => {
        format!("Transaction cost exceeds current gas limit. Limit: {}, got: {}. Try decreasing supplied gas.", limit, got)
}
InvalidSignature(ref sig) => format!("Invalid signature: {}", sig),
InvalidChainId => "Invalid chain id.".into(),
InvalidGasLimit(_) => "Supplied gas is beyond limit.".into(),
SenderBanned => "Sender is banned in local queue.".into(),
RecipientBanned => "Recipient is banned in local queue.".into(),
CodeBanned => "Code is banned in local queue.".into(),
NotAllowed => "Transaction is not permitted.".into(),
TooBig => "Transaction is too big, see chain specification for the limit.".into(),
InvalidRlp(ref descr) => format!("Invalid RLP data: {}", descr),
```
Fixes #1187 

### Test Plan
Tests still pass.