### PR TITLE
Estimate considered good if it is within 1 order of magnitude

### DIFF
--- a/e2e/src/bin/historic_prices.rs
+++ b/e2e/src/bin/historic_prices.rs
@@ -6,8 +6,8 @@ use std::{fs::File, io::Write, path::PathBuf};
 use structopt::StructOpt;
 
 /// Threshold logarithmic distance from the actual price at which an estimate is
-/// considered "bad"; currently `0.1 * price < estimate < 10 * price`.
-const BAD_ESTIMATE_THRESHOLD_LOG_DISTANCE: f64 = 1.0;
+/// considered "bad"; currently `0.01 * price < estimate < 100 * price`.
+const BAD_ESTIMATE_THRESHOLD_LOG_DISTANCE: f64 = 2.0;
 
 /// Common options for analyzing historic batch data.
 #[derive(Debug, StructOpt)]
@@ -141,17 +141,17 @@ where
     ) -> Result<()> {
         let price_estimate = estimate.unwrap_or_default();
         let error = (price_estimate as f64 - price as f64).abs() / price as f64;
-        let distance = (price_estimate as f64 / price as f64).log10().abs();
+        let distance = (price_estimate as f64 / price as f64).log10();
         writeln!(
             &mut self.output,
-            "{},{},{},{},{}",
-            batch, token, price, price_estimate, error,
+            "{},{},{},{},{},{}",
+            batch, token, price, price_estimate, error, distance,
         )?;
 
         self.samples += 1;
         if estimate.is_some() {
             self.total_error += error;
-            self.bad_estimates += (distance >= BAD_ESTIMATE_THRESHOLD_LOG_DISTANCE) as usize;
+            self.bad_estimates += (distance.abs() >= BAD_ESTIMATE_THRESHOLD_LOG_DISTANCE) as usize;
         } else {
             self.missed_estimates += 1;
         }

--- a/e2e/src/bin/historic_prices.rs
+++ b/e2e/src/bin/historic_prices.rs
@@ -6,8 +6,8 @@ use std::{fs::File, io::Write, path::PathBuf};
 use structopt::StructOpt;
 
 /// Threshold logarithmic distance from the actual price at which an estimate is
-/// considered "bad"; currently `0.01 * price < estimate < 100 * price`.
-const BAD_ESTIMATE_THRESHOLD_LOG_DISTANCE: f64 = 2.0;
+/// considered "bad"; currently `0.1 * price < estimate < 10 * price`.
+const BAD_ESTIMATE_THRESHOLD_LOG_DISTANCE: f64 = 1.0;
 
 /// Common options for analyzing historic batch data.
 #[derive(Debug, StructOpt)]

--- a/e2e/src/bin/historic_prices.rs
+++ b/e2e/src/bin/historic_prices.rs
@@ -5,8 +5,9 @@ use pricegraph::{Element, Pricegraph, TokenId};
 use std::{fs::File, io::Write, path::PathBuf};
 use structopt::StructOpt;
 
-/// Threshold at which a price estimate is considered "bad"; currently 10%.
-const BAD_ESTIMATE_THRESHOLD: f64 = 0.1;
+/// Threshold logarithmic distance from the actual price at which an estimate is
+/// considered "bad"; currently `0.01 * price < estimate < 100 * price`.
+const BAD_ESTIMATE_THRESHOLD_LOG_DISTANCE: f64 = 2.0;
 
 /// Common options for analyzing historic batch data.
 #[derive(Debug, StructOpt)]
@@ -114,7 +115,10 @@ where
     }
 
     fn header(&mut self) -> Result<()> {
-        writeln!(&mut self.output, "batch,token,price,estimate,error")?;
+        writeln!(
+            &mut self.output,
+            "batch,token,price,estimate,error,distance",
+        )?;
         Ok(())
     }
 }
@@ -137,6 +141,7 @@ where
     ) -> Result<()> {
         let price_estimate = estimate.unwrap_or_default();
         let error = (price_estimate as f64 - price as f64).abs() / price as f64;
+        let distance = (price_estimate as f64 / price as f64).log10().abs();
         writeln!(
             &mut self.output,
             "{},{},{},{},{}",
@@ -146,7 +151,7 @@ where
         self.samples += 1;
         if estimate.is_some() {
             self.total_error += error;
-            self.bad_estimates += (error > BAD_ESTIMATE_THRESHOLD) as usize;
+            self.bad_estimates += (distance >= BAD_ESTIMATE_THRESHOLD_LOG_DISTANCE) as usize;
         } else {
             self.missed_estimates += 1;
         }


### PR DESCRIPTION
Previously we were using the absolute error to determine if a price estimate was bad. This was not exactly correct, because its more important for the estimate to be within a certain x orders of magnitude of the real price.

### Test Plan

```
cargo run --release -p e2e --bin historic_prices -- --orderbook-file target/orderbook-file-mainnet
   Compiling e2e v1.0.0 (/var/home/nlordell/Developer/dex-services/e2e)
    Finished release [optimized] target(s) in 3.29s
     Running `target/release/historic_prices --orderbook-file target/orderbook-file-mainnet`
58296 / 58296 [=====================================================================] 100.00 % 364.71/s
Processed 16548 token prices: average error 22941.12%, bad 2.91%, missed 9.39%.
```