### PR TITLE
Fix scientific notation in comments and use it where possible

### DIFF
--- a/core/src/price_estimation.rs
+++ b/core/src/price_estimation.rs
@@ -43,13 +43,13 @@ pub trait PriceEstimating {
     /// able to retrieve a price estimate for a given token.
     ///
     /// Prices are in the same format as is expected by the Smart Contract and
-    /// the solver, so the amount of OWL in atoms to purchase 10e18 of the
+    /// the solver, so the amount of OWL in atoms to purchase 1e18 of the
     /// corresponding token.
     fn get_token_prices<'a>(&'a self, orders: &[Order]) -> BoxFuture<'a, Tokens>;
 
     /// Retrieves a price estimate for ETH in OWL atoms. This price is in the
     /// same format as the above method, so the amount of OWL in atoms to
-    /// purchase 1.0 ETH (or 10e18 wei).
+    /// purchase 1.0 ETH (or 1e18 wei).
     #[allow(clippy::needless_lifetimes)]
     fn get_eth_price<'a>(&'a self) -> BoxFuture<'a, Option<u128>>;
 }

--- a/core/src/price_estimation/clients/generic_client.rs
+++ b/core/src/price_estimation/clients/generic_client.rs
@@ -315,9 +315,9 @@ mod tests {
         assert_eq!(
             prices,
             hash_map! {
-                TokenId(1) => nonzero!((0.7 * 10f64.powi(18)) as u128),
-                TokenId(4) => nonzero!((1.2 * 10f64.powi(30)) as u128),
-                TokenId(6) => nonzero!(10u128.pow(18))
+                TokenId(1) => nonzero!(0.7e18 as u128),
+                TokenId(4) => nonzero!(1.2e30 as u128),
+                TokenId(6) => nonzero!(1e18 as u128)
             }
         );
     }
@@ -395,9 +395,9 @@ mod tests {
         assert_eq!(
             prices,
             hash_map! {
-                TokenId(1) => nonzero!(10f64.powi(18) as u128),
-                TokenId(4) => nonzero!(10f64.powi(30) as u128),
-                TokenId(6) => nonzero!(10f64.powi(18) as u128),
+                TokenId(1) => nonzero!(1e18 as u128),
+                TokenId(4) => nonzero!(1e30 as u128),
+                TokenId(6) => nonzero!(1e18 as u128),
             }
         );
     }

--- a/core/src/price_estimation/clients/kraken.rs
+++ b/core/src/price_estimation/clients/kraken.rs
@@ -216,8 +216,8 @@ mod tests {
         assert_eq!(
             prices,
             hash_map! {
-                TokenId(1) => nonzero!((99.0 * 10f64.powi(18)) as u128),
-                TokenId(4) => nonzero!((1.01 * 10f64.powi(30)) as u128),
+                TokenId(1) => nonzero!(99e18 as u128),
+                TokenId(4) => nonzero!(1.01e30 as u128),
             }
         );
     }

--- a/core/src/price_finding/min_avg_fee.rs
+++ b/core/src/price_finding/min_avg_fee.rs
@@ -71,7 +71,7 @@ impl MinAverageFeeComputing for ApproximateMinAverageFee {
 fn compute_min_average_fee(eth_price: f64, gas_price: f64) -> f64 {
     const GAS_PER_ORDER: f64 = 120_000.0;
 
-    let owl_per_eth = eth_price / 10f64.powi(18);
+    let owl_per_eth = eth_price / 1e18;
     let gas_price_in_owl = owl_per_eth * gas_price;
 
     GAS_PER_ORDER * gas_price_in_owl
@@ -128,8 +128,8 @@ mod tests {
 
     #[test]
     fn computes_min_average_fee() {
-        let gas_price = 40.0 * 10.0f64.powi(9);
-        let eth_price = 240.0 * 10.0f64.powi(18);
+        let gas_price = 40e9;
+        let eth_price = 240e18;
 
         assert_approx_eq!(
             compute_min_average_fee(eth_price, gas_price),

--- a/core/src/token_info.rs
+++ b/core/src/token_info.rs
@@ -72,14 +72,10 @@ mod tests {
     #[test]
     fn token_get_price() {
         for (token, usd_price, expected) in &[
-            (TokenBaseInfo::new("USDC", 6), 0.99, 0.99 * 10f64.powi(30)),
-            (TokenBaseInfo::new("DAI", 18), 1.01, 1.01 * 10f64.powi(18)),
-            (TokenBaseInfo::new("FAKE", 32), 1.0, 10f64.powi(4)),
-            (
-                TokenBaseInfo::new("SCAM", 42),
-                10f64.powi(10),
-                10f64.powi(4),
-            ),
+            (TokenBaseInfo::new("USDC", 6), 0.99, 0.99e30),
+            (TokenBaseInfo::new("DAI", 18), 1.01, 1.01e18),
+            (TokenBaseInfo::new("FAKE", 32), 1.0, 1e4),
+            (TokenBaseInfo::new("SCAM", 42), 1e10, 1e4),
         ] {
             let owl_price = token.get_owl_price(*usd_price);
             assert_eq!(owl_price, *expected as u128);

--- a/e2e/tests/stablex_test.rs
+++ b/e2e/tests/stablex_test.rs
@@ -32,7 +32,7 @@ fn test_with_ganache() {
 
     // Using realistic prices helps non naive solvers find a solution in case
     // they filter out orders that are extremely small.
-    let usd_price_in_fee = u128::pow(10, 18);
+    let usd_price_in_fee = 10u128.pow(18);
 
     instance
         .deposit(tokens[0].address(), (3000 * usd_price_in_fee).into())

--- a/pricegraph/benches/pricegraph.rs
+++ b/pricegraph/benches/pricegraph.rs
@@ -26,7 +26,7 @@ pub fn transitive_orderbook(c: &mut Criterion) {
 pub fn estimate_limit_price(c: &mut Criterion) {
     let pricegraph = read_default_pricegraph();
     let dai_weth = TokenPair { buy: 7, sell: 1 };
-    let eth = 10.0f64.powi(18);
+    let eth = 1e18;
     let volumes = &[0.1 * eth, eth, 10.0 * eth, 100.0 * eth, 1000.0 * eth];
 
     let mut group = c.benchmark_group("Pricegraph::estimate_limit_price");

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -100,7 +100,7 @@ mod tests {
         // cargo test -p pricegraph real_orderbooks -- --nocapture
         // ```
 
-        let base_unit = 10.0f64.powi(18);
+        let base_unit = 1e18;
 
         let dai_weth = Market { base: 7, quote: 1 };
         let volume = 1.0 * base_unit;

--- a/pricegraph/wasm/README.md
+++ b/pricegraph/wasm/README.md
@@ -15,7 +15,7 @@ const estimator = new PriceEstimator(encodedOrders);
 const [WETH, DAI] = [1, 7];
 console.log(
     "WETH/DAI price estimate:",
-    estimator.estimatePrice(WETH, DAI, 100 * 10e18),
+    estimator.estimatePrice(WETH, DAI, 100e18),
 );
 esimator.free();
 ```

--- a/pricegraph/wasm/tests/nodejs.rs
+++ b/pricegraph/wasm/tests/nodejs.rs
@@ -22,11 +22,7 @@ fn time<T>(f: impl FnOnce() -> T) -> (T, f64) {
 #[wasm_bindgen_test]
 fn estimate_price() {
     let (estimator, load_time) = time(|| PriceEstimator::new(&*data::DEFAULT_ORDERBOOK).unwrap());
-    let (price, estimate_time) = time(|| {
-        estimator
-            .estimate_price(7, 1, 100.0 * 10.0f64.powi(18))
-            .unwrap()
-    });
+    let (price, estimate_time) = time(|| estimator.estimate_price(7, 1, 100e18).unwrap());
 
     console_log!(
         "DAI-WETH price for selling 100 WETH: 1 WETH = {} DAI (load {}ms, estimate {}ms)",


### PR DESCRIPTION
This PR fixes scientific notation in comments (for example 10e18 is 10 * 10^18, which is not what the comment intended). Also change code to use scientific notation where possible, since `1e18` is much more concise than `10.0f64.powi(18)`.

### Test Plan

No logic change, so Rustc and `cargo test`.