### PR TITLE
Search by symbol

### DIFF
--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -30,9 +30,10 @@ macro_rules! std_map {
 }
 
 macro_rules! immediate {
-    ($expression:expr) => {
-        async move { $expression }.boxed()
-    };
+    ($expression:expr) => {{
+        let value = $expression;
+        async move { value }.boxed()
+    }};
 }
 
 #[cfg(test)]

--- a/core/src/token_info.rs
+++ b/core/src/token_info.rs
@@ -66,6 +66,10 @@ mod mock {
             ids: &[TokenId],
         ) -> BoxFuture<'a, Result<HashMap<TokenId, TokenBaseInfo>>>;
         fn all_ids<'a>(&'a self) -> BoxFuture<'a, Result<Vec<TokenId>>>;
+        fn find_token_by_symbol<'a>(
+            &'a self,
+            symbol: &str,
+        ) -> BoxFuture<'a, Result<Option<(TokenId, TokenBaseInfo)>>>;
     }
 
     impl<T: TokenInfoFetching_ + Send + Sync> TokenInfoFetching for T {
@@ -80,6 +84,12 @@ mod mock {
         }
         fn all_ids<'a>(&'a self) -> BoxFuture<'a, Result<Vec<TokenId>>> {
             TokenInfoFetching_::all_ids(self)
+        }
+        fn find_token_by_symbol<'a>(
+            &'a self,
+            symbol: &'a str,
+        ) -> BoxFuture<'a, Result<Option<(TokenId, TokenBaseInfo)>>> {
+            TokenInfoFetching_::find_token_by_symbol(self, symbol)
         }
     }
 }

--- a/core/src/token_info.rs
+++ b/core/src/token_info.rs
@@ -48,7 +48,7 @@ pub trait TokenInfoFetching: Send + Sync {
             let infos = self.get_token_infos(&self.all_ids().await?).await?;
             Ok(infos
                 .into_iter()
-                .find(|(_, info)| info.symbol() == symbol || info.alias == symbol))
+                .find(|(_, info)| info.matches_symbol(symbol)))
         }
         .boxed()
     }
@@ -130,6 +130,11 @@ impl TokenBaseInfo {
     pub fn get_owl_price(&self, usd_price: f64) -> u128 {
         let pow = 36 - (self.decimals as i32);
         (usd_price * 10f64.powi(pow)) as _
+    }
+
+    /// Returns true if the token alias or symbol matches the speciefied symbol.
+    pub fn matches_symbol(&self, symbol: &str) -> bool {
+        self.alias == symbol || self.symbol() == symbol
     }
 }
 

--- a/core/src/token_info/cached.rs
+++ b/core/src/token_info/cached.rs
@@ -69,14 +69,13 @@ impl TokenInfoCache {
         Ok(())
     }
 
-    async fn uncached_tokens<'a>(
-        &'a self,
-        ids: impl IntoIterator<Item = &'a TokenId> + 'a,
-    ) -> impl Iterator<Item = TokenId> + 'a {
+    async fn uncached_tokens(&self, ids: impl IntoIterator<Item = &TokenId>) -> Vec<TokenId> {
         let cache = self.cache.read().await;
         ids.into_iter()
             .copied()
-            .filter(move |id| !cache.contains_key(id))
+            .filter(|id| !cache.contains_key(id))
+            // NOTE: Make sure to `collect` to not hold the `cache` lock.
+            .collect()
     }
 
     async fn find_cached_token_by_symbol(&self, symbol: &str) -> Option<(TokenId, TokenBaseInfo)> {

--- a/core/src/token_info/cached.rs
+++ b/core/src/token_info/cached.rs
@@ -69,12 +69,14 @@ impl TokenInfoCache {
         Ok(())
     }
 
-    async fn uncached_tokens(&self, ids: impl IntoIterator<Item = &TokenId>) -> Vec<TokenId> {
+    async fn uncached_tokens<'a>(
+        &'a self,
+        ids: impl IntoIterator<Item = &'a TokenId> + 'a,
+    ) -> impl Iterator<Item = TokenId> + 'a {
         let cache = self.cache.read().await;
         ids.into_iter()
             .copied()
-            .filter(|id| !cache.contains_key(id))
-            .collect()
+            .filter(move |id| !cache.contains_key(id))
     }
 
     async fn find_cached_token_by_symbol(&self, symbol: &str) -> Option<(TokenId, TokenBaseInfo)> {

--- a/core/src/token_info/hardcoded.rs
+++ b/core/src/token_info/hardcoded.rs
@@ -55,8 +55,9 @@ impl TokenInfoFetching for TokenData {
             .0
             .get(&id)
             .cloned()
-            .ok_or_else(|| anyhow!("Token {:?} not found in hardcoded data", id));
-        immediate!(Ok(info?.into()))
+            .ok_or_else(|| anyhow!("Token {:?} not found in hardcoded data", id))
+            .map(Into::into);
+        immediate!(info)
     }
 
     fn all_ids<'a>(&'a self) -> BoxFuture<'a, Result<Vec<TokenId>>> {

--- a/price-estimator/src/main.rs
+++ b/price-estimator/src/main.rs
@@ -119,7 +119,7 @@ fn main() {
     let cache: HashMap<_, _> = options.token_data.clone().into();
     let token_info = TokenInfoCache::with_cache(contract.clone(), cache);
     token_info
-        .cache_all(10)
+        .cache_all()
         .wait()
         .expect("failed to cache token infos");
     let token_info = Arc::new(token_info);

--- a/price-estimator/src/models/currency_pair.rs
+++ b/price-estimator/src/models/currency_pair.rs
@@ -59,10 +59,17 @@ pub enum TokenRef {
 
 impl TokenRef {
     /// Convert this token reference into an exchange token ID.
-    pub async fn as_token_id(&self, _token_infos: &dyn TokenInfoFetching) -> Result<TokenId> {
+    pub async fn as_token_id(&self, token_infos: &dyn TokenInfoFetching) -> Result<TokenId> {
         match self {
             TokenRef::Id(id) => Ok(*id),
-            _ => bail!("not yet implemented"),
+            TokenRef::Address(_) => bail!("not yet implemented"),
+            TokenRef::Symbol(symbol) => {
+                let (id, _) = token_infos
+                    .find_token_by_symbol(symbol)
+                    .await?
+                    .ok_or_else(|| anyhow!("token symbol {} not found", symbol))?;
+                Ok(id.into())
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds the ability of to use symbols for currency pairs. Note that the symbols are retrieved from the EVM, so it is possible that names with duplicates (such as `DAI`) run into collisions and require updating our deployment.

### Test Plan

```
$ cargo run -p price-estimator -- --token-data '{"T0009":{"alias":"sUSD depr","decimals":18},"T0012":{"alias":"SAI","decimals":18},"T0015":{"alias":"SNX depr","decimals":18}}'
...
$ curl -s 'http://localhost:8080/api/v1/markets/WETH-DAI/estimated-buy-amount/1000?atoms=false' | jq
{
  "baseTokenId": 1,
  "quoteTokenId": 7,
  "buyAmountInBase": "2.3573254925937595",
  "sellAmountInQuote": "1000"
}
$ curl -s 'http://localhost:8080/api/v1/markets/ETH-DAI/estimated-buy-amount/1000?atoms=false' | jq # Bonus!
{
  "baseTokenId": 1,
  "quoteTokenId": 7,
  "buyAmountInBase": "2.3573254925937595",
  "sellAmountInQuote": "1000"
}
```