### PR TITLE
make /markets and /estimated-best-ask-price return consistent prices

### DIFF
--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -312,7 +312,9 @@ async fn estimate_best_ask_price(
         .pricegraph(query.time, PricegraphKind::WithRoundingBuffer)
         .await
         .map_err(RejectionReason::InternalError)?
-        .estimate_limit_price(token_pair, 0.0);
+        .estimate_limit_price(token_pair, 0.0)
+        // The price above is in base, but we need to return it in quote.
+        .map(|p| 1.0 / p);
 
     let result = PriceEstimateResult(price);
     let result = match query.unit {


### PR DESCRIPTION
Fixes #1344

For more context see discussion in the issue. I added a long comment in the updated unit test justifying why the logic is now correct if the price is in quote.

Alternatively we could also just invert the price after it has been turned in the PriceEstimateResult type. Generally it would probably be nice to have some kind of meta information about what is base and what is quote in the result type (similar to how we have it for 

https://dex-price-estimator.gnosis.io/api/v1/markets/11-4/estimated-buy-amount/100000000?atoms=true

> {"baseTokenId":11,"quoteTokenId":4,"buyAmountInBase":"837137","sellAmountInQuote":"100000000"}

### Test Plan
Adjusted unit test