### PR TITLE
Shared filter context

### DIFF
--- a/price-estimator/src/main.rs
+++ b/price-estimator/src/main.rs
@@ -5,6 +5,7 @@ mod models;
 mod orderbook;
 mod solver_rounding_buffer;
 
+use crate::filter::Context;
 use core::{
     contracts::{stablex_contract::StableXContractImpl, web3_provider},
     http::HttpFactory,
@@ -143,7 +144,11 @@ fn main() {
         options.orderbook_update_interval,
     ));
 
-    let filter = filter::all(orderbook, token_info, price_rounding_buffer);
+    let filter = filter::all(Context {
+        orderbook,
+        token_info,
+        price_rounding_buffer,
+    });
     let serve_task = runtime.spawn(warp::serve(filter).run(options.bind_address));
 
     log::info!("Server ready.");


### PR DESCRIPTION
This PR introduces a shared filter context for price estimation routes. The main motivation behind this is to add new filters for amounts so that there are less `if query.atoms { ... }` everywhere to do query conversions and move some of that into filters to make the actual handlers a little more `warp` agnostic.

I'm not 100% what the best way to structure this is at the moment, so I will leave this in a Draft PR for now.

### Test Plan

Unit tests.