### PR TITLE
include warp logs by default

### DIFF
--- a/price-estimator/src/main.rs
+++ b/price-estimator/src/main.rs
@@ -36,7 +36,7 @@ struct Options {
     #[structopt(
         long,
         env = "DFUSION_LOG",
-        default_value = "warn,price_estimator=info,core=info,warp=info"
+        default_value = "warn,price_estimator=info,core=info,warp::filters::log=info"
     )]
     log_filter: String,
 

--- a/price-estimator/src/main.rs
+++ b/price-estimator/src/main.rs
@@ -36,7 +36,7 @@ struct Options {
     #[structopt(
         long,
         env = "DFUSION_LOG",
-        default_value = "warn,price_estimator=info,core=info"
+        default_value = "warn,price_estimator=info,core=info,warp=info"
     )]
     log_filter: String,
 


### PR DESCRIPTION
This PR enables `warp` logs by default so we see the incoming HTTP requests. There is currently an issue that each request gets logged multiple times.

### Test Plan

```
$ cargo run -p price-estimator
...
2020-08-12T14:46:20.705Z INFO [warp::filters::log] 127.0.0.1:47362 "GET /api/v1/markets/1-7/estimated-buy-amount/200000000000000000000 HTTP/1.1" 404 "-" "Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:79.0) Gecko/20100101 Firefox/79.0" 69.681µs
2020-08-12T14:46:20.710Z INFO [warp::filters::log] 127.0.0.1:47362 "GET /api/v1/markets/1-7/estimated-buy-amount/200000000000000000000 HTTP/1.1" 200 "-" "Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:79.0) Gecko/20100101 Firefox/79.0" 4.809587ms
2020-08-12T14:46:28.310Z INFO [warp::filters::log] 127.0.0.1:47362 "GET /api/v1/markets/9-7/estimated-buy-amount/200000000000000000000 HTTP/1.1" 404 "-" "Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:79.0) Gecko/20100101 Firefox/79.0" 83.841µs
2020-08-12T14:46:28.317Z INFO [warp::filters::log] 127.0.0.1:47362 "GET /api/v1/markets/9-7/estimated-buy-amount/200000000000000000000 HTTP/1.1" 200 "-" "Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:79.0) Gecko/20100101 Firefox/79.0" 6.268008ms
2020-08-12T14:46:31.767Z INFO [warp::filters::log] 127.0.0.1:47362 "GET /api/v1/markets/9-7/estimated-buy-amount/200000000000000000000 HTTP/1.1" 404 "-" "Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:79.0) Gecko/20100101 Firefox/79.0" 71.601µs
2020-08-12T14:46:31.769Z INFO [warp::filters::log] 127.0.0.1:47362 "GET /api/v1/markets/9-7/estimated-buy-amount/200000000000000000000 HTTP/1.1" 500 "-" "Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:79.0) Gecko/20100101 Firefox/79.0" 7.724678ms
2020-08-12T14:46:31.769Z INFO [warp::filters::log] 127.0.0.1:47362 "GET /api/v1/markets/9-7/estimated-buy-amount/200000000000000000000 HTTP/1.1" 404 "-" "Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:79.0) Gecko/20100101 Firefox/79.0" 98.357µs
2020-08-12T14:46:31.770Z INFO [warp::filters::log] 127.0.0.1:47362 "GET /api/v1/markets/9-7/estimated-buy-amount/200000000000000000000 HTTP/1.1" 404 "-" "Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:79.0) Gecko/20100101 Firefox/79.0" 53.73µs
...
```