### PR TITLE
Remove non openapi documentation

### DIFF
--- a/price-estimator/README.md
+++ b/price-estimator/README.md
@@ -1,102 +1,10 @@
 ## API
 
-All endpoints use the query part of the URL with these key-values:
+The api is documented with [OpenAPI](https://www.openapis.org/) in `openapi.yml`. It can be accessed in a rendered and interactive fashion on https://editor.swagger.io/ through `File -> Import file`.
 
-* `unit`: Either `atoms` or `baseunits` (default). If set to `atoms` all amounts are denominated in the smallest available unit (atom) of the token. If `baseunits` all amounts are denominated in the "natural" unit of the respective token given by the number of decimals specified through the ERC20 interface. TODO: `baseunits` is currently not implemented for all URLs.
-* `atoms`: Deprecated. An boolean alias for `unit` parameter where `atoms=true` is equivalent to `unit=atoms` and `atoms=false` is equivalent to `unit=baseunits`.
-* `hops`: TODO: document this once it has been implemented.
-* `batchId`: Specify a specific batch ID to compute the estimate for, only accounting orders that are valid at the specified batch. If no batch ID is specified, the current batch that is collecting orders will be used.
+TODO: Add a binary or docker image that can host the interactive ui without an external service.
 
-Example: `<path>?unit=atoms&batchId=1337`
-
-The endpoint documentation references these types:
-
-* A *token id* is a natural number >= 0 in decimal notation. It refers to the token ids in the smart contract. Example: `0`
-* A *token amount* is given as a floating point number formatted according to https://doc.rust-lang.org/std/primitive.f64.html#impl-FromStr which resembles numbers in json closely. Examples: `0`, `1.1`.
-* A *market* is of the form `<base token id>-<quote token id>`. Example: `0-1`
-
-The service exposes the following endpoints:
-
-### Markets
-
-`GET /api/v1/markets/:market`
-
-Example Request: `/api/v1/markets/1-7?unit=atoms`
-
-Example Response:
-
-```json
-{
-    "asks": [
-        { "price": 407.6755405630054, "volume": 9.389082650375993 }
-    ],
-    "bids": [
-        { "price": 5508028446685.359, "volume": 3.2264600472733105 }
-    ],
-}
-```
-
-Returns the transitive orderbook (containing bids and asks) for the given base and quote token.
-
-### Estimated Buy Amount
-
-`GET /api/v1/markets/:market/estimated-buy-amount/:sell-amount-in-quote-token`
-
-Example Request: `/api/v1/markets/1-7/estimated-buy-amount/20000000000000000000?unit=atoms`
-
-Example Response:
-
-```json
-{
-    "baseTokenId": 1,
-    "quoteTokenId": 7,
-    "buyAmountInBase": "79480982311034354",
-    "sellAmountInQuote": "20000000000000000000",
-}
-```
-
-* `buyAmountInBase` estimates the buy amount (in base tokens) a user can set as a limit order while still expecting to be completely matched when selling the given amount of quote token.
-* The other fields repeat the parameters in the URL back.
-
-### Estimated Amounts At Price
-
-`GET /api/v1/markets/:market/estimated-amounts-at-price/:price-in-quote`
-
-Example Request: `/api/v1/markets/1-7/estimated-amounts-at-price/245.5?unit=atoms`
-
-Example Response:
-
-```json
-{
-    "baseTokenId": 1,
-    "quoteTokenId": 7,
-    "buyAmountInBase": "6098377078823660544",
-    "sellAmountInQuote": "1497151572851208749056"
-}
-```
-
-The following result indicates that if we wanted to buy ETH (token 2) for DAI (token 7) and pay 245.5 DAI per unit of ETH, we would be able to sell an estimated maximum 1497.15 DAI.
-
-* `sellAmountInBase` estimates the sell amount (in quote tokens) a user can completely fill in the following batch at the specified `price_in_quote`.
-* `buyAmountInBase` is the computed buy amount (in base tokens) for the order from the specified price and estimated sell amount. Note that it might be possible to use a higher buy amount for the same returned sell amount and still likely get completely matched by the solver. This buy amount can be computed with a subsequent estimate buy amount API call using the returned sell amount in quote value.
-* The other fields repeat the parameters in the URL back.
-
-### Estimated Best Ask Price
-
-`GET /api/v1/markets/:market/estimated-best-ask-price`
-
-Example Request: `/api/v1/markets/1-7/estimated-best-ask-price?unit=atoms`
-
-Example Responses:
-
-```json
-297.8
-```
-
-The response is a json number or `null`.
-It represents the exchange rate for the market. In the example we can exchange ~300 DAI (token 7) for 1 ETH (token 1). Note that the true exchange rate depends on the buy amount whereas this exchange rate is for a theoretical 0 amount.
-
-# Testing
+## Testing
 
 To test a locally running price estimator with the frontend at https://mesa.eth.link/ we need to set our browser to allow websites to access localhost and change the URL that the javascript uses for the price estimator. With chromium:
 

--- a/price-estimator/openapi.yml
+++ b/price-estimator/openapi.yml
@@ -2,6 +2,13 @@ openapi: 3.0.3
 info:
   version: 0.0.1
   title: Price Estimator OpenAPI
+servers:
+- url: https://price-estimate-mainnet.dev.gnosisdev.com
+  description: Staging
+- url: https://dex-price-estimator.gnosis.io
+  description: Production
+- url: http://localhost:8080
+  description: Local
 paths:
   /api/v1/markets/{market}/estimated-buy-amount/{sell amount in quote}:
     get:
@@ -81,6 +88,11 @@ components:
   schemas:
     NumberParameter:
       type: number
+    Unit:
+      type: string
+      enum: [baseunits, atoms]
+      default: baseunits
+      example: baseunits
     AmountResponse:
       type: object
       properties:
@@ -137,10 +149,7 @@ components:
       description: If `baseunits` (the default) all amounts are denominated in the "natural" unit of the respective token given by the number of decimals specified through the ERC20 interface. If set to `atoms` all amounts are denominated in the smallest available unit (atom) of the token.
       required: false
       schema:
-        type: string
-        enum: [baseunits, atoms]
-        default: baseunits
-        example: baseunits
+        $ref: "#/components/schemas/Unit"
     BatchId:
       name: batchId
       in: query


### PR DESCRIPTION
We should not duplicate the documentation and openapi is the better
format.

### Test Plan
Follow steps in readme and try interactive request.