### PR TITLE
Version orderbook file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,17 +504,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "serde_with",
- "slog",
- "slog-async",
- "slog-envlogger",
- "slog-scope",
- "slog-stdlog",
- "slog-term",
- "thiserror",
- "typenum",
- "uint",
- "url 2.1.1",
 ]
 
 [[package]]
@@ -3015,6 +3004,7 @@ dependencies = [
  "slog-stdlog",
  "slog-term",
  "thiserror",
+ "typenum",
  "uint",
  "url 2.1.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,6 +504,17 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "serde_with",
+ "slog",
+ "slog-async",
+ "slog-envlogger",
+ "slog-scope",
+ "slog-stdlog",
+ "slog-term",
+ "thiserror",
+ "typenum",
+ "uint",
+ "url 2.1.1",
 ]
 
 [[package]]

--- a/services-core/Cargo.toml
+++ b/services-core/Cargo.toml
@@ -32,6 +32,7 @@ slog-scope = "4.3.0"
 slog-stdlog = "4.1.0"
 slog-term = "2.6.0"
 thiserror = "1.0"
+typenum = "1.12.0"
 uint = "0.8"
 url = "2.1.1"
 

--- a/services-core/src/history/events.rs
+++ b/services-core/src/history/events.rs
@@ -1,6 +1,6 @@
 use crate::{
     models::{AccountState, BatchId, Order},
-    orderbook::{streamed::State, StableXOrderBookReading},
+    orderbook::streamed::State,
     serialization::Version,
 };
 use anyhow::{Context, Result};

--- a/services-core/src/history/events.rs
+++ b/services-core/src/history/events.rs
@@ -40,7 +40,7 @@ struct Value {
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct EventRegistry {
-    version: Version<U1>,
+    version: Version<typenum::U2>,
     events: BTreeMap<EventSortKey, Value>,
 }
 

--- a/services-core/src/history/events.rs
+++ b/services-core/src/history/events.rs
@@ -40,7 +40,7 @@ struct Value {
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct EventRegistry {
-    version: Version<typenum::U2>,
+    version: Version<U1>,
     events: BTreeMap<EventSortKey, Value>,
 }
 

--- a/services-core/src/history/events.rs
+++ b/services-core/src/history/events.rs
@@ -1,6 +1,7 @@
 use crate::{
     models::{AccountState, BatchId, Order},
-    orderbook::streamed::State,
+    orderbook::{streamed::State, StableXOrderBookReading},
+    serialization::Version,
 };
 use anyhow::{Context, Result};
 use contracts::batch_exchange;
@@ -9,12 +10,12 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
     convert::TryFrom,
-    fs,
-    fs::File,
+    fs::{self, File},
     io::{BufReader, BufWriter, Read, Write},
     ops::Bound,
     path::Path,
 };
+use typenum::U1;
 
 // Ethereum events (logs) can be both created and removed. Removals happen if the chain reorganizes
 // and ends up not including block that was previously thought to be part of the chain.
@@ -39,6 +40,7 @@ struct Value {
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct EventRegistry {
+    version: Version<U1>,
     events: BTreeMap<EventSortKey, Value>,
 }
 
@@ -264,7 +266,10 @@ mod tests {
                 )
             })
             .collect();
-        let events = EventRegistry { events };
+        let events = EventRegistry {
+            version: Default::default(),
+            events,
+        };
         let serialized_events = bincode::serialize(&events).expect("Failed to serialize events");
         let deserialized_events =
             EventRegistry::read(&serialized_events[..]).expect("Failed to deserialize events");
@@ -292,7 +297,10 @@ mod tests {
 
         let mut events = BTreeMap::new();
         events.insert(event_key, value);
-        let initial_events = EventRegistry { events };
+        let initial_events = EventRegistry {
+            version: Default::default(),
+            events,
+        };
 
         let test_path = Path::new("/tmp/my_test_events.ron");
         initial_events.write_to_file(test_path).unwrap();

--- a/services-core/src/lib.rs
+++ b/services-core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod models;
 pub mod orderbook;
 pub mod price_estimation;
 pub mod price_finding;
+pub mod serialization;
 pub mod solution_submission;
 pub mod time;
 pub mod token_info;

--- a/services-core/src/orderbook/streamed/updating_orderbook.rs
+++ b/services-core/src/orderbook/streamed/updating_orderbook.rs
@@ -70,8 +70,8 @@ impl UpdatingOrderbook {
                     if path.exists() {
                         // Exclude warning when file doesn't exist (i.e. on first startup)
                         warn!(
-                            "Failed to construct orderbook from path (using default): {}",
-                            error
+                            "Failed to construct orderbook from path (using default): {:?}",
+                            error,
                         );
                     }
                 }

--- a/services-core/src/serialization.rs
+++ b/services-core/src/serialization.rs
@@ -7,8 +7,9 @@ use serde::{
 use std::marker::PhantomData;
 use typenum::Unsigned;
 
-/// A format version identifier to prevent previous versions of event registry
-/// from being parsed as if
+/// A format version identifier to prevent different formats of serialized data
+/// (such as the `EventRegistry`) to be conflated with eachother. This 0-sized
+/// struct uses a compile-time version constant to encode a format version.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct Version<T>(PhantomData<T>);
 

--- a/services-core/src/serialization.rs
+++ b/services-core/src/serialization.rs
@@ -1,0 +1,54 @@
+//! Module containing `serde` serialization helpers.
+
+use serde::{
+    de::{Deserialize, Deserializer, Error},
+    ser::{Serialize, Serializer},
+};
+use std::marker::PhantomData;
+use typenum::Unsigned;
+
+/// A format version identifier to prevent previous versions of event registry
+/// from being parsed as if
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct Version<T>(PhantomData<T>);
+
+impl<T> Version<T>
+where
+    T: Unsigned,
+{
+    /// The version number value required for serializing and deserializing.
+    pub const VALUE: u32 = T::U32;
+}
+
+impl<T> Serialize for Version<T>
+where
+    T: Unsigned,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        u32::serialize(&Self::VALUE, serializer)
+    }
+}
+
+impl<'de, T> Deserialize<'de> for Version<T>
+where
+    T: Unsigned,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let version = u32::deserialize(deserializer)?;
+        if Self::VALUE == version {
+            Ok(Default::default())
+        } else {
+            Err(D::Error::custom(format!(
+                "invalid version '{}', expecter '{}'",
+                version,
+                Self::VALUE,
+            )))
+        }
+    }
+}

--- a/services-core/src/serialization.rs
+++ b/services-core/src/serialization.rs
@@ -45,7 +45,7 @@ where
             Ok(Default::default())
         } else {
             Err(D::Error::custom(format!(
-                "invalid version '{}', expecter '{}'",
+                "invalid version '{}', expected '{}'",
                 version,
                 Self::VALUE,
             )))


### PR DESCRIPTION
This PR adds a new `version` field to the `EventRegistry` to ensure that the orderbook file is compatible between new driver and price-estimator versions. This is because the `bincode` serialization seems to only care about binary size and may conflate unrelated types as well as different fields as long as they:
- are the same size
- are in the same position

This new `Version` struct is a 0-sized serialization helper that ensure that the file matches the correct version when deserializing. This gives us some manual control when updating the orderbook file structure so we can ensure it doesn't incorrectly read an orderbook file in the old format.

### Test Plan

First check that a significant change to the orderbook type goes undetected:
```
$ cargo checkout master
$ cargo run -p price-estimator -- --orderbook-file target/orderbook.mainnet.bin --log-filter "error,core::orderbook=info"
    Finished dev [unoptimized + debuginfo] target(s) in 0.08s
     Running `target/debug/price-estimator --orderbook-file target/orderbook.mainnet.bin --log-filter 'error,core::orderbook=info'`
2020-08-11T06:52:26.097Z INFO [core::orderbook::streamed::updating_orderbook] Updating event based orderbook with from block 0 to block 10637118.
2020-08-11T07:10:45.764Z INFO [core::orderbook::streamed::updating_orderbook] Received 215399 events.
2020-08-11T07:23:39.519Z INFO [core::orderbook::streamed::updating_orderbook] Finished applying events
^C
```

<details>
<summary>apply this patch:</summary>
<p>

```diff
diff --git a/core/src/history/events.rs b/core/src/history/events.rs
index 47433ed..661dfd0 100644
--- a/core/src/history/events.rs
+++ b/core/src/history/events.rs
@@ -23,13 +23,20 @@ use typenum::U1;
 // However, the orderbook state (`State`) cannot remove events. To support this, we keep an ordered
 // list of all events based on which the state is built.
 
-#[derive(Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 struct EventSortKey {
     block_number: u64,
     /// Is included to differentiate events from the same block number but different blocks which
     /// can happen during reorgs.
     block_hash: H256,
-    log_index: usize,
+    log_number: f64,
+}
+
+impl Eq for EventSortKey {}
+impl Ord for EventSortKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.partial_cmp(other).unwrap()
+    }
 }
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -65,7 +72,7 @@ impl EventRegistry {
         let key = EventSortKey {
             block_number,
             block_hash,
-            log_index,
+            log_number: log_index as _,
         };
         match event_data {
             EventData::Added(event) => self.events.insert(key, Value { event, batch_id }),
@@ -77,7 +84,7 @@ impl EventRegistry {
         self.events.split_off(&EventSortKey {
             block_number,
             block_hash: H256::zero(),
-            log_index: 0,
+            log_number: 0.0,
         });
     }

```

</p>
</details>

Restart the price estimation service and see that it reused the orderbook despite the wildly different and incompatible types:
```
$ cargo run -p price-estimator -- --orderbook-file target/orderbook.mainnet.bin --log-filter "error,core::orderbook=info"
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/price-estimator --orderbook-file target/orderbook.mainnet.bin --log-filter 'error,core::orderbook=info'`
2020-08-11T13:05:53.150Z INFO [core::orderbook::streamed::updating_orderbook] successfully recovered orderbook from path
...
```

Now verify that manually bumping to a new version works:
```
$ cargo checkout version-orderbook-file
$ cargo run -p price-estimator -- --orderbook-file target/orderbook.mainnet.bin --log-filter "error,core::orderbook=info"
2020-08-11T11:47:09.441Z INFO [core::orderbook::streamed::updating_orderbook] Updating event based orderbook with from block 0 to block 10638444.
2020-08-11T11:55:17.419Z INFO [core::orderbook::streamed::updating_orderbook] Received 215728 events.
2020-08-11T12:08:34.632Z INFO [core::orderbook::streamed::updating_orderbook] Finished applying events
```

<details>
<summary>bump the version number:</summary>
<p>

```diff
diff --git a/core/src/history/events.rs b/core/src/history/events.rs
index 42911af..ae9adba 100644
--- a/core/src/history/events.rs
+++ b/core/src/history/events.rs
@@ -41,7 +41,7 @@ struct Value {
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct EventRegistry {
-    version: Version<U1>,
+    version: Version<typenum::U2>,
     events: BTreeMap<EventSortKey, Value>,
 }
 
```

</p>
</details>

And check that restarting the service re-queries past events.
```
$ cargo run -p price-estimator -- --orderbook-file target/orderbook.mainnet.bin --log-filter "error,core::orderbook=info"
   Compiling price-estimator v0.1.0 (/var/home/nlordell/Developer/gnosis/dex-services/price-estimator)
    Finished dev [unoptimized + debuginfo] target(s) in 14.43s
     Running `target/debug/price-estimator --orderbook-file target/orderbook.mainnet.bin --log-filter 'error,core::orderbook=info'`
2020-08-11T12:27:37.561Z WARN [core::orderbook::streamed::updating_orderbook] Failed to construct orderbook from path (using default): Failed to read file: File { fd: 29, path: "/var/home/nlordell/Developer/gnosis/dex-services/target/orderbook.mainnet.bin", read: true, write: false }

Caused by:
    0: Failed to load event registry from bytes
    1: invalid version '1', expected '2'
^C
```