### PR TITLE
Implement HistoricOrderbookReading for the event-based orderbook

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod orderbook;
 pub mod price_estimation;
 pub mod price_finding;
 pub mod solution_submission;
+pub mod time;
 pub mod token_info;
 pub mod transport;
 pub mod util;

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -31,7 +31,7 @@ macro_rules! std_map {
 
 macro_rules! immediate {
     ($expression:expr) => {
-        async move { $expression }.boxed()
+        futures::future::FutureExt::boxed(async move { $expression })
     };
 }
 

--- a/core/src/models/batch_id.rs
+++ b/core/src/models/batch_id.rs
@@ -1,3 +1,4 @@
+use crate::time::SystemTimeExt as _;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::time::{Duration, SystemTime, SystemTimeError};
@@ -27,12 +28,11 @@ impl BatchId {
         Self::current(SystemTime::now()).expect("system time earlier than Unix epoch")
     }
 
-    pub fn current(now: SystemTime) -> std::result::Result<Self, SystemTimeError> {
-        let time_since_epoch = now.duration_since(SystemTime::UNIX_EPOCH)?;
-        Ok(Self::from_timestamp(time_since_epoch.as_secs()))
+    pub fn current(now: SystemTime) -> Result<Self, SystemTimeError> {
+        Ok(Self::from_timestamp(now.as_timestamp()?))
     }
 
-    pub fn currently_being_solved(now: SystemTime) -> std::result::Result<Self, SystemTimeError> {
+    pub fn currently_being_solved(now: SystemTime) -> Result<Self, SystemTimeError> {
         Self::current(now).map(|batch_id| batch_id.prev())
     }
 

--- a/core/src/orderbook.rs
+++ b/core/src/orderbook.rs
@@ -1,5 +1,6 @@
 mod auction_data_reader;
 mod filtered_orderbook;
+pub mod history;
 mod onchain_filtered_orderbook;
 mod paginated_orderbook;
 mod shadow_orderbook;
@@ -34,15 +35,16 @@ pub trait StableXOrderBookReading: Send + Sync {
         &'a self,
         batch_id_to_solve: u32,
     ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>>;
+
     /// Perform potential heavy initialization of the orderbook. If this fails or wasn't called
-    // the orderbook will initialize on first use of `get_auction_data`.
+    /// the orderbook will initialize on first use of `get_auction_data`.
     fn initialize<'a>(&'a self) -> BoxFuture<'a, Result<()>> {
         async { Ok(()) }.boxed()
     }
 }
 
 /// Always suceeds with empty orderbook.
-pub struct NoopOrderbook {}
+pub struct NoopOrderbook;
 
 impl StableXOrderBookReading for NoopOrderbook {
     fn get_auction_data<'a>(&'a self, _: u32) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>> {

--- a/core/src/orderbook/history.rs
+++ b/core/src/orderbook/history.rs
@@ -1,0 +1,98 @@
+//! Module for historic orderbook reading.
+
+use super::{NoopOrderbook, StableXOrderBookReading};
+use crate::models::{AccountState, Order};
+use anyhow::Result;
+use ethcontract::BlockNumber;
+use futures::future::BoxFuture;
+use std::time::SystemTime;
+
+/// Trait for reading historic orderbook data.
+pub trait HistoricOrderbookReading: StableXOrderBookReading {
+    /// Retrieves the open orderbook at the specified block number.
+    ///
+    /// The open orderbook is defined as the auction state for the current batch
+    /// at the specified block number. This implies that, assuming no futher
+    /// changes to the exchange, this will be the auction state passed to the
+    /// solver to be submitted in the next batch.
+    fn get_auction_data_for_block<'a>(
+        &'a self,
+        block_number: BlockNumber,
+    ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>>;
+
+    /// Retrieves the open orderbook at the specified timestamp.
+    fn get_auction_data_for_timestamp<'a>(
+        &'a self,
+        timestamp: SystemTime,
+    ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>>;
+}
+
+impl HistoricOrderbookReading for NoopOrderbook {
+    fn get_auction_data_for_block<'a>(
+        &'a self,
+        _: BlockNumber,
+    ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>> {
+        immediate!(Ok(Default::default()))
+    }
+
+    fn get_auction_data_for_timestamp<'a>(
+        &'a self,
+        _: SystemTime,
+    ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>> {
+        immediate!(Ok(Default::default()))
+    }
+}
+
+#[cfg(test)]
+mod mock {
+    use super::*;
+
+    /// Proxy trait used for mocking a `HistoricOrderbookReading` to work around
+    /// the fact that `mockall` doesn't support trait inheritance.
+    #[mockall::automock]
+    pub trait Proxy {
+        fn get_auction_data<'a>(
+            &'a self,
+            batch_id_to_solve: u32,
+        ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>>;
+        fn initialize<'a>(&'a self) -> BoxFuture<'a, Result<()>>;
+        fn get_auction_data_for_block<'a>(
+            &'a self,
+            block_number: BlockNumber,
+        ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>>;
+        fn get_auction_data_for_timestamp<'a>(
+            &'a self,
+            timestamp: SystemTime,
+        ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>>;
+    }
+
+    impl StableXOrderBookReading for MockProxy {
+        fn get_auction_data<'a>(
+            &'a self,
+            batch_id_to_solve: u32,
+        ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>> {
+            Proxy::get_auction_data(self, batch_id_to_solve)
+        }
+        fn initialize<'a>(&'a self) -> BoxFuture<'a, Result<()>> {
+            Proxy::initialize(self)
+        }
+    }
+
+    impl HistoricOrderbookReading for MockProxy {
+        fn get_auction_data_for_block<'a>(
+            &'a self,
+            block_number: BlockNumber,
+        ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>> {
+            Proxy::get_auction_data_for_block(self, block_number)
+        }
+        fn get_auction_data_for_timestamp<'a>(
+            &'a self,
+            timestamp: SystemTime,
+        ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>> {
+            Proxy::get_auction_data_for_timestamp(self, timestamp)
+        }
+    }
+}
+
+#[cfg(test)]
+pub use mock::MockProxy as MockHistoricOrderbookReading;

--- a/core/src/time.rs
+++ b/core/src/time.rs
@@ -1,0 +1,24 @@
+//! Time utilites for dealing with batches.
+
+use std::time::{Duration, SystemTime, SystemTimeError};
+
+/// `SystemTime` extention trait.
+pub trait SystemTimeExt {
+    /// Creates a new `SystemTime` from a Unix timestamp.
+    ///
+    /// Returns `None` if the specified timestamp cannot be represented.
+    fn from_timestamp(timestamp: u64) -> Option<SystemTime> {
+        SystemTime::UNIX_EPOCH.checked_add(Duration::from_secs(timestamp))
+    }
+
+    /// Convert the system time into a timestamp in seconds from the Unix epoch.
+    ///
+    /// Returns an error if the system time is earlier the Unix epoch.
+    fn as_timestamp(&self) -> Result<u64, SystemTimeError>;
+}
+
+impl SystemTimeExt for SystemTime {
+    fn as_timestamp(&self) -> Result<u64, SystemTimeError> {
+        Ok(self.duration_since(SystemTime::UNIX_EPOCH)?.as_secs())
+    }
+}

--- a/core/src/token_info.rs
+++ b/core/src/token_info.rs
@@ -1,9 +1,9 @@
+use crate::models::TokenId;
 use anyhow::Result;
 use futures::future::{BoxFuture, FutureExt as _};
 use lazy_static::lazy_static;
 use std::{collections::HashMap, num::NonZeroU128};
 
-use crate::models::TokenId;
 pub mod cached;
 pub mod hardcoded;
 pub mod onchain;

--- a/core/src/token_info/hardcoded.rs
+++ b/core/src/token_info/hardcoded.rs
@@ -1,18 +1,13 @@
 //! This module contains fallback token data that should be used by the price
 //! estimator when prices are not available.
 
-use crate::models::TokenId;
-use crate::price_estimation::price_source::PriceSource;
-use anyhow::{anyhow, Context, Error, Result};
-
-use futures::future::{BoxFuture, FutureExt};
-use serde::Deserialize;
-use std::collections::HashMap;
-use std::iter::FromIterator;
-use std::num::NonZeroU128;
-use std::str::FromStr;
-
 use super::{TokenBaseInfo, TokenInfoFetching};
+use crate::{models::TokenId, price_estimation::price_source::PriceSource};
+use anyhow::{anyhow, Context, Error, Result};
+use futures::future::BoxFuture;
+use serde::Deserialize;
+use std::{collections::HashMap, iter::FromIterator, num::NonZeroU128, str::FromStr};
+
 #[cfg_attr(test, derive(Eq, PartialEq))]
 #[derive(Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]

--- a/price-estimator/README.md
+++ b/price-estimator/README.md
@@ -1,12 +1,13 @@
 ## API
 
-All endpoints use the query part of the url with these key-values:
+All endpoints use the query part of the URL with these key-values:
 
-* `atoms`: Required. If set to `true` all amounts are denominated in the smallest available unit (base quantity) of the token. If `false` all amounts are denominated in the "natural" unit of the respective token given by the number of decimals specified through the ERC20 interface. TODO: `false` is currently only implemented for estimated-buy-amount and estimated-amounts-at-price .
-* `hops`: Optional. TODO: document this once it has been implemented.
-* `batchId`: Optional. Specify a specific batch ID to compute the estimate for, only accounting orders that are valid at the specified batch. If no batch ID is specified, the current batch that is collecting orders will be used.
+* `unit`: Either `atoms` or `baseunits` (default). If set to `atoms` all amounts are denominated in the smallest available unit (atom) of the token. If `baseunits` all amounts are denominated in the "natural" unit of the respective token given by the number of decimals specified through the ERC20 interface. TODO: `baseunits` is currently not implemented for all URLs.
+* `atoms`: Deprecated. An boolean alias for `unit` parameter where `atoms=true` is equivalent to `unit=atoms` and `atoms=false` is equivalent to `unit=baseunits`.
+* `hops`: TODO: document this once it has been implemented.
+* `batchId`: Specify a specific batch ID to compute the estimate for, only accounting orders that are valid at the specified batch. If no batch ID is specified, the current batch that is collecting orders will be used.
 
-Example: `<path>?atoms=true`
+Example: `<path>?unit=atoms&batchId=1337`
 
 The endpoint documentation references these types:
 
@@ -20,7 +21,7 @@ The service exposes the following endpoints:
 
 `GET /api/v1/markets/:market`
 
-Example Request: `/api/v1/markets/1-7?atoms=true`
+Example Request: `/api/v1/markets/1-7?unit=atoms`
 
 Example Response:
 
@@ -41,7 +42,7 @@ Returns the transitive orderbook (containing bids and asks) for the given base a
 
 `GET /api/v1/markets/:market/estimated-buy-amount/:sell-amount-in-quote-token`
 
-Example Request: `/api/v1/markets/1-7/estimated-buy-amount/20000000000000000000?atoms=true`
+Example Request: `/api/v1/markets/1-7/estimated-buy-amount/20000000000000000000?unit=atoms`
 
 Example Response:
 
@@ -55,13 +56,13 @@ Example Response:
 ```
 
 * `buyAmountInBase` estimates the buy amount (in base tokens) a user can set as a limit order while still expecting to be completely matched when selling the given amount of quote token.
-* The other fields repeat the parameters in the url back.
+* The other fields repeat the parameters in the URL back.
 
 ### Estimated Amounts At Price
 
 `GET /api/v1/markets/:market/estimated-amounts-at-price/:price-in-quote`
 
-Example Request: `/api/v1/markets/1-7/estimated-amounts-at-price/245.5?atoms=true`
+Example Request: `/api/v1/markets/1-7/estimated-amounts-at-price/245.5?unit=atoms`
 
 Example Response:
 
@@ -78,13 +79,13 @@ The following result indicates that if we wanted to buy ETH (token 2) for DAI (t
 
 * `sellAmountInBase` estimates the sell amount (in quote tokens) a user can completely fill in the following batch at the specified `price_in_quote`.
 * `buyAmountInBase` is the computed buy amount (in base tokens) for the order from the specified price and estimated sell amount. Note that it might be possible to use a higher buy amount for the same returned sell amount and still likely get completely matched by the solver. This buy amount can be computed with a subsequent estimate buy amount API call using the returned sell amount in quote value.
-* The other fields repeat the parameters in the url back.
+* The other fields repeat the parameters in the URL back.
 
 ### Estimated Best Ask Price
 
 `GET /api/v1/markets/:market/estimated-best-ask-price`
 
-Example Request: `/api/v1/markets/1-7/estimated-best-ask-price?atoms=true`
+Example Request: `/api/v1/markets/1-7/estimated-best-ask-price?unit=atoms`
 
 Example Responses:
 
@@ -97,7 +98,7 @@ It represents the exchange rate for the market. In the example we can exchange ~
 
 # Testing
 
-To test a locally running price estimator with the frontend at https://mesa.eth.link/ we need to set our browser to allow websites to access localhost and change the url that the javascript uses for the price estimator. With chromium:
+To test a locally running price estimator with the frontend at https://mesa.eth.link/ we need to set our browser to allow websites to access localhost and change the URL that the javascript uses for the price estimator. With chromium:
 
 1. `chromium --disable-web-security --user-data-dir=temp/`.
 2. Open the frontend.
@@ -105,7 +106,7 @@ To test a locally running price estimator with the frontend at https://mesa.eth.
 4. In the browser console enter `dexPriceEstimatorApi.urlsByNetwork[1] = "http://localhost:8080/api/v1/"`.
 5. Induce a request by changing the sell amount and check that price estimator prints that it handled the request.
 
-It is useful to start the price estimator with logging enabled, using the gnosis staging node url and using a permanent orderbook file:
+It is useful to start the price estimator with logging enabled, using the gnosis staging node URL and using a permanent orderbook file:
 
 ```
 env RUST_LOG=warn,price_estimator=info,core=info cargo run -p price-estimator -- --node-url https://staging-openethereum.mainnet.gnosisdev.com --orderbook-file ../orderbook-file-mainnet

--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -173,11 +173,11 @@ async fn get_markets(
     query: QueryParameters,
     orderbook: Arc<Orderbook>,
 ) -> Result<impl Reply, Rejection> {
-    if !query.atoms {
+    if query.unit != Unit::Atoms {
         return Err(warp::reject());
     }
     let transitive_orderbook = orderbook
-        .pricegraph(query.batch_id, PricegraphKind::Raw)
+        .pricegraph(query.generation, PricegraphKind::Raw)
         .await
         .map_err(error::internal_server_rejection)?
         .transitive_orderbook(*market, None);
@@ -203,18 +203,19 @@ async fn estimate_buy_amount(
     orderbook: Arc<Orderbook>,
     token_infos: Arc<dyn TokenInfoFetching>,
 ) -> Result<impl Reply, Rejection> {
-    let (sell_amount_in_quote, sell_amount_in_quote_atoms) = if query.atoms {
-        (
+    let (sell_amount_in_quote, sell_amount_in_quote_atoms) = match query.unit {
+        Unit::Atoms => (
             Amount::Atoms(sell_amount_in_quote as _),
             sell_amount_in_quote,
-        )
-    } else {
-        let token_info = get_token_info(token_pair.sell, token_infos.as_ref()).await?;
-        let amount = Amount::BaseUnits(sell_amount_in_quote);
-        (amount, amount.as_atoms(&token_info) as _)
+        ),
+        Unit::BaseUnits => {
+            let token_info = get_token_info(token_pair.sell, token_infos.as_ref()).await?;
+            let amount = Amount::BaseUnits(sell_amount_in_quote);
+            (amount, amount.as_atoms(&token_info) as _)
+        }
     };
     let transitive_order = orderbook
-        .pricegraph(query.batch_id, PricegraphKind::Raw)
+        .pricegraph(query.generation, PricegraphKind::Raw)
         .await
         .map_err(error::internal_server_rejection)?
         .order_for_sell_amount(token_pair, sell_amount_in_quote_atoms);
@@ -224,7 +225,8 @@ async fn estimate_buy_amount(
             .map(|order| apply_rounding_buffer(order.buy, price_rounding_buffer))
             .unwrap_or_default() as _,
     );
-    if !query.atoms {
+
+    if query.unit == Unit::BaseUnits {
         let token_info = get_token_info(token_pair.buy, token_infos.as_ref()).await?;
         buy_amount_in_base = buy_amount_in_base.into_base_units(&token_info)
     };
@@ -247,33 +249,34 @@ async fn estimate_amounts_at_price(
     token_infos: Arc<dyn TokenInfoFetching>,
 ) -> Result<impl Reply, Rejection> {
     let pricegraph = orderbook
-        .pricegraph(query.batch_id, PricegraphKind::Raw)
+        .pricegraph(query.generation, PricegraphKind::Raw)
         .await
         .map_err(error::internal_server_rejection)?;
-    let result = if query.atoms {
-        estimate_amounts_at_price_atoms(
+    let result = match query.unit {
+        Unit::Atoms => estimate_amounts_at_price_atoms(
             token_pair,
             price_in_quote,
             price_rounding_buffer,
             pricegraph,
-        )
-    } else {
-        let buy_token_info = get_token_info(token_pair.buy, token_infos.as_ref()).await?;
-        let sell_token_info = get_token_info(token_pair.sell, token_infos.as_ref()).await?;
-        let price_in_quote_atoms = price_in_quote
-            * (sell_token_info.base_unit_in_atoms().get() as f64
-                / buy_token_info.base_unit_in_atoms().get() as f64);
-        let mut result = estimate_amounts_at_price_atoms(
-            token_pair,
-            price_in_quote_atoms,
-            price_rounding_buffer,
-            pricegraph,
-        );
-        result.buy_amount_in_base = result.buy_amount_in_base.into_base_units(&buy_token_info);
-        result.sell_amount_in_quote = result
-            .sell_amount_in_quote
-            .into_base_units(&sell_token_info);
-        result
+        ),
+        Unit::BaseUnits => {
+            let buy_token_info = get_token_info(token_pair.buy, token_infos.as_ref()).await?;
+            let sell_token_info = get_token_info(token_pair.sell, token_infos.as_ref()).await?;
+            let price_in_quote_atoms = price_in_quote
+                * (sell_token_info.base_unit_in_atoms().get() as f64
+                    / buy_token_info.base_unit_in_atoms().get() as f64);
+            let mut result = estimate_amounts_at_price_atoms(
+                token_pair,
+                price_in_quote_atoms,
+                price_rounding_buffer,
+                pricegraph,
+            );
+            result.buy_amount_in_base = result.buy_amount_in_base.into_base_units(&buy_token_info);
+            result.sell_amount_in_quote = result
+                .sell_amount_in_quote
+                .into_base_units(&sell_token_info);
+            result
+        }
     };
     Ok(warp::reply::json(&result))
 }
@@ -313,11 +316,11 @@ async fn estimate_best_ask_price(
     price_rounding_buffer: f64,
     orderbook: Arc<Orderbook>,
 ) -> Result<impl Reply, Rejection> {
-    if !query.atoms {
+    if query.unit != Unit::Atoms {
         return Err(warp::reject());
     }
     let price = orderbook
-        .pricegraph(query.batch_id, PricegraphKind::Raw)
+        .pricegraph(query.generation, PricegraphKind::Raw)
         .await
         .map_err(error::internal_server_rejection)?
         .estimate_limit_price(token_pair, 0.0)
@@ -409,7 +412,7 @@ mod tests {
         assert_eq!(token_pair.buy, 0);
         assert_eq!(token_pair.sell, 65535);
         assert_eq!(volume, 1.0);
-        assert_eq!(query.atoms, true);
+        assert_eq!(query.unit, Unit::Atoms);
         assert_eq!(query.hops, Some(2));
     }
 
@@ -423,7 +426,7 @@ mod tests {
             .unwrap();
         assert_eq!(market.base, 1);
         assert_eq!(market.quote, 2);
-        assert_eq!(query.atoms, true);
+        assert_eq!(query.unit, Unit::Atoms);
         assert_eq!(query.hops, Some(3));
     }
 
@@ -522,7 +525,7 @@ mod tests {
         assert_eq!(token_pair.buy, 0);
         assert_eq!(token_pair.sell, 65535);
         assert!((volume - 0.5).abs() < f64::EPSILON);
-        assert_eq!(query.atoms, true);
+        assert_eq!(query.unit, Unit::Atoms);
         assert_eq!(query.hops, None);
     }
 
@@ -536,7 +539,7 @@ mod tests {
             .unwrap();
         assert_eq!(token_pair.buy, 0);
         assert_eq!(token_pair.sell, 65535);
-        assert_eq!(query.atoms, true);
+        assert_eq!(query.unit, Unit::Atoms);
         assert_eq!(query.hops, None);
     }
 }

--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -419,7 +419,7 @@ mod tests {
     #[test]
     fn markets_ok() {
         let (market, query) = warp::test::request()
-            .path("/markets/1-2?atoms=true&hops=3")
+            .path("/markets/1-2?atoms=true&hops=3&batchId=123")
             .filter(&markets_filter())
             .now_or_never()
             .unwrap()
@@ -428,27 +428,7 @@ mod tests {
         assert_eq!(market.quote, 2);
         assert_eq!(query.unit, Unit::Atoms);
         assert_eq!(query.hops, Some(3));
-    }
-
-    #[test]
-    fn missing_hops_ok() {
-        let (_, _, query) = warp::test::request()
-            .path("/markets/0-65535/estimated-buy-amount/1?atoms=true")
-            .filter(&estimated_buy_amount_filter())
-            .now_or_never()
-            .unwrap()
-            .unwrap();
-        assert_eq!(query.hops, None);
-    }
-
-    #[test]
-    fn missing_query() {
-        assert!(warp::test::request()
-            .path("/markets/0-0/estimated-buy-amount/0")
-            .filter(&estimated_buy_amount_filter())
-            .now_or_never()
-            .unwrap()
-            .is_err());
+        assert_eq!(query.generation, Generation::Batch(123.into()));
     }
 
     #[test]
@@ -488,22 +468,6 @@ mod tests {
         for path in &[
             "/markets/0-1/estimated-buy-amount/",
             "/markets/0-1/estimated-buy-amount/asdf",
-        ] {
-            assert!(warp::test::request()
-                .path(path)
-                .filter(&estimated_buy_amount_filter())
-                .now_or_never()
-                .unwrap()
-                .is_err());
-        }
-    }
-
-    #[test]
-    fn estimated_buy_amount_no_float_volume() {
-        for path in &[
-            "/markets/0-1/estimated-buy-amount/0.0",
-            "/markets/0-1/estimated-buy-amount/1.0",
-            "/markets/0-1/estimated-buy-amount/0.5",
         ] {
             assert!(warp::test::request()
                 .path(path)

--- a/price-estimator/src/models.rs
+++ b/price-estimator/src/models.rs
@@ -1,5 +1,9 @@
-use core::{models::BatchId, token_info::TokenBaseInfo};
-use serde::{Deserialize, Serialize};
+mod query;
+
+pub use self::query::*;
+use anyhow::Result;
+use core::token_info::TokenBaseInfo;
+use serde::Serialize;
 use serde_with::rust::display_fromstr;
 use std::{cmp::Ordering, num::ParseIntError, ops::Deref, str::FromStr};
 
@@ -40,15 +44,6 @@ impl FromStr for Market {
             quote: quote_token_id,
         }))
     }
-}
-
-/// The query part of the url.
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct QueryParameters {
-    pub atoms: bool,
-    pub hops: Option<u16>,
-    pub batch_id: Option<BatchId>,
 }
 
 #[derive(Serialize)]

--- a/price-estimator/src/models/query.rs
+++ b/price-estimator/src/models/query.rs
@@ -45,7 +45,6 @@ pub enum Generation {
 #[serde(rename_all = "camelCase")]
 struct RawQuery {
     atoms: Option<bool>,
-    unit: Option<Unit>,
     hops: Option<usize>,
     batch_id: Option<BatchId>,
 }
@@ -55,12 +54,10 @@ impl TryFrom<RawQuery> for QueryParameters {
 
     fn try_from(raw: RawQuery) -> Result<Self> {
         Ok(QueryParameters {
-            unit: match (raw.atoms, raw.unit) {
-                (Some(true), None) => Unit::Atoms,
-                (Some(false), None) => Unit::BaseUnits,
-                (None, Some(unit)) => unit,
-                (None, None) => bail!("'atoms' or 'unit' parameter must be specified"),
-                _ => bail!("specified both 'atoms' and 'unit' parameters"),
+            unit: match raw.atoms {
+                Some(true) => Unit::Atoms,
+                Some(false) => Unit::BaseUnits,
+                None => bail!("'atoms' or parameter must be specified"),
             },
             hops: raw.hops,
             generation: match raw.batch_id {

--- a/price-estimator/src/models/query.rs
+++ b/price-estimator/src/models/query.rs
@@ -28,6 +28,12 @@ pub enum Unit {
     BaseUnits,
 }
 
+impl Default for Unit {
+    fn default() -> Self {
+        Unit::BaseUnits
+    }
+}
+
 /// When to perform a price estimate.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Generation {
@@ -42,9 +48,10 @@ pub enum Generation {
 
 /// Intermediate raw query parameters used for parsing.
 #[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 struct RawQuery {
     atoms: Option<bool>,
+    unit: Option<Unit>,
     hops: Option<usize>,
     batch_id: Option<BatchId>,
 }
@@ -54,10 +61,12 @@ impl TryFrom<RawQuery> for QueryParameters {
 
     fn try_from(raw: RawQuery) -> Result<Self> {
         Ok(QueryParameters {
-            unit: match raw.atoms {
-                Some(true) => Unit::Atoms,
-                Some(false) => Unit::BaseUnits,
-                None => bail!("'atoms' or parameter must be specified"),
+            unit: match (raw.atoms, raw.unit) {
+                (Some(true), None) => Unit::Atoms,
+                (Some(false), None) => Unit::BaseUnits,
+                (None, Some(unit)) => unit,
+                (None, None) => Unit::default(),
+                _ => bail!("only one of 'atoms' or 'unit' parameters can be specified"),
             },
             hops: raw.hops,
             generation: match raw.batch_id {
@@ -65,5 +74,57 @@ impl TryFrom<RawQuery> for QueryParameters {
                 None => Generation::Current,
             },
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::future::FutureExt as _;
+    use warp::Rejection;
+
+    fn query_params(params: &str) -> Result<QueryParameters, Rejection> {
+        warp::test::request()
+            .path(&format!("/{}", params))
+            .filter(&warp::query::<QueryParameters>())
+            .now_or_never()
+            .unwrap()
+    }
+
+    #[test]
+    fn default_query_parameters() {
+        let query = query_params("").unwrap();
+        assert_eq!(query.unit, Unit::BaseUnits);
+        assert_eq!(query.hops, None);
+        assert_eq!(query.generation, Generation::Current);
+    }
+
+    #[test]
+    fn all_query_parameters() {
+        let query = query_params("?unit=atoms&hops=42&batchId=1337").unwrap();
+        assert_eq!(query.unit, Unit::Atoms);
+        assert_eq!(query.hops, Some(42));
+        assert_eq!(query.generation, Generation::Batch(1337.into()));
+    }
+
+    #[test]
+    fn invalid_parameters() {
+        assert!(query_params("?unit=invalid").is_err());
+        assert!(query_params("?hops=invalid").is_err());
+        assert!(query_params("?batch_id=invalid").is_err());
+    }
+
+    #[test]
+    fn atoms_query_parameter() {
+        let query = query_params("?atoms=true").unwrap();
+        assert_eq!(query.unit, Unit::Atoms);
+
+        let query = query_params("?atoms=false").unwrap();
+        assert_eq!(query.unit, Unit::BaseUnits);
+    }
+
+    #[test]
+    fn mutually_exclusive_unit_parameter() {
+        assert!(query_params("?unit=atoms&atoms=true").is_err());
     }
 }

--- a/price-estimator/src/models/query.rs
+++ b/price-estimator/src/models/query.rs
@@ -1,0 +1,72 @@
+//! Module implementing parsing request query parameters.
+
+use anyhow::{bail, Error, Result};
+use core::models::BatchId;
+use serde::Deserialize;
+use std::convert::TryFrom;
+
+/// Common query parameters shared across all price estimation routes.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(try_from = "RawQuery")]
+pub struct QueryParameters {
+    /// The unit of the token amounts.
+    pub unit: Unit,
+    /// The maximum number of hops (i.e. maximum ring trade length) used by the
+    /// `pricegraph` search algorithm.
+    pub hops: Option<usize>,
+    /// The generation to load the orderbook at.
+    pub generation: Generation,
+}
+
+/// Units for token amounts.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum Unit {
+    /// Atoms, smallest unit for a token.
+    Atoms,
+    /// Base units, such that `1.0` is `10.pow(decimals)` atoms.
+    BaseUnits,
+}
+
+/// When to perform a price estimate.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Generation {
+    /// The `Pricegraph` will be contructed from the current state of the
+    /// orderbook.
+    Current,
+    /// The `Pricegraph` will be contructed from the finalized orderbook at the
+    /// specified batch. This will be the same orderbook that is provided to the
+    /// solver when solving for the specified batch.
+    Batch(BatchId),
+}
+
+/// Intermediate raw query parameters used for parsing.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawQuery {
+    atoms: Option<bool>,
+    unit: Option<Unit>,
+    hops: Option<usize>,
+    batch_id: Option<BatchId>,
+}
+
+impl TryFrom<RawQuery> for QueryParameters {
+    type Error = Error;
+
+    fn try_from(raw: RawQuery) -> Result<Self> {
+        Ok(QueryParameters {
+            unit: match (raw.atoms, raw.unit) {
+                (Some(true), None) => Unit::Atoms,
+                (Some(false), None) => Unit::BaseUnits,
+                (None, Some(unit)) => unit,
+                (None, None) => bail!("'atoms' or 'unit' parameter must be specified"),
+                _ => bail!("specified both 'atoms' and 'unit' parameters"),
+            },
+            hops: raw.hops,
+            generation: match raw.batch_id {
+                Some(batch_id) => Generation::Batch(batch_id),
+                None => Generation::Current,
+            },
+        })
+    }
+}

--- a/price-estimator/src/models/query.rs
+++ b/price-estimator/src/models/query.rs
@@ -44,6 +44,12 @@ pub enum Generation {
     /// specified batch. This will be the same orderbook that is provided to the
     /// solver when solving for the specified batch.
     Batch(BatchId),
+    /// The `Pricegraph` will be contructed from the events up to, and
+    /// including, the specified block.
+    Block(u64),
+    /// The `Pricegraph` will be contructed from the events that occured up to,
+    /// and including, the specified timestamp.
+    Timestamp(u64),
 }
 
 /// Intermediate raw query parameters used for parsing.
@@ -54,6 +60,8 @@ struct RawQuery {
     unit: Option<Unit>,
     hops: Option<usize>,
     batch_id: Option<BatchId>,
+    block_number: Option<u64>,
+    timestamp: Option<u64>,
 }
 
 impl TryFrom<RawQuery> for QueryParameters {
@@ -69,9 +77,12 @@ impl TryFrom<RawQuery> for QueryParameters {
                 _ => bail!("only one of 'atoms' or 'unit' parameters can be specified"),
             },
             hops: raw.hops,
-            generation: match raw.batch_id {
-                Some(batch_id) => Generation::Batch(batch_id),
-                None => Generation::Current,
+            generation: match (raw.batch_id, raw.block_number, raw.timestamp) {
+                (None, None, None) => Generation::Current,
+                (Some(batch_id), None, None) => Generation::Batch(batch_id),
+                (None, Some(block_number), None) => Generation::Block(block_number),
+                (None, None, Some(timestamp)) => Generation::Timestamp(timestamp),
+                _ => bail!("only one of 'batchId', 'blockNumber', or 'timestamp' parameters can be specified"),
             },
         })
     }
@@ -110,8 +121,11 @@ mod tests {
     #[test]
     fn invalid_parameters() {
         assert!(query_params("?unit=invalid").is_err());
+        assert!(query_params("?atoms=invalid").is_err());
         assert!(query_params("?hops=invalid").is_err());
         assert!(query_params("?batch_id=invalid").is_err());
+        assert!(query_params("?blockNumber=invalid").is_err());
+        assert!(query_params("?timestampe=invalid").is_err());
     }
 
     #[test]
@@ -124,7 +138,26 @@ mod tests {
     }
 
     #[test]
+    fn generation_query_parameters() {
+        let query = query_params("?batchId=42").unwrap();
+        assert_eq!(query.generation, Generation::Batch(42.into()));
+
+        let query = query_params("?blockNumber=123").unwrap();
+        assert_eq!(query.generation, Generation::Block(123));
+
+        let query = query_params("?timestamp=1337").unwrap();
+        assert_eq!(query.generation, Generation::Timestamp(1337));
+    }
+
+    #[test]
     fn mutually_exclusive_unit_parameter() {
         assert!(query_params("?unit=atoms&atoms=true").is_err());
+    }
+
+    #[test]
+    fn mutually_exclusive_generation_parameter() {
+        assert!(query_params("?batchId=123&blockNumber=456").is_err());
+        assert!(query_params("?blockNumber=123&timestamp=456").is_err());
+        assert!(query_params("?timestamp=123&batchId=456").is_err());
     }
 }

--- a/price-estimator/src/models/query.rs
+++ b/price-estimator/src/models/query.rs
@@ -129,6 +129,11 @@ mod tests {
     }
 
     #[test]
+    fn unknown_parameter() {
+        assert!(query_params("?answer=42").is_err());
+    }
+
+    #[test]
     fn atoms_query_parameter() {
         let query = query_params("?atoms=true").unwrap();
         assert_eq!(query.unit, Unit::Atoms);

--- a/price-estimator/src/orderbook.rs
+++ b/price-estimator/src/orderbook.rs
@@ -1,4 +1,6 @@
-use crate::{infallible_price_source::PriceCacheUpdater, solver_rounding_buffer};
+use crate::{
+    infallible_price_source::PriceCacheUpdater, models::Generation, solver_rounding_buffer,
+};
 use anyhow::Result;
 use core::{
     models::{AccountState, BatchId, Order, TokenId},
@@ -49,11 +51,12 @@ impl Orderbook {
 
     pub async fn pricegraph(
         &self,
-        batch_id: Option<BatchId>,
+        generation: Generation,
         pricegraph_type: PricegraphKind,
     ) -> Result<Pricegraph> {
-        match batch_id {
-            Some(batch_id) => {
+        match generation {
+            Generation::Current => Ok(self.cached_pricegraph(pricegraph_type).await),
+            Generation::Batch(batch_id) => {
                 let mut auction_data = self.auction_data(batch_id).await?;
                 if matches!(pricegraph_type, PricegraphKind::WithRoundingBuffer) {
                     self.apply_rounding_buffer_to_auction_data(&mut auction_data)
@@ -61,7 +64,6 @@ impl Orderbook {
                 }
                 Ok(pricegraph_from_auction_data(&auction_data))
             }
-            None => Ok(self.cached_pricegraph(pricegraph_type).await),
         }
     }
 

--- a/price-estimator/src/orderbook.rs
+++ b/price-estimator/src/orderbook.rs
@@ -1,7 +1,7 @@
 use crate::{
     infallible_price_source::PriceCacheUpdater, models::Generation, solver_rounding_buffer,
 };
-use anyhow::Result;
+use anyhow::{bail, Result};
 use core::{
     models::{AccountState, BatchId, Order, TokenId},
     orderbook::StableXOrderBookReading,
@@ -64,6 +64,7 @@ impl Orderbook {
                 }
                 Ok(pricegraph_from_auction_data(&auction_data))
             }
+            Generation::Block(_) | Generation::Timestamp(_) => bail!("not yet implemented"),
         }
     }
 


### PR DESCRIPTION
This PR implements the new `HistoricOrderbookReading` for the event-based orderbook.

This PR depends on #1292

### Test Plan

Added unit test for constructing an orderbook by a timestamp for the event registry.