### PR TITLE
Single fetch per token

### DIFF
--- a/core/src/token_info/cached.rs
+++ b/core/src/token_info/cached.rs
@@ -284,6 +284,8 @@ mod tests {
     #[test]
     fn token_infos_fetched_once() {
         let mut inner = MockTokenInfoFetching::new();
+        // NOTE: Use `return_once` to ensure this test panics if there is
+        // more than one request.
         inner.expect_get_token_info().return_once(|_| {
             immediate!(Ok(TokenBaseInfo {
                 alias: "FOO".to_string(),


### PR DESCRIPTION
Fixes #1155

This PR adds code to track pending token info requests for the cache. The new caching procedure will first check the cache to see if the token info was already retrieved and then create a future and put it into a "pending" hash map so that other simultaneous requests for the same token info block on the same future instead of fetching it again.

This PR is a draft as it does add some additional complexity around the token info caching, so if the general sentiment is that it isn't worth it, then we can abandon this and close the issue for it. 

### Test Plan

Added new unit test. I plan on adding an additional test for the error paths for concurrent requests if the general consensus is to keep this change.