### PR TITLE
Introduce trait for mocking current time

### DIFF
--- a/core/src/driver/scheduler/system.rs
+++ b/core/src/driver/scheduler/system.rs
@@ -1,7 +1,9 @@
 use super::{AuctionTimingConfiguration, Scheduler};
-use crate::driver::stablex_driver::{DriverResult, StableXDriver};
-use crate::models::BatchId;
-use crate::util::FutureWaitExt as _;
+use crate::{
+    driver::stablex_driver::{DriverResult, StableXDriver},
+    models::BatchId,
+    util::{AsyncSleep, AsyncSleeping, DefaultNow, FutureWaitExt as _, Now},
+};
 use anyhow::{Context, Result};
 use crossbeam_utils::thread::Scope;
 use log::error;
@@ -48,16 +50,15 @@ impl<'a> SystemScheduler<'a> {
             .auction_timing_configuration
             .earliest_solution_submit_time;
         scope.spawn(move |_| {
-            while let Some(time_limit) = solver_deadline.checked_duration_since(Instant::now()) {
-                let driver_result = driver
-                    .run(batch_id, time_limit, min_solution_submit_time)
-                    .wait();
-                log_driver_result(batch_id, &driver_result);
-                match driver_result {
-                    DriverResult::Retry(_) => thread::sleep(RETRY_SLEEP_DURATION),
-                    DriverResult::Ok | DriverResult::Skip(_) => break,
-                }
-            }
+            solve(
+                batch_id,
+                solver_deadline,
+                min_solution_submit_time,
+                driver,
+                &DefaultNow {},
+                &AsyncSleep {},
+            )
+            .wait();
         });
     }
 
@@ -97,6 +98,26 @@ impl<'a> SystemScheduler<'a> {
         };
 
         Ok(action)
+    }
+}
+
+async fn solve(
+    batch_id: BatchId,
+    solver_deadline: Instant,
+    min_solution_submit_time: Duration,
+    driver: &dyn StableXDriver,
+    now: &dyn Now,
+    sleep: &dyn AsyncSleeping,
+) {
+    while let Some(time_limit) = solver_deadline.checked_duration_since(now.instant_now()) {
+        let driver_result = driver
+            .run(batch_id, time_limit, min_solution_submit_time)
+            .await;
+        log_driver_result(batch_id, &driver_result);
+        match driver_result {
+            DriverResult::Retry(_) => sleep.sleep(RETRY_SLEEP_DURATION).await,
+            DriverResult::Ok | DriverResult::Skip(_) => break,
+        }
     }
 }
 
@@ -141,7 +162,10 @@ impl<'a> Scheduler for SystemScheduler<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::driver::stablex_driver::MockStableXDriver;
+    use crate::{
+        driver::stablex_driver::MockStableXDriver,
+        util::{MockAsyncSleeping, MockNow},
+    };
     use anyhow::anyhow;
     use futures::future::FutureExt as _;
 
@@ -252,6 +276,43 @@ mod tests {
                 .unwrap(),
             Action::Sleep(Duration::from_secs(11))
         );
+    }
+
+    #[test]
+    fn solve_checks_deadline() {
+        lazy_static::lazy_static! {
+            static ref EPOCH: Instant = Instant::now();
+        };
+
+        let mut driver = MockStableXDriver::new();
+        driver
+            .expect_run()
+            .returning(|_, _, _| immediate!(DriverResult::Retry(anyhow!(""))));
+        let mut sleep = MockAsyncSleeping::new();
+        sleep.expect_sleep().returning(|_| immediate!(()));
+
+        let mut now = MockNow::new();
+        now.expect_instant_now().times(1).returning(|| *EPOCH);
+        now.expect_instant_now()
+            .times(1)
+            .returning(|| *EPOCH + Duration::from_secs(2));
+        now.expect_instant_now()
+            .times(1)
+            .returning(|| *EPOCH + Duration::from_secs(4));
+        now.expect_instant_now()
+            .times(1)
+            .returning(|| *EPOCH + Duration::from_secs(6));
+
+        assert!(solve(
+            BatchId(0),
+            *EPOCH + Duration::from_secs(5),
+            Duration::from_secs(0),
+            &driver,
+            &now,
+            &sleep,
+        )
+        .now_or_never()
+        .is_some());
     }
 
     // Allows a human to observe real behavior by looking at the log output.

--- a/core/src/driver/scheduler/system.rs
+++ b/core/src/driver/scheduler/system.rs
@@ -2,7 +2,7 @@ use super::{AuctionTimingConfiguration, Scheduler};
 use crate::{
     driver::stablex_driver::{DriverResult, StableXDriver},
     models::BatchId,
-    util::{AsyncSleep, AsyncSleeping, DefaultNow, FutureWaitExt as _, Now},
+    util::{self, AsyncSleep, AsyncSleeping, FutureWaitExt as _, Now},
 };
 use anyhow::{Context, Result};
 use crossbeam_utils::thread::Scope;
@@ -55,7 +55,7 @@ impl<'a> SystemScheduler<'a> {
                 solver_deadline,
                 min_solution_submit_time,
                 driver,
-                &DefaultNow {},
+                &util::default_now(),
                 &AsyncSleep {},
             )
             .wait();

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -1,6 +1,9 @@
 use ethcontract::U256;
 use futures::future::{BoxFuture, FutureExt as _};
-use std::{future::Future, time::Duration};
+use std::{
+    future::Future,
+    time::{Duration, Instant, SystemTime},
+};
 
 pub trait CeiledDiv {
     /// Panics on overflow.
@@ -66,6 +69,22 @@ pub trait AsyncSleeping: Send + Sync {
 }
 pub struct AsyncSleep;
 impl AsyncSleeping for AsyncSleep {}
+
+#[cfg_attr(test, mockall::automock)]
+pub trait Now: Send + Sync {
+    fn system_now(&self) -> SystemTime;
+    fn instant_now(&self) -> Instant;
+}
+
+pub struct DefaultNow;
+impl Now for DefaultNow {
+    fn system_now(&self) -> SystemTime {
+        SystemTime::now()
+    }
+    fn instant_now(&self) -> Instant {
+        Instant::now()
+    }
+}
 
 #[cfg(test)]
 pub mod test_util {

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -67,6 +67,7 @@ pub trait AsyncSleeping: Send + Sync {
         async_std::task::sleep(duration).boxed()
     }
 }
+
 pub struct AsyncSleep;
 impl AsyncSleeping for AsyncSleep {}
 
@@ -76,7 +77,11 @@ pub trait Now: Send + Sync {
     fn instant_now(&self) -> Instant;
 }
 
-pub struct DefaultNow;
+pub fn default_now() -> impl Now {
+    DefaultNow {}
+}
+
+struct DefaultNow;
 impl Now for DefaultNow {
     fn system_now(&self) -> SystemTime {
         SystemTime::now()


### PR DESCRIPTION
and show one example of how it would be used.

We've talked about this kind of trait before as an alternative to the "action pattern". What do you think of this implementation? I would like to use it in my refactor to get rid of the sleeping in stablex_driver and solution_submission.

### Test Plan
CI