### PR TITLE
fetch batch for block number

### DIFF
--- a/core/src/orderbook/streamed/updating_orderbook.rs
+++ b/core/src/orderbook/streamed/updating_orderbook.rs
@@ -220,9 +220,7 @@ impl StableXOrderBookReading for UpdatingOrderbook {
         batch_id_to_solve: u32,
     ) -> BoxFuture<Result<(AccountState, Vec<Order>)>> {
         self.do_with_context(move |context| {
-            context
-                .orderbook
-                .get_auction_data_for_batch(batch_id_to_solve)
+            immediate!(context.orderbook.auction_state_for_batch(batch_id_to_solve))
         })
         .boxed()
     }


### PR DESCRIPTION
This PR modifies the `UpdatingOrderbook` implementation to read the timestamp for the block number so that the batch ID is more accurate.

### Test Plan

`EventRegistry` is tested by unit tests. Unfortunately the `UpdatingOrderbook` does not have unit tests and it does not seem trivial to set one up. Fortunately, only very little logic was added there (`updating_orderbook.rs`) so please review with extra attention. Suggestions for a better test plan are welcome!