### PR TITLE
Add SystemTime utilities

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod orderbook;
 pub mod price_estimation;
 pub mod price_finding;
 pub mod solution_submission;
+pub mod time;
 pub mod token_info;
 pub mod transport;
 pub mod util;

--- a/core/src/models/batch_id.rs
+++ b/core/src/models/batch_id.rs
@@ -1,3 +1,4 @@
+use crate::time::SystemTimeExt as _;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::time::{Duration, SystemTime, SystemTimeError};
@@ -27,12 +28,11 @@ impl BatchId {
         Self::current(SystemTime::now()).expect("system time earlier than Unix epoch")
     }
 
-    pub fn current(now: SystemTime) -> std::result::Result<Self, SystemTimeError> {
-        let time_since_epoch = now.duration_since(SystemTime::UNIX_EPOCH)?;
-        Ok(Self::from_timestamp(time_since_epoch.as_secs()))
+    pub fn current(now: SystemTime) -> Result<Self, SystemTimeError> {
+        Ok(Self::from_timestamp(now.as_timestamp()?))
     }
 
-    pub fn currently_being_solved(now: SystemTime) -> std::result::Result<Self, SystemTimeError> {
+    pub fn currently_being_solved(now: SystemTime) -> Result<Self, SystemTimeError> {
         Self::current(now).map(|batch_id| batch_id.prev())
     }
 

--- a/core/src/models/batch_id.rs
+++ b/core/src/models/batch_id.rs
@@ -41,7 +41,7 @@ impl BatchId {
     }
 
     pub fn order_collection_start_time(self) -> SystemTime {
-        SystemTime::UNIX_EPOCH + Duration::from_secs(self.as_timestamp())
+        SystemTime::from_timestamp(self.as_timestamp())
     }
 
     pub fn solve_start_time(self) -> SystemTime {

--- a/core/src/time.rs
+++ b/core/src/time.rs
@@ -1,0 +1,24 @@
+//! Time utilites for dealing with batches.
+
+use std::time::{Duration, SystemTime, SystemTimeError};
+
+/// `SystemTime` extention trait.
+pub trait SystemTimeExt {
+    /// Creates a new `SystemTime` from a Unix timestamp.
+    ///
+    /// Returns `None` if the specified timestamp cannot be represented.
+    fn from_timestamp(timestamp: u64) -> Option<SystemTime> {
+        SystemTime::UNIX_EPOCH.checked_add(Duration::from_secs(timestamp))
+    }
+
+    /// Convert the system time into a timestamp in seconds from the Unix epoch.
+    ///
+    /// Returns an error if the system time is earlier the Unix epoch.
+    fn as_timestamp(&self) -> Result<u64, SystemTimeError>;
+}
+
+impl SystemTimeExt for SystemTime {
+    fn as_timestamp(&self) -> Result<u64, SystemTimeError> {
+        Ok(self.duration_since(SystemTime::UNIX_EPOCH)?.as_secs())
+    }
+}

--- a/core/src/time.rs
+++ b/core/src/time.rs
@@ -5,9 +5,14 @@ use std::time::{Duration, SystemTime, SystemTimeError};
 /// `SystemTime` extention trait.
 pub trait SystemTimeExt {
     /// Creates a new `SystemTime` from a Unix timestamp.
+    fn from_timestamp(timestamp: u64) -> SystemTime {
+        SystemTime::UNIX_EPOCH + Duration::from_secs(timestamp)
+    }
+
+    /// Creates a new `SystemTime` from a Unix timestamp.
     ///
     /// Returns `None` if the specified timestamp cannot be represented.
-    fn from_timestamp(timestamp: u64) -> Option<SystemTime> {
+    fn checked_from_timestamp(timestamp: u64) -> Option<SystemTime> {
         SystemTime::UNIX_EPOCH.checked_add(Duration::from_secs(timestamp))
     }
 


### PR DESCRIPTION
This PR adds some SystemTime utilities for converting to and from timestamps.

### Test Plan

Refactored `SystemTime` arithmetic to its own module, so Rustc + CI.