### PR TITLE
Fix how min average fee is passed to solver

### DIFF
--- a/core/src/economic_viability.rs
+++ b/core/src/economic_viability.rs
@@ -17,6 +17,8 @@ const GAS_PER_TRADE: f64 = 120_000.0;
 #[cfg_attr(test, mockall::automock)]
 pub trait EconomicViabilityComputing: Send + Sync + 'static {
     /// Used by the solver so that it only considers solution that are economically viable.
+    /// This is the minimum average amount of earned fees per order. The total amount of paid fees
+    /// is twice this because half of the fee is burnt.
     fn min_average_fee<'a>(&'a self) -> BoxFuture<'a, Result<u128>>;
     /// The maximum gas price at which submitting the solution is still economically viable.
     fn max_gas_price<'a>(

--- a/core/src/price_finding/optimization_price_finder.rs
+++ b/core/src/price_finding/optimization_price_finder.rs
@@ -282,7 +282,9 @@ impl PriceFinding for OptimisationPriceFinder {
             // `blocking::unblock` requires the closure to be 'static.
             let io_methods = self.io_methods.clone();
             let solver_type = self.solver_type;
-            let min_avg_fee_per_order = self.economic_viability.min_average_fee().await?;
+            // The solver expects the fee amount as the total paid fees. Half of the paid fees are
+            // burned and half earned.
+            let min_avg_paid_fee_per_order = 2 * self.economic_viability.min_average_fee().await?;
             let internal_optimizer = self.internal_optimizer;
             let result = blocking::unblock!(io_methods.run_solver(
                 &input_file,
@@ -290,7 +292,7 @@ impl PriceFinding for OptimisationPriceFinder {
                 &result_folder,
                 solver_type,
                 time_limit,
-                min_avg_fee_per_order,
+                min_avg_paid_fee_per_order,
                 internal_optimizer,
             ))
             .with_context(|| format!("error running {:?} solver", self.solver_type))?;


### PR DESCRIPTION
Solver expects total amount of paid fee while we were passing *earned*
fees, which is half of the total. This lead to many solutions failing
with benign error: max gas price lower than fast price.

See https://github.com/gnosis/dex-open-solver/blob/593d2022568b669a4f6fe65a333e05e8b3f01971/src/match.py#L49.
I found this through checking a recent solution and seeing that the fee in the solution.json was double than what we printed in the logs and that the min-avg-fee-per-order was only upheld assuming the doubled fee.

### Test Plan
CI