### PR TITLE
only use one root logger

### DIFF
--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -84,7 +84,6 @@ fn markets(
         .and(warp::any().map(move || orderbook.clone()))
         .and(warp::any().map(move || token_info.clone()))
         .and_then(get_markets)
-        .with(warp::log("price_estimator::api::markets"))
 }
 
 /// Validate a request of the form
@@ -98,7 +97,6 @@ fn estimated_buy_amount(
         .and(warp::any().map(move || orderbook.clone()))
         .and(warp::any().map(move || token_info.clone()))
         .and_then(estimate_buy_amount)
-        .with(warp::log("price_estimator::api::estimate_buy_amount"))
 }
 
 /// Validate a request of the form:
@@ -112,7 +110,6 @@ fn estimated_amounts_at_price(
         .and(warp::any().map(move || orderbook.clone()))
         .and(warp::any().map(move || token_info.clone()))
         .and_then(estimate_amounts_at_price)
-        .with(warp::log("price_estimator::api::estimate_amounts_at_price"))
 }
 
 /// Validate a request of the form:
@@ -126,7 +123,6 @@ fn estimated_best_ask_price(
         .and(warp::any().map(move || orderbook.clone()))
         .and(warp::any().map(move || token_infos.clone()))
         .and_then(estimate_best_ask_price)
-        .with(warp::log("price_estimator::api::estimate_best_ask_price"))
 }
 
 fn markets_prefix() -> impl Filter<Extract = (CurrencyPair,), Error = Rejection> + Copy {

--- a/price-estimator/src/main.rs
+++ b/price-estimator/src/main.rs
@@ -26,6 +26,7 @@ use std::{
 use structopt::StructOpt;
 use tokio::{runtime, time};
 use url::Url;
+use warp::Filter;
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "price estimator", rename_all = "kebab")]
@@ -157,7 +158,7 @@ fn main() {
         options.orderbook_update_interval,
     ));
 
-    let filter = filter::all(orderbook, token_info);
+    let filter = filter::all(orderbook, token_info).with(warp::log("price_estimator"));
     let serve_task = runtime.spawn(warp::serve(filter).run(options.bind_address));
 
     log::info!("Server ready.");


### PR DESCRIPTION
This PR changes the filters to only use one root logger so we don't get spammed with logs for each request.

### Test Plan

Run the price estimator:
```
$ cargo run -p price-estimator -- --orderbook-file target/orderbook-file-mainnet --log-filter warp::filters::log=info
```

In a separate terminal send the following resquests:
```
$ curl -s 'http://localhost:8080/' | jq '.message'
"invalid url path"
$ curl -s 'http://localhost:8080/api/v1/markets/9-7/estimated-buy-amount/1?atoms=false' | jq '.message'
"request with atoms=true for token we don't have erc20 info for"
$ curl -s 'http://localhost:8080/api/v1/markets/9-DAI/estimated-buy-amount/1?atoms=false' | jq '.message'
"token symbol or address not found"
```

And check the logs:
```
2020-08-12T15:13:48.492Z INFO [warp::filters::log] 127.0.0.1:47940 "GET / HTTP/1.1" 404 "-" "curl/7.69.1" 82.229µs
2020-08-12T15:14:00.778Z INFO [warp::filters::log] 127.0.0.1:47944 "GET /api/v1/markets/9-7/estimated-buy-amount/1 HTTP/1.1" 400 "-" "curl/7.69.1" 11.049296ms
2020-08-12T15:14:10.123Z INFO [warp::filters::log] 127.0.0.1:47948 "GET /api/v1/markets/9-DAI/estimated-buy-amount/1 HTTP/1.1" 400 "-" "curl/7.69.1" 343.622µs
```
