### PR TITLE
Bump private and open solver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ dist: bionic
 language: rust
 env:
   global:
-    - OPEN_SOLVER_VERSION=v0.0.11
-    - PRIVATE_SOLVER_VERSION=v0.8.3
+    - OPEN_SOLVER_VERSION=v0.0.12
+    - PRIVATE_SOLVER_VERSION=v0.8.4
 
 jobs:
   fast_finish: true


### PR DESCRIPTION
The solver bumps incorporate the stronger economic viability restriction for solution:

Every individual order (except those that sell OWL) now needs to contribute a certain amount of fees (by, default, the same value as passed as `--minAvgFeePerOrder` is used).