### PR TITLE
Increase private solver version to v0.8.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ language: rust
 env:
   global:
     - OPEN_SOLVER_VERSION=v0.0.11
-    - PRIVATE_SOLVER_VERSION=v0.8.2
+    - PRIVATE_SOLVER_VERSION=v0.8.3
 
 jobs:
   fast_finish: true


### PR DESCRIPTION
This solver bump includes:

* make writing intermediate/auxiliary output files optional (and deactivate by default): https://github.com/gnosis/dex-solver/pull/321
* deactivate economic viability constraint in first stage of the two-stage model: https://github.com/gnosis/dex-solver/pull/324
