### PR TITLE
Shared logger in price estimator.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2290,7 +2290,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "core",
- "env_logger",
  "ethcontract",
  "futures 0.3.5",
  "log 0.4.11",

--- a/price-estimator/Cargo.toml
+++ b/price-estimator/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 core = { path = "../core" }
-env_logger = "0.7"
 ethcontract = "0.7"
 futures = "0.3"
 log = "0.4"

--- a/price-estimator/src/main.rs
+++ b/price-estimator/src/main.rs
@@ -31,7 +31,7 @@ use url::Url;
 struct Options {
     /// The log filter to use.
     ///
-    /// This follows the `slog-envlogger` syntax (e.g. 'info,driver=debug').
+    /// This follows the `slog-envlogger` syntax (e.g. 'info,price_estimator=debug').
     #[structopt(
         long,
         env = "DFUSION_LOG",

--- a/price-estimator/src/main.rs
+++ b/price-estimator/src/main.rs
@@ -8,6 +8,7 @@ mod solver_rounding_buffer;
 use core::{
     contracts::{stablex_contract::StableXContractImpl, web3_provider},
     http::HttpFactory,
+    logging,
     metrics::{HttpMetrics, MetricsServer},
     orderbook::EventBasedOrderbook,
     token_info::{cached::TokenInfoCache, hardcoded::TokenData},
@@ -28,6 +29,16 @@ use url::Url;
 #[derive(Debug, StructOpt)]
 #[structopt(name = "price estimator", rename_all = "kebab")]
 struct Options {
+    /// The log filter to use.
+    ///
+    /// This follows the `slog-envlogger` syntax (e.g. 'info,driver=debug').
+    #[structopt(
+        long,
+        env = "DFUSION_LOG",
+        default_value = "warn,price_estimator=info,core=info"
+    )]
+    log_filter: String,
+
     #[structopt(long, env = "BIND_ADDRESS", default_value = "0.0.0.0:8080")]
     bind_address: SocketAddr,
 
@@ -84,11 +95,12 @@ struct Options {
 
 fn main() {
     let options = Options::from_args();
-    env_logger::init();
+    let (_, _guard) = logging::init(&options.log_filter);
     log::info!(
         "Starting price estimator with runtime options: {:#?}",
         options
     );
+
     let price_rounding_buffer = options.price_rounding_buffer;
     assert!(price_rounding_buffer.is_finite());
     assert!(price_rounding_buffer >= 0.0 && price_rounding_buffer <= 1.0);


### PR DESCRIPTION
Fixes #1280 

Used the shared logging component.

### Test Plan

Run the price estimator and see logs:
```
$ cargo run -p price-estimator -- --orderbook-file target/orderbook-file-mainnet                                                  
    Finished dev [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/price-estimator --orderbook-file target/orderbook-file-mainnet`
2020-08-10T16:03:42.612Z INFO [price_estimator] Starting price estimator with runtime options: Options {
...
```