### PR TITLE
Historic trades

### DIFF
--- a/e2e/src/bin/historic_prices.rs
+++ b/e2e/src/bin/historic_prices.rs
@@ -5,11 +5,10 @@ use pricegraph::{Element, Pricegraph, TokenPair};
 use std::{fs::File, io::Write, path::PathBuf};
 use structopt::StructOpt;
 
-/// Common options for analyzing historic batch data.
 #[derive(Debug, StructOpt)]
 #[structopt(
     name = "historic_prices",
-    about = "Utility for computing historic exchange prices.",
+    about = "Utility for computing historic exchange token prices.",
     rename_all = "kebab"
 )]
 struct Options {

--- a/e2e/src/bin/historic_trades.rs
+++ b/e2e/src/bin/historic_trades.rs
@@ -9,7 +9,7 @@ use std::{fs::File, io::Write, path::PathBuf};
 use structopt::StructOpt;
 
 const FULLY_FILLED_THREASHOLD: f64 = 0.95;
-const MIN_AMOUNT: u128 = 10_000;
+const MIN_AMOUNT: u128 = pricegraph::MIN_AMOUNT as _;
 
 /// Common options for analyzing historic batch data.
 #[derive(Debug, StructOpt)]

--- a/e2e/src/bin/historic_trades.rs
+++ b/e2e/src/bin/historic_trades.rs
@@ -1,8 +1,11 @@
 use anyhow::Result;
-use core::{history::Settlement, models::BatchId};
+use core::{
+    contracts::stablex_contract::batch_exchange::event_data::Trade, history::Settlement,
+    models::BatchId,
+};
 use e2e::cmd;
 use pricegraph::{Element, Pricegraph, TokenPair};
-use std::path::PathBuf;
+use std::{fs::File, io::Write, path::PathBuf};
 use structopt::StructOpt;
 
 const FULLY_FILLED_THREASHOLD: f64 = 0.95;
@@ -18,10 +21,15 @@ struct Options {
     /// The events registry file store containing past exchange events.
     #[structopt(long, env = "ORDERBOOK_FILE", parse(from_os_str))]
     orderbook_file: PathBuf,
+
+    /// The output directory for the computed results.
+    #[structopt(long, env = "OUTPUT_DIR", default_value = "target", parse(from_os_str))]
+    output_dir: PathBuf,
 }
 
 fn main() -> Result<()> {
     let options = Options::from_args();
+    let mut report = Report::new(File::create(options.output_dir.join("trades.csv"))?)?;
 
     cmd::for_each_batch(&options.orderbook_file, |history, batch| {
         let auction_elements = history.auction_elements_for_batch(batch)?;
@@ -29,15 +37,8 @@ fn main() -> Result<()> {
 
         let new_orders = auction_elements
             .iter()
-            .filter_map(|element| {
-                if batch == element.valid.from {
-                    Some(element)
-                } else {
-                    None
-                }
-            })
-            .filter(|order| order.price.numerator != 0 && order.price.denominator != 0)
-            .collect::<Vec<_>>();
+            .filter(|order| batch == order.valid.from)
+            .filter(|order| order.price.numerator != 0 && order.price.denominator != 0);
         for order in new_orders {
             let pricegraph = Pricegraph::new(
                 auction_elements
@@ -53,40 +54,157 @@ fn main() -> Result<()> {
                 pricegraph.estimate_limit_price(order.pair, effective_amount);
 
             if limit_price > estimated_limit_price.unwrap_or_default() {
-                // NOTE: Unreasonable price on order.
+                let settled_xrate = settlement
+                    .as_ref()
+                    .and_then(|settlement| find_settled_exchange_rate(settlement, order.pair));
+                match settled_xrate {
+                    Some(xrate) if xrate > limit_price => {
+                        report.overly_pessimistic_estimate(batch, &order, xrate)?
+                    }
+                    _ => report.unreasonable_order(batch, &order)?,
+                };
+
                 continue;
             }
 
-            match settlement.as_ref().and_then(|settlement| {
-                settlement
-                    .trades
-                    .iter()
-                    .find(|trade| (trade.owner, trade.order_id) == (order.user, order.id))
-            }) {
+            let settlement = match settlement.as_ref() {
+                Some(value) => value,
+                None => {
+                    report.no_solution(batch, &order)?;
+                    continue;
+                }
+            };
+
+            match find_trade(settlement, order) {
                 Some(trade) => {
                     let trade_ratio = trade.executed_sell_amount as f64 / effective_amount;
                     if trade_ratio > FULLY_FILLED_THREASHOLD {
-                        // NOTE: WOOHOO! Estimate was correct!
-                        continue;
+                        report.fully_matched(batch, &order, &trade)?;
                     } else {
-                        todo!("report partial trade");
+                        report.fully_matched(batch, &order, &trade)?;
                     }
                 }
-                None => {
-                    let settled_xrate = settlement.as_ref().and_then(|settlement| {
-
-                    });
-                    if matches!(settled_xrate, Some(xrate) if xrate < 
-                    todo!("report missed trade");
-                }
+                None => match find_settled_exchange_rate(settlement, order.pair) {
+                    Some(xrate) if xrate > limit_price => {
+                        report.disregarded_order(batch, &order)?
+                    }
+                    Some(xrate) => report.incorrect_estimate(batch, &order, xrate)?,
+                    None => report.not_traded(batch, &order)?,
+                },
             }
         }
 
         Ok(())
-    })
+    })?;
+
+    report.summary()
 }
 
-enum Trade {
-    FullyMatched,
-    Skipped,
+fn find_trade<'a>(settlement: &'a Settlement, order: &Element) -> Option<&'a Trade> {
+    settlement
+        .trades
+        .iter()
+        .find(|trade| (trade.owner, trade.order_id) == (order.user, order.id))
+}
+
+fn find_settled_exchange_rate(settlement: &Settlement, pair: TokenPair) -> Option<f64> {
+    let buy_token_index = settlement
+        .solution
+        .token_ids_for_price
+        .iter()
+        .position(|&id| id == pair.buy)?;
+    let sell_token_index = settlement
+        .solution
+        .token_ids_for_price
+        .iter()
+        .position(|&id| id == pair.sell)?;
+
+    // NOTE: This is unintuitive, but the echange rate is computed as the sell
+    // price over the buy price. This is best illustrated by an example:
+    // - The price of WETH is ~200 OWL
+    // - The price of DAI is ~1 OWL
+    // - The limit price for an order buying WETH and selling DAI would be
+    //   `buy_amount / sell_amount` which sould be around `1 / 200` since you
+    //   would only be able to buy around 1 WETH for 200 DAI
+    // So, by example, the `xrate = sell_price / buy_price`.
+    Some(
+        settlement.solution.prices[sell_token_index] as f64
+            / settlement.solution.prices[buy_token_index] as f64,
+    )
+}
+
+struct Report<T> {
+    output: T,
+    skipped: usize,
+    success: usize,
+    failed: usize,
+}
+
+impl<T> Report<T>
+where
+    T: Write,
+{
+    fn new(mut output: T) -> Result<Self> {
+        write!(&mut output, "")?;
+        Ok(Report {
+            output,
+            skipped: 0,
+            success: 0,
+            failed: 0,
+        })
+    }
+
+    fn unreasonable_order(&mut self, batch: BatchId, order: &Element) -> Result<()> {
+        self.skipped += 1;
+        Ok(())
+    }
+
+    fn overly_pessimistic_estimate(
+        &mut self,
+        batch: BatchId,
+        order: &Element,
+        settled_price: f64,
+    ) -> Result<()> {
+        self.skipped += 1;
+        Ok(())
+    }
+
+    fn no_solution(&mut self, batch: BatchId, order: &Element) -> Result<()> {
+        self.skipped += 1;
+        Ok(())
+    }
+
+    fn fully_matched(&mut self, batch: BatchId, order: &Element, trade: &Trade) -> Result<()> {
+        self.success += 1;
+        Ok(())
+    }
+
+    fn partially_matched(&mut self, batch: BatchId, order: &Element, trade: &Trade) -> Result<()> {
+        self.failed += 1;
+        Ok(())
+    }
+
+    fn disregarded_order(&mut self, batch: BatchId, order: &Element) -> Result<()> {
+        self.skipped += 1;
+        Ok(())
+    }
+
+    fn incorrect_estimate(
+        &mut self,
+        batch: BatchId,
+        order: &Element,
+        settled_price: f64,
+    ) -> Result<()> {
+        self.failed += 1;
+        Ok(())
+    }
+
+    fn not_traded(&mut self, batch: BatchId, order: &Element) -> Result<()> {
+        self.failed += 1;
+        Ok(())
+    }
+
+    fn summary(&mut self) -> Result<()> {
+        Ok(())
+    }
 }

--- a/e2e/src/bin/historic_trades.rs
+++ b/e2e/src/bin/historic_trades.rs
@@ -1,0 +1,92 @@
+use anyhow::Result;
+use core::{history::Settlement, models::BatchId};
+use e2e::cmd;
+use pricegraph::{Element, Pricegraph, TokenPair};
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+const FULLY_FILLED_THREASHOLD: f64 = 0.95;
+
+/// Common options for analyzing historic batch data.
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "historic_trades",
+    about = "Utility for comparing historic trades to price estimates.",
+    rename_all = "kebab"
+)]
+struct Options {
+    /// The events registry file store containing past exchange events.
+    #[structopt(long, env = "ORDERBOOK_FILE", parse(from_os_str))]
+    orderbook_file: PathBuf,
+}
+
+fn main() -> Result<()> {
+    let options = Options::from_args();
+
+    cmd::for_each_batch(&options.orderbook_file, |history, batch| {
+        let auction_elements = history.auction_elements_for_batch(batch)?;
+        let settlement = history.settlement_for_batch(batch);
+
+        let new_orders = auction_elements
+            .iter()
+            .filter_map(|element| {
+                if batch == element.valid.from {
+                    Some(element)
+                } else {
+                    None
+                }
+            })
+            .filter(|order| order.price.numerator != 0 && order.price.denominator != 0)
+            .collect::<Vec<_>>();
+        for order in new_orders {
+            let pricegraph = Pricegraph::new(
+                auction_elements
+                    .iter()
+                    .filter(|element| (element.user, element.id) != (order.user, order.id))
+                    .cloned(),
+            );
+
+            let limit_price = order.price.numerator as f64 / order.price.denominator as f64;
+            let effective_amount =
+                pricegraph::num::u256_to_f64(order.balance).min(order.remaining_sell_amount as _);
+            let estimated_limit_price =
+                pricegraph.estimate_limit_price(order.pair, effective_amount);
+
+            if limit_price > estimated_limit_price.unwrap_or_default() {
+                // NOTE: Unreasonable price on order.
+                continue;
+            }
+
+            match settlement.as_ref().and_then(|settlement| {
+                settlement
+                    .trades
+                    .iter()
+                    .find(|trade| (trade.owner, trade.order_id) == (order.user, order.id))
+            }) {
+                Some(trade) => {
+                    let trade_ratio = trade.executed_sell_amount as f64 / effective_amount;
+                    if trade_ratio > FULLY_FILLED_THREASHOLD {
+                        // NOTE: WOOHOO! Estimate was correct!
+                        continue;
+                    } else {
+                        todo!("report partial trade");
+                    }
+                }
+                None => {
+                    let settled_xrate = settlement.as_ref().and_then(|settlement| {
+
+                    });
+                    if matches!(settled_xrate, Some(xrate) if xrate < 
+                    todo!("report missed trade");
+                }
+            }
+        }
+
+        Ok(())
+    })
+}
+
+enum Trade {
+    FullyMatched,
+    Skipped,
+}

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -15,13 +15,13 @@ pub use self::encoding::*;
 pub use self::orderbook::*;
 
 /// The fee factor that is applied to each order's buy price.
-const FEE_FACTOR: f64 = 1.0 / 0.999;
+pub const FEE_FACTOR: f64 = 1.0 / 0.999;
 
 /// The minimum amount that must be traded for an order to be valid within a
 /// solution. Orders with effective sell amounts smaller than this amount can
 /// safely be ignored, and transitive orders with flows that trade amounts
 /// smaller than this are not considered for price estimates.
-const MIN_AMOUNT: f64 = 10_000.0;
+pub const MIN_AMOUNT: f64 = 10_000.0;
 
 /// API entry point for computing price estimates and transitive orderbooks for
 /// a give auction.


### PR DESCRIPTION
Fixes #1022 

This PR implements historic trade estimates to compute how accurate the price graph is relative to historic batches.

This PR is rather big, I can try and split it into smaller pieces if it becomes too much to review.

### Test Plan

Run the historic trades and see that around 6% of pricegraph estimates are off (This takes a very long time).
```
cargo run --release -p e2e --bin historic_trades -- --orderbook-file target/orderbook-file-mainnet
   Compiling pricegraph v0.1.0 (/var/home/nlordell/Developer/dex-services/pricegraph)
   Compiling core v0.1.0 (/var/home/nlordell/Developer/dex-services/core)
   Compiling e2e v1.0.0 (/var/home/nlordell/Developer/dex-services/e2e)
    Finished release [optimized] target(s) in 30.55s
     Running `target/release/historic_trades --orderbook-file target/orderbook-file-mainnet`
54083 / 54083 [=============================================================] 100.00 % 28.00/s
Processed 87872 orders: 93.03% correct, 2.04% failed, 4.93% skipped.
```
