### PR TITLE
Unit parameter with default

### DIFF
--- a/price-estimator/README.md
+++ b/price-estimator/README.md
@@ -1,12 +1,13 @@
 ## API
 
-All endpoints use the query part of the url with these key-values:
+All endpoints use the query part of the URL with these key-values:
 
-* `atoms`: Required. If set to `true` all amounts are denominated in the smallest available unit (base quantity) of the token. If `false` all amounts are denominated in the "natural" unit of the respective token given by the number of decimals specified through the ERC20 interface. TODO: `false` is currently only implemented for estimated-buy-amount and estimated-amounts-at-price .
-* `hops`: Optional. TODO: document this once it has been implemented.
-* `batchId`: Optional. Specify a specific batch ID to compute the estimate for, only accounting orders that are valid at the specified batch. If no batch ID is specified, the current batch that is collecting orders will be used.
+* `unit`: Either `atoms` or `baseunits` (default). If set to `atoms` all amounts are denominated in the smallest available unit (atom) of the token. If `baseunits` all amounts are denominated in the "natural" unit of the respective token given by the number of decimals specified through the ERC20 interface. TODO: `baseunits` is currently not implemented for all URLs.
+* `atoms`: Deprecated. An boolean alias for `unit` parameter where `atoms=true` is equivalent to `unit=atoms` and `atoms=false` is equivalent to `unit=baseunits`.
+* `hops`: TODO: document this once it has been implemented.
+* `batchId`: Specify a specific batch ID to compute the estimate for, only accounting orders that are valid at the specified batch. If no batch ID is specified, the current batch that is collecting orders will be used.
 
-Example: `<path>?atoms=true`
+Example: `<path>?unit=atoms&batchId=1337`
 
 The endpoint documentation references these types:
 
@@ -20,7 +21,7 @@ The service exposes the following endpoints:
 
 `GET /api/v1/markets/:market`
 
-Example Request: `/api/v1/markets/1-7?atoms=true`
+Example Request: `/api/v1/markets/1-7?unit=atoms`
 
 Example Response:
 
@@ -41,7 +42,7 @@ Returns the transitive orderbook (containing bids and asks) for the given base a
 
 `GET /api/v1/markets/:market/estimated-buy-amount/:sell-amount-in-quote-token`
 
-Example Request: `/api/v1/markets/1-7/estimated-buy-amount/20000000000000000000?atoms=true`
+Example Request: `/api/v1/markets/1-7/estimated-buy-amount/20000000000000000000?unit=atoms`
 
 Example Response:
 
@@ -55,13 +56,13 @@ Example Response:
 ```
 
 * `buyAmountInBase` estimates the buy amount (in base tokens) a user can set as a limit order while still expecting to be completely matched when selling the given amount of quote token.
-* The other fields repeat the parameters in the url back.
+* The other fields repeat the parameters in the URL back.
 
 ### Estimated Amounts At Price
 
 `GET /api/v1/markets/:market/estimated-amounts-at-price/:price-in-quote`
 
-Example Request: `/api/v1/markets/1-7/estimated-amounts-at-price/245.5?atoms=true`
+Example Request: `/api/v1/markets/1-7/estimated-amounts-at-price/245.5?unit=atoms`
 
 Example Response:
 
@@ -78,13 +79,13 @@ The following result indicates that if we wanted to buy ETH (token 2) for DAI (t
 
 * `sellAmountInBase` estimates the sell amount (in quote tokens) a user can completely fill in the following batch at the specified `price_in_quote`.
 * `buyAmountInBase` is the computed buy amount (in base tokens) for the order from the specified price and estimated sell amount. Note that it might be possible to use a higher buy amount for the same returned sell amount and still likely get completely matched by the solver. This buy amount can be computed with a subsequent estimate buy amount API call using the returned sell amount in quote value.
-* The other fields repeat the parameters in the url back.
+* The other fields repeat the parameters in the URL back.
 
 ### Estimated Best Ask Price
 
 `GET /api/v1/markets/:market/estimated-best-ask-price`
 
-Example Request: `/api/v1/markets/1-7/estimated-best-ask-price?atoms=true`
+Example Request: `/api/v1/markets/1-7/estimated-best-ask-price?unit=atoms`
 
 Example Responses:
 
@@ -97,7 +98,7 @@ It represents the exchange rate for the market. In the example we can exchange ~
 
 # Testing
 
-To test a locally running price estimator with the frontend at https://mesa.eth.link/ we need to set our browser to allow websites to access localhost and change the url that the javascript uses for the price estimator. With chromium:
+To test a locally running price estimator with the frontend at https://mesa.eth.link/ we need to set our browser to allow websites to access localhost and change the URL that the javascript uses for the price estimator. With chromium:
 
 1. `chromium --disable-web-security --user-data-dir=temp/`.
 2. Open the frontend.
@@ -105,7 +106,7 @@ To test a locally running price estimator with the frontend at https://mesa.eth.
 4. In the browser console enter `dexPriceEstimatorApi.urlsByNetwork[1] = "http://localhost:8080/api/v1/"`.
 5. Induce a request by changing the sell amount and check that price estimator prints that it handled the request.
 
-It is useful to start the price estimator with logging enabled, using the gnosis staging node url and using a permanent orderbook file:
+It is useful to start the price estimator with logging enabled, using the gnosis staging node URL and using a permanent orderbook file:
 
 ```
 env RUST_LOG=warn,price_estimator=info,core=info cargo run -p price-estimator -- --node-url https://staging-openethereum.mainnet.gnosisdev.com --orderbook-file ../orderbook-file-mainnet

--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -397,7 +397,7 @@ mod tests {
     #[test]
     fn markets_ok() {
         let (market, query) = warp::test::request()
-            .path("/markets/1-2?atoms=true&hops=3")
+            .path("/markets/1-2?atoms=true&hops=3&batchId=123")
             .filter(&markets_filter())
             .now_or_never()
             .unwrap()
@@ -406,27 +406,7 @@ mod tests {
         assert_eq!(market.quote, 2);
         assert_eq!(query.unit, Unit::Atoms);
         assert_eq!(query.hops, Some(3));
-    }
-
-    #[test]
-    fn missing_hops_ok() {
-        let (_, _, query) = warp::test::request()
-            .path("/markets/0-65535/estimated-buy-amount/1?atoms=true")
-            .filter(&estimated_buy_amount_filter())
-            .now_or_never()
-            .unwrap()
-            .unwrap();
-        assert_eq!(query.hops, None);
-    }
-
-    #[test]
-    fn missing_query() {
-        assert!(warp::test::request()
-            .path("/markets/0-0/estimated-buy-amount/0")
-            .filter(&estimated_buy_amount_filter())
-            .now_or_never()
-            .unwrap()
-            .is_err());
+        assert_eq!(query.generation, Generation::Batch(123.into()));
     }
 
     #[test]
@@ -466,22 +446,6 @@ mod tests {
         for path in &[
             "/markets/0-1/estimated-buy-amount/",
             "/markets/0-1/estimated-buy-amount/asdf",
-        ] {
-            assert!(warp::test::request()
-                .path(path)
-                .filter(&estimated_buy_amount_filter())
-                .now_or_never()
-                .unwrap()
-                .is_err());
-        }
-    }
-
-    #[test]
-    fn estimated_buy_amount_no_float_volume() {
-        for path in &[
-            "/markets/0-1/estimated-buy-amount/0.0",
-            "/markets/0-1/estimated-buy-amount/1.0",
-            "/markets/0-1/estimated-buy-amount/0.5",
         ] {
             assert!(warp::test::request()
                 .path(path)

--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -406,7 +406,7 @@ mod tests {
         assert_eq!(market.quote, 2);
         assert_eq!(query.unit, Unit::Atoms);
         assert_eq!(query.hops, Some(3));
-        assert_eq!(query.generation, Generation::Batch(123.into()));
+        assert_eq!(query.time, EstimationTime::Batch(123.into()));
     }
 
     #[test]

--- a/price-estimator/src/models/query.rs
+++ b/price-estimator/src/models/query.rs
@@ -28,6 +28,12 @@ pub enum Unit {
     BaseUnits,
 }
 
+impl Default for Unit {
+    fn default() -> Self {
+        Unit::BaseUnits
+    }
+}
+
 /// When to perform a price estimate.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum EstimationTime {
@@ -39,9 +45,10 @@ pub enum EstimationTime {
 
 /// Intermediate raw query parameters used for parsing.
 #[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 struct RawQuery {
     atoms: Option<bool>,
+    unit: Option<Unit>,
     hops: Option<usize>,
     batch_id: Option<BatchId>,
 }
@@ -51,10 +58,12 @@ impl TryFrom<RawQuery> for QueryParameters {
 
     fn try_from(raw: RawQuery) -> Result<Self> {
         Ok(QueryParameters {
-            unit: match raw.atoms {
-                Some(true) => Unit::Atoms,
-                Some(false) => Unit::BaseUnits,
-                None => bail!("'atoms' or parameter must be specified"),
+            unit: match (raw.atoms, raw.unit) {
+                (Some(true), None) => Unit::Atoms,
+                (Some(false), None) => Unit::BaseUnits,
+                (None, Some(unit)) => unit,
+                (None, None) => Unit::default(),
+                _ => bail!("only one of 'atoms' or 'unit' parameters can be specified"),
             },
             hops: raw.hops,
             time: match raw.batch_id {
@@ -62,5 +71,57 @@ impl TryFrom<RawQuery> for QueryParameters {
                 None => EstimationTime::Now,
             },
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::future::FutureExt as _;
+    use warp::Rejection;
+
+    fn query_params(params: &str) -> Result<QueryParameters, Rejection> {
+        warp::test::request()
+            .path(&format!("/{}", params))
+            .filter(&warp::query::<QueryParameters>())
+            .now_or_never()
+            .unwrap()
+    }
+
+    #[test]
+    fn default_query_parameters() {
+        let query = query_params("").unwrap();
+        assert_eq!(query.unit, Unit::BaseUnits);
+        assert_eq!(query.hops, None);
+        assert_eq!(query.generation, Generation::Current);
+    }
+
+    #[test]
+    fn all_query_parameters() {
+        let query = query_params("?unit=atoms&hops=42&batchId=1337").unwrap();
+        assert_eq!(query.unit, Unit::Atoms);
+        assert_eq!(query.hops, Some(42));
+        assert_eq!(query.generation, Generation::Batch(1337.into()));
+    }
+
+    #[test]
+    fn invalid_parameters() {
+        assert!(query_params("?unit=invalid").is_err());
+        assert!(query_params("?hops=invalid").is_err());
+        assert!(query_params("?batch_id=invalid").is_err());
+    }
+
+    #[test]
+    fn atoms_query_parameter() {
+        let query = query_params("?atoms=true").unwrap();
+        assert_eq!(query.unit, Unit::Atoms);
+
+        let query = query_params("?atoms=false").unwrap();
+        assert_eq!(query.unit, Unit::BaseUnits);
+    }
+
+    #[test]
+    fn mutually_exclusive_unit_parameter() {
+        assert!(query_params("?unit=atoms&atoms=true").is_err());
     }
 }

--- a/price-estimator/src/models/query.rs
+++ b/price-estimator/src/models/query.rs
@@ -93,7 +93,7 @@ mod tests {
         let query = query_params("").unwrap();
         assert_eq!(query.unit, Unit::BaseUnits);
         assert_eq!(query.hops, None);
-        assert_eq!(query.generation, Generation::Current);
+        assert_eq!(query.time, EstimationTime::Now);
     }
 
     #[test]
@@ -101,7 +101,7 @@ mod tests {
         let query = query_params("?unit=atoms&hops=42&batchId=1337").unwrap();
         assert_eq!(query.unit, Unit::Atoms);
         assert_eq!(query.hops, Some(42));
-        assert_eq!(query.generation, Generation::Batch(1337.into()));
+        assert_eq!(query.time, EstimationTime::Batch(1337.into()));
     }
 
     #[test]


### PR DESCRIPTION
Recreated PR from #1287 as it was merged into the wrong branch.

Fixes #1106

This PR adds defaults the unit to use base units instead of requiring the atoms parameter.

### Test Plan

Run the price estimator and check the new routes:
```
$ cargo run -p price-estimator
...
$ curl -s 'http://localhost:8080/api/v1/markets/7-1/estimated-buy-amount/1' | jq '.buyAmountInBase'
"373.97582492490005"
$ curl -s 'http://localhost:8080/api/v1/markets/7-1/estimated-buy-amount/1?unit=baseunits' | jq '.buyAmountInBase'
"373.97582492490005"
$ curl -s 'http://localhost:8080/api/v1/markets/7-1/estimated-buy-amount/1?atoms=false' | jq '.buyAmountInBase'
"373.97582492490005"
$ curl -s 'http://localhost:8080/api/v1/markets/7-1/estimated-buy-amount/1000000000000000000?unit=atoms' | jq '.buyAmountInBase'
"373975824924900065280"
$ curl -s 'http://localhost:8080/api/v1/markets/7-1/estimated-buy-amount/1000000000000000000?atoms=true' | jq '.buyAmountInBase'
"373975824924900065280"
$ curl -s 'http://localhost:8080/api/v1/markets/7-1/estimated-buy-amount/1?atoms=true&unit=atoms' | jq
{
  "message": "invalid url query"
}
```