### PR TITLE
Use slightly higher min_avg_fee compared to max_gas_price

### DIFF
--- a/core/src/economic_viability.rs
+++ b/core/src/economic_viability.rs
@@ -5,7 +5,7 @@ use crate::{
     gas_station::GasPriceEstimating, models::solution::EconomicViabilityInfo,
     price_estimation::PriceEstimating,
 };
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context as _, Result};
 use ethcontract::U256;
 use futures::future::{BoxFuture, FutureExt as _};
 use std::sync::Arc;
@@ -30,6 +30,10 @@ pub struct EconomicViabilityComputer {
     price_oracle: Arc<dyn PriceEstimating + Send + Sync>,
     gas_station: Arc<dyn GasPriceEstimating + Send + Sync>,
     subsidy_factor: f64,
+    /// We multiply the min average fee by this amount to ensure that if a solution has this minimum
+    /// amount it will still be end up economically viable even when the gas or eth price moves
+    /// slightly between solution computation and submission.
+    min_avg_fee_factor: f64,
 }
 
 impl EconomicViabilityComputer {
@@ -37,11 +41,13 @@ impl EconomicViabilityComputer {
         price_oracle: Arc<dyn PriceEstimating + Send + Sync>,
         gas_station: Arc<dyn GasPriceEstimating + Send + Sync>,
         subsidy_factor: f64,
+        min_avg_fee_factor: f64,
     ) -> Self {
         EconomicViabilityComputer {
             price_oracle,
             gas_station,
             subsidy_factor,
+            min_avg_fee_factor,
         }
     }
 
@@ -54,7 +60,12 @@ impl EconomicViabilityComputer {
     }
 
     async fn gas_price(&self) -> Result<f64> {
-        let fast = self.gas_station.estimate_gas_price().await?.fast;
+        let fast = self
+            .gas_station
+            .estimate_gas_price()
+            .await
+            .context("failed to get gas price")?
+            .fast;
         Ok(pricegraph::num::u256_to_f64(fast))
     }
 }
@@ -65,12 +76,11 @@ impl EconomicViabilityComputing for EconomicViabilityComputer {
             let eth_price = self.eth_price_in_owl().await?;
             let gas_price = self.gas_price().await?;
 
-            let fee = min_average_fee(eth_price, gas_price);
+            let fee = min_average_fee(eth_price, gas_price) * self.min_avg_fee_factor;
             let subsidized = fee / self.subsidy_factor;
             log::debug!(
-                "computed min average fee to be {}, subsidized to {}",
-                fee,
-                subsidized,
+                "computed min average fee to be {}, subsidized to {} based on eth price {} gas price {}",
+                fee, subsidized, eth_price, gas_price
             );
 
             Ok(subsidized as _)
@@ -88,6 +98,10 @@ impl EconomicViabilityComputing for EconomicViabilityComputer {
             let eth_price = self.eth_price_in_owl().await?;
             let cap = gas_price_cap(eth_price, earned_fee, num_trades);
             let subsidized = cap * self.subsidy_factor;
+            log::debug!(
+                "computed max gas price to be {} subsidized to {} based on earned fee {} num trades {} eth price {}",
+                cap, subsidized, earned_fee, num_trades, eth_price
+            );
             Ok(U256::from(subsidized as u128))
         }
         .boxed()
@@ -218,12 +232,18 @@ mod tests {
                 ..Default::default()
             }))
         });
-        let economic_viability =
-            EconomicViabilityComputer::new(Arc::new(price_oracle), Arc::new(gas_station), 10.0);
+        let subsidy = 10.0f64;
+        let min_avg_fee_factor = 1.1f64;
+        let economic_viability = EconomicViabilityComputer::new(
+            Arc::new(price_oracle),
+            Arc::new(gas_station),
+            subsidy,
+            min_avg_fee_factor,
+        );
 
         assert_eq!(
             economic_viability.min_average_fee().wait().unwrap(),
-            1152e14 as u128, // 0.1152 OWL
+            ((1152e15 * min_avg_fee_factor) / subsidy) as u128, // 0.1152 OWL
         );
 
         let info = EconomicViabilityInfo {

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -165,6 +165,16 @@ struct Options {
     )]
     economic_viability_subsidy_factor: f64,
 
+    /// We multiply the economically viable min average fee by this amount to ensure that if a
+    /// solution has this minimum amount it will still be end up economically viable even when the
+    /// gas or eth price moves slightly between solution computation and submission.
+    #[structopt(
+        long,
+        env = "ECONOMIC_VIABILITY_MIN_AVG_FEE_FACTOR",
+        default_value = "1.1"
+    )]
+    economic_viability_min_avg_fee_factor: f64,
+
     /// The default minimum average fee per order. This is passed to the solver
     /// in case the computing its value fails. Its unit is [OWL]
     #[structopt(long, env = "MIN_AVG_FEE_PER_ORDER", default_value = "0")]
@@ -271,6 +281,7 @@ fn main() {
             price_oracle.clone(),
             gas_station.clone(),
             options.economic_viability_subsidy_factor,
+            options.economic_viability_min_avg_fee_factor,
         )),
         Box::new(FixedEconomicViabilityComputer::new(
             Some(options.default_min_avg_fee_per_order),


### PR DESCRIPTION
Currently we calculate the min avg fee and max gas price so that if the
solution earns exactly min avg fee it can be submitted at exactly fast
gas price while not losing money.
This is a problem when the gas price or eth price moves slightly between
the start of solution creation and submitting. To be more robust this
commit adds 10% to the min average fee.

Context for this is that I saw a lot of " Solution does not generate enough fees for the transaction to execute quickly enough" in the logs with the open solver and I think this is the reason. Also added more debug logs so I can check the logs in more detail in the future.

### Test Plan
Adjusted unit tests and added some debug prints .