### PR TITLE
Do not keep retrying to fetch token infos if call reverts

### DIFF
--- a/core/src/price_estimation.rs
+++ b/core/src/price_estimation.rs
@@ -71,10 +71,8 @@ impl PriceOracle {
         token_data: TokenData,
         update_interval: Duration,
     ) -> Result<Self> {
-        let token_info_fetcher = Arc::new(TokenInfoCache::with_cache(
-            contract,
-            token_data.clone().into(),
-        ));
+        let cache: HashMap<_, _> = token_data.clone().into();
+        let token_info_fetcher = Arc::new(TokenInfoCache::with_cache(contract, cache));
         let mut price_sources =
             external_price_sources(http_factory, token_info_fetcher.clone(), update_interval)?;
         price_sources.push(Box::new(PricegraphEstimator::new(orderbook_reader)));

--- a/price-estimator/src/main.rs
+++ b/price-estimator/src/main.rs
@@ -16,8 +16,10 @@ use core::{
 use ethcontract::PrivateKey;
 use orderbook::Orderbook;
 use prometheus::Registry;
-use std::net::SocketAddr;
-use std::{num::ParseIntError, path::PathBuf, sync::Arc, thread, time::Duration};
+use std::{
+    collections::HashMap, net::SocketAddr, num::ParseIntError, path::PathBuf, sync::Arc, thread,
+    time::Duration,
+};
 use structopt::StructOpt;
 use tokio::{runtime, time};
 use url::Url;
@@ -92,7 +94,8 @@ fn main() {
             .unwrap(),
     );
 
-    let token_info = TokenInfoCache::with_cache(contract.clone(), options.token_data.into());
+    let cache: HashMap<_, _> = options.token_data.clone().into();
+    let token_info = TokenInfoCache::with_cache(contract.clone(), cache);
     token_info
         .cache_all(10)
         .wait()


### PR DESCRIPTION
There are many tokens who do not implement the ERC20 standard and for
which fetching the token base info fails. In these cases it does not
make sense keep retrying. Instead we cache the error and return it back.

Fixes #1242 

### Test Plan
New unit test, manually tested that calling cache all twice does not fetch errors again on second try.