### PR TITLE
Handle internal server errors

### DIFF
--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error,
+    error::{self, InternalError},
     models::*,
     orderbook::{Orderbook, PricegraphKind},
 };
@@ -54,6 +54,10 @@ async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
     } else if let Some(NoTokenInfo) = err.find() {
         code = StatusCode::BAD_REQUEST;
         message = "request with atoms=true for token we don't have erc20 info for";
+    } else if let Some(InternalError(err)) = err.find() {
+        log::warn!("internal server error: {:?}", err);
+        code = StatusCode::INTERNAL_SERVER_ERROR;
+        message = "internal server error";
     } else if let Some(warp::reject::InvalidQuery { .. }) = err.find() {
         code = StatusCode::BAD_REQUEST;
         message = "invalid url query";


### PR DESCRIPTION
Fixes #1141

This PR implements explicit handling of the `InternalError` warp rejection.

### Test Plan

Unfortunately this error is not so easy to trigger, so apply the following patch:
```diff
diff --git a/price-estimator/src/filter.rs b/price-estimator/src/filter.rs
index 1a2f551..3a1445a 100644
--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -174,7 +174,8 @@ async fn get_markets(
     orderbook: Arc<Orderbook>,
 ) -> Result<impl Reply, Rejection> {
     if !query.atoms {
-        return Err(warp::reject());
+        //return Err(warp::reject());
+        return Err(error::internal_server_rejection(anyhow::anyhow!("test")));
     }
     let transitive_orderbook = orderbook
         .pricegraph(query.batch_id, PricegraphKind::Raw)
```

Run the price estimator, and trigger the error:
```
$ curl -s 'http://localhost:8080/api/v1/markets/1-7?atoms=false' | jq
{
  "message": "internal server error"
}
```

Also, notice how the error information appears in the logs:
```
$ cargo run -p price-estimator
...
[2020-08-03T13:47:11Z WARN  price_estimator::filter] internal server error: test
...
```