### PR TITLE
Fix panic caused by wait() instead of await

### DIFF
--- a/core/src/driver/scheduler/system.rs
+++ b/core/src/driver/scheduler/system.rs
@@ -147,7 +147,7 @@ async fn submit(
         );
         sleep.sleep(duration).await;
     }
-    let result = driver.submit_solution(batch_id, solution).wait();
+    let result = driver.submit_solution(batch_id, solution).await;
     log_submit_result(batch_id, &result);
 }
 


### PR DESCRIPTION
The async fn should not be using wait(). Crashes because it is not
allowed to wait() in a future that is itself wait()ed.

[Optional] 
Fixes #issue

*<Context of what this change does, why it is needed and how it is accomplished>*

### Test Plan
*<Explain how you and a reviewer have/intend to test this change>*