### PR TITLE
Use new rounding buffer in estimate_buy_amount route

### DIFF
--- a/price-estimator/src/infallible_price_source.rs
+++ b/price-estimator/src/infallible_price_source.rs
@@ -51,7 +51,6 @@ pub struct PriceCacheUpdater {
 }
 
 impl PriceCacheUpdater {
-    #[allow(dead_code)]
     pub fn new(
         token_info: Arc<dyn TokenInfoFetching>,
         external_price_sources: Vec<Box<dyn PriceSource + Send + Sync>>,

--- a/price-estimator/src/main.rs
+++ b/price-estimator/src/main.rs
@@ -76,11 +76,6 @@ struct Options {
     )]
     price_source_update_interval: Duration,
 
-    /// The safety margin to subtract from the estimated price, in order to make it more likely to
-    /// be matched.
-    #[structopt(long, env = "PRICE_ROUNDING_BUFFER", default_value = "0.001")]
-    price_rounding_buffer: f64,
-
     /// JSON encoded backup token information like in the driver. Used as an override to the ERC20
     /// information we fetch from the block chain in case that information is wrong or unavailable
     /// which can happen for example when tokens do not implement the standard properly.
@@ -100,10 +95,6 @@ fn main() {
         "Starting price estimator with runtime options: {:#?}",
         options
     );
-
-    let price_rounding_buffer = options.price_rounding_buffer;
-    assert!(price_rounding_buffer.is_finite());
-    assert!(price_rounding_buffer >= 0.0 && price_rounding_buffer <= 1.0);
 
     let driver_http_metrics = setup_driver_metrics();
     let http_factory = HttpFactory::new(options.timeout, driver_http_metrics);
@@ -155,7 +146,7 @@ fn main() {
         options.orderbook_update_interval,
     ));
 
-    let filter = filter::all(orderbook, token_info, price_rounding_buffer);
+    let filter = filter::all(orderbook, token_info);
     let serve_task = runtime.spawn(warp::serve(filter).run(options.bind_address));
 
     log::info!("Server ready.");

--- a/price-estimator/src/orderbook.rs
+++ b/price-estimator/src/orderbook.rs
@@ -84,15 +84,14 @@ impl Orderbook {
         Ok(())
     }
 
-    // TODO: this function is going to be used in some routes
-    pub async fn _rounding_buffer(&self, token_pair: TokenPair) -> Result<f64> {
+    pub async fn rounding_buffer(&self, token_pair: TokenPair) -> f64 {
         let price_source = self.infallible_price_source.inner().await;
-        Ok(solver_rounding_buffer::rounding_buffer(
+        solver_rounding_buffer::rounding_buffer(
             price_source.price(TokenId(0)).get() as f64,
             price_source.price(TokenId(token_pair.sell)).get() as f64,
             price_source.price(TokenId(token_pair.buy)).get() as f64,
             self.extra_rounding_buffer_factor,
-        ))
+        )
     }
 
     /// Update the infallible price source with the averaged prices of the external price sources


### PR DESCRIPTION
Finally :)

### Test Plan
Run the price estimator from master, the price estimator from this PR and the price estimator from master with rounding-buffer-factor set to 0.0. Compare results. We see that in the estimate-buy-amount route the buy amount is the lowest for the master price estimator which is lower than the this PR's default price estimator which is lower than this PR's price estimator with no rounding buffer. Example:

```
# No rounding buffer
curl "localhost:8082/api/v1/markets/4-7/estimated-buy-amount/1?atoms=false"
{"baseTokenId":4,"quoteTokenId":7,"buyAmountInBase":"1.010907","sellAmountInQuote":"1"}
# Solver based rounding buffer
curl "localhost:8080/api/v1/markets/4-7/estimated-buy-amount/1?atoms=false"
{"baseTokenId":4,"quoteTokenId":7,"buyAmountInBase":"1.010707","sellAmountInQuote":"1"}
# Old rounding buffer
curl "localhost:8081/api/v1/markets/4-7/estimated-buy-amount/1?atoms=false"
{"baseTokenId":4,"quoteTokenId":7,"buyAmountInBase":"1.009896","sellAmountInQuote":"1"}
```

Also checked that /markets route is still the same.