### PR TITLE
Refactor query parameter parsing to allow mutually exclusive values

### DIFF
--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -165,7 +165,7 @@ async fn get_markets(
     // This route intentionally uses the raw pricegraph without rounding buffer so that orders are
     // unmodified.
     let transitive_orderbook = orderbook
-        .pricegraph(query.generation, PricegraphKind::Raw)
+        .pricegraph(query.time, PricegraphKind::Raw)
         .await
         .map_err(error::internal_server_rejection)?
         .transitive_orderbook(*market, None);
@@ -203,7 +203,7 @@ async fn estimate_buy_amount(
     };
     let rounding_buffer = orderbook.rounding_buffer(token_pair).await;
     let pricegraph = orderbook
-        .pricegraph(query.generation, PricegraphKind::WithRoundingBuffer)
+        .pricegraph(query.time, PricegraphKind::WithRoundingBuffer)
         .await
         .map_err(error::internal_server_rejection)?;
     // This reduced sell amount is what the solver would see after applying the rounding buffer.
@@ -236,7 +236,7 @@ async fn estimate_amounts_at_price(
     token_infos: Arc<dyn TokenInfoFetching>,
 ) -> Result<impl Reply, Rejection> {
     let pricegraph = orderbook
-        .pricegraph(query.generation, PricegraphKind::WithRoundingBuffer)
+        .pricegraph(query.time, PricegraphKind::WithRoundingBuffer)
         .await
         .map_err(error::internal_server_rejection)?;
     let rounding_buffer = orderbook.rounding_buffer(token_pair).await;
@@ -306,7 +306,7 @@ async fn estimate_best_ask_price(
         return Err(warp::reject());
     }
     let price = orderbook
-        .pricegraph(query.generation, PricegraphKind::WithRoundingBuffer)
+        .pricegraph(query.time, PricegraphKind::WithRoundingBuffer)
         .await
         .map_err(error::internal_server_rejection)?
         .estimate_limit_price(token_pair, 0.0);

--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -159,13 +159,13 @@ async fn get_markets(
     query: QueryParameters,
     orderbook: Arc<Orderbook>,
 ) -> Result<impl Reply, Rejection> {
-    if !query.atoms {
+    if query.unit != Unit::Atoms {
         return Err(warp::reject());
     }
     // This route intentionally uses the raw pricegraph without rounding buffer so that orders are
     // unmodified.
     let transitive_orderbook = orderbook
-        .pricegraph(query.batch_id, PricegraphKind::Raw)
+        .pricegraph(query.generation, PricegraphKind::Raw)
         .await
         .map_err(error::internal_server_rejection)?
         .transitive_orderbook(*market, None);
@@ -190,19 +190,20 @@ async fn estimate_buy_amount(
     orderbook: Arc<Orderbook>,
     token_infos: Arc<dyn TokenInfoFetching>,
 ) -> Result<impl Reply, Rejection> {
-    let (sell_amount_in_quote, sell_amount_in_quote_atoms) = if query.atoms {
-        (
+    let (sell_amount_in_quote, sell_amount_in_quote_atoms) = match query.unit {
+        Unit::Atoms => (
             Amount::Atoms(sell_amount_in_quote as _),
             sell_amount_in_quote,
-        )
-    } else {
-        let token_info = get_token_info(token_pair.sell, token_infos.as_ref()).await?;
-        let amount = Amount::BaseUnits(sell_amount_in_quote);
-        (amount, amount.as_atoms(&token_info) as _)
+        ),
+        Unit::BaseUnits => {
+            let token_info = get_token_info(token_pair.sell, token_infos.as_ref()).await?;
+            let amount = Amount::BaseUnits(sell_amount_in_quote);
+            (amount, amount.as_atoms(&token_info) as _)
+        }
     };
     let rounding_buffer = orderbook.rounding_buffer(token_pair).await;
     let pricegraph = orderbook
-        .pricegraph(query.batch_id, PricegraphKind::WithRoundingBuffer)
+        .pricegraph(query.generation, PricegraphKind::WithRoundingBuffer)
         .await
         .map_err(error::internal_server_rejection)?;
     // This reduced sell amount is what the solver would see after applying the rounding buffer.
@@ -213,7 +214,7 @@ async fn estimate_buy_amount(
 
     let mut buy_amount_in_base =
         Amount::Atoms(transitive_order.map(|order| order.buy).unwrap_or_default() as _);
-    if !query.atoms {
+    if query.unit == Unit::BaseUnits {
         let token_info = get_token_info(token_pair.buy, token_infos.as_ref()).await?;
         buy_amount_in_base = buy_amount_in_base.into_base_units(&token_info)
     };
@@ -235,29 +236,35 @@ async fn estimate_amounts_at_price(
     token_infos: Arc<dyn TokenInfoFetching>,
 ) -> Result<impl Reply, Rejection> {
     let pricegraph = orderbook
-        .pricegraph(query.batch_id, PricegraphKind::WithRoundingBuffer)
+        .pricegraph(query.generation, PricegraphKind::WithRoundingBuffer)
         .await
         .map_err(error::internal_server_rejection)?;
     let rounding_buffer = orderbook.rounding_buffer(token_pair).await;
-    let result = if query.atoms {
-        estimate_amounts_at_price_atoms(token_pair, price_in_quote, &pricegraph, rounding_buffer)
-    } else {
-        let buy_token_info = get_token_info(token_pair.buy, token_infos.as_ref()).await?;
-        let sell_token_info = get_token_info(token_pair.sell, token_infos.as_ref()).await?;
-        let price_in_quote_atoms = price_in_quote
-            * (sell_token_info.base_unit_in_atoms().get() as f64
-                / buy_token_info.base_unit_in_atoms().get() as f64);
-        let mut result = estimate_amounts_at_price_atoms(
+    let result = match query.unit {
+        Unit::Atoms => estimate_amounts_at_price_atoms(
             token_pair,
-            price_in_quote_atoms,
+            price_in_quote,
             &pricegraph,
             rounding_buffer,
-        );
-        result.buy_amount_in_base = result.buy_amount_in_base.into_base_units(&buy_token_info);
-        result.sell_amount_in_quote = result
-            .sell_amount_in_quote
-            .into_base_units(&sell_token_info);
-        result
+        ),
+        Unit::BaseUnits => {
+            let buy_token_info = get_token_info(token_pair.buy, token_infos.as_ref()).await?;
+            let sell_token_info = get_token_info(token_pair.sell, token_infos.as_ref()).await?;
+            let price_in_quote_atoms = price_in_quote
+                * (sell_token_info.base_unit_in_atoms().get() as f64
+                    / buy_token_info.base_unit_in_atoms().get() as f64);
+            let mut result = estimate_amounts_at_price_atoms(
+                token_pair,
+                price_in_quote_atoms,
+                &pricegraph,
+                rounding_buffer,
+            );
+            result.buy_amount_in_base = result.buy_amount_in_base.into_base_units(&buy_token_info);
+            result.sell_amount_in_quote = result
+                .sell_amount_in_quote
+                .into_base_units(&sell_token_info);
+            result
+        }
     };
     Ok(warp::reply::json(&result))
 }
@@ -295,11 +302,11 @@ async fn estimate_best_ask_price(
     query: QueryParameters,
     orderbook: Arc<Orderbook>,
 ) -> Result<impl Reply, Rejection> {
-    if !query.atoms {
+    if query.unit != Unit::Atoms {
         return Err(warp::reject());
     }
     let price = orderbook
-        .pricegraph(query.batch_id, PricegraphKind::WithRoundingBuffer)
+        .pricegraph(query.generation, PricegraphKind::WithRoundingBuffer)
         .await
         .map_err(error::internal_server_rejection)?
         .estimate_limit_price(token_pair, 0.0);
@@ -383,7 +390,7 @@ mod tests {
         assert_eq!(token_pair.buy, 0);
         assert_eq!(token_pair.sell, 65535);
         assert_eq!(volume, 1.0);
-        assert_eq!(query.atoms, true);
+        assert_eq!(query.unit, Unit::Atoms);
         assert_eq!(query.hops, Some(2));
     }
 
@@ -397,7 +404,7 @@ mod tests {
             .unwrap();
         assert_eq!(market.base, 1);
         assert_eq!(market.quote, 2);
-        assert_eq!(query.atoms, true);
+        assert_eq!(query.unit, Unit::Atoms);
         assert_eq!(query.hops, Some(3));
     }
 
@@ -496,7 +503,7 @@ mod tests {
         assert_eq!(token_pair.buy, 0);
         assert_eq!(token_pair.sell, 65535);
         assert!((volume - 0.5).abs() < f64::EPSILON);
-        assert_eq!(query.atoms, true);
+        assert_eq!(query.unit, Unit::Atoms);
         assert_eq!(query.hops, None);
     }
 
@@ -510,7 +517,7 @@ mod tests {
             .unwrap();
         assert_eq!(token_pair.buy, 0);
         assert_eq!(token_pair.sell, 65535);
-        assert_eq!(query.atoms, true);
+        assert_eq!(query.unit, Unit::Atoms);
         assert_eq!(query.hops, None);
     }
 }

--- a/price-estimator/src/models.rs
+++ b/price-estimator/src/models.rs
@@ -1,5 +1,9 @@
-use core::{models::BatchId, token_info::TokenBaseInfo};
-use serde::{Deserialize, Serialize};
+mod query;
+
+pub use self::query::*;
+use anyhow::Result;
+use core::token_info::TokenBaseInfo;
+use serde::Serialize;
 use serde_with::rust::display_fromstr;
 use std::{cmp::Ordering, num::ParseIntError, ops::Deref, str::FromStr};
 
@@ -40,15 +44,6 @@ impl FromStr for Market {
             quote: quote_token_id,
         }))
     }
-}
-
-/// The query part of the url.
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct QueryParameters {
-    pub atoms: bool,
-    pub hops: Option<u16>,
-    pub batch_id: Option<BatchId>,
 }
 
 #[derive(Serialize)]

--- a/price-estimator/src/models/query.rs
+++ b/price-estimator/src/models/query.rs
@@ -45,7 +45,6 @@ pub enum Generation {
 #[serde(rename_all = "camelCase")]
 struct RawQuery {
     atoms: Option<bool>,
-    unit: Option<Unit>,
     hops: Option<usize>,
     batch_id: Option<BatchId>,
 }
@@ -55,12 +54,10 @@ impl TryFrom<RawQuery> for QueryParameters {
 
     fn try_from(raw: RawQuery) -> Result<Self> {
         Ok(QueryParameters {
-            unit: match (raw.atoms, raw.unit) {
-                (Some(true), None) => Unit::Atoms,
-                (Some(false), None) => Unit::BaseUnits,
-                (None, Some(unit)) => unit,
-                (None, None) => bail!("'atoms' or 'unit' parameter must be specified"),
-                _ => bail!("specified both 'atoms' and 'unit' parameters"),
+            unit: match raw.atoms {
+                Some(true) => Unit::Atoms,
+                Some(false) => Unit::BaseUnits,
+                None => bail!("'atoms' or parameter must be specified"),
             },
             hops: raw.hops,
             generation: match raw.batch_id {

--- a/price-estimator/src/models/query.rs
+++ b/price-estimator/src/models/query.rs
@@ -1,0 +1,72 @@
+//! Module implementing parsing request query parameters.
+
+use anyhow::{bail, Error, Result};
+use core::models::BatchId;
+use serde::Deserialize;
+use std::convert::TryFrom;
+
+/// Common query parameters shared across all price estimation routes.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(try_from = "RawQuery")]
+pub struct QueryParameters {
+    /// The unit of the token amounts.
+    pub unit: Unit,
+    /// The maximum number of hops (i.e. maximum ring trade length) used by the
+    /// `pricegraph` search algorithm.
+    pub hops: Option<usize>,
+    /// The generation to load the orderbook at.
+    pub generation: Generation,
+}
+
+/// Units for token amounts.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum Unit {
+    /// Atoms, smallest unit for a token.
+    Atoms,
+    /// Base units, such that `1.0` is `10.pow(decimals)` atoms.
+    BaseUnits,
+}
+
+/// When to perform a price estimate.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Generation {
+    /// The `Pricegraph` will be contructed from the current state of the
+    /// orderbook.
+    Current,
+    /// The `Pricegraph` will be contructed from the finalized orderbook at the
+    /// specified batch. This will be the same orderbook that is provided to the
+    /// solver when solving for the specified batch.
+    Batch(BatchId),
+}
+
+/// Intermediate raw query parameters used for parsing.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawQuery {
+    atoms: Option<bool>,
+    unit: Option<Unit>,
+    hops: Option<usize>,
+    batch_id: Option<BatchId>,
+}
+
+impl TryFrom<RawQuery> for QueryParameters {
+    type Error = Error;
+
+    fn try_from(raw: RawQuery) -> Result<Self> {
+        Ok(QueryParameters {
+            unit: match (raw.atoms, raw.unit) {
+                (Some(true), None) => Unit::Atoms,
+                (Some(false), None) => Unit::BaseUnits,
+                (None, Some(unit)) => unit,
+                (None, None) => bail!("'atoms' or 'unit' parameter must be specified"),
+                _ => bail!("specified both 'atoms' and 'unit' parameters"),
+            },
+            hops: raw.hops,
+            generation: match raw.batch_id {
+                Some(batch_id) => Generation::Batch(batch_id),
+                None => Generation::Current,
+            },
+        })
+    }
+}

--- a/price-estimator/src/models/query.rs
+++ b/price-estimator/src/models/query.rs
@@ -14,8 +14,8 @@ pub struct QueryParameters {
     /// The maximum number of hops (i.e. maximum ring trade length) used by the
     /// `pricegraph` search algorithm.
     pub hops: Option<usize>,
-    /// The generation to load the orderbook at.
-    pub generation: Generation,
+    /// The time to load the orderbook at to perform estimations.
+    pub time: EstimationTime,
 }
 
 /// Units for token amounts.
@@ -30,13 +30,10 @@ pub enum Unit {
 
 /// When to perform a price estimate.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Generation {
-    /// The `Pricegraph` will be contructed from the current state of the
-    /// orderbook.
-    Current,
-    /// The `Pricegraph` will be contructed from the finalized orderbook at the
-    /// specified batch. This will be the same orderbook that is provided to the
-    /// solver when solving for the specified batch.
+pub enum EstimationTime {
+    /// Estimate with the current open orderbook.
+    Now,
+    /// Estimate with the finalized orderbook at the specified batch.
     Batch(BatchId),
 }
 
@@ -60,9 +57,9 @@ impl TryFrom<RawQuery> for QueryParameters {
                 None => bail!("'atoms' or parameter must be specified"),
             },
             hops: raw.hops,
-            generation: match raw.batch_id {
-                Some(batch_id) => Generation::Batch(batch_id),
-                None => Generation::Current,
+            time: match raw.batch_id {
+                Some(batch_id) => EstimationTime::Batch(batch_id),
+                None => EstimationTime::Now,
             },
         })
     }

--- a/price-estimator/src/orderbook.rs
+++ b/price-estimator/src/orderbook.rs
@@ -1,4 +1,6 @@
-use crate::{infallible_price_source::PriceCacheUpdater, solver_rounding_buffer};
+use crate::{
+    infallible_price_source::PriceCacheUpdater, models::Generation, solver_rounding_buffer,
+};
 use anyhow::Result;
 use core::{
     models::{AccountState, BatchId, Order, TokenId},
@@ -49,11 +51,12 @@ impl Orderbook {
 
     pub async fn pricegraph(
         &self,
-        batch_id: Option<BatchId>,
+        generation: Generation,
         pricegraph_type: PricegraphKind,
     ) -> Result<Pricegraph> {
-        match batch_id {
-            Some(batch_id) => {
+        match generation {
+            Generation::Current => Ok(self.cached_pricegraph(pricegraph_type).await),
+            Generation::Batch(batch_id) => {
                 let mut auction_data = self.auction_data(batch_id).await?;
                 if matches!(pricegraph_type, PricegraphKind::WithRoundingBuffer) {
                     self.apply_rounding_buffer_to_auction_data(&mut auction_data)
@@ -61,7 +64,6 @@ impl Orderbook {
                 }
                 Ok(pricegraph_from_auction_data(&auction_data))
             }
-            None => Ok(self.cached_pricegraph(pricegraph_type).await),
         }
     }
 

--- a/price-estimator/src/orderbook.rs
+++ b/price-estimator/src/orderbook.rs
@@ -1,5 +1,5 @@
 use crate::{
-    infallible_price_source::PriceCacheUpdater, models::Generation, solver_rounding_buffer,
+    infallible_price_source::PriceCacheUpdater, models::EstimationTime, solver_rounding_buffer,
 };
 use anyhow::Result;
 use core::{
@@ -51,12 +51,12 @@ impl Orderbook {
 
     pub async fn pricegraph(
         &self,
-        generation: Generation,
+        time: EstimationTime,
         pricegraph_type: PricegraphKind,
     ) -> Result<Pricegraph> {
-        match generation {
-            Generation::Current => Ok(self.cached_pricegraph(pricegraph_type).await),
-            Generation::Batch(batch_id) => {
+        match time {
+            EstimationTime::Now => Ok(self.cached_pricegraph(pricegraph_type).await),
+            EstimationTime::Batch(batch_id) => {
                 let mut auction_data = self.auction_data(batch_id).await?;
                 if matches!(pricegraph_type, PricegraphKind::WithRoundingBuffer) {
                     self.apply_rounding_buffer_to_auction_data(&mut auction_data)


### PR DESCRIPTION
This PR is a precursor to #1272 to enable mutually exclusive query parameters (`?batch=123&blockNumber=456&timestamp=789` for example, where each exactly one or none of these parameters should be present).

### Test Plan

Unit tests, they check query parameter parsing.