### PR TITLE
Add query parameter to filter addresses out of the orderbook

### DIFF
--- a/price-estimator/openapi.yml
+++ b/price-estimator/openapi.yml
@@ -31,6 +31,7 @@ paths:
           example: 1
         - $ref: "#/components/parameters/Unit"
         - $ref: "#/components/parameters/BatchId"
+        - $ref: "#/components/parameters/IgnoreAddresses"
   /api/v1/markets/{market}/estimated-amounts-at-price/{price}:
     get:
       summary: Estimated Amounts At Price
@@ -52,6 +53,7 @@ paths:
           example: 400
         - $ref: "#/components/parameters/Unit"
         - $ref: "#/components/parameters/BatchId"
+        - $ref: "#/components/parameters/IgnoreAddresses"
   /api/v1/markets/{market}/estimated-best-ask-price:
     get:
       summary: Estimated Best Ask Price
@@ -69,6 +71,7 @@ paths:
         - $ref: "#/components/parameters/Market"
         - $ref: "#/components/parameters/Unit"
         - $ref: "#/components/parameters/BatchId"
+        - $ref: "#/components/parameters/IgnoreAddresses"
   /api/v1/markets/{market}:
     get:
       summary: Market
@@ -84,6 +87,7 @@ paths:
         - $ref: "#/components/parameters/Market"
         - $ref: "#/components/parameters/Unit"
         - $ref: "#/components/parameters/BatchId"
+        - $ref: "#/components/parameters/IgnoreAddresses"
 components:
   schemas:
     NumberParameter:
@@ -93,6 +97,9 @@ components:
       enum: [baseunits, atoms]
       default: baseunits
       example: baseunits
+    IgnoreAddressesParameter:
+      type: string
+      default: ""
     AmountResponse:
       type: object
       properties:
@@ -157,3 +164,17 @@ components:
       required: false
       schema:
         type: integer
+    IgnoreAddresses:
+      name: ignoreAddresses
+      in: query
+      description: Comma separated list of addresses in hex notation whose orders should be ignored. Capitalization of letters does not matter. No space after the commas.
+      required: false
+      schema:
+        $ref: "#/components/schemas/IgnoreAddressesParameter"
+      examples:
+        empty:
+          summary: Empty
+          value: ""
+        list:
+          summary: Two Addresses
+          value: 0x00000000000000000000000000000000000000a0,0x00000000000000000000000000000000000000A1

--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -168,7 +168,7 @@ async fn get_markets(
     // This route intentionally uses the raw pricegraph without rounding buffer so that orders are
     // unmodified.
     let transitive_orderbook = orderbook
-        .pricegraph(query.time, PricegraphKind::Raw)
+        .pricegraph(query.time, &query.ignore_addresses, PricegraphKind::Raw)
         .await
         .map_err(RejectionReason::InternalError)?
         .transitive_orderbook(market, None);
@@ -205,7 +205,11 @@ async fn estimate_buy_amount(
     };
     let rounding_buffer = orderbook.rounding_buffer(token_pair).await;
     let pricegraph = orderbook
-        .pricegraph(query.time, PricegraphKind::WithRoundingBuffer)
+        .pricegraph(
+            query.time,
+            &query.ignore_addresses,
+            PricegraphKind::WithRoundingBuffer,
+        )
         .await
         .map_err(RejectionReason::InternalError)?;
     // This reduced sell amount is what the solver would see after applying the rounding buffer.
@@ -239,7 +243,11 @@ async fn estimate_amounts_at_price(
 ) -> Result<impl Reply, Rejection> {
     let token_pair = get_market(pair, &*token_infos).await?.bid_pair();
     let pricegraph = orderbook
-        .pricegraph(query.time, PricegraphKind::WithRoundingBuffer)
+        .pricegraph(
+            query.time,
+            &query.ignore_addresses,
+            PricegraphKind::WithRoundingBuffer,
+        )
         .await
         .map_err(RejectionReason::InternalError)?;
     let rounding_buffer = orderbook.rounding_buffer(token_pair).await;
@@ -309,7 +317,11 @@ async fn estimate_best_ask_price(
     let market = get_market(pair, &*token_infos).await?;
     let token_pair = market.bid_pair();
     let price = orderbook
-        .pricegraph(query.time, PricegraphKind::WithRoundingBuffer)
+        .pricegraph(
+            query.time,
+            &query.ignore_addresses,
+            PricegraphKind::WithRoundingBuffer,
+        )
         .await
         .map_err(RejectionReason::InternalError)?
         .estimate_limit_price(token_pair, 0.0)

--- a/price-estimator/src/models/query.rs
+++ b/price-estimator/src/models/query.rs
@@ -101,7 +101,9 @@ fn parse_address(string: &str) -> Result<Address> {
     } else {
         &string[..]
     };
-    string.parse().context("failed to parse address")
+    string
+        .parse()
+        .with_context(|| format!("failed to parse address: {}", string))
 }
 
 #[cfg(test)]

--- a/price-estimator/src/models/query.rs
+++ b/price-estimator/src/models/query.rs
@@ -1,7 +1,8 @@
 //! Module implementing parsing request query parameters.
 
-use anyhow::{bail, Error, Result};
+use anyhow::{bail, Context as _, Error, Result};
 use core::models::BatchId;
+use ethcontract::Address;
 use serde::Deserialize;
 use std::convert::TryFrom;
 
@@ -16,6 +17,8 @@ pub struct QueryParameters {
     pub hops: Option<usize>,
     /// The time to load the orderbook at to perform estimations.
     pub time: EstimationTime,
+    /// Addresses whose orders should be ignored.
+    pub ignore_addresses: Vec<Address>,
 }
 
 /// Units for token amounts.
@@ -59,6 +62,8 @@ struct RawQuery {
     batch_id: Option<BatchId>,
     block_number: Option<u64>,
     timestamp: Option<u64>,
+    // String instead of Vec<Address> because the urlencoded standard does not support lists.
+    ignore_addresses: Option<String>,
 }
 
 impl TryFrom<RawQuery> for QueryParameters {
@@ -81,8 +86,22 @@ impl TryFrom<RawQuery> for QueryParameters {
                 (None, None, Some(timestamp)) => EstimationTime::Timestamp(timestamp),
                 _ => bail!("only one of 'batchId', 'blockNumber', or 'timestamp' parameters can be specified"),
             },
+            ignore_addresses: raw.ignore_addresses.as_deref().map(parse_addresses).transpose()?.unwrap_or_default()
         })
     }
+}
+
+fn parse_addresses(string: &str) -> Result<Vec<Address>> {
+    string.split(',').map(parse_address).collect()
+}
+
+fn parse_address(string: &str) -> Result<Address> {
+    let string = if string.starts_with("0x") {
+        &string[2..]
+    } else {
+        &string[..]
+    };
+    string.parse().context("failed to parse address")
 }
 
 #[cfg(test)]
@@ -105,6 +124,7 @@ mod tests {
         assert_eq!(query.unit, Unit::BaseUnits);
         assert_eq!(query.hops, None);
         assert_eq!(query.time, EstimationTime::Now);
+        assert_eq!(query.ignore_addresses, Vec::new());
     }
 
     #[test]
@@ -113,6 +133,30 @@ mod tests {
         assert_eq!(query.unit, Unit::Atoms);
         assert_eq!(query.hops, Some(42));
         assert_eq!(query.time, EstimationTime::Batch(1337.into()));
+    }
+
+    #[test]
+    fn address() {
+        let query = query_params(
+            "?ignoreAddresses=\
+            0000000000000000000000000000000000000000,\
+            0000000000000000000000000000000000000001,\
+            000000000000000000000000000000000000000a,\
+            000000000000000000000000000000000000000A,\
+            0x0000000000000000000000000000000000000002\
+            ",
+        )
+        .unwrap();
+        assert_eq!(
+            query.ignore_addresses,
+            vec![
+                Address::from_low_u64_be(0),
+                Address::from_low_u64_be(1),
+                Address::from_low_u64_be(10),
+                Address::from_low_u64_be(10),
+                Address::from_low_u64_be(2),
+            ]
+        );
     }
 
     #[test]

--- a/price-estimator/src/orderbook.rs
+++ b/price-estimator/src/orderbook.rs
@@ -210,4 +210,32 @@ mod tests {
         assert!(before_update_price != after_update_price);
         assert_eq!(after_update_price.get(), 3);
     }
+
+    #[test]
+    fn uses_ignored_addresses() {
+        let mut account_state = AccountState::default();
+        let mut create_order = |address| {
+            let amount = 10u128.pow(18);
+            account_state.0.insert((address, 0), amount.into());
+            Order {
+                id: 0,
+                account_id: address,
+                buy_token: 1,
+                sell_token: 0,
+                numerator: amount,
+                denominator: amount,
+                remaining_sell_amount: amount,
+                valid_from: 0,
+                valid_until: 0,
+            }
+        };
+        let orders = vec![
+            create_order(Address::from_low_u64_be(0)),
+            create_order(Address::from_low_u64_be(1)),
+            create_order(Address::from_low_u64_be(2)),
+        ];
+        let pricegraph =
+            pricegraph_from_auction_data(&(account_state, orders), &[Address::from_low_u64_be(1)]);
+        assert_eq!(pricegraph.full_orderbook().num_orders(), 2);
+    }
 }

--- a/price-estimator/src/orderbook.rs
+++ b/price-estimator/src/orderbook.rs
@@ -6,6 +6,7 @@ use core::{
     models::{AccountState, BatchId, Order, TokenId},
     orderbook::StableXOrderBookReading,
 };
+use ethcontract::Address;
 use futures::future;
 use pricegraph::{Pricegraph, TokenPair};
 use tokio::sync::RwLock;
@@ -52,20 +53,27 @@ impl Orderbook {
     pub async fn pricegraph(
         &self,
         time: EstimationTime,
+        ignore_addresses: &[Address],
         pricegraph_type: PricegraphKind,
     ) -> Result<Pricegraph> {
-        match time {
-            EstimationTime::Now => Ok(self.cached_pricegraph(pricegraph_type).await),
-            EstimationTime::Batch(batch_id) => {
-                let mut auction_data = self.auction_data(batch_id).await?;
-                if matches!(pricegraph_type, PricegraphKind::WithRoundingBuffer) {
-                    self.apply_rounding_buffer_to_auction_data(&mut auction_data)
-                        .await?;
-                }
-                Ok(pricegraph_from_auction_data(&auction_data))
+        let mut auction_data = match (time, ignore_addresses.is_empty()) {
+            (EstimationTime::Now, true) => {
+                return Ok(self.cached_pricegraph(pricegraph_type).await)
             }
-            EstimationTime::Block(_) | EstimationTime::Timestamp(_) => bail!("not yet implemented"),
+            (EstimationTime::Now, false) => self.auction_data(BatchId::now()).await?,
+            (EstimationTime::Batch(batch_id), _) => self.auction_data(batch_id).await?,
+            (EstimationTime::Block(_), _) | (EstimationTime::Timestamp(_), _) => {
+                bail!("not yet implemented")
+            }
+        };
+        if matches!(pricegraph_type, PricegraphKind::WithRoundingBuffer) {
+            self.apply_rounding_buffer_to_auction_data(&mut auction_data)
+                .await?;
         }
+        Ok(pricegraph_from_auction_data(
+            &auction_data,
+            ignore_addresses,
+        ))
     }
 
     /// Recreate the pricegraph orderbook and update the infallible price source.
@@ -73,13 +81,13 @@ impl Orderbook {
         let mut auction_data = self.auction_data(BatchId::now()).await?;
 
         // TODO: Move this cpu heavy computation out of the async function using spawn_blocking.
-        let pricegraph = pricegraph_from_auction_data(&auction_data);
+        let pricegraph = pricegraph_from_auction_data(&auction_data, &[]);
         self.update_infallible_price_source(&pricegraph).await;
         self.pricegraph_cache.write().await.pricegraph_raw = pricegraph;
 
         self.apply_rounding_buffer_to_auction_data(&mut auction_data)
             .await?;
-        let pricegraph = pricegraph_from_auction_data(&auction_data);
+        let pricegraph = pricegraph_from_auction_data(&auction_data, &[]);
         self.pricegraph_cache
             .write()
             .await
@@ -146,11 +154,15 @@ impl Orderbook {
 
 type AuctionData = (AccountState, Vec<Order>);
 
-fn pricegraph_from_auction_data(auction_data: &AuctionData) -> Pricegraph {
+fn pricegraph_from_auction_data(
+    auction_data: &AuctionData,
+    ignore_addresses: &[Address],
+) -> Pricegraph {
     Pricegraph::new(
         auction_data
             .1
             .iter()
+            .filter(|order| !ignore_addresses.contains(&order.account_id))
             .map(|order| order.to_element_with_accounts(&auction_data.0)),
     )
 }


### PR DESCRIPTION
Fixes  #1252 

### Test Plan
CI unit test for the parameter parsing. Also tested with the openapi by manually injecting a fake large order into the orderbook

```rust
        let address = Address::from_low_u64_be(1);
        let amount = 10u128.pow(25);
        auction_data.0.insert((address, 0), amount.into());
        auction_data.1.push(Order {
            id: 0,
            account_id: address,
            buy_token: 7,
            sell_token: 0,
            numerator: amount / 10,
            denominator: amount,
            remaining_sell_amount: amount,
            valid_from: 0,
            valid_until: u32::MAX - 1,
        });
```

This order is better than any other for the this token pair. So when I query estimated-buy-amounts with a sell amount of 100 base units I see that I get 1000 base units back.
Then I change the request to filter out orders from this address and see that the result goes down to the expect ~ 100 base units.