### PR TITLE
parallelize historic trades script

### DIFF
--- a/e2e/src/bin/historic_trades.rs
+++ b/e2e/src/bin/historic_trades.rs
@@ -3,7 +3,7 @@ use core::{
     contracts::stablex_contract::batch_exchange::event_data::Trade, history::Settlement,
     models::BatchId,
 };
-use e2e::cmd;
+use e2e::cmd::{self, Reporting};
 use pricegraph::{Element, Pricegraph, TokenPair, FEE_FACTOR, U256};
 use std::{fs::File, io::Write, path::PathBuf};
 use structopt::StructOpt;
@@ -34,38 +34,46 @@ fn main() -> Result<()> {
     let mut report = Report::new(File::create(options.output_dir.join("trades.csv"))?);
     report.header()?;
 
-    cmd::for_each_batch_sync(&options.orderbook_file, |history, batch| {
-        let auction_elements = history.auction_elements_for_batch(batch)?;
-        let settlement = history.settlement_for_batch(batch);
+    cmd::for_each_batch(
+        &options.orderbook_file,
+        report,
+        |sampler, history, batch| {
+            let auction_elements = history.auction_elements_for_batch(batch)?;
+            let settlement = history.settlement_for_batch(batch);
 
-        let new_orders = auction_elements
-            .iter()
-            .filter(|order| batch == order.valid.from)
-            .filter(|order| order.price.numerator != 0 && order.price.denominator > MIN_AMOUNT)
-            .filter(|order| order.balance > U256::from(MIN_AMOUNT));
-        for order in new_orders {
-            let settlement = settlement.as_ref();
-            let pricegraph = Pricegraph::new(
-                auction_elements
-                    .iter()
-                    .filter(|element| (element.user, element.id) != (order.user, order.id))
-                    .cloned(),
-            );
+            let new_orders = auction_elements
+                .iter()
+                .filter(|order| batch == order.valid.from)
+                .filter(|order| order.price.numerator != 0 && order.price.denominator > MIN_AMOUNT)
+                .filter(|order| order.balance > U256::from(MIN_AMOUNT));
+            for order in new_orders {
+                let settlement = settlement.as_ref();
+                let pricegraph = Pricegraph::new(
+                    auction_elements
+                        .iter()
+                        .filter(|element| (element.user, element.id) != (order.user, order.id))
+                        .cloned(),
+                );
 
-            let meta = OrderMetadata::compute(settlement, order, &pricegraph);
-            let result = if meta.is_reasonably_priced_order() {
-                process_reasonable_order(&meta)
-            } else {
-                process_unreasonable_order(&meta)
-            };
+                let meta = OrderMetadata::compute(settlement, order, &pricegraph);
+                let result = if meta.is_reasonably_priced_order() {
+                    process_reasonable_order(&meta)
+                } else {
+                    process_unreasonable_order(&meta)
+                };
 
-            report.record_result(batch, settlement, order, &meta, result)?;
-        }
+                sampler.sample(Sample {
+                    batch,
+                    solved: settlement.is_some(),
+                    order_uid: format!("{}-{}", order.user, order.id),
+                    meta,
+                    result,
+                })?;
+            }
 
-        Ok(())
-    })?;
-
-    report.summary()
+            Ok(())
+        },
+    )
 }
 
 fn process_reasonable_order(meta: &OrderMetadata) -> TradeResult {
@@ -234,6 +242,14 @@ enum TradeResult {
     NotTraded,
 }
 
+struct Sample {
+    batch: BatchId,
+    solved: bool,
+    order_uid: String,
+    meta: OrderMetadata,
+    result: TradeResult,
+}
+
 struct Report<T> {
     output: T,
     skipped: usize,
@@ -257,8 +273,8 @@ where
     fn header(&mut self) -> Result<()> {
         let rows = [
             "batch",
-            "order",
             "solved",
+            "order",
             "sellAmount",
             "limitPrice",
             "estimatedXrate",
@@ -268,32 +284,30 @@ where
         writeln!(&mut self.output, "{}", rows.join(","))?;
         Ok(())
     }
+}
 
-    fn record_result(
-        &mut self,
-        batch: BatchId,
-        settlement: Option<&Settlement>,
-        order: &Element,
-        meta: &OrderMetadata,
-        result: TradeResult,
-    ) -> Result<()> {
-        let order_uid = format!("{}-{}", order.user, order.id);
-        let solved = settlement.is_some();
+impl<T> Reporting for Report<T>
+where
+    T: Write,
+{
+    type Sample = Sample;
+    type Summary = ();
 
+    fn sample(&mut self, sample: Sample) -> Result<()> {
         writeln!(
             &mut self.output,
             "{},{},{},{},{},{},{},{}",
-            batch,
-            order_uid,
-            solved,
-            meta.effective_sell_amount,
-            meta.limit_price,
-            meta.estimated_limit_price.unwrap_or_default(),
-            meta.settled_xrate.unwrap_or_default(),
-            meta.fill_ratio().unwrap_or_default(),
+            sample.batch,
+            sample.solved,
+            sample.order_uid,
+            sample.meta.effective_sell_amount,
+            sample.meta.limit_price,
+            sample.meta.estimated_limit_price.unwrap_or_default(),
+            sample.meta.settled_xrate.unwrap_or_default(),
+            sample.meta.fill_ratio().unwrap_or_default(),
         )?;
 
-        match result {
+        match sample.result {
             TradeResult::FullyMatched | TradeResult::UnreasonableOrderNotMatched => {
                 self.success += 1
             }
@@ -309,7 +323,7 @@ where
         Ok(())
     }
 
-    fn summary(&mut self) -> Result<()> {
+    fn finalize(self) -> Result<()> {
         let total = self.success + self.skipped + self.failed;
         let percent = |value: usize| 100.0 * value as f64 / total as f64;
         println!(

--- a/e2e/src/cmd.rs
+++ b/e2e/src/cmd.rs
@@ -7,24 +7,6 @@ use pbr::ProgressBar;
 use rayon::prelude::*;
 use std::{io, path::Path, sync::mpsc};
 
-/// DEPRECATED: Runs a closure for each batch for the specified event history.
-pub fn for_each_batch_sync(
-    orderbook_file: impl AsRef<Path>,
-    mut f: impl FnMut(&ExchangeHistory, BatchId) -> Result<()>,
-) -> Result<()> {
-    let history = ExchangeHistory::from_filestore(orderbook_file)?;
-
-    let batches = history.batches_until_now();
-    let mut progress = ProgressBar::on(io::stderr(), batches.batch_count());
-
-    for batch in batches {
-        progress.inc();
-        f(&history, batch)?;
-    }
-
-    Ok(())
-}
-
 /// Runs a closure for each batch for the specified event history.
 pub fn for_each_batch<R, F>(
     orderbook_file: impl AsRef<Path>,


### PR DESCRIPTION
This PR is a followup to #1229 where the `historic_trades` script is also parallelized.

### Test Plan

Before :turtle: `33.93 min`
```
$ time -p target/release/historic_trades --orderbook-file target/orderbook.mainnet.bin  
55415 / 55415 [=============================================] 100.00 % 27.23/s
Processed 88306 orders: 92.99% correct, 2.10% failed, 4.91% skipped.
real 2035.79
user 2012.65
sys 18.42
```

After :rabbit2: `8.48 min`
```
$ time -p target/release/historic_trades --orderbook-file target/orderbook.mainnet.bin
55422 / 55422 [============================================] 100.00 % 109.16/s
Processed 88306 orders: 92.98% correct, 2.10% failed, 4.92% skipped.
real 508.52
user 3951.13
sys 10.13
```