### PR TITLE
[Hotfix] Fix price estimator deployment

### DIFF
--- a/price-estimator/docker/Dockerfile
+++ b/price-estimator/docker/Dockerfile
@@ -2,6 +2,7 @@ FROM clux/muslrust:stable as builder
 WORKDIR /usr/src/app
 COPY Cargo.toml .
 COPY Cargo.lock .
+COPY contracts contracts
 COPY core core
 COPY driver driver
 COPY dex-contracts dex-contracts


### PR DESCRIPTION
Masterbuild is failing because of missing directory in the docker build script: https://travis-ci.com/github/gnosis/dex-services/builds/178783483

### Test Plan
See master deploy succeed again