### PR TITLE
Add method for reading orderbook at block number

### DIFF
--- a/core/src/contracts/stablex_contract.rs
+++ b/core/src/contracts/stablex_contract.rs
@@ -92,6 +92,9 @@ pub trait StableXContract: Send + Sync {
     /// Retrieve the time remaining in the batch.
     fn get_current_auction_remaining_time<'a>(&'a self) -> BoxFuture<'a, Result<Duration>>;
 
+    /// Retrieve the current auction index at the specified block number.
+    fn get_auction_index_at_block<'a>(&'a self, block: BlockNumber) -> BoxFuture<'a, Result<u32>>;
+
     /// Searches for the block number of the last block of the given batch. If
     /// the batch has not yet been finalized, then the block number for the
     /// `"latest"` block is returned.
@@ -158,14 +161,7 @@ pub trait StableXContract: Send + Sync {
 
 impl StableXContract for StableXContractImpl {
     fn get_current_auction_index<'a>(&'a self) -> BoxFuture<'a, Result<u32>> {
-        async move {
-            self.instance
-                .get_current_batch_id()
-                .call()
-                .await
-                .map_err(Error::from)
-        }
-        .boxed()
+        self.get_auction_index_at_block(BlockNumber::Latest)
     }
 
     fn get_current_auction_remaining_time<'a>(&'a self) -> BoxFuture<'a, Result<Duration>> {
@@ -176,6 +172,18 @@ impl StableXContract for StableXContractImpl {
                 .call()
                 .await?;
             Ok(Duration::from_secs(seconds.as_u64()))
+        }
+        .boxed()
+    }
+
+    fn get_auction_index_at_block<'a>(&'a self, block: BlockNumber) -> BoxFuture<'a, Result<u32>> {
+        async move {
+            self.instance
+                .get_current_batch_id()
+                .block(block)
+                .call()
+                .await
+                .map_err(Error::from)
         }
         .boxed()
     }

--- a/core/src/driver/stablex_driver.rs
+++ b/core/src/driver/stablex_driver.rs
@@ -61,7 +61,10 @@ impl StableXDriverImpl {
     }
 
     async fn get_orderbook(&self, batch_to_solve: u32) -> Result<(AccountState, Vec<Order>)> {
-        let get_auction_data_result = self.orderbook_reader.get_auction_data(batch_to_solve).await;
+        let get_auction_data_result = self
+            .orderbook_reader
+            .get_auction_data_for_batch(batch_to_solve)
+            .await;
         self.metrics
             .auction_orders_fetched(batch_to_solve, &get_auction_data_result);
         get_auction_data_result
@@ -253,7 +256,7 @@ mod tests {
         let latest_solution_submit_time = Duration::from_secs(120);
 
         reader
-            .expect_get_auction_data()
+            .expect_get_auction_data_for_batch()
             .with(eq(batch))
             .return_once({
                 let result = (state.clone(), orders.clone());
@@ -296,7 +299,7 @@ mod tests {
         let economic_viability = Arc::new(MockEconomicViabilityComputing::new());
 
         reader
-            .expect_get_auction_data()
+            .expect_get_auction_data_for_batch()
             .returning(|_| async { Err(anyhow!("Error")) }.boxed());
 
         let driver = StableXDriverImpl::new(
@@ -332,7 +335,7 @@ mod tests {
         let latest_solution_submit_time = Duration::from_secs(120);
 
         reader
-            .expect_get_auction_data()
+            .expect_get_auction_data_for_batch()
             .with(eq(batch))
             .return_once({
                 let result = (state, orders);
@@ -374,7 +377,7 @@ mod tests {
         let latest_solution_submit_time = Duration::from_secs(120);
 
         reader
-            .expect_get_auction_data()
+            .expect_get_auction_data_for_batch()
             .with(eq(batch))
             .return_once(move |_| async { Ok((state, orders)) }.boxed());
 
@@ -567,7 +570,7 @@ mod tests {
         let latest_solution_submit_time = Duration::from_secs(0);
 
         reader
-            .expect_get_auction_data()
+            .expect_get_auction_data_for_batch()
             .with(eq(batch))
             .return_once(move |_| {
                 // NOTE: Wait for an epsilon to go by so that the time limit

--- a/core/src/history/events.rs
+++ b/core/src/history/events.rs
@@ -226,6 +226,12 @@ impl StableXOrderBookReading for EventRegistry {
         immediate!(self.auction_state_for_batch(batch_id_to_solve))
     }
 
+    /// Returns the state of the open orderbook at the closest block before (or
+    /// on) the specified block with an exchange event.
+    ///
+    /// This is a limitation of the `EventRegistry` implementation where an
+    /// accurate batch ID for a block number cannot be determined unless there
+    /// is an event on that block.
     fn get_auction_data_for_block(
         &self,
         block: BlockNumber,

--- a/core/src/history/events.rs
+++ b/core/src/history/events.rs
@@ -219,7 +219,7 @@ impl TryFrom<&Path> for EventRegistry {
 }
 
 impl StableXOrderBookReading for EventRegistry {
-    fn get_auction_data(
+    fn get_auction_data_for_batch(
         &self,
         batch_id_to_solve: u32,
     ) -> BoxFuture<Result<(AccountState, Vec<Order>)>> {
@@ -393,13 +393,21 @@ mod tests {
         }));
         events.handle_event_data(deposit_2, 2, 0, H256::zero(), 0);
 
-        let auction_data = events.get_auction_data(2).now_or_never().unwrap().unwrap();
+        let auction_data = events
+            .get_auction_data_for_batch(2)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
         assert_eq!(
             auction_data.0.read_balance(0, Address::from_low_u64_be(2)),
             U256::from(3)
         );
         events.delete_events_starting_at_block(1);
-        let auction_data = events.get_auction_data(1).now_or_never().unwrap().unwrap();
+        let auction_data = events
+            .get_auction_data_for_batch(1)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
         assert_eq!(
             auction_data.0.read_balance(0, Address::from_low_u64_be(2)),
             U256::from(1)
@@ -454,7 +462,11 @@ mod tests {
         events.handle_event_data(withdraw_request, 1, 0, H256::zero(), 0);
         events.handle_event_data(token_listing_0, 0, 0, H256::zero(), 0);
 
-        let auction_data = events.get_auction_data(2).now_or_never().unwrap().unwrap();
+        let auction_data = events
+            .get_auction_data_for_batch(2)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
         assert_eq!(
             auction_data.0.read_balance(0, Address::from_low_u64_be(2)),
             U256::from(7)
@@ -501,7 +513,11 @@ mod tests {
         events.handle_event_data(deposit_0, 0, 3, H256::zero(), 0);
         events.handle_event_data(deposit_1, 1, 0, H256::zero(), BatchId(2).as_timestamp());
 
-        let auction_data = events.get_auction_data(0).now_or_never().unwrap().unwrap();
+        let auction_data = events
+            .get_auction_data_for_batch(0)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
         assert_eq!(
             auction_data.0.read_balance(0, Address::from_low_u64_be(2)),
             U256::from(42)

--- a/core/src/orderbook.rs
+++ b/core/src/orderbook.rs
@@ -2,15 +2,16 @@ mod filtered_orderbook;
 pub mod streamed;
 mod util;
 
-pub use self::filtered_orderbook::{FilteredOrderbookReader, OrderbookFilter};
-pub use self::streamed::Orderbook as EventBasedOrderbook;
+pub use self::{
+    filtered_orderbook::{FilteredOrderbookReader, OrderbookFilter},
+    streamed::Orderbook as EventBasedOrderbook,
+};
 use crate::models::{AccountState, Order};
 use anyhow::Result;
+use ethcontract::BlockNumber;
 use futures::future::BoxFuture;
-#[cfg(test)]
-use mockall::automock;
 
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 pub trait StableXOrderBookReading: Send + Sync {
     /// Returns the current state of the order book, including account balances
     /// and open orders or an error in case it cannot get this information.
@@ -20,6 +21,15 @@ pub trait StableXOrderBookReading: Send + Sync {
     fn get_auction_data<'a>(
         &'a self,
         batch_id_to_solve: u32,
+    ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>>;
+
+    /// Returns the state of the open orderbook at the specified block number.
+    ///
+    /// The open orderbook contains orders and balances that are valid for the
+    /// current batch at the given block.
+    fn get_auction_data_for_block<'a>(
+        &'a self,
+        block_number: BlockNumber,
     ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>>;
 
     /// Perform potential heavy initialization of the orderbook. If this fails or wasn't called
@@ -33,7 +43,14 @@ pub trait StableXOrderBookReading: Send + Sync {
 pub struct NoopOrderbook;
 
 impl StableXOrderBookReading for NoopOrderbook {
-    fn get_auction_data<'a>(&'a self, _: u32) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>> {
+    fn get_auction_data(&self, _: u32) -> BoxFuture<Result<(AccountState, Vec<Order>)>> {
+        immediate!(Ok(Default::default()))
+    }
+
+    fn get_auction_data_for_block(
+        &self,
+        _: BlockNumber,
+    ) -> BoxFuture<Result<(AccountState, Vec<Order>)>> {
         immediate!(Ok(Default::default()))
     }
 }

--- a/core/src/orderbook.rs
+++ b/core/src/orderbook.rs
@@ -18,7 +18,7 @@ pub trait StableXOrderBookReading: Send + Sync {
     ///
     /// # Arguments
     /// * `batch_id_to_solve` - the index for which returned orders should be valid
-    fn get_auction_data<'a>(
+    fn get_auction_data_for_batch<'a>(
         &'a self,
         batch_id_to_solve: u32,
     ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>>;
@@ -33,7 +33,7 @@ pub trait StableXOrderBookReading: Send + Sync {
     ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>>;
 
     /// Perform potential heavy initialization of the orderbook. If this fails or wasn't called
-    /// the orderbook will initialize on first use of `get_auction_data`.
+    /// the orderbook will initialize on first use of `get_auction_data_*`.
     fn initialize<'a>(&'a self) -> BoxFuture<'a, Result<()>> {
         immediate!(Ok(()))
     }
@@ -43,7 +43,7 @@ pub trait StableXOrderBookReading: Send + Sync {
 pub struct NoopOrderbook;
 
 impl StableXOrderBookReading for NoopOrderbook {
-    fn get_auction_data(&self, _: u32) -> BoxFuture<Result<(AccountState, Vec<Order>)>> {
+    fn get_auction_data_for_batch(&self, _: u32) -> BoxFuture<Result<(AccountState, Vec<Order>)>> {
         immediate!(Ok(Default::default()))
     }
 

--- a/core/src/orderbook/filtered_orderbook.rs
+++ b/core/src/orderbook/filtered_orderbook.rs
@@ -39,6 +39,33 @@ impl OrderbookFilter {
             TokenFilter::Blacklist(_) => None,
         }
     }
+
+    /// Applies the filter for the specified auction state.
+    pub fn apply(&self, (state, orders): (AccountState, Vec<Order>)) -> (AccountState, Vec<Order>) {
+        let token_filtered_orders: Vec<Order> = match &self.tokens {
+            TokenFilter::Whitelist(token_list) => orders
+                .into_iter()
+                .filter(|o| token_list.contains(&o.buy_token) && token_list.contains(&o.sell_token))
+                .collect(),
+            TokenFilter::Blacklist(token_list) => orders
+                .into_iter()
+                .filter(|o| {
+                    !token_list.contains(&o.buy_token) && !token_list.contains(&o.sell_token)
+                })
+                .collect(),
+        };
+        let user_filtered_orders = token_filtered_orders.into_iter().filter(|o| {
+            if let Some(user_filter) = self.users.get(&o.account_id) {
+                match user_filter {
+                    UserOrderFilter::All => false,
+                    UserOrderFilter::OrderIds(ids) => !ids.contains(&o.id),
+                }
+            } else {
+                true
+            }
+        });
+        util::canonicalize_auction_data(state, user_filtered_orders)
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
@@ -67,50 +94,38 @@ impl FilteredOrderbookReader {
 }
 
 impl StableXOrderBookReading for FilteredOrderbookReader {
-    fn get_auction_data<'b>(
-        &'b self,
+    fn get_auction_data(
+        &self,
         batch_id_to_solve: u32,
-    ) -> BoxFuture<'b, Result<(AccountState, Vec<Order>)>> {
+    ) -> BoxFuture<Result<(AccountState, Vec<Order>)>> {
         async move {
-            let (state, orders) = self.orderbook.get_auction_data(batch_id_to_solve).await?;
-            let token_filtered_orders: Vec<Order> = match &self.filter.tokens {
-                TokenFilter::Whitelist(token_list) => orders
-                    .into_iter()
-                    .filter(|o| {
-                        token_list.contains(&o.buy_token) && token_list.contains(&o.sell_token)
-                    })
-                    .collect(),
-                TokenFilter::Blacklist(token_list) => orders
-                    .into_iter()
-                    .filter(|o| {
-                        !token_list.contains(&o.buy_token) && !token_list.contains(&o.sell_token)
-                    })
-                    .collect(),
-            };
-            let user_filtered_orders = token_filtered_orders.into_iter().filter(|o| {
-                if let Some(user_filter) = self.filter.users.get(&o.account_id) {
-                    match user_filter {
-                        UserOrderFilter::All => false,
-                        UserOrderFilter::OrderIds(ids) => !ids.contains(&o.id),
-                    }
-                } else {
-                    true
-                }
-            });
-            Ok(util::canonicalize_auction_data(state, user_filtered_orders))
+            let auction_data = self.orderbook.get_auction_data(batch_id_to_solve).await?;
+            Ok(self.filter.apply(auction_data))
         }
         .boxed()
     }
 
-    fn initialize<'b>(&'b self) -> BoxFuture<'b, Result<()>> {
+    fn get_auction_data_for_block(
+        &self,
+        block: BlockNumber,
+    ) -> BoxFuture<Result<(AccountState, Vec<Order>)>> {
+        async move {
+            let auction_data = self.orderbook.get_auction_data_for_block(block).await?;
+            Ok(self.filter.apply(auction_data))
+        }
+        .boxed()
+    }
+
+    fn initialize(&self) -> BoxFuture<Result<()>> {
         self.orderbook.initialize()
     }
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use crate::models::order::test_util::create_order_for_test;
+    use mockall::predicate::eq;
     use std::str::FromStr;
 
     #[test]
@@ -266,5 +281,27 @@ mod test {
         let (state, filtered_orders) = reader.get_auction_data(0).now_or_never().unwrap().unwrap();
         assert_eq!(filtered_orders, vec![]);
         assert_eq!(state, AccountState::default());
+    }
+
+    #[test]
+    fn forwards_block_number_to_inner_filter() {
+        let mut inner = MockStableXOrderBookReading::default();
+        inner
+            .expect_get_auction_data_for_block()
+            .with(eq(BlockNumber::Number(42.into())))
+            .return_once(|_| immediate!(Ok(Default::default())));
+
+        let filter = OrderbookFilter {
+            tokens: TokenFilter::default(),
+            users: HashMap::new(),
+        };
+
+        let reader = FilteredOrderbookReader::new(Box::new(inner), filter);
+
+        reader
+            .get_auction_data_for_block(42.into())
+            .now_or_never()
+            .unwrap()
+            .unwrap();
     }
 }

--- a/core/src/orderbook/streamed/updating_orderbook.rs
+++ b/core/src/orderbook/streamed/updating_orderbook.rs
@@ -224,6 +224,6 @@ impl StableXOrderBookReading for UpdatingOrderbook {
     }
 
     fn initialize(&self) -> BoxFuture<Result<()>> {
-        self.do_with_context(|_| async { Ok(()) }.boxed()).boxed()
+        self.do_with_context(|_| immediate!(Ok(()))).boxed()
     }
 }

--- a/core/src/orderbook/streamed/updating_orderbook.rs
+++ b/core/src/orderbook/streamed/updating_orderbook.rs
@@ -24,8 +24,8 @@ pub struct UpdatingOrderbook {
     web3: Web3,
     block_page_size: usize,
     /// We need a mutex because otherwise the struct wouldn't be Sync which is needed because we use
-    /// the orderbook in multiple threads. The mutex is locked in `get_auction_data` while the
-    /// orderbook is updated with new events.
+    /// the orderbook in multiple threads. The mutex is locked in `get_auction_data_for_batch` while
+    /// the orderbook is updated with new events.
     /// None means that we have not yet been initialized.
     context: Mutex<Option<Context>>,
     /// File path where orderbook is written to disk.
@@ -40,7 +40,7 @@ struct Context {
 
 impl UpdatingOrderbook {
     /// Does not block on initializing the orderbook. This will happen in the first call to
-    /// `get_auction_data` which can thus take a long time to complete.
+    /// `get_auction_data_*` which can thus take a long time to complete.
     pub fn new(
         contract: Arc<dyn StableXContract>,
         web3: Web3,
@@ -207,12 +207,16 @@ impl UpdatingOrderbook {
 
 impl StableXOrderBookReading for UpdatingOrderbook {
     /// Blocks on updating the orderbook. This can be expensive if `initialize` hasn't been called before.
-    fn get_auction_data(
+    fn get_auction_data_for_batch(
         &self,
         batch_id_to_solve: u32,
     ) -> BoxFuture<Result<(AccountState, Vec<Order>)>> {
-        self.do_with_context(move |context| context.orderbook.get_auction_data(batch_id_to_solve))
-            .boxed()
+        self.do_with_context(move |context| {
+            context
+                .orderbook
+                .get_auction_data_for_batch(batch_id_to_solve)
+        })
+        .boxed()
     }
 
     fn get_auction_data_for_block(

--- a/core/src/orderbook/streamed/updating_orderbook.rs
+++ b/core/src/orderbook/streamed/updating_orderbook.rs
@@ -207,14 +207,23 @@ impl UpdatingOrderbook {
 
 impl StableXOrderBookReading for UpdatingOrderbook {
     /// Blocks on updating the orderbook. This can be expensive if `initialize` hasn't been called before.
-    fn get_auction_data<'a>(
-        &'a self,
+    fn get_auction_data(
+        &self,
         batch_id_to_solve: u32,
-    ) -> BoxFuture<'a, Result<(AccountState, Vec<Order>)>> {
+    ) -> BoxFuture<Result<(AccountState, Vec<Order>)>> {
         self.do_with_context(move |context| context.orderbook.get_auction_data(batch_id_to_solve))
             .boxed()
     }
-    fn initialize<'a>(&'a self) -> BoxFuture<'a, Result<()>> {
+
+    fn get_auction_data_for_block(
+        &self,
+        block: BlockNumber,
+    ) -> BoxFuture<Result<(AccountState, Vec<Order>)>> {
+        self.do_with_context(move |context| context.orderbook.get_auction_data_for_block(block))
+            .boxed()
+    }
+
+    fn initialize(&self) -> BoxFuture<Result<()>> {
         self.do_with_context(|_| async { Ok(()) }.boxed()).boxed()
     }
 }

--- a/core/src/price_estimation/orderbook_based.rs
+++ b/core/src/price_estimation/orderbook_based.rs
@@ -26,8 +26,10 @@ impl PriceSource for PricegraphEstimator {
     ) -> BoxFuture<'a, Result<HashMap<TokenId, NonZeroU128>>> {
         async move {
             let batch = BatchId::currently_being_solved(SystemTime::now())?;
-            let (account_state, orders) =
-                self.orderbook_reader.get_auction_data(batch.into()).await?;
+            let (account_state, orders) = self
+                .orderbook_reader
+                .get_auction_data_for_batch(batch.into())
+                .await?;
             let pricegraph = Pricegraph::new(orders.iter().map(|order| {
                 order.to_element(account_state.read_balance(order.sell_token, order.account_id))
             }));

--- a/price-estimator/src/orderbook.rs
+++ b/price-estimator/src/orderbook.rs
@@ -115,7 +115,7 @@ impl Orderbook {
 
     async fn auction_data(&self, batch_id: BatchId) -> Result<AuctionData> {
         self.orderbook_reading
-            .get_auction_data(batch_id.into())
+            .get_auction_data_for_batch(batch_id.into())
             .await
     }
 


### PR DESCRIPTION
This PR adds a new `StableXOrderbookReading::get_auction_data_for_block` trait method with additional implementations.

This would be an alternative to introducing a new trait for querying at a block number and timestamp in #1290. In a follow up PR I can add the method for querying at a specific timestamp as well.

### Test Plan

Added some new unit tests.