### PR TITLE
Handle block queries

### DIFF
--- a/price-estimator/README.md
+++ b/price-estimator/README.md
@@ -10,7 +10,7 @@ Alternatively locally with docker
 docker run -p 80:8080 -e SWAGGER_JSON=/openapi.yml --mount type=bind,src="$PWD/openapi.yml",dst=/openapi.yml swaggerapi/swagger-ui
 ```
 
-and open http://localhost:80 .
+and open <http://localhost:80>.
 
 ## Testing
 

--- a/price-estimator/openapi.yml
+++ b/price-estimator/openapi.yml
@@ -32,6 +32,7 @@ paths:
         - $ref: "#/components/parameters/Unit"
         - $ref: "#/components/parameters/BatchId"
         - $ref: "#/components/parameters/IgnoreAddresses"
+        - $ref: "#/components/parameters/BlockNumber"
   /api/v1/markets/{market}/estimated-amounts-at-price/{price}:
     get:
       summary: Estimated Amounts At Price
@@ -54,6 +55,7 @@ paths:
         - $ref: "#/components/parameters/Unit"
         - $ref: "#/components/parameters/BatchId"
         - $ref: "#/components/parameters/IgnoreAddresses"
+        - $ref: "#/components/parameters/BlockNumber"
   /api/v1/markets/{market}/estimated-best-ask-price:
     get:
       summary: Estimated Best Ask Price
@@ -72,6 +74,7 @@ paths:
         - $ref: "#/components/parameters/Unit"
         - $ref: "#/components/parameters/BatchId"
         - $ref: "#/components/parameters/IgnoreAddresses"
+        - $ref: "#/components/parameters/BlockNumber"
   /api/v1/markets/{market}:
     get:
       summary: Market
@@ -88,6 +91,7 @@ paths:
         - $ref: "#/components/parameters/Unit"
         - $ref: "#/components/parameters/BatchId"
         - $ref: "#/components/parameters/IgnoreAddresses"
+        - $ref: "#/components/parameters/BlockNumber"
 components:
   schemas:
     NumberParameter:
@@ -186,3 +190,10 @@ components:
         list:
           summary: Two Addresses
           value: 0x00000000000000000000000000000000000000a0,0x00000000000000000000000000000000000000A1
+    BlockNumber:
+      name: blockNumber
+      in: query
+      description: The block number to compute the estimate for. This will use th open orderbook at that block (i.e. orders that will be considered for solving the current batch at the block number). This parameter cannot be specified together with the "batchId" query parameter.
+      required: false
+      schema:
+        type: integer

--- a/price-estimator/openapi.yml
+++ b/price-estimator/openapi.yml
@@ -193,7 +193,7 @@ components:
     BlockNumber:
       name: blockNumber
       in: query
-      description: The block number to compute the estimate for. This will use th open orderbook at that block (i.e. orders that will be considered for solving the current batch at the block number). This parameter cannot be specified together with the "batchId" query parameter.
+      description: The block number to compute the estimate for. This will use the open orderbook at that block (i.e. orders that will be considered for solving the current batch at the block number). This parameter cannot be specified together with the "batchId" query parameter.
       required: false
       schema:
         type: integer

--- a/price-estimator/src/orderbook.rs
+++ b/price-estimator/src/orderbook.rs
@@ -56,7 +56,7 @@ impl Orderbook {
         ignore_addresses: &[Address],
         pricegraph_type: PricegraphKind,
     ) -> Result<Pricegraph> {
-        if ignore_addresses.is_empty() {
+        if time == EstimationTime::Now && ignore_addresses.is_empty() {
             Ok(self.cached_pricegraph(pricegraph_type).await)
         } else {
             let mut auction_data = self.auction_data(time).await?;
@@ -130,6 +130,7 @@ impl Orderbook {
                     .await
             }
             EstimationTime::Block(block_number) => {
+                log::error!("foo");
                 self.orderbook_reading
                     .get_auction_data_for_block(block_number)
                     .await

--- a/price-estimator/src/orderbook.rs
+++ b/price-estimator/src/orderbook.rs
@@ -130,7 +130,6 @@ impl Orderbook {
                     .await
             }
             EstimationTime::Block(block_number) => {
-                log::error!("foo");
                 self.orderbook_reading
                     .get_auction_data_for_block(block_number)
                     .await


### PR DESCRIPTION
Fixes #1272.

This PR adds code to handle the `blockNUmber` price estimate queries and use the orderbook at the specified block.

### Test Plan

Start the price estimator and look into the past!
```
$ curl -s 'http://localhost:8080/api/v1/markets/ETH-USDC/estimated-best-ask-price?blockNumber=10000000' | jq
202.9252312603078
$ curl -s 'http://localhost:8080/api/v1/markets/ETH-USDC/estimated-best-ask-price' | jq                     
351.9815151148865
```