### PR TITLE
Parallelize batch processing in E2E scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,10 +746,12 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "core",
+ "crossbeam",
  "ethcontract",
  "futures 0.3.5",
  "pbr",
  "pricegraph",
+ "rayon",
  "structopt",
 ]
 

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2018"
 [dependencies]
 anyhow = "1"
 core = { path = "../core" }
+crossbeam = "0.7"
 ethcontract = "0.7.2"
 futures = { version = "0.3.5", features = ["compat"] }
 pbr = "1.0.3"
 pricegraph = { path = "../pricegraph" }
+rayon = "1.3"
 structopt = "0.3.15"

--- a/e2e/src/bin/historic_prices.rs
+++ b/e2e/src/bin/historic_prices.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use core::{history::Settlement, models::BatchId};
-use e2e::cmd;
+use e2e::cmd::{self, Reporting, Sampler};
 use pricegraph::{Element, Pricegraph, TokenId};
 use std::{fs::File, io::Write, path::PathBuf};
 use structopt::StructOpt;
@@ -30,30 +30,31 @@ fn main() -> Result<()> {
     let mut report = Report::new(File::create(&options.output_dir.join("prices.csv"))?);
 
     report.header()?;
-    cmd::for_each_batch(&options.orderbook_file, |history, batch| {
-        let settlement = match history.settlement_for_batch(batch) {
-            Some(value) => value,
-            None => return Ok(()),
-        };
+    cmd::for_each_batch(
+        &options.orderbook_file,
+        report,
+        move |sampler, history, batch| {
+            let settlement = match history.settlement_for_batch(batch) {
+                Some(value) => value,
+                None => return Ok(()),
+            };
 
-        let auction_elements = history.auction_elements_for_batch(batch)?;
-        check_batch_prices(&mut report, batch, &auction_elements, &settlement)?;
+            let auction_elements = history.auction_elements_for_batch(batch)?;
+            check_batch_prices(&sampler, batch, &auction_elements, &settlement)?;
 
-        Ok(())
-    })?;
+            Ok(())
+        },
+    )?;
 
-    report.summary()
+    Ok(())
 }
 
-fn check_batch_prices<T>(
-    report: &mut Report<T>,
+fn check_batch_prices(
+    sampler: &Sampler<Row>,
     batch: BatchId,
     auction_elements: &[Element],
     settlement: &Settlement,
-) -> Result<()>
-where
-    T: Write,
-{
+) -> Result<()> {
     let token_ids = &settlement.solution.token_ids_for_price;
     let prices = &settlement.solution.prices;
     debug_assert_eq!(
@@ -72,10 +73,22 @@ where
         let price = prices[token_index];
         let estimate = pricegraph.estimate_token_price(token).unwrap_or(0.0) as u128;
 
-        report.row(batch, token, price, estimate)?;
+        sampler.sample(Row {
+            batch,
+            token,
+            price,
+            estimate,
+        })?;
     }
 
     Ok(())
+}
+
+struct Row {
+    batch: BatchId,
+    token: TokenId,
+    price: u128,
+    estimate: u128,
 }
 
 struct Report<T> {
@@ -102,8 +115,24 @@ where
         writeln!(&mut self.output, "batch,token,price,estimate,error")?;
         Ok(())
     }
+}
 
-    fn row(&mut self, batch: BatchId, token: TokenId, price: u128, estimate: u128) -> Result<()> {
+impl<T> Reporting for Report<T>
+where
+    T: Write,
+{
+    type Sample = Row;
+    type Summary = ();
+
+    fn sample(
+        &mut self,
+        Row {
+            batch,
+            token,
+            price,
+            estimate,
+        }: Row,
+    ) -> Result<()> {
         let error = (estimate as f64 - price as f64).abs() / price as f64;
         writeln!(
             &mut self.output,
@@ -118,7 +147,7 @@ where
         Ok(())
     }
 
-    fn summary(&self) -> Result<()> {
+    fn finalize(self) -> Result<()> {
         println!(
             "Processed {} token prices: bad estimates {:.2}%, average error {:.2}%.",
             self.samples,

--- a/e2e/src/bin/historic_prices.rs
+++ b/e2e/src/bin/historic_prices.rs
@@ -73,7 +73,7 @@ fn check_batch_prices(
         let price = prices[token_index];
         let estimate = pricegraph.estimate_token_price(token).unwrap_or(0.0) as u128;
 
-        sampler.sample(Row {
+        sampler.record_sample(Row {
             batch,
             token,
             price,
@@ -124,7 +124,7 @@ where
     type Sample = Row;
     type Summary = ();
 
-    fn sample(
+    fn record_sample(
         &mut self,
         Row {
             batch,

--- a/e2e/src/bin/historic_trades.rs
+++ b/e2e/src/bin/historic_trades.rs
@@ -34,7 +34,7 @@ fn main() -> Result<()> {
     let mut report = Report::new(File::create(options.output_dir.join("trades.csv"))?);
     report.header()?;
 
-    cmd::for_each_batch(&options.orderbook_file, |history, batch| {
+    cmd::for_each_batch_sync(&options.orderbook_file, |history, batch| {
         let auction_elements = history.auction_elements_for_batch(batch)?;
         let settlement = history.settlement_for_batch(batch);
 

--- a/e2e/src/cmd.rs
+++ b/e2e/src/cmd.rs
@@ -1,12 +1,14 @@
 //! Module containing command line helpers for e2e scripts.
 
-use anyhow::Result;
+use anyhow::{Error, Result};
 use core::{history::ExchangeHistory, models::BatchId};
+use crossbeam::thread;
 use pbr::ProgressBar;
-use std::{io, path::Path};
+use rayon::prelude::*;
+use std::{io, path::Path, sync::mpsc};
 
-/// Runs a closure for each batch for the specified event history.
-pub fn for_each_batch(
+/// DEPRECATED: Runs a closure for each batch for the specified event history.
+pub fn for_each_batch_sync(
     orderbook_file: impl AsRef<Path>,
     mut f: impl FnMut(&ExchangeHistory, BatchId) -> Result<()>,
 ) -> Result<()> {
@@ -21,4 +23,102 @@ pub fn for_each_batch(
     }
 
     Ok(())
+}
+
+/// Runs a closure for each batch for the specified event history.
+pub fn for_each_batch<R, F>(
+    orderbook_file: impl AsRef<Path>,
+    mut report: R,
+    handler: F,
+) -> Result<R::Summary>
+where
+    R: Reporting,
+    F: Fn(&Sampler<R::Sample>, &ExchangeHistory, BatchId) -> Result<()> + Send + Sync,
+{
+    let history = ExchangeHistory::from_filestore(orderbook_file)?;
+
+    let batches = history.batches_until_now();
+    let mut progress = ProgressBar::on(io::stderr(), batches.batch_count());
+
+    let (samples_tx, samples_rx) = mpsc::channel();
+    let sampler = Sampler(samples_tx);
+
+    thread::scope(|scope| {
+        scope.spawn(move |_| {
+            if let Err(err) = batches
+                .collect::<Vec<_>>()
+                .into_par_iter()
+                .try_for_each_with(sampler.clone(), move |sampler, batch| {
+                    handler(&sampler, &history, batch)?;
+                    sampler.batch_complete()
+                })
+            {
+                sampler.error(err);
+            }
+        });
+
+        while let Ok(result) = samples_rx.recv() {
+            match result? {
+                Some(sample) => report.sample(sample)?,
+                None => {
+                    progress.inc();
+                }
+            }
+        }
+
+        report.finalize()
+    })
+    .expect("inner thread panicked when processing batches")
+}
+
+/// A struct used for providing samples to the reporter.
+#[derive(Debug)]
+pub struct Sampler<T>(mpsc::Sender<Result<Option<T>>>);
+
+// NOTE: Manually implement clone, the derive unecessarily adds a `T: Clone`
+// type bound.
+impl<T> Clone for Sampler<T> {
+    fn clone(&self) -> Self {
+        Sampler(self.0.clone())
+    }
+}
+
+impl<T> Sampler<T> {
+    /// Sends a sample to the recording instance.
+    pub fn sample(&self, sample: T) -> Result<()> {
+        self.send(Some(sample))
+    }
+
+    /// Reports a batch was completed to increment the progress indicator.
+    fn batch_complete(&self) -> Result<()> {
+        self.send(None)
+    }
+
+    fn send(&self, value: Option<T>) -> Result<()> {
+        // NOTE: Get rid of the `T` value since we don't care about recovering
+        // it and allows us to remove the `T: Send + Sync + 'static` bounds.
+        self.0.send(Ok(value)).map_err(|_| mpsc::SendError(()))?;
+        Ok(())
+    }
+
+    /// Reports an error to the progress collecting thread.
+    fn error(&self, err: Error) {
+        // NOTE: If the channel is already closed, then we don't care about
+        // propagating the error.
+        let _ = self.0.send(Err(err));
+    }
+}
+
+/// A trait for reporting samples collected from each batch run.
+pub trait Reporting {
+    /// The sample type.
+    type Sample: Send;
+    /// The summary type.
+    type Summary;
+
+    /// Record a sample.
+    fn sample(&mut self, sample: Self::Sample) -> Result<()>;
+
+    /// Finilize the recording of samples.
+    fn finalize(self) -> Result<Self::Summary>;
 }

--- a/e2e/src/cmd.rs
+++ b/e2e/src/cmd.rs
@@ -59,7 +59,7 @@ where
 
         while let Ok(result) = samples_rx.recv() {
             match result? {
-                Some(sample) => report.sample(sample)?,
+                Some(sample) => report.record_sample(sample)?,
                 None => {
                     progress.inc();
                 }
@@ -85,7 +85,7 @@ impl<T> Clone for Sampler<T> {
 
 impl<T> Sampler<T> {
     /// Sends a sample to the recording instance.
-    pub fn sample(&self, sample: T) -> Result<()> {
+    pub fn record_sample(&self, sample: T) -> Result<()> {
         self.send(Some(sample))
     }
 
@@ -117,7 +117,7 @@ pub trait Reporting {
     type Summary;
 
     /// Record a sample.
-    fn sample(&mut self, sample: Self::Sample) -> Result<()>;
+    fn record_sample(&mut self, sample: Self::Sample) -> Result<()>;
 
     /// Finilize the recording of samples.
     fn finalize(self) -> Result<Self::Summary>;


### PR DESCRIPTION
This PR uses the `rayon` library to parallelize processing each batch to speed things up. This takes advantage of the fact that the auction state and `pricegraph` can be computed "on-the fly" from an immutable event collection in order to take full advantage of all CPU cores :rocket: 

Additionally, the nasty threading bits and dealing with synchronization has been abstracted behind a `Reporting` trait to make things easier and reduce boiler plate.

:warning: There is one disadvantage in that the output is **no longer in order**. I don't think that is a huge issue, since the data can be ordered when it is being processed and analyzed.

### Test Plan

Before `233.85s` :turtle: 
```
$ time -p target/release/historic_prices --orderbook-file target/orderbook.mainnet.bin
54678 / 54678 [==============================================] 100.00 % 230.39/s
Processed 13743 token prices: bad estimates 45.19%, average error 27643.61%.
real 237.53
user 233.85
sys 2.78
```

After `53.27s` :rocket: 
```
$ time -p target/release/historic_prices --orderbook-file target/orderbook.mainnet.bin
54678 / 54678 [=============================================] 100.00 % 1033.13/s
Processed 13743 token prices: bad estimates 45.22%, average error 27938.76%.
real 53.27
user 397.93
sys 2.05
```

A 4.5x increase on an 8-core machine. Notice how the `user` time is almost double. We are losing a lot of time dealing with thread synchronization, and might be able to speed it up even a bit more.