### PR TITLE
Block number and timestamp query parameters

### DIFF
--- a/price-estimator/src/models/query.rs
+++ b/price-estimator/src/models/query.rs
@@ -41,6 +41,12 @@ pub enum EstimationTime {
     Now,
     /// Estimate with the finalized orderbook at the specified batch.
     Batch(BatchId),
+    /// The `Pricegraph` will be contructed from the events up to, and
+    /// including, the specified block.
+    Block(u64),
+    /// The `Pricegraph` will be contructed from the events that occured up to,
+    /// and including, the specified timestamp.
+    Timestamp(u64),
 }
 
 /// Intermediate raw query parameters used for parsing.
@@ -51,6 +57,8 @@ struct RawQuery {
     unit: Option<Unit>,
     hops: Option<usize>,
     batch_id: Option<BatchId>,
+    block_number: Option<u64>,
+    timestamp: Option<u64>,
 }
 
 impl TryFrom<RawQuery> for QueryParameters {
@@ -66,9 +74,12 @@ impl TryFrom<RawQuery> for QueryParameters {
                 _ => bail!("only one of 'atoms' or 'unit' parameters can be specified"),
             },
             hops: raw.hops,
-            time: match raw.batch_id {
-                Some(batch_id) => EstimationTime::Batch(batch_id),
-                None => EstimationTime::Now,
+            time: match (raw.batch_id, raw.block_number, raw.timestamp) {
+                (None, None, None) => EstimationTime::Now,
+                (Some(batch_id), None, None) => EstimationTime::Batch(batch_id),
+                (None, Some(block_number), None) => EstimationTime::Block(block_number),
+                (None, None, Some(timestamp)) => EstimationTime::Timestamp(timestamp),
+                _ => bail!("only one of 'batchId', 'blockNumber', or 'timestamp' parameters can be specified"),
             },
         })
     }
@@ -107,8 +118,11 @@ mod tests {
     #[test]
     fn invalid_parameters() {
         assert!(query_params("?unit=invalid").is_err());
+        assert!(query_params("?atoms=invalid").is_err());
         assert!(query_params("?hops=invalid").is_err());
         assert!(query_params("?batch_id=invalid").is_err());
+        assert!(query_params("?blockNumber=invalid").is_err());
+        assert!(query_params("?timestampe=invalid").is_err());
     }
 
     #[test]
@@ -121,7 +135,26 @@ mod tests {
     }
 
     #[test]
+    fn generation_query_parameters() {
+        let query = query_params("?batchId=42").unwrap();
+        assert_eq!(query.time, EstimationTime::Batch(42.into()));
+
+        let query = query_params("?blockNumber=123").unwrap();
+        assert_eq!(query.time, EstimationTime::Block(123));
+
+        let query = query_params("?timestamp=1337").unwrap();
+        assert_eq!(query.time, EstimationTime::Timestamp(1337));
+    }
+
+    #[test]
     fn mutually_exclusive_unit_parameter() {
         assert!(query_params("?unit=atoms&atoms=true").is_err());
+    }
+
+    #[test]
+    fn mutually_exclusive_generation_parameter() {
+        assert!(query_params("?batchId=123&blockNumber=456").is_err());
+        assert!(query_params("?blockNumber=123&timestamp=456").is_err());
+        assert!(query_params("?timestamp=123&batchId=456").is_err());
     }
 }

--- a/price-estimator/src/models/query.rs
+++ b/price-estimator/src/models/query.rs
@@ -126,6 +126,11 @@ mod tests {
     }
 
     #[test]
+    fn unknown_parameter() {
+        assert!(query_params("?answer=42").is_err());
+    }
+
+    #[test]
     fn atoms_query_parameter() {
         let query = query_params("?atoms=true").unwrap();
         assert_eq!(query.unit, Unit::Atoms);

--- a/price-estimator/src/orderbook.rs
+++ b/price-estimator/src/orderbook.rs
@@ -1,7 +1,7 @@
 use crate::{
     infallible_price_source::PriceCacheUpdater, models::EstimationTime, solver_rounding_buffer,
 };
-use anyhow::Result;
+use anyhow::{bail, Result};
 use core::{
     models::{AccountState, BatchId, Order, TokenId},
     orderbook::StableXOrderBookReading,
@@ -64,6 +64,7 @@ impl Orderbook {
                 }
                 Ok(pricegraph_from_auction_data(&auction_data))
             }
+            EstimationTime::Block(_) | EstimationTime::Timestamp(_) => bail!("not yet implemented"),
         }
     }
 


### PR DESCRIPTION
This PR is the first step to #1272 and introduces new query parameters. They are currently not supported by the service and return internal server errors.

### Test Plan

See that the parameter causes a `internal server error` instead of a `invalid url query`.
```
$ cargo run -p price-estimator
...
$ curl -s 'http://localhost:8080/api/v1/markets/7-1/estimated-buy-amount/1?blockNumber=1337' | jq
{
  "message": "internal server error"
}
```