### PR TITLE
Use npmjs registry instead of building contracts 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,6 @@
 target
 !target/debug/driver
 !target/release/driver
-dex-contracts
-!dex-contracts/build
 **/node_modules
 .git
 .vscode

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "dex-contracts"]
-	path = dex-contracts
-	url = https://github.com/gnosis/dex-contracts

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ env:
     - OPEN_SOLVER_VERSION=v0.0.11
     - PRIVATE_SOLVER_VERSION=v0.8.2
 
-install:
-  - nvm install 12 && nvm alias default 12 && npm install -g yarn@latest && yarn --version
-  - (cd dex-contracts && yarn --frozen-lockfile && yarn run prepack)
-
 jobs:
   fast_finish: true
   allow_failures:
@@ -27,7 +23,6 @@ jobs:
       rust: stable
       cache:
         directories:
-          - $HOME/.cache/yarn
           - $HOME/.cargo/bin
       before_cache:
         - rm -rf "$TRAVIS_HOME/.cargo/registry/src"

--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ It contains two sub-projects that both implement the market mechanism described 
 ### Requirements
 
 - Rust (stable)
-- Node.js v12 LTS
 - Docker and Docker-compose (stable)
-- libpq - the PostgreSQL library
 
 The project may work with other versions of these tools but they are not tested.
 
@@ -45,9 +43,8 @@ Clone the repository, its submodule, and run the container
 ```bash
 git clone git@github.com:gnosis/dex-services.git
 cd dex-services
-git submodule update --init
 docker-compose up -d ganache-cli
-(cd dex-contracts && yarn && yarn prepack && npx truffle migrate)
+(cd contracts; cargo run --bin deploy --features bin
 ```
 
 ## BatchExchange
@@ -67,33 +64,35 @@ You can run the rust binary locally (without docker). For that you will have to 
 cargo run
 ```
 
-The following commands will help you interact with a testnet instance.
+Additionally, the `dex-contracts` repository contains additional scripts to help you interact with a testnet instance.
 In order to setup the environment (fund test users with tokens and list those on the exchange) as well as to make a first deposit/order you can run:
 
 ```
+git clone git@github.com:gnosis/dex-contracts.git
 cd dex-contracts
-npx truffle exec scripts/stablex/setup_environment.js
-npx truffle exec scripts/stablex/deposit.js --accountId=0 --tokenId=0 --amount=3000
-npx truffle exec scripts/stablex/deposit.js --accountId=1 --tokenId=1 --amount=3000
-npx truffle exec scripts/stablex/place_order.js --accountId=0 --buyToken=1 --sellToken=0 --minBuy=999 --maxSell=2000 --validFor=20
-npx truffle exec scripts/stablex/place_order.js --accountId=1 --buyToken=0 --sellToken=1 --minBuy=1996 --maxSell=999 --validFor=20
+yarn && yarn prepack
+yarn truffle-exec scripts/setup_environment.js
+yarn truffle-exec scripts/deposit.js --accountId=0 --tokenId=0 --amount=3000
+yarn truffle-exec scripts/deposit.js --accountId=1 --tokenId=1 --amount=3000
+yarn truffle-exec scripts/place_order.js --accountId=0 --buyToken=1 --sellToken=0 --minBuy=999 --maxSell=2000 --validFor=20
+yarn truffle-exec scripts/place_order.js --accountId=1 --buyToken=0 --sellToken=1 --minBuy=1996 --maxSell=999 --validFor=20
 ```
 
 It will then take up to 5 minutes (auctions close every 00, 05, 10 ... of the hour). On ganache you can expedite this process by running:
 
 ```
-npx truffle exec scripts/stablex/close_auction.js
+yarn truffle-exec scripts/close_auction.js
 ```
 
 You should then see the docker container computing and applying a solution to the most recent auction. In order to withdraw your proceeds you can request a withdraw, wait for one auction for it to become claimable and claim it:
 
 ```
-npx truffle exec scripts/stablex/request_withdraw.js --accountId=0 --tokenId=1 --amount=999
-npx truffle exec scripts/stablex/close_auction.js
-npx truffle exec scripts/stablex/claim_withdraw.js --accountId=0 --tokenId=1
+yarn truffle-exec scripts/request_withdraw.js --accountId=0 --tokenId=1 --amount=999
+yarn truffle-exec scripts/close_auction.js
+yarn truffle-exec scripts/claim_withdraw.js --accountId=0 --tokenId=1
 ```
 
-**Note:** Whenever stopping the `ganache-cli` service (e.g. by running `docker-compose down` you have to re-migrate the dex-contract before restarting `stablex`)
+**Note:** Whenever stopping the `ganache-cli` service (e.g. by running `docker-compose down` you have to re-deploy the contracts before restarting `stablex`)
 
 ## Tests
 

--- a/contracts/build.rs
+++ b/contracts/build.rs
@@ -4,6 +4,8 @@ use std::{env, fs, path::Path};
 #[path = "src/paths.rs"]
 mod paths;
 
+const DEX_CONTRACTS_VERSION: &str = "0.4.1";
+
 fn main() {
     // NOTE: This is a workaround for `rerun-if-changed` directives for
     // non-existant files cause the crate's build unit to get flagged for a
@@ -16,18 +18,18 @@ fn main() {
 
     generate_contract("BatchExchange");
     generate_contract("BatchExchangeViewer");
-    generate_contract("IdToAddressBiMap");
-    generate_contract("IterableAppendOnlySet");
-    generate_contract("TokenOWL");
-    generate_contract("TokenOWLProxy");
 }
 
 fn generate_contract(name: &str) {
-    let artifact = format!("../dex-contracts/build/contracts/{}.json", name);
+    let artifact = format!(
+        "npm:@gnosis.pm/dex-contracts@{}/build/contracts/{}.json",
+        DEX_CONTRACTS_VERSION, name,
+    );
     let address_file = paths::contract_address_file(name);
     let dest = env::var("OUT_DIR").unwrap();
 
-    let mut builder = Builder::new(artifact)
+    let mut builder = Builder::from_source_url(artifact)
+        .unwrap()
         .with_visibility_modifier(Some("pub"))
         .add_event_derive("serde::Deserialize")
         .add_event_derive("serde::Serialize");

--- a/contracts/src/bin/deploy.rs
+++ b/contracts/src/bin/deploy.rs
@@ -15,6 +15,15 @@ use std::{
     time::{Duration, Instant, SystemTime},
 };
 
+ethcontract::contract!("npm:@gnosis.pm/owl-token@3.1.0/build/contracts/TokenOWL.json");
+ethcontract::contract!("npm:@gnosis.pm/owl-token@3.1.0/build/contracts/TokenOWLProxy.json");
+ethcontract::contract!(
+    "npm:@gnosis.pm/solidity-data-structures@1.2.4/build/contracts/IdToAddressBiMap.json",
+);
+ethcontract::contract!(
+    "npm:@gnosis.pm/solidity-data-structures@1.2.4/build/contracts/IterableAppendOnlySet.json",
+);
+
 fn main() {
     env_logger::init_from_env(Env::default().default_filter_or("warn,deploy=info"));
 

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -7,7 +7,3 @@ pub mod paths;
 
 include!(concat!(env!("OUT_DIR"), "/BatchExchange.rs"));
 include!(concat!(env!("OUT_DIR"), "/BatchExchangeViewer.rs"));
-include!(concat!(env!("OUT_DIR"), "/IdToAddressBiMap.rs"));
-include!(concat!(env!("OUT_DIR"), "/IterableAppendOnlySet.rs"));
-include!(concat!(env!("OUT_DIR"), "/TokenOWL.rs"));
-include!(concat!(env!("OUT_DIR"), "/TokenOWLProxy.rs"));

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,15 +8,6 @@ services:
     logging:
       driver: "none"
 
-  truffle:
-    command: /app/run.sh
-    build:
-      context: driver/docker/truffle
-    depends_on:
-      - ganache-cli
-    volumes:
-      - ./dex-contracts:/app/dex-contracts
-
   stablex:
     build:
       context: .

--- a/driver/docker/rust/release/open_solver/Dockerfile
+++ b/driver/docker/rust/release/open_solver/Dockerfile
@@ -1,5 +1,3 @@
 FROM stablex-binary-public
 
 ENV SOLVER_TYPE=open-solver
-# Copy smart contract build artifacts
-COPY dex-contracts/build dex-contracts/build

--- a/driver/docker/rust/release/private_solver/Dockerfile
+++ b/driver/docker/rust/release/private_solver/Dockerfile
@@ -1,5 +1,3 @@
 FROM stablex-binary-private
 
 ENV SOLVER_TYPE=standard-solver
-# Copy smart contract build artifacts
-COPY dex-contracts/build dex-contracts/build

--- a/driver/docker/truffle/Dockerfile
+++ b/driver/docker/truffle/Dockerfile
@@ -1,5 +1,0 @@
-FROM node:10.15-alpine
-
-# Create app directory
-WORKDIR /app/dex-contracts
-COPY run.sh /app/run.sh

--- a/driver/docker/truffle/run.sh
+++ b/driver/docker/truffle/run.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-export GANACHE_HOST='ganache-cli'
-npx truffle migrate --reset
-touch build/migration.flag

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -6,8 +6,7 @@ To run the stableX related tests locally,
 
 ```sh
 # T1:
-docker-compose down && docker-compose up ganache-cli truffle
-# Wait for message `dex-services_truffle_1 exited with code 0`
+ci/setup_contracts.sh
 
 # T2:
 cargo run -p driver -- --node-url http://localhost:8545 --network-id 5777 --private-key 4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d --solver-type naive-solver --scheduler evm
@@ -22,8 +21,7 @@ cargo test -p e2e ganache -- --nocapture
 
 ```sh
 # T1:
-docker-compose down && docker-compose up ganache-cli truffle
-# Wait for message `dex-services_truffle_1 exited with code 0`
+ci/setup_contracts.sh
 
 # T2:
 # <private-key> is some private key with Rinkeby OWL, DAI and ETH (for gas)

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -1,5 +1,6 @@
-ethcontract::contract!(pub "dex-contracts/build/contracts/IERC20.json");
-ethcontract::contract!(pub "dex-contracts/build/contracts/ERC20Mintable.json");
+ethcontract::contract!(pub "npm:@gnosis.pm/dex-contracts@0.4.1/build/contracts/IERC20.json");
+ethcontract::contract!(pub "npm:@gnosis.pm/owl-token@3.1.0/build/contracts/TokenOWL.json");
+ethcontract::contract!(pub "npm:@openzeppelin/contracts@3.1.0/build/contracts/ERC20Mintable.json");
 
 pub mod cmd;
 pub mod common;

--- a/e2e/src/stablex.rs
+++ b/e2e/src/stablex.rs
@@ -3,9 +3,9 @@ use crate::{
         approve, create_accounts_with_funded_tokens, wait_for, FutureBuilderExt, FutureWaitExt,
         MAX_GAS,
     },
-    IERC20,
+    TokenOWL, IERC20,
 };
-use contracts::{BatchExchange, TokenOWL};
+use contracts::BatchExchange;
 use ethcontract::{Account, Address, Http, Web3, U256};
 
 pub fn setup_stablex(

--- a/price-estimator/docker/Dockerfile
+++ b/price-estimator/docker/Dockerfile
@@ -5,7 +5,6 @@ COPY Cargo.lock .
 COPY contracts contracts
 COPY core core
 COPY driver driver
-COPY dex-contracts dex-contracts
 COPY e2e e2e
 COPY pricegraph pricegraph
 COPY price-estimator price-estimator


### PR DESCRIPTION
Fixes #689 

This PR removes the dex-contracts submodule and any NodeJS/Truffle requirements. Note that this change makes the `contracts` crate retrieve the Truffle JSON artifact from npm packges. Alternatively, we could vendor the JSON artifacts so they aren't retrieved on build.

### Test Plan

CI!