### PR TITLE
Replace crossbream scoped thread with asycnstd task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,7 +470,6 @@ dependencies = [
  "byteorder",
  "chrono",
  "contracts",
- "crossbeam-utils",
  "ethcontract",
  "futures 0.3.5",
  "isahc",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,7 +12,6 @@ blocking = "0.5.1"
 byteorder = "1.3.4"
 chrono = { version = "0.4.15", default-features = false  }
 contracts = { path = "../contracts" }
-crossbeam-utils = "0.7"
 ethcontract = "0.7.2"
 futures = { version = "0.3.5", features = ["compat"] }
 isahc = { version = "0.9.8", features = ["json"] }

--- a/core/src/contracts/stablex_contract.rs
+++ b/core/src/contracts/stablex_contract.rs
@@ -84,7 +84,7 @@ pub enum NoopTransactionError {
 }
 
 #[cfg_attr(test, automock)]
-pub trait StableXContract {
+pub trait StableXContract: Send + Sync {
     /// Retrieve the current batch ID that is accepting orders. Note that this
     /// is always `1` greater than the batch ID that is accepting solutions.
     fn get_current_auction_index<'a>(&'a self) -> BoxFuture<'a, Result<u32>>;

--- a/core/src/driver/scheduler.rs
+++ b/core/src/driver/scheduler.rs
@@ -7,8 +7,7 @@ use crate::contracts::stablex_contract::StableXContract;
 use crate::driver::stablex_driver::StableXDriver;
 use crate::models::batch_id::SOLVING_WINDOW;
 use anyhow::{anyhow, Error, Result};
-use std::str::FromStr;
-use std::time::Duration;
+use std::{str::FromStr, sync::Arc, time::Duration};
 
 /// A scheduler that can be started in order to run the driver for each batch.
 pub trait Scheduler {
@@ -94,12 +93,12 @@ pub enum SchedulerKind {
 
 impl SchedulerKind {
     /// Creates a new scheduler based on the parameters.
-    pub fn create<'a>(
+    pub fn create(
         &self,
-        exchange: &'a dyn StableXContract,
-        driver: &'a (dyn StableXDriver + Sync),
+        exchange: Arc<dyn StableXContract>,
+        driver: Arc<dyn StableXDriver>,
         config: AuctionTimingConfiguration,
-    ) -> Box<dyn Scheduler + 'a> {
+    ) -> Box<dyn Scheduler> {
         match self {
             SchedulerKind::System => Box::new(SystemScheduler::new(driver, config)),
             SchedulerKind::Evm => Box::new(EvmScheduler::new(exchange, driver, config)),

--- a/core/src/driver/scheduler/system.rs
+++ b/core/src/driver/scheduler/system.rs
@@ -2,7 +2,7 @@ use super::{AuctionTimingConfiguration, Scheduler};
 use crate::{
     driver::stablex_driver::{DriverError, StableXDriver},
     models::{BatchId, Solution},
-    util::{self, AsyncSleep, AsyncSleeping, FutureWaitExt as _, Now},
+    util::{self, AsyncSleep, AsyncSleeping, Now},
 };
 use anyhow::{Context, Result};
 use std::{

--- a/core/src/driver/scheduler/system.rs
+++ b/core/src/driver/scheduler/system.rs
@@ -5,16 +5,16 @@ use crate::{
     util::{self, AsyncSleep, AsyncSleeping, FutureWaitExt as _, Now},
 };
 use anyhow::{Context, Result};
-use crossbeam_utils::thread::Scope;
 use std::{
+    sync::Arc,
     thread,
     time::{Duration, Instant, SystemTime},
 };
 
 const RETRY_SLEEP_DURATION: Duration = Duration::from_secs(1);
 
-pub struct SystemScheduler<'a> {
-    driver: &'a (dyn StableXDriver + Sync),
+pub struct SystemScheduler {
+    driver: Arc<dyn StableXDriver>,
     auction_timing_configuration: AuctionTimingConfiguration,
     last_solved_batch: Option<BatchId>,
 }
@@ -25,9 +25,9 @@ enum Action {
     Sleep(Duration),
 }
 
-impl<'a> SystemScheduler<'a> {
+impl SystemScheduler {
     pub fn new(
-        driver: &'a (dyn StableXDriver + Sync),
+        driver: Arc<dyn StableXDriver>,
         auction_timing_configuration: AuctionTimingConfiguration,
     ) -> Self {
         Self {
@@ -37,28 +37,21 @@ impl<'a> SystemScheduler<'a> {
         }
     }
 
-    fn start_solving_in_thread<'b>(
-        &self,
-        batch_id: BatchId,
-        solver_deadline: Instant,
-        scope: &Scope<'b>,
-    ) where
-        'a: 'b,
-    {
-        let driver = self.driver;
+    fn start_solving_in_background(&self, batch_id: BatchId, solver_deadline: Instant) {
+        let driver = self.driver.clone();
         let earliest_solution_submit_time = self
             .auction_timing_configuration
             .earliest_solution_submit_time;
-        scope.spawn(move |_| {
+        async_std::task::spawn(async move {
             solve_and_submit(
                 batch_id,
                 solver_deadline,
                 earliest_solution_submit_time,
-                driver,
+                driver.as_ref(),
                 &util::default_now(),
                 &AsyncSleep {},
             )
-            .wait();
+            .await;
         });
     }
 
@@ -105,7 +98,7 @@ async fn solve_and_submit(
     batch_id: BatchId,
     solver_deadline: Instant,
     earliest_solution_submit_time: Duration,
-    driver: &dyn StableXDriver,
+    driver: &(dyn StableXDriver),
     now: &dyn Now,
     sleep: &dyn AsyncSleeping,
 ) {
@@ -134,7 +127,7 @@ async fn submit(
     batch_id: BatchId,
     earliest_solution_submit_time: Duration,
     solution: Solution,
-    driver: &dyn StableXDriver,
+    driver: &(dyn StableXDriver),
     now: &dyn Now,
     sleep: &dyn AsyncSleeping,
 ) {
@@ -172,28 +165,25 @@ fn log_submit_result(batch_id: BatchId, result: &Result<()>) {
     }
 }
 
-impl<'a> Scheduler for SystemScheduler<'a> {
+impl Scheduler for SystemScheduler {
     fn start(&mut self) -> ! {
-        crossbeam_utils::thread::scope(|scope| -> ! {
-            loop {
-                match self.determine_action(SystemTime::now()) {
-                    Ok(Action::Sleep(duration)) => {
-                        log::info!("Sleeping {}s.", duration.as_secs());
-                        thread::sleep(duration);
-                    }
-                    Ok(Action::Solve(batch_id, duration)) => {
-                        log::info!("Starting to solve batch {}.", batch_id);
-                        self.last_solved_batch = Some(batch_id);
-                        self.start_solving_in_thread(batch_id, Instant::now() + duration, scope)
-                    }
-                    Err(err) => {
-                        log::error!("Scheduler error: {:?}", err);
-                        thread::sleep(RETRY_SLEEP_DURATION);
-                    }
-                };
-            }
-        })
-        .unwrap();
+        loop {
+            match self.determine_action(SystemTime::now()) {
+                Ok(Action::Sleep(duration)) => {
+                    log::info!("Sleeping {}s.", duration.as_secs());
+                    thread::sleep(duration);
+                }
+                Ok(Action::Solve(batch_id, duration)) => {
+                    log::info!("Starting to solve batch {}.", batch_id);
+                    self.last_solved_batch = Some(batch_id);
+                    self.start_solving_in_background(batch_id, Instant::now() + duration);
+                }
+                Err(err) => {
+                    log::error!("Scheduler error: {:?}", err);
+                    thread::sleep(RETRY_SLEEP_DURATION);
+                }
+            };
+        }
     }
 }
 
@@ -216,7 +206,7 @@ mod tests {
             latest_solution_submit_time: Duration::from_secs(20),
             earliest_solution_submit_time: Duration::from_secs(0),
         };
-        let scheduler = SystemScheduler::new(&driver, auction_timing_configuration);
+        let scheduler = SystemScheduler::new(Arc::new(driver), auction_timing_configuration);
 
         let base_time = SystemTime::UNIX_EPOCH + Duration::from_secs(300);
 
@@ -271,7 +261,7 @@ mod tests {
             latest_solution_submit_time: Duration::from_secs(20),
             earliest_solution_submit_time: Duration::from_secs(0),
         };
-        let mut scheduler = SystemScheduler::new(&driver, auction_timing_configuration);
+        let mut scheduler = SystemScheduler::new(Arc::new(driver), auction_timing_configuration);
         scheduler.last_solved_batch = Some(BatchId(0));
 
         let base_time = SystemTime::UNIX_EPOCH + Duration::from_secs(300);
@@ -428,7 +418,7 @@ mod tests {
             latest_solution_submit_time: Duration::from_secs(20),
             earliest_solution_submit_time: Duration::from_secs(0),
         };
-        let mut scheduler = SystemScheduler::new(&driver, auction_timing_configuration);
+        let mut scheduler = SystemScheduler::new(Arc::new(driver), auction_timing_configuration);
 
         scheduler.start();
     }

--- a/core/src/orderbook/onchain_filtered_orderbook.rs
+++ b/core/src/orderbook/onchain_filtered_orderbook.rs
@@ -11,14 +11,14 @@ use futures::future::{BoxFuture, FutureExt as _};
 use std::sync::Arc;
 
 pub struct OnchainFilteredOrderBookReader {
-    contract: Arc<dyn StableXContract + Send + Sync>,
+    contract: Arc<dyn StableXContract>,
     page_size: u16,
     filter: Vec<u16>,
 }
 
 impl OnchainFilteredOrderBookReader {
     pub fn new(
-        contract: Arc<dyn StableXContract + Send + Sync>,
+        contract: Arc<dyn StableXContract>,
         page_size: u16,
         filter: &OrderbookFilter,
     ) -> Self {

--- a/core/src/orderbook/paginated_orderbook.rs
+++ b/core/src/orderbook/paginated_orderbook.rs
@@ -13,12 +13,12 @@ use std::sync::Arc;
 /// contract in a paginated way.
 /// This avoid hitting gas limits when the total amount of orders is large.
 pub struct PaginatedStableXOrderBookReader {
-    contract: Arc<dyn StableXContract + Send + Sync>,
+    contract: Arc<dyn StableXContract>,
     page_size: u16,
 }
 
 impl PaginatedStableXOrderBookReader {
-    pub fn new(contract: Arc<dyn StableXContract + Send + Sync>, page_size: u16) -> Self {
+    pub fn new(contract: Arc<dyn StableXContract>, page_size: u16) -> Self {
         Self {
             contract,
             page_size,

--- a/core/src/orderbook/streamed/updating_orderbook.rs
+++ b/core/src/orderbook/streamed/updating_orderbook.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 /// An event based orderbook that automatically updates itself with new events from the contract.
 pub struct UpdatingOrderbook {
-    contract: Arc<dyn StableXContract + Send + Sync>,
+    contract: Arc<dyn StableXContract>,
     web3: Web3,
     block_page_size: usize,
     /// We need a mutex because otherwise the struct wouldn't be Sync which is needed because we use
@@ -42,7 +42,7 @@ impl UpdatingOrderbook {
     /// Does not block on initializing the orderbook. This will happen in the first call to
     /// `get_auction_data` which can thus take a long time to complete.
     pub fn new(
-        contract: Arc<dyn StableXContract + Send + Sync>,
+        contract: Arc<dyn StableXContract>,
         web3: Web3,
         block_page_size: usize,
         path: Option<PathBuf>,

--- a/core/src/price_finding.rs
+++ b/core/src/price_finding.rs
@@ -17,13 +17,13 @@ pub fn create_price_finder(
     price_oracle: Arc<dyn PriceEstimating + Send + Sync>,
     min_avg_fee: Arc<dyn EconomicViabilityComputing>,
     internal_optimizer: InternalOptimizer,
-) -> Box<dyn PriceFinding + Sync> {
+) -> Arc<dyn PriceFinding + Send + Sync> {
     if solver_type == SolverType::NaiveSolver {
         info!("Using naive price finder");
-        Box::new(NaiveSolver::new(fee))
+        Arc::new(NaiveSolver::new(fee))
     } else {
         info!("Using {:?} optimization price finder", solver_type);
-        Box::new(OptimisationPriceFinder::new(
+        Arc::new(OptimisationPriceFinder::new(
             fee,
             solver_type,
             price_oracle,


### PR DESCRIPTION
This involves converting several structs to store Arcs instead of references. This is more code in terms of lines but also simplifies lifetimes so imo it's an improvement.

### Test Plan
CI and `cargo test -p core system::tests::test_real -- --ignored --nocapture`