### PR TITLE
Introduce HistoricOrderbookReading trait

### DIFF
--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -31,7 +31,7 @@ macro_rules! std_map {
 
 macro_rules! immediate {
     ($expression:expr) => {
-        async move { $expression }.boxed()
+        futures::future::FutureExt::boxed(async move { $expression })
     };
 }
 

--- a/core/src/orderbook.rs
+++ b/core/src/orderbook.rs
@@ -1,6 +1,6 @@
 mod auction_data_reader;
+pub mod block_or_timestamp;
 mod filtered_orderbook;
-pub mod history;
 mod onchain_filtered_orderbook;
 mod paginated_orderbook;
 mod shadow_orderbook;

--- a/core/src/orderbook.rs
+++ b/core/src/orderbook.rs
@@ -1,5 +1,6 @@
 mod auction_data_reader;
 mod filtered_orderbook;
+pub mod history;
 mod onchain_filtered_orderbook;
 mod paginated_orderbook;
 mod shadow_orderbook;
@@ -34,15 +35,16 @@ pub trait StableXOrderBookReading: Send + Sync {
         &'a self,
         batch_id_to_solve: u32,
     ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>>;
+
     /// Perform potential heavy initialization of the orderbook. If this fails or wasn't called
-    // the orderbook will initialize on first use of `get_auction_data`.
+    /// the orderbook will initialize on first use of `get_auction_data`.
     fn initialize<'a>(&'a self) -> BoxFuture<'a, Result<()>> {
         async { Ok(()) }.boxed()
     }
 }
 
 /// Always suceeds with empty orderbook.
-pub struct NoopOrderbook {}
+pub struct NoopOrderbook;
 
 impl StableXOrderBookReading for NoopOrderbook {
     fn get_auction_data<'a>(&'a self, _: u32) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>> {

--- a/core/src/orderbook/block_or_timestamp.rs
+++ b/core/src/orderbook/block_or_timestamp.rs
@@ -7,8 +7,8 @@ use ethcontract::BlockNumber;
 use futures::future::BoxFuture;
 use std::time::SystemTime;
 
-/// Trait for reading historic orderbook data.
-pub trait HistoricOrderbookReading: StableXOrderBookReading {
+/// Trait for reading orderbook data by block or timestamp.
+pub trait OrderbookReadingByBlockOrTimestamp: StableXOrderBookReading {
     /// Retrieves the open orderbook at the specified block number.
     ///
     /// The open orderbook is defined as the auction state for the current batch
@@ -27,7 +27,7 @@ pub trait HistoricOrderbookReading: StableXOrderBookReading {
     ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>>;
 }
 
-impl HistoricOrderbookReading for NoopOrderbook {
+impl OrderbookReadingByBlockOrTimestamp for NoopOrderbook {
     fn get_auction_data_for_block<'a>(
         &'a self,
         _: BlockNumber,
@@ -47,8 +47,8 @@ impl HistoricOrderbookReading for NoopOrderbook {
 mod mock {
     use super::*;
 
-    /// Proxy trait used for mocking a `HistoricOrderbookReading` to work around
-    /// the fact that `mockall` doesn't support trait inheritance.
+    /// Proxy trait used for mocking a `OrderbookReadingByBlockOrTimestamp` to
+    /// work around the fact that `mockall` doesn't support trait inheritance.
     #[mockall::automock]
     pub trait Proxy {
         fn get_auction_data<'a>(
@@ -78,7 +78,7 @@ mod mock {
         }
     }
 
-    impl HistoricOrderbookReading for MockProxy {
+    impl OrderbookReadingByBlockOrTimestamp for MockProxy {
         fn get_auction_data_for_block<'a>(
             &'a self,
             block_number: BlockNumber,
@@ -95,4 +95,4 @@ mod mock {
 }
 
 #[cfg(test)]
-pub use mock::MockProxy as MockHistoricOrderbookReading;
+pub use mock::MockProxy as MockOrderbookReadingByBlockOrTimestamp;

--- a/core/src/orderbook/history.rs
+++ b/core/src/orderbook/history.rs
@@ -1,0 +1,98 @@
+//! Module for historic orderbook reading.
+
+use super::{NoopOrderbook, StableXOrderBookReading};
+use crate::models::{AccountState, Order};
+use anyhow::Result;
+use ethcontract::BlockNumber;
+use futures::future::BoxFuture;
+use std::time::SystemTime;
+
+/// Trait for reading historic orderbook data.
+pub trait HistoricOrderbookReading: StableXOrderBookReading {
+    /// Retrieves the open orderbook at the specified block number.
+    ///
+    /// The open orderbook is defined as the auction state for the current batch
+    /// at the specified block number. This implies that, assuming no futher
+    /// changes to the exchange, this will be the auction state passed to the
+    /// solver to be submitted in the next batch.
+    fn get_auction_data_for_block<'a>(
+        &'a self,
+        block_number: BlockNumber,
+    ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>>;
+
+    /// Retrieves the open orderbook at the specified timestamp.
+    fn get_auction_data_for_timestamp<'a>(
+        &'a self,
+        timestamp: SystemTime,
+    ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>>;
+}
+
+impl HistoricOrderbookReading for NoopOrderbook {
+    fn get_auction_data_for_block<'a>(
+        &'a self,
+        _: BlockNumber,
+    ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>> {
+        immediate!(Ok(Default::default()))
+    }
+
+    fn get_auction_data_for_timestamp<'a>(
+        &'a self,
+        _: SystemTime,
+    ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>> {
+        immediate!(Ok(Default::default()))
+    }
+}
+
+#[cfg(test)]
+mod mock {
+    use super::*;
+
+    /// Proxy trait used for mocking a `HistoricOrderbookReading` to work around
+    /// the fact that `mockall` doesn't support trait inheritance.
+    #[mockall::automock]
+    pub trait Proxy {
+        fn get_auction_data<'a>(
+            &'a self,
+            batch_id_to_solve: u32,
+        ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>>;
+        fn initialize<'a>(&'a self) -> BoxFuture<'a, Result<()>>;
+        fn get_auction_data_for_block<'a>(
+            &'a self,
+            block_number: BlockNumber,
+        ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>>;
+        fn get_auction_data_for_timestamp<'a>(
+            &'a self,
+            timestamp: SystemTime,
+        ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>>;
+    }
+
+    impl StableXOrderBookReading for MockProxy {
+        fn get_auction_data<'a>(
+            &'a self,
+            batch_id_to_solve: u32,
+        ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>> {
+            Proxy::get_auction_data(self, batch_id_to_solve)
+        }
+        fn initialize<'a>(&'a self) -> BoxFuture<'a, Result<()>> {
+            Proxy::initialize(self)
+        }
+    }
+
+    impl HistoricOrderbookReading for MockProxy {
+        fn get_auction_data_for_block<'a>(
+            &'a self,
+            block_number: BlockNumber,
+        ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>> {
+            Proxy::get_auction_data_for_block(self, block_number)
+        }
+        fn get_auction_data_for_timestamp<'a>(
+            &'a self,
+            timestamp: SystemTime,
+        ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>> {
+            Proxy::get_auction_data_for_timestamp(self, timestamp)
+        }
+    }
+}
+
+#[cfg(test)]
+pub use mock::MockProxy as MockHistoricOrderbookReading;

--- a/core/src/token_info.rs
+++ b/core/src/token_info.rs
@@ -1,9 +1,9 @@
+use crate::models::TokenId;
 use anyhow::Result;
 use futures::future::{BoxFuture, FutureExt as _};
 use lazy_static::lazy_static;
 use std::{collections::HashMap, num::NonZeroU128};
 
-use crate::models::TokenId;
 pub mod cached;
 pub mod hardcoded;
 pub mod onchain;

--- a/core/src/token_info/hardcoded.rs
+++ b/core/src/token_info/hardcoded.rs
@@ -1,18 +1,13 @@
 //! This module contains fallback token data that should be used by the price
 //! estimator when prices are not available.
 
-use crate::models::TokenId;
-use crate::price_estimation::price_source::PriceSource;
-use anyhow::{anyhow, Context, Error, Result};
-
-use futures::future::{BoxFuture, FutureExt};
-use serde::Deserialize;
-use std::collections::HashMap;
-use std::iter::FromIterator;
-use std::num::NonZeroU128;
-use std::str::FromStr;
-
 use super::{TokenBaseInfo, TokenInfoFetching};
+use crate::{models::TokenId, price_estimation::price_source::PriceSource};
+use anyhow::{anyhow, Context, Error, Result};
+use futures::future::BoxFuture;
+use serde::Deserialize;
+use std::{collections::HashMap, iter::FromIterator, num::NonZeroU128, str::FromStr};
+
 #[cfg_attr(test, derive(Eq, PartialEq))]
 #[derive(Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
This PR adds a new `HistoricOrderbookReading` trait for reading the orderbook at arbitrary batches and timestamps. This will be used for #1272 in order to construct historic `Pricegraph`s at specified block numbers and timestamps.

### Test Plan

Adds to new trait without any implementations - so Rustc!