### PR TITLE
Move solution submission batch id check to scheduler

### DIFF
--- a/core/src/driver/scheduler.rs
+++ b/core/src/driver/scheduler.rs
@@ -100,7 +100,7 @@ impl SchedulerKind {
         config: AuctionTimingConfiguration,
     ) -> Box<dyn Scheduler> {
         match self {
-            SchedulerKind::System => Box::new(SystemScheduler::new(driver, config)),
+            SchedulerKind::System => Box::new(SystemScheduler::new(exchange, driver, config)),
             SchedulerKind::Evm => Box::new(EvmScheduler::new(exchange, driver, config)),
         }
     }


### PR DESCRIPTION
It is more appropriate there. The evm scheduler already knows that the
batch id is correct so no new code is added there.

[Optional] 
Fixes #707
*<Context of what this change does, why it is needed and how it is accomplished>*

### Test Plan
CI, new unit test