### PR TITLE
Combine gas price cap and min avg fee computation

### DIFF
--- a/core/src/driver/stablex_driver.rs
+++ b/core/src/driver/stablex_driver.rs
@@ -129,7 +129,7 @@ impl<'a> StableXDriverImpl<'a> {
         };
 
         let submitted = if let Some(objective_value) = verified {
-            let fee = solution.burnt_fees();
+            let fee = solution.earned_fee();
             let num_trades = solution.executed_orders.len();
             let gas_price_cap = gas_price_cap(fee, num_trades, self.gas_price_cap_subsidy_factor);
             info!(

--- a/core/src/models/solution.rs
+++ b/core/src/models/solution.rs
@@ -18,6 +18,12 @@ pub struct Solution {
     pub executed_orders: Vec<ExecutedOrder>,
 }
 
+#[derive(Debug, Copy, Clone)]
+pub struct EconomicViabilityInfo {
+    pub num_executed_orders: usize,
+    pub earned_fee: U256,
+}
+
 impl Solution {
     pub fn trivial() -> Self {
         Solution {
@@ -33,7 +39,14 @@ impl Solution {
             .any(|order| order.sell_amount > 0)
     }
 
-    pub fn burnt_fees(&self) -> U256 {
+    pub fn economic_viability_info(&self) -> EconomicViabilityInfo {
+        EconomicViabilityInfo {
+            num_executed_orders: self.executed_orders.len(),
+            earned_fee: self.earned_fee(),
+        }
+    }
+
+    pub fn earned_fee(&self) -> U256 {
         // We expect that only the fee token has an imbalance so by calculating the total imbalance
         // this must be equal to the fee token imbalance. This allows us to calculate the burnt fees
         // without accessing the orderbook solely based on the solution.
@@ -108,7 +121,7 @@ pub mod tests {
     }
 
     #[test]
-    fn burnt_fees_is_half_total_token_imbalance() {
+    fn earned_fee_is_half_total_token_imbalance() {
         let solution = Solution {
             prices: HashMap::new(),
             executed_orders: vec![
@@ -132,6 +145,6 @@ pub mod tests {
                 },
             ],
         };
-        assert_eq!(solution.burnt_fees(), U256::from(2));
+        assert_eq!(solution.earned_fee(), U256::from(2));
     }
 }

--- a/core/src/price_finding.rs
+++ b/core/src/price_finding.rs
@@ -4,7 +4,7 @@ pub mod optimization_price_finder;
 pub mod price_finder_interface;
 
 pub use self::{
-    min_avg_fee::MinAverageFeeComputing,
+    min_avg_fee::EconomicViabilityComputing,
     naive_solver::NaiveSolver,
     optimization_price_finder::OptimisationPriceFinder,
     price_finder_interface::{Fee, InternalOptimizer, PriceFinding, SolverType},
@@ -17,7 +17,7 @@ pub fn create_price_finder(
     fee: Option<Fee>,
     solver_type: SolverType,
     price_oracle: Arc<dyn PriceEstimating + Send + Sync>,
-    min_avg_fee: Arc<dyn MinAverageFeeComputing>,
+    min_avg_fee: Arc<dyn EconomicViabilityComputing>,
     internal_optimizer: InternalOptimizer,
 ) -> Box<dyn PriceFinding + Sync> {
     if solver_type == SolverType::NaiveSolver {

--- a/core/src/price_finding/min_avg_fee.rs
+++ b/core/src/price_finding/min_avg_fee.rs
@@ -1,64 +1,94 @@
 //! Module implementing minimum average fee computation based on reference token
 //! price estimates.
 
-use crate::{gas_station::GasPriceEstimating, price_estimation::PriceEstimating};
+use crate::{
+    gas_station::GasPriceEstimating, models::solution::EconomicViabilityInfo,
+    price_estimation::PriceEstimating,
+};
 use anyhow::{anyhow, Result};
+use ethcontract::U256;
 use futures::future::{BoxFuture, FutureExt as _};
 use std::sync::Arc;
 
-/// Trait that abstracts the minimum average fee computation.
+/// The approximate amount of gas used in a solution per trade. In practice the value depends on how
+/// much gas is used in the reversion of the previous solution.
+const GAS_PER_TRADE: f64 = 120_000.0;
+
 #[cfg_attr(test, mockall::automock)]
-pub trait MinAverageFeeComputing: Send + Sync + 'static {
-    /// Retrieves the current minimum average fee.
-    fn current<'a>(&'a self) -> BoxFuture<'a, Result<u128>>;
+pub trait EconomicViabilityComputing: Send + Sync + 'static {
+    /// Used by the solver so that it only considers solution that are economically viable.
+    fn min_average_fee<'a>(&'a self) -> BoxFuture<'a, Result<u128>>;
+    /// The maximum gas price at which submitting the solution is still economically viable.
+    fn max_gas_price<'a>(
+        &'a self,
+        economic_viability_info: EconomicViabilityInfo,
+    ) -> BoxFuture<'a, Result<U256>>;
 }
 
-/// Implementation for computing the minumum average fee based on an approximate
-/// gas amount per touched order, current gas price estimates and and ETH price
-/// estimates.
-pub struct ApproximateMinAverageFee {
+/// Economic viability constraints based on the current gas and eth price.
+pub struct EconomicViabilityComputer {
     price_oracle: Arc<dyn PriceEstimating + Send + Sync>,
     gas_station: Arc<dyn GasPriceEstimating + Send + Sync>,
     subsidy_factor: f64,
 }
 
-impl ApproximateMinAverageFee {
+impl EconomicViabilityComputer {
     pub fn new(
         price_oracle: Arc<dyn PriceEstimating + Send + Sync>,
         gas_station: Arc<dyn GasPriceEstimating + Send + Sync>,
         subsidy_factor: f64,
     ) -> Self {
-        ApproximateMinAverageFee {
+        EconomicViabilityComputer {
             price_oracle,
             gas_station,
             subsidy_factor,
         }
     }
+
+    async fn eth_price_in_owl(&self) -> Result<f64> {
+        self.price_oracle
+            .get_eth_price()
+            .await
+            .map(|price| price as f64)
+            .ok_or_else(|| anyhow!("failed to find ETH price estimate"))
+    }
+
+    async fn gas_price(&self) -> Result<f64> {
+        let fast = self.gas_station.estimate_gas_price().await?.fast;
+        Ok(pricegraph::num::u256_to_f64(fast))
+    }
 }
 
-impl MinAverageFeeComputing for ApproximateMinAverageFee {
-    fn current(&self) -> BoxFuture<'_, Result<u128>> {
+impl EconomicViabilityComputing for EconomicViabilityComputer {
+    fn min_average_fee(&self) -> BoxFuture<'_, Result<u128>> {
         async move {
-            let eth_price_in_owl = self
-                .price_oracle
-                .get_eth_price()
-                .await
-                .ok_or_else(|| anyhow!("failed to find ETH price estimate"))?;
+            let eth_price = self.eth_price_in_owl().await?;
+            let gas_price = self.gas_price().await?;
 
-            let fast_gas_price = self.gas_station.estimate_gas_price().await?.fast;
-
-            let fee = compute_min_average_fee(
-                eth_price_in_owl as _,
-                pricegraph::num::u256_to_f64(fast_gas_price),
-            );
-            let subsidized_fee = fee / self.subsidy_factor;
+            let fee = min_average_fee(eth_price, gas_price);
+            let subsidized = fee / self.subsidy_factor;
             log::debug!(
                 "computed min average fee to be {}, subsidized to {}",
                 fee,
-                subsidized_fee,
+                subsidized,
             );
 
-            Ok(subsidized_fee as _)
+            Ok(subsidized as _)
+        }
+        .boxed()
+    }
+
+    fn max_gas_price<'a>(
+        &'a self,
+        economic_viability_info: EconomicViabilityInfo,
+    ) -> BoxFuture<'a, Result<U256>> {
+        async move {
+            let earned_fee = pricegraph::num::u256_to_f64(economic_viability_info.earned_fee);
+            let num_trades = economic_viability_info.num_executed_orders;
+            let eth_price = self.eth_price_in_owl().await?;
+            let cap = gas_price_cap(eth_price, earned_fee, num_trades);
+            let subsidized = cap * self.subsidy_factor;
+            Ok(U256::from(subsidized as u128))
         }
         .boxed()
     }
@@ -68,51 +98,86 @@ impl MinAverageFeeComputing for ApproximateMinAverageFee {
 /// reference token and a gas price estimate. Returns the minimum average fee
 /// in reference token that must be accumulated per order in order for a
 /// solution to be economically viable.
-fn compute_min_average_fee(eth_price: f64, gas_price: f64) -> f64 {
-    const GAS_PER_ORDER: f64 = 120_000.0;
-
+fn min_average_fee(eth_price: f64, gas_price: f64) -> f64 {
     let owl_per_eth = eth_price / 1e18;
     let gas_price_in_owl = owl_per_eth * gas_price;
-
-    GAS_PER_ORDER * gas_price_in_owl
+    GAS_PER_TRADE * gas_price_in_owl
 }
 
-/// Fixed minimum average fee.
-pub struct FixedMinAverageFee(pub u128);
+/// The gas price cap is selected so that submitting solution is still roughly profitable.
+fn gas_price_cap(eth_price: f64, earned_fee: f64, num_trades: usize) -> f64 {
+    let owl_per_eth = eth_price / 1e18;
+    let gas_use = GAS_PER_TRADE * (num_trades as f64);
+    earned_fee / (owl_per_eth * gas_use)
+}
 
-impl MinAverageFeeComputing for FixedMinAverageFee {
-    fn current(&self) -> BoxFuture<'_, Result<u128>> {
-        immediate!(Ok(self.0))
+/// Fixed values.
+pub struct FixedEconomicViabilityComputer {
+    min_average_fee: Option<u128>,
+    max_gas_price: Option<U256>,
+}
+
+impl FixedEconomicViabilityComputer {
+    pub fn new(min_average_fee: Option<u128>, max_gas_price: Option<U256>) -> Self {
+        Self {
+            min_average_fee,
+            max_gas_price,
+        }
     }
 }
 
-/// Priority minimum average fee computing that takes the first successfully
-/// computed minimum average fee.
-pub struct PriorityMinAverageFee(Vec<Box<dyn MinAverageFeeComputing>>);
+impl EconomicViabilityComputing for FixedEconomicViabilityComputer {
+    fn min_average_fee(&self) -> BoxFuture<'_, Result<u128>> {
+        immediate!(self
+            .min_average_fee
+            .ok_or_else(|| anyhow!("no min average fee set")))
+    }
 
-impl PriorityMinAverageFee {
+    fn max_gas_price<'a>(&'a self, _: EconomicViabilityInfo) -> BoxFuture<'a, Result<U256>> {
+        immediate!(self
+            .max_gas_price
+            .ok_or_else(|| anyhow!("no max gas price set")))
+    }
+}
+
+/// Takes the first successful inner computer.
+pub struct PriorityEconomicViabilityComputer(Vec<Box<dyn EconomicViabilityComputing>>);
+
+impl PriorityEconomicViabilityComputer {
     /// Creates a new priority minimum average fee computing from the specified
     /// implementations.
-    pub fn new(inner: Vec<Box<dyn MinAverageFeeComputing>>) -> Self {
-        PriorityMinAverageFee(inner)
+    pub fn new(inner: Vec<Box<dyn EconomicViabilityComputing>>) -> Self {
+        PriorityEconomicViabilityComputer(inner)
+    }
+
+    async fn until_success<T>(
+        &self,
+        mut operation: impl FnMut(&dyn EconomicViabilityComputing) -> BoxFuture<Result<T>>,
+    ) -> Result<T> {
+        for inner in self.0.iter() {
+            match operation(inner.as_ref()).await {
+                Ok(value) => return Ok(value),
+                Err(err) => log::warn!("failed operation: {:?}", err),
+            }
+        }
+        Err(anyhow!(
+            "failed operation with all internal implementations"
+        ))
     }
 }
 
-impl MinAverageFeeComputing for PriorityMinAverageFee {
-    fn current(&self) -> BoxFuture<'_, Result<u128>> {
-        async move {
-            for inner in self.0.iter() {
-                match inner.current().await {
-                    Ok(value) => return Ok(value),
-                    Err(err) => log::warn!("failed to compute minimum average fee: {:?}", err),
-                }
-            }
+impl EconomicViabilityComputing for PriorityEconomicViabilityComputer {
+    fn min_average_fee(&self) -> BoxFuture<'_, Result<u128>> {
+        self.until_success(EconomicViabilityComputing::min_average_fee)
+            .boxed()
+    }
 
-            Err(anyhow!(
-                "failure computing minimum average fee with all internal implementations"
-            ))
-        }
-        .boxed()
+    fn max_gas_price<'a>(
+        &'a self,
+        economic_viability_info: EconomicViabilityInfo,
+    ) -> BoxFuture<'a, Result<U256>> {
+        self.until_success(move |computer| computer.max_gas_price(economic_viability_info))
+            .boxed()
     }
 }
 
@@ -130,11 +195,13 @@ mod tests {
     fn computes_min_average_fee() {
         let gas_price = 40e9;
         let eth_price = 240e18;
+        assert_approx_eq!(min_average_fee(eth_price, gas_price), 1152e15);
+    }
 
-        assert_approx_eq!(
-            compute_min_average_fee(eth_price, gas_price),
-            1_152_000_000_000_000_000.0
-        );
+    #[test]
+    fn computes_gas_price_cap() {
+        // 50 owl fee, ~600 gwei gas price cap
+        assert_approx_eq!(gas_price_cap(240e18, 50e18, 3), 578703703703.7037);
     }
 
     #[test]
@@ -142,38 +209,47 @@ mod tests {
         let mut price_oracle = MockPriceEstimating::new();
         price_oracle
             .expect_get_eth_price()
-            .returning(|| immediate!(Some(240 * 10u128.pow(18))));
+            .returning(|| immediate!(Some(240e18 as u128)));
 
         let mut gas_station = MockGasPriceEstimating::new();
         gas_station.expect_estimate_gas_price().returning(|| {
             immediate!(Ok(GasPrice {
-                fast: (40 * 10u128.pow(9)).into(),
+                fast: (40e9 as u128).into(),
                 ..Default::default()
             }))
         });
+        let economic_viability =
+            EconomicViabilityComputer::new(Arc::new(price_oracle), Arc::new(gas_station), 10.0);
 
-        let min_avg_fee =
-            ApproximateMinAverageFee::new(Arc::new(price_oracle), Arc::new(gas_station), 10.0);
         assert_eq!(
-            min_avg_fee.current().wait().unwrap(),
-            115_200_000_000_000_000, // 0.1152 OWL
+            economic_viability.min_average_fee().wait().unwrap(),
+            1152e14 as u128, // 0.1152 OWL
+        );
+
+        let info = EconomicViabilityInfo {
+            num_executed_orders: 3,
+            earned_fee: U256::from(50e18 as u128),
+        };
+        assert_eq!(
+            economic_viability.max_gas_price(info).wait().unwrap(),
+            U256::from(5787037037037u128)
         );
     }
 
     #[test]
     fn priority_impl_takes_first_success() {
-        let priority_min_avg_fee = PriorityMinAverageFee::new(
+        let priority_min_avg_fee = PriorityEconomicViabilityComputer::new(
             vec![Err(anyhow!("some error")), Ok(42), Ok(1337)]
                 .into_iter()
-                .map(|result| -> Box<dyn MinAverageFeeComputing> {
-                    let mut mock = MockMinAverageFeeComputing::new();
-                    mock.expect_current()
+                .map(|result| -> Box<dyn EconomicViabilityComputing> {
+                    let mut mock = MockEconomicViabilityComputing::new();
+                    mock.expect_min_average_fee()
                         .return_once(move || immediate!(result));
                     Box::new(mock)
                 })
                 .collect(),
         );
 
-        assert_eq!(priority_min_avg_fee.current().wait().unwrap(), 42);
+        assert_eq!(priority_min_avg_fee.min_average_fee().wait().unwrap(), 42);
     }
 }

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -14,7 +14,10 @@ use core::orderbook::{
 use core::price_estimation::PriceOracle;
 use core::price_finding::{
     self,
-    min_avg_fee::{ApproximateMinAverageFee, FixedMinAverageFee, PriorityMinAverageFee},
+    min_avg_fee::{
+        EconomicViabilityComputer, FixedEconomicViabilityComputer,
+        PriorityEconomicViabilityComputer,
+    },
     Fee, InternalOptimizer, SolverType,
 };
 use core::solution_submission::StableXSolutionSubmitter;
@@ -264,13 +267,16 @@ fn main() {
         .unwrap(),
     );
 
-    let min_avg_fee = Arc::new(PriorityMinAverageFee::new(vec![
-        Box::new(ApproximateMinAverageFee::new(
+    let min_avg_fee = Arc::new(PriorityEconomicViabilityComputer::new(vec![
+        Box::new(EconomicViabilityComputer::new(
             price_oracle.clone(),
             gas_station.clone(),
             options.economic_viability_subsidy_factor,
         )),
-        Box::new(FixedMinAverageFee(options.default_min_avg_fee_per_order)),
+        Box::new(FixedEconomicViabilityComputer::new(
+            Some(options.default_min_avg_fee_per_order),
+            None,
+        )),
     ]));
 
     // Setup price.


### PR DESCRIPTION
In the next PR the file will be moved and stablex_driver will make use
of it to calculate the max gas price.

### Test Plan
CI, adapted old unit tests and added new.