### PR TITLE
Add benchmarking section to price estimator README

### DIFF
--- a/price-estimator/README.md
+++ b/price-estimator/README.md
@@ -110,3 +110,26 @@ It is useful to start the price estimator with logging enabled, using the gnosis
 ```
 env RUST_LOG=warn,price_estimator=info,core=info cargo run -p price-estimator -- --node-url https://staging-openethereum.mainnet.gnosisdev.com --orderbook-file ../orderbook-file-mainnet
 ```
+
+## Benchmarking
+
+Benchmarking can be performed with your HTTP request benchmarking application of choice. For example using `autocannon` with `npx`:
+```
+$ cargo run -p price-estimator &
+$ npx autocannon -c 1000 -d 300 'http://localhost:8080/api/v1/markets/1-7/estimated-buy-amount/1000000000000000000?atoms=true'
+Running 300s test @ http://localhost:8080/api/v1/markets/1-7/estimated-buy-amount/100000000000000000000?atoms=true
+1000 connections
+
+┌─────────┬──────┬───────┬────────┬────────┬───────┬──────────┬────────────┐
+│ Stat    │ 2.5% │ 50%   │ 97.5%  │ 99%    │ Avg   │ Stdev    │ Max        │
+├─────────┼──────┼───────┼────────┼────────┼───────┼──────────┼────────────┤
+│ Latency │ 3 ms │ 40 ms │ 163 ms │ 200 ms │ 51 ms │ 42.88 ms │ 1248.19 ms │
+└─────────┴──────┴───────┴────────┴────────┴───────┴──────────┴────────────┘
+┌───────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬────────┐
+│ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg     │ Stdev   │ Min    │
+├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼────────┤
+│ Req/Sec   │ 10695   │ 11375   │ 20943   │ 23311   │ 19420.7 │ 3485.85 │ 10442  │
+├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼────────┤
+│ Bytes/Sec │ 2.46 MB │ 2.62 MB │ 4.82 MB │ 5.36 MB │ 4.47 MB │ 802 kB  │ 2.4 MB │
+└───────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴────────┘
+```


### PR DESCRIPTION
Closes #977 

This PR just adds a benchmarking section to the price estimator README so we can close the benchmarking issue for now.

### Test Plan

Run the commands in the documentation.