### PR TITLE
[Easy] Move MarketResults into its own file

### DIFF
--- a/price-estimator/src/models.rs
+++ b/price-estimator/src/models.rs
@@ -1,11 +1,11 @@
 mod currency_pair;
+mod markets_results;
 mod query;
 
-pub use self::{currency_pair::*, query::*};
+pub use self::{currency_pair::*, markets_results::*, query::*};
 use core::token_info::TokenBaseInfo;
 use serde::Serialize;
 use serde_with::rust::display_fromstr;
-use std::cmp::Ordering;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -61,57 +61,6 @@ impl Amount {
     }
 }
 
-#[derive(Debug, Serialize)]
-pub struct MarketsResult {
-    pub asks: Vec<TransitiveOrder>,
-    pub bids: Vec<TransitiveOrder>,
-}
-
-enum TransitiveOrderbookOrdering {
-    PriceAscending,
-    PriceDescending,
-}
-
-fn sort_and_aggregate_orders_by_price(
-    mut orders: Vec<TransitiveOrder>,
-    ordering: TransitiveOrderbookOrdering,
-) -> Vec<TransitiveOrder> {
-    let compare = |a: &TransitiveOrder, b: &TransitiveOrder| {
-        let (a, b) = match ordering {
-            TransitiveOrderbookOrdering::PriceAscending => (a, b),
-            TransitiveOrderbookOrdering::PriceDescending => (b, a),
-        };
-        a.price.partial_cmp(&b.price).unwrap_or(Ordering::Less)
-    };
-    orders.sort_unstable_by(compare);
-    let mut result = Vec::<TransitiveOrder>::with_capacity(orders.len());
-    for order in orders.into_iter().filter(|order| !order.price.is_nan()) {
-        match result.last_mut() {
-            #[allow(clippy::float_cmp)]
-            Some(last) if last.price == order.price => last.volume += order.volume,
-            _ => result.push(order),
-        }
-    }
-    result
-}
-
-impl From<&pricegraph::TransitiveOrderbook> for MarketsResult {
-    fn from(orderbook: &pricegraph::TransitiveOrderbook) -> Self {
-        let to_order = |(price, volume)| TransitiveOrder { price, volume };
-        // The frontend currently (2020-30-06) requires a specific ordering of the orders. We
-        // consider this a bug but until it is fixed we need this workaround.
-        let asks = sort_and_aggregate_orders_by_price(
-            orderbook.ask_prices().map(to_order).collect(),
-            TransitiveOrderbookOrdering::PriceAscending,
-        );
-        let bids = sort_and_aggregate_orders_by_price(
-            orderbook.bid_prices().map(to_order).collect(),
-            TransitiveOrderbookOrdering::PriceDescending,
-        );
-        Self { asks, bids }
-    }
-}
-
 /// A type representing a market price estimate result. Prices in a market are
 /// always represented in the quote token.
 #[derive(Debug, Serialize)]
@@ -145,90 +94,6 @@ mod tests {
             "sellAmountInQuote": "4.2",
         });
         assert_eq!(json, expected);
-    }
-
-    #[test]
-    fn transitive_orderbook_serialization() {
-        let original = MarketsResult {
-            asks: vec![TransitiveOrder {
-                price: 1.0,
-                volume: 2.0,
-            }],
-            bids: vec![TransitiveOrder {
-                price: 3.5,
-                volume: 4.0,
-            }],
-        };
-        let serialized = serde_json::to_string(&original).unwrap();
-        let json: Value = serde_json::from_str(&serialized).unwrap();
-        let expected = serde_json::json!({
-            "asks": [{"price": 1.0, "volume": 2.0}],
-            "bids": [{"price": 3.5, "volume": 4.0}],
-        });
-        assert_eq!(json, expected);
-    }
-
-    #[test]
-    fn sanitize_orders_sums_volume_at_same_price() {
-        let original = vec![
-            TransitiveOrder {
-                price: 1.0,
-                volume: 1.0,
-            },
-            TransitiveOrder {
-                price: 1.0,
-                volume: 2.0,
-            },
-            TransitiveOrder {
-                price: 2.0,
-                volume: 3.0,
-            },
-            TransitiveOrder {
-                price: 1.0,
-                volume: 4.0,
-            },
-            TransitiveOrder {
-                price: 2.0,
-                volume: 5.0,
-            },
-            TransitiveOrder {
-                price: 3.0,
-                volume: 6.0,
-            },
-            TransitiveOrder {
-                price: 2.0,
-                volume: 7.0,
-            },
-        ];
-        let mut expected = vec![
-            TransitiveOrder {
-                price: 1.0,
-                volume: 7.0,
-            },
-            TransitiveOrder {
-                price: 2.0,
-                volume: 15.0,
-            },
-            TransitiveOrder {
-                price: 3.0,
-                volume: 6.0,
-            },
-        ];
-        assert_eq!(
-            sort_and_aggregate_orders_by_price(
-                original.clone(),
-                TransitiveOrderbookOrdering::PriceAscending
-            ),
-            expected
-        );
-        expected.reverse();
-        assert_eq!(
-            sort_and_aggregate_orders_by_price(
-                original,
-                TransitiveOrderbookOrdering::PriceDescending
-            ),
-            expected
-        );
     }
 
     #[test]

--- a/price-estimator/src/models/markets_results.rs
+++ b/price-estimator/src/models/markets_results.rs
@@ -1,0 +1,144 @@
+use super::TransitiveOrder;
+use serde::Serialize;
+use std::cmp::Ordering;
+
+#[derive(Debug, Serialize)]
+pub struct MarketsResult {
+    pub asks: Vec<TransitiveOrder>,
+    pub bids: Vec<TransitiveOrder>,
+}
+
+impl From<&pricegraph::TransitiveOrderbook> for MarketsResult {
+    fn from(orderbook: &pricegraph::TransitiveOrderbook) -> Self {
+        let to_order = |(price, volume)| TransitiveOrder { price, volume };
+        // The frontend currently (2020-30-06) requires a specific ordering of the orders. We
+        // consider this a bug but until it is fixed we need this workaround.
+        let asks = sort_and_aggregate_orders_by_price(
+            orderbook.ask_prices().map(to_order).collect(),
+            TransitiveOrderbookOrdering::PriceAscending,
+        );
+        let bids = sort_and_aggregate_orders_by_price(
+            orderbook.bid_prices().map(to_order).collect(),
+            TransitiveOrderbookOrdering::PriceDescending,
+        );
+        Self { asks, bids }
+    }
+}
+
+enum TransitiveOrderbookOrdering {
+    PriceAscending,
+    PriceDescending,
+}
+
+fn sort_and_aggregate_orders_by_price(
+    mut orders: Vec<TransitiveOrder>,
+    ordering: TransitiveOrderbookOrdering,
+) -> Vec<TransitiveOrder> {
+    let compare = |a: &TransitiveOrder, b: &TransitiveOrder| {
+        let (a, b) = match ordering {
+            TransitiveOrderbookOrdering::PriceAscending => (a, b),
+            TransitiveOrderbookOrdering::PriceDescending => (b, a),
+        };
+        a.price.partial_cmp(&b.price).unwrap_or(Ordering::Less)
+    };
+    orders.sort_unstable_by(compare);
+    let mut result = Vec::<TransitiveOrder>::with_capacity(orders.len());
+    for order in orders.into_iter().filter(|order| !order.price.is_nan()) {
+        match result.last_mut() {
+            #[allow(clippy::float_cmp)]
+            Some(last) if last.price == order.price => last.volume += order.volume,
+            _ => result.push(order),
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    #[test]
+    fn transitive_orderbook_serialization() {
+        let original = MarketsResult {
+            asks: vec![TransitiveOrder {
+                price: 1.0,
+                volume: 2.0,
+            }],
+            bids: vec![TransitiveOrder {
+                price: 3.5,
+                volume: 4.0,
+            }],
+        };
+        let serialized = serde_json::to_string(&original).unwrap();
+        let json: Value = serde_json::from_str(&serialized).unwrap();
+        let expected = serde_json::json!({
+            "asks": [{"price": 1.0, "volume": 2.0}],
+            "bids": [{"price": 3.5, "volume": 4.0}],
+        });
+        assert_eq!(json, expected);
+    }
+
+    #[test]
+    fn sanitize_orders_sums_volume_at_same_price() {
+        let original = vec![
+            TransitiveOrder {
+                price: 1.0,
+                volume: 1.0,
+            },
+            TransitiveOrder {
+                price: 1.0,
+                volume: 2.0,
+            },
+            TransitiveOrder {
+                price: 2.0,
+                volume: 3.0,
+            },
+            TransitiveOrder {
+                price: 1.0,
+                volume: 4.0,
+            },
+            TransitiveOrder {
+                price: 2.0,
+                volume: 5.0,
+            },
+            TransitiveOrder {
+                price: 3.0,
+                volume: 6.0,
+            },
+            TransitiveOrder {
+                price: 2.0,
+                volume: 7.0,
+            },
+        ];
+        let mut expected = vec![
+            TransitiveOrder {
+                price: 1.0,
+                volume: 7.0,
+            },
+            TransitiveOrder {
+                price: 2.0,
+                volume: 15.0,
+            },
+            TransitiveOrder {
+                price: 3.0,
+                volume: 6.0,
+            },
+        ];
+        assert_eq!(
+            sort_and_aggregate_orders_by_price(
+                original.clone(),
+                TransitiveOrderbookOrdering::PriceAscending
+            ),
+            expected
+        );
+        expected.reverse();
+        assert_eq!(
+            sort_and_aggregate_orders_by_price(
+                original,
+                TransitiveOrderbookOrdering::PriceDescending
+            ),
+            expected
+        );
+    }
+}


### PR DESCRIPTION
Part of #1082 

I'm planning to implement `into_base_units` on MarketResults. Given there is already some logic regarding this type and models.rs itself is getting big, this PR just moves it into it's own file

### Test Plan
CI since no logic changed