### PR TITLE
Add address to TokenBaseInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Then specify the solver image you want to use as a build argument, e.g.:
 docker-compose build --build-arg SOLVER_BASE=163030813197.dkr.ecr.eu-central-1.amazonaws.com/dex-solver:master stablex-debug
 ```
 
-Afterwards, when you run your environment as above, the linear optimizer should be automatically used. 
+Afterwards, when you run your environment as above, the linear optimizer should be automatically used.
 Note that the e2e tests might no longer work, as their resolution depends on the naive and not the optimal solving strategy.
 
 ## Configuration
@@ -206,9 +206,10 @@ OPTIONS:
         --token-data <token-data>
             JSON encoded backup token information to provide to the solver.
 
-            For example: '{ "T0001": { "alias": "WETH", "decimals": 18, "externalPrice": 200000000000000000000, },
-            "T0004": { "alias": "USDC", "decimals": 6, "externalPrice": 1000000000000000000000000000000, } }' [env:
-            TOKEN_DATA=]  [default: {}]
+            For example: '{ "T0001": { "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "alias": "WETH",
+            "decimals": 18, "externalPrice": 200000000000000000000, }, "T0004": { "address":
+            "0x0000000000000000000000000000000000000000", "alias": "USDC", "decimals": 6, "externalPrice":
+            1000000000000000000000000000000, } }' [env: TOKEN_DATA=]  [default: {}]           TOKEN_DATA=]  [default: {}]
 ```
 
 ### Orderbook Filter Example

--- a/core/src/price_estimation.rs
+++ b/core/src/price_estimation.rs
@@ -203,13 +203,15 @@ mod tests {
     use super::*;
     use crate::token_info::hardcoded::{TokenData, TokenInfoOverride};
     use anyhow::anyhow;
+    use ethcontract::Address;
     use price_source::{MockPriceSource, NoopPriceSource};
 
     #[test]
     fn price_oracle_fetches_token_prices() {
+        let address = Address::from_low_u64_be(0);
         let tokens = Arc::new(TokenData::from(hash_map! {
-            TokenId(1) => TokenInfoOverride::new("WETH", 18, None),
-            TokenId(2) => TokenInfoOverride::new("USDT", 6, None),
+            TokenId(1) => TokenInfoOverride::new(address, "WETH", 18, None),
+            TokenId(2) => TokenInfoOverride::new(address, "USDT", 6, None),
         }));
 
         let mut source = MockPriceSource::new();
@@ -256,7 +258,7 @@ mod tests {
     #[test]
     fn price_oracle_ignores_source_error() {
         let tokens = Arc::new(TokenData::from(hash_map! {
-            TokenId(1) => TokenInfoOverride::new("WETH", 18, None),
+            TokenId(1) => TokenInfoOverride::new(Address::from_low_u64_be(0), "WETH", 18, None),
         }));
 
         let mut source = MockPriceSource::new();

--- a/core/src/price_estimation/clients/dexag.rs
+++ b/core/src/price_estimation/clients/dexag.rs
@@ -8,11 +8,14 @@ pub type DexagClient = GenericClient<DexagHttpApi>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::http::HttpFactory;
-    use crate::models::TokenId;
-    use crate::price_estimation::price_source::PriceSource;
-    use crate::token_info::hardcoded::{TokenData, TokenInfoOverride};
-    use crate::util::FutureWaitExt as _;
+    use crate::{
+        http::HttpFactory,
+        models::TokenId,
+        price_estimation::price_source::PriceSource,
+        token_info::hardcoded::{TokenData, TokenInfoOverride},
+        util::FutureWaitExt as _,
+    };
+    use ethcontract::Address;
     use std::sync::Arc;
 
     // Run with `cargo test online_dexag_client -- --ignored --nocapture`.
@@ -21,17 +24,18 @@ mod tests {
     fn online_dexag_client() {
         use std::time::Instant;
 
+        let address = Address::from_low_u64_be(0);
         let tokens = hash_map! {
-            TokenId(1) => TokenInfoOverride::new("WETH", 18, None),
-            TokenId(2) => TokenInfoOverride::new("USDT", 6, None),
-            TokenId(3) => TokenInfoOverride::new("TUSD", 18, None),
-            TokenId(4) => TokenInfoOverride::new("USDC", 6, None),
-            TokenId(5) => TokenInfoOverride::new("PAX", 18, None),
-            TokenId(6) => TokenInfoOverride::new("GUSD", 2, None),
-            TokenId(7) => TokenInfoOverride::new("DAI", 18, None),
-            TokenId(8) => TokenInfoOverride::new("sETH", 18, None),
-            TokenId(9) => TokenInfoOverride::new("sUSD", 18, None),
-            TokenId(15) => TokenInfoOverride::new("SNX", 18, None)
+            TokenId(1) => TokenInfoOverride::new(address, "WETH", 18, None),
+            TokenId(2) => TokenInfoOverride::new(address, "USDT", 6, None),
+            TokenId(3) => TokenInfoOverride::new(address, "TUSD", 18, None),
+            TokenId(4) => TokenInfoOverride::new(address, "USDC", 6, None),
+            TokenId(5) => TokenInfoOverride::new(address, "PAX", 18, None),
+            TokenId(6) => TokenInfoOverride::new(address, "GUSD", 2, None),
+            TokenId(7) => TokenInfoOverride::new(address, "DAI", 18, None),
+            TokenId(8) => TokenInfoOverride::new(address, "sETH", 18, None),
+            TokenId(9) => TokenInfoOverride::new(address, "sUSD", 18, None),
+            TokenId(15) => TokenInfoOverride::new(address, "SNX", 18, None)
         };
         let mut ids: Vec<TokenId> = tokens.keys().copied().collect();
 

--- a/core/src/price_estimation/clients/generic_client.rs
+++ b/core/src/price_estimation/clients/generic_client.rs
@@ -171,6 +171,7 @@ mod tests {
     use super::*;
     use crate::token_info::hardcoded::{TokenData, TokenInfoOverride};
     use anyhow::anyhow;
+    use ethcontract::Address;
     use lazy_static::lazy_static;
     use mockall::{predicate::*, Sequence};
     use std::sync::Once;
@@ -214,7 +215,9 @@ mod tests {
         api.expect_get_token_list()
             .returning(|| async { Ok(Vec::new()) }.boxed());
 
-        let tokens = hash_map! { TokenId::from(6) => TokenInfoOverride::new("DAI", 18, None)};
+        let tokens = hash_map! {
+            TokenId::from(6) => TokenInfoOverride::new(Address::from_low_u64_be(0), "DAI", 18, None)
+        };
         assert!(GenericClient::<MockApi>::with_api_and_tokens(
             api,
             Arc::new(TokenData::from(tokens))
@@ -228,7 +231,9 @@ mod tests {
     #[test]
     fn get_token_prices_initialization_fails_then_works() {
         initialize_mockapi_context();
-        let tokens = hash_map! { TokenId::from(1) => TokenInfoOverride::new("ETH", 18, None)};
+        let tokens = hash_map! {
+            TokenId::from(1) => TokenInfoOverride::new(Address::from_low_u64_be(0), "ETH", 18, None)
+        };
         let mut api = MockApi::new();
         let mut seq = Sequence::new();
 
@@ -271,10 +276,11 @@ mod tests {
         initialize_mockapi_context();
         let mut api = MockApi::new();
 
+        let address = Address::from_low_u64_be(0);
         let tokens = hash_map! {
-            TokenId(6) => TokenInfoOverride::new("DAI", 18, None),
-            TokenId(1) => TokenInfoOverride::new("ETH", 18, None),
-            TokenId(4) => TokenInfoOverride::new("USDC", 6, None),
+            TokenId(6) => TokenInfoOverride::new(address, "DAI", 18, None),
+            TokenId(1) => TokenInfoOverride::new(address,"ETH", 18, None),
+            TokenId(4) => TokenInfoOverride::new(address,"USDC", 6, None),
         };
         lazy_static! {
             static ref API_TOKENS: [MockGenericToken; 3] =
@@ -317,9 +323,10 @@ mod tests {
         initialize_mockapi_context();
         let mut api = MockApi::new();
 
+        let address = Address::from_low_u64_be(0);
         let tokens = hash_map! {
-            TokenId(6) => TokenInfoOverride::new("DAI", 18, None),
-            TokenId(1) => TokenInfoOverride::new("ETH", 18, None)
+            TokenId(6) => TokenInfoOverride::new(address, "DAI", 18, None),
+            TokenId(1) => TokenInfoOverride::new(address, "ETH", 18, None)
         };
 
         lazy_static! {
@@ -358,10 +365,11 @@ mod tests {
         initialize_mockapi_context();
         let mut api = MockApi::new();
 
+        let address = Address::from_low_u64_be(0);
         let tokens = hash_map! {
-            TokenId(6) => TokenInfoOverride::new("dai", 18, None),
-            TokenId(1) => TokenInfoOverride::new("ETH", 18, None),
-            TokenId(4) => TokenInfoOverride::new("sUSD", 6, None)
+            TokenId(6) => TokenInfoOverride::new(address, "dai", 18, None),
+            TokenId(1) => TokenInfoOverride::new(address, "ETH", 18, None),
+            TokenId(4) => TokenInfoOverride::new(address, "sUSD", 6, None)
         };
 
         lazy_static! {
@@ -397,9 +405,10 @@ mod tests {
         initialize_mockapi_context();
         let mut api = MockApi::new();
 
+        let address = Address::from_low_u64_be(0);
         let tokens = hash_map! {
-            TokenId(6) => TokenInfoOverride::new("DAI", 18, None),
-            TokenId(1) => TokenInfoOverride::new("ETH", 18, None)
+            TokenId(6) => TokenInfoOverride::new(address, "DAI", 18, None),
+            TokenId(1) => TokenInfoOverride::new(address, "ETH", 18, None)
         };
 
         lazy_static! {

--- a/core/src/price_estimation/clients/kraken.rs
+++ b/core/src/price_estimation/clients/kraken.rs
@@ -149,17 +149,20 @@ fn find_asset_pair<'a>(
 mod tests {
     use super::api::{MockKrakenApi, TickerInfo};
     use super::*;
-    use crate::token_info::hardcoded::{TokenData, TokenInfoOverride};
-    use crate::util::FutureWaitExt as _;
-    use std::collections::HashSet;
-    use std::time::Instant;
+    use crate::{
+        token_info::hardcoded::{TokenData, TokenInfoOverride},
+        util::FutureWaitExt as _,
+    };
+    use ethcontract::Address;
+    use std::{collections::HashSet, time::Instant};
 
     #[test]
     fn get_token_prices() {
+        let address = Address::from_low_u64_be(0);
         let tokens = hash_map! {
-            TokenId(1) => TokenInfoOverride::new("ETH", 18, None),
-            TokenId(4) => TokenInfoOverride::new("USDC", 6, None),
-            TokenId(5) => TokenInfoOverride::new("PAX", 18, None),
+            TokenId(1) => TokenInfoOverride::new(address, "ETH", 18, None),
+            TokenId(4) => TokenInfoOverride::new(address, "USDC", 6, None),
+            TokenId(5) => TokenInfoOverride::new(address, "PAX", 18, None),
         };
 
         let mut api = MockKrakenApi::new();
@@ -224,17 +227,18 @@ mod tests {
         // cargo test online_kraken_prices -- --ignored --nocapture
         // ```
 
+        let address = Address::from_low_u64_be(0);
         let tokens = hash_map! {
-            TokenId(1) => TokenInfoOverride::new("WETH", 18, None),
-            TokenId(2) => TokenInfoOverride::new("USDT", 6, None),
-            TokenId(3) => TokenInfoOverride::new("TUSD", 18, None),
-            TokenId(4) => TokenInfoOverride::new("USDC", 6, None),
-            TokenId(5) => TokenInfoOverride::new("PAX", 18, None),
-            TokenId(6) => TokenInfoOverride::new("GUSD", 2, None),
-            TokenId(7) => TokenInfoOverride::new("DAI", 18, None),
-            TokenId(8) => TokenInfoOverride::new("sETH", 18, None),
-            TokenId(9) => TokenInfoOverride::new("sUSD", 18, None),
-            TokenId(15) => TokenInfoOverride::new("SNX", 18, None),
+            TokenId(1) => TokenInfoOverride::new(address, "WETH", 18, None),
+            TokenId(2) => TokenInfoOverride::new(address, "USDT", 6, None),
+            TokenId(3) => TokenInfoOverride::new(address, "TUSD", 18, None),
+            TokenId(4) => TokenInfoOverride::new(address, "USDC", 6, None),
+            TokenId(5) => TokenInfoOverride::new(address, "PAX", 18, None),
+            TokenId(6) => TokenInfoOverride::new(address, "GUSD", 2, None),
+            TokenId(7) => TokenInfoOverride::new(address, "DAI", 18, None),
+            TokenId(8) => TokenInfoOverride::new(address, "sETH", 18, None),
+            TokenId(9) => TokenInfoOverride::new(address, "sUSD", 18, None),
+            TokenId(15) => TokenInfoOverride::new(address, "SNX", 18, None),
         };
         let token_ids: Vec<TokenId> = tokens.keys().copied().collect();
 

--- a/core/src/price_estimation/clients/oneinch.rs
+++ b/core/src/price_estimation/clients/oneinch.rs
@@ -8,11 +8,14 @@ pub type OneinchClient = GenericClient<OneinchHttpApi>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::http::HttpFactory;
-    use crate::models::TokenId;
-    use crate::price_estimation::price_source::PriceSource;
-    use crate::token_info::hardcoded::{TokenData, TokenInfoOverride};
-    use crate::util::FutureWaitExt as _;
+    use crate::{
+        http::HttpFactory,
+        models::TokenId,
+        price_estimation::price_source::PriceSource,
+        token_info::hardcoded::{TokenData, TokenInfoOverride},
+        util::FutureWaitExt as _,
+    };
+    use ethcontract::Address;
     use std::sync::Arc;
 
     // Run with `cargo test online_oneinch_client -- --ignored --nocapture`.
@@ -21,17 +24,18 @@ mod tests {
     fn online_oneinch_client() {
         use std::time::Instant;
 
+        let address = Address::from_low_u64_be(0);
         let tokens = hash_map! {
-            TokenId(1) => TokenInfoOverride::new("WETH", 18, None),
-            TokenId(2) => TokenInfoOverride::new("USDT", 6, None),
-            TokenId(3) => TokenInfoOverride::new("TUSD", 18, None),
-            TokenId(4) => TokenInfoOverride::new("USDC", 6, None),
-            TokenId(5) => TokenInfoOverride::new("PAX", 18, None),
-            TokenId(6) => TokenInfoOverride::new("GUSD", 2, None),
-            TokenId(7) => TokenInfoOverride::new("DAI", 18, None),
-            TokenId(8) => TokenInfoOverride::new("sETH", 18, None),
-            TokenId(9) => TokenInfoOverride::new("sUSD", 18, None),
-            TokenId(15) => TokenInfoOverride::new("SNX", 18, None),
+            TokenId(1) => TokenInfoOverride::new(address, "WETH", 18, None),
+            TokenId(2) => TokenInfoOverride::new(address, "USDT", 6, None),
+            TokenId(3) => TokenInfoOverride::new(address, "TUSD", 18, None),
+            TokenId(4) => TokenInfoOverride::new(address, "USDC", 6, None),
+            TokenId(5) => TokenInfoOverride::new(address, "PAX", 18, None),
+            TokenId(6) => TokenInfoOverride::new(address, "GUSD", 2, None),
+            TokenId(7) => TokenInfoOverride::new(address, "DAI", 18, None),
+            TokenId(8) => TokenInfoOverride::new(address, "sETH", 18, None),
+            TokenId(9) => TokenInfoOverride::new(address, "sUSD", 18, None),
+            TokenId(15) => TokenInfoOverride::new(address, "SNX", 18, None),
         };
         let mut ids: Vec<TokenId> = tokens.keys().copied().collect();
 

--- a/core/src/token_info/cached.rs
+++ b/core/src/token_info/cached.rs
@@ -221,6 +221,7 @@ mod tests {
     use super::super::MockTokenInfoFetching;
     use super::*;
     use anyhow::anyhow;
+    use ethcontract::Address;
     use mockall::predicate::eq;
 
     fn revert_error() -> Error {
@@ -237,6 +238,7 @@ mod tests {
 
         inner.expect_get_token_info().times(1).returning(|_| {
             immediate!(Ok(TokenBaseInfo {
+                address: Address::from_low_u64_be(0),
                 alias: "Foo".to_owned(),
                 decimals: 18,
             }))
@@ -326,6 +328,7 @@ mod tests {
     fn can_be_seeded_with_a_cache() {
         let inner = MockTokenInfoFetching::new();
         let hardcoded = TokenBaseInfo {
+            address: Address::from_low_u64_be(0),
             alias: "Foo".to_owned(),
             decimals: 42,
         };
@@ -360,6 +363,7 @@ mod tests {
                 immediate!(Err(anyhow!("")))
             } else {
                 immediate!(Ok(TokenBaseInfo {
+                    address: Address::from_low_u64_be(0),
                     alias: String::new(),
                     decimals: token_id.0 as u8,
                 }))
@@ -388,6 +392,7 @@ mod tests {
             .times(4)
             .returning(|token_id| {
                 immediate!(Ok(TokenBaseInfo {
+                    address: Address::from_low_u64_be(0),
                     alias: token_id.to_string(),
                     decimals: 1
                 }))
@@ -417,6 +422,7 @@ mod tests {
     #[test]
     fn find_token_by_symbol_doesnt_query_if_in_cache() {
         let owl = TokenBaseInfo {
+            address: Address::from_low_u64_be(0),
             alias: "OWL".to_owned(),
             decimals: 18,
         };
@@ -442,6 +448,7 @@ mod tests {
     #[test]
     fn find_token_by_symbol_updates_cache_for_missing_symbol() {
         let owl = TokenBaseInfo {
+            address: Address::from_low_u64_be(0),
             alias: "OWL".to_owned(),
             decimals: 18,
         };
@@ -479,6 +486,7 @@ mod tests {
             (
                 TokenId(id),
                 TokenBaseInfo {
+                    address: Address::from_low_u64_be(0),
                     alias: "OWL".to_owned(),
                     decimals: 18,
                 },
@@ -500,6 +508,7 @@ mod tests {
     #[test]
     fn fetches_tokens_with_lower_ids_when_searching_for_symbol() {
         let owl = TokenBaseInfo {
+            address: Address::from_low_u64_be(0),
             alias: "OWL".to_owned(),
             decimals: 18,
         };

--- a/core/src/token_info/onchain.rs
+++ b/core/src/token_info/onchain.rs
@@ -7,8 +7,8 @@ use crate::contracts::stablex_contract::StableXContractImpl;
 impl TokenInfoFetching for StableXContractImpl {
     fn get_token_info<'a>(&'a self, id: TokenId) -> BoxFuture<'a, Result<TokenBaseInfo>> {
         async move {
-            let (_, alias, decimals) = self.get_token_info(id.into()).await?;
-            Ok(TokenBaseInfo { alias, decimals })
+            let (address, alias, decimals) = self.get_token_info(id.into()).await?;
+            Ok(TokenBaseInfo { address, alias, decimals })
         }
         .boxed()
     }

--- a/core/src/token_info/onchain.rs
+++ b/core/src/token_info/onchain.rs
@@ -8,7 +8,11 @@ impl TokenInfoFetching for StableXContractImpl {
     fn get_token_info<'a>(&'a self, id: TokenId) -> BoxFuture<'a, Result<TokenBaseInfo>> {
         async move {
             let (address, alias, decimals) = self.get_token_info(id.into()).await?;
-            Ok(TokenBaseInfo { address, alias, decimals })
+            Ok(TokenBaseInfo {
+                address,
+                alias,
+                decimals,
+            })
         }
         .boxed()
     }

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -76,11 +76,13 @@ struct Options {
     ///
     /// For example: '{
     ///   "T0001": {
+    ///     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
     ///     "alias": "WETH",
     ///     "decimals": 18,
     ///     "externalPrice": 200000000000000000000,
     ///   },
     ///   "T0004": {
+    ///     "address": "0x0000000000000000000000000000000000000000",
     ///     "alias": "USDC",
     ///     "decimals": 6,
     ///     "externalPrice": 1000000000000000000000000000000,

--- a/price-estimator/openapi.yml
+++ b/price-estimator/openapi.yml
@@ -149,7 +149,15 @@ components:
       required: true
       schema:
         type: string
-        example: 1-7
+      examples:
+        token_ids:
+          summary: Token Ids
+          value: 1-7
+        symbols:
+          summary: Symbols
+          value: WETH-DAI
+        addresses:
+          value: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2-0x6b175474e89094c44da98b954eedeac495271d0f
     Unit:
       name: unit
       in: query

--- a/price-estimator/src/infallible_price_source.rs
+++ b/price-estimator/src/infallible_price_source.rs
@@ -93,6 +93,7 @@ impl PriceCacheUpdater {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ethcontract::Address;
 
     #[test]
     fn use_existing_price() {
@@ -107,6 +108,7 @@ mod tests {
     fn fallback_to_base_unit() {
         let token = TokenId(1);
         let token_info = TokenBaseInfo {
+            address: Address::from_low_u64_be(0),
             alias: String::new(),
             decimals: 1,
         };

--- a/price-estimator/src/models.rs
+++ b/price-estimator/src/models.rs
@@ -89,6 +89,7 @@ pub struct ErrorResult {
 mod tests {
     use super::*;
     use assert_approx_eq::assert_approx_eq;
+    use ethcontract::Address;
     use serde_json::Value;
 
     #[test]
@@ -113,10 +114,12 @@ mod tests {
     #[test]
     fn amount_unit_conversion() {
         let owl = TokenBaseInfo {
+            address: Address::from_low_u64_be(0),
             alias: "OWL".into(),
             decimals: 18,
         };
         let usdc = TokenBaseInfo {
+            address: Address::from_low_u64_be(0),
             alias: "USDC".into(),
             decimals: 6,
         };
@@ -136,10 +139,12 @@ mod tests {
     #[test]
     fn price_estimate_into_base_units() {
         let owl = TokenBaseInfo {
+            address: Address::from_low_u64_be(0),
             alias: "OWL".into(),
             decimals: 18,
         };
         let usdc = TokenBaseInfo {
+            address: Address::from_low_u64_be(0),
             alias: "USDC".into(),
             decimals: 6,
         };

--- a/price-estimator/src/models/currency_pair.rs
+++ b/price-estimator/src/models/currency_pair.rs
@@ -1,6 +1,6 @@
 //! Module containing currency pair model implementation.
 
-use anyhow::{anyhow, bail, Error, Result};
+use anyhow::{anyhow, Error, Result};
 use core::token_info::TokenInfoFetching;
 use ethcontract::Address;
 use pricegraph::{Market, TokenId};
@@ -62,7 +62,13 @@ impl TokenRef {
     pub async fn as_token_id(&self, token_infos: &dyn TokenInfoFetching) -> Result<TokenId> {
         match self {
             TokenRef::Id(id) => Ok(*id),
-            TokenRef::Address(_) => bail!("not yet implemented"),
+            TokenRef::Address(address) => {
+                let (id, _) = token_infos
+                    .find_token_by_address(*address)
+                    .await?
+                    .ok_or_else(|| anyhow!("token address {} not found", address))?;
+                Ok(id.into())
+            }
             TokenRef::Symbol(symbol) => {
                 let (id, _) = token_infos
                     .find_token_by_symbol(symbol)

--- a/price-estimator/src/models/markets_results.rs
+++ b/price-estimator/src/models/markets_results.rs
@@ -87,6 +87,7 @@ mod tests {
     use super::*;
     use assert_approx_eq::assert_approx_eq;
     use core::token_info::TokenBaseInfo;
+    use ethcontract::Address;
     use serde_json::Value;
 
     #[test]
@@ -187,10 +188,12 @@ mod tests {
             }],
         };
         let base = TokenBaseInfo {
+            address: Address::from_low_u64_be(0),
             alias: "WETH".into(),
             decimals: 18,
         };
         let quote = TokenBaseInfo {
+            address: Address::from_low_u64_be(0),
             alias: "USDC".into(),
             decimals: 6,
         };


### PR DESCRIPTION
in preparation for allowing token infos to be looked up by address.

### Test Plan
Unit for deserialize address format. Will need to adjust staging config to include addresses in the override info before merging.