### PR TITLE
[Trivial] Log verified solutions with correct stage

### DIFF
--- a/core/src/metrics/stablex_metrics.rs
+++ b/core/src/metrics/stablex_metrics.rs
@@ -144,7 +144,7 @@ impl StableXMetrics {
         batch: u32,
         res: &Result<U256, SolutionSubmissionError>,
     ) {
-        let stage_label = &[ProcessingStage::Solved.as_ref()];
+        let stage_label = &[ProcessingStage::Verified.as_ref()];
         self.processing_times
             .with_label_values(stage_label)
             .set(time_elapsed_since_batch_start(batch));


### PR DESCRIPTION
While trying to pull the data from how many "verified" solutions we manage to submit I noticed that we don't have information on this in the graphana dashboard. We should be seeing a verified event in the processing times graph.

Reason for the absence is a copy paste error in the metrics code I introduced a few months back.

### Test Plan

Once merged I expect to see verified stage times in staging graphana.