### PR TITLE
Number of hops in price estimator

### DIFF
--- a/e2e/src/bin/historic_prices.rs
+++ b/e2e/src/bin/historic_prices.rs
@@ -8,6 +8,7 @@ use structopt::StructOpt;
 /// Threshold logarithmic distance from the actual price at which an estimate is
 /// considered "bad"; currently `0.1 * price < estimate < 10 * price`.
 const BAD_ESTIMATE_THRESHOLD_LOG_DISTANCE: f64 = 1.0;
+const MAX_MATCHED_ORDERS_IN_BATCH: u16 = 30;
 
 /// Common options for analyzing historic batch data.
 #[derive(Debug, StructOpt)]
@@ -72,7 +73,9 @@ fn check_batch_prices(
         .filter(|(_, token)| *token != 0)
     {
         let price = prices[token_index];
-        let estimate = pricegraph.estimate_token_price(token).map(|p| p as u128);
+        let estimate = pricegraph
+            .estimate_token_price(token, Some(MAX_MATCHED_ORDERS_IN_BATCH))
+            .map(|p| p as u128);
 
         samples.record_sample(Row {
             batch,

--- a/price-estimator/src/amounts_at_price.rs
+++ b/price-estimator/src/amounts_at_price.rs
@@ -1,14 +1,14 @@
-use pricegraph::{Pricegraph, TokenPair, TransitiveOrder};
+use pricegraph::{Pricegraph, TokenPairRange, TransitiveOrder};
 
 /// An overlapping order where buy / sell ≈ price and the amounts take into account that the solver
 /// will subtract the rounding buffer from the sell amount.
 pub fn order_at_price_with_rounding_buffer(
-    token_pair: TokenPair,
+    token_pair_range: TokenPairRange,
     limit_price: f64,
     pricegraph: &Pricegraph,
     rounding_buffer: f64,
 ) -> Option<TransitiveOrder> {
-    let order = pricegraph.order_for_limit_price(token_pair, limit_price)?;
+    let order = pricegraph.order_for_limit_price(token_pair_range, limit_price)?;
     // We know that an order is still overlapping if it has a limit price <= this one. The limit
     // price of this order is usually larger (better for the seller) than the user requested limit
     // price.
@@ -38,7 +38,7 @@ pub fn order_at_price_with_rounding_buffer(
         let buy = order_that_user_places.buy;
         log::debug!(
             "unable to fulfill price constraint for token pair {}-{} at price {} using buy amount {} sell amount {}",
-            token_pair.buy, token_pair.sell, limit_price, buy, sell
+            token_pair_range.pair.buy, token_pair_range.pair.sell, limit_price, buy, sell
         );
         Some(TransitiveOrder { sell, buy })
     }
@@ -69,7 +69,10 @@ mod tests {
         let limit_price = 0.5;
         let rounding_buffer = 1000.0;
         let result = order_at_price_with_rounding_buffer(
-            TokenPair { buy: 1, sell: 0 },
+            TokenPairRange {
+                pair: TokenPair { buy: 1, sell: 0 },
+                hops: None,
+            },
             limit_price,
             &pricegraph,
             rounding_buffer,
@@ -103,7 +106,10 @@ mod tests {
         let limit_price = 0.998;
         let rounding_buffer = 1000.0;
         let result = order_at_price_with_rounding_buffer(
-            TokenPair { buy: 1, sell: 0 },
+            TokenPairRange {
+                pair: TokenPair { buy: 1, sell: 0 },
+                hops: None,
+            },
             limit_price,
             &pricegraph,
             rounding_buffer,

--- a/price-estimator/src/models/query.rs
+++ b/price-estimator/src/models/query.rs
@@ -14,7 +14,7 @@ pub struct QueryParameters {
     pub unit: Unit,
     /// The maximum number of hops (i.e. maximum ring trade length) used by the
     /// `pricegraph` search algorithm.
-    pub hops: Option<usize>,
+    pub hops: Option<u16>,
     /// The time to load the orderbook at to perform estimations.
     pub time: EstimationTime,
     /// Addresses whose orders should be ignored.
@@ -58,7 +58,7 @@ pub enum EstimationTime {
 struct RawQuery {
     atoms: Option<bool>,
     unit: Option<Unit>,
-    hops: Option<usize>,
+    hops: Option<u16>,
     batch_id: Option<BatchId>,
     block_number: Option<u64>,
     timestamp: Option<u64>,

--- a/pricegraph/fuzz/fuzz_targets/pricegraph.rs
+++ b/pricegraph/fuzz/fuzz_targets/pricegraph.rs
@@ -1,7 +1,7 @@
 #![no_main]
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
-use pricegraph::{Element, Market, Pricegraph, TokenId, TokenPair};
+use pricegraph::{Element, Market, Pricegraph, TokenId, TokenPairRange};
 use std::iter::once;
 
 // Limit the maximum token id that is allowed to appear in the generated orders. Without this we can
@@ -12,8 +12,15 @@ const MAX_TOKEN_ID: u16 = 16;
 
 #[derive(Arbitrary, Debug)]
 enum Operation {
-    OrderForSellAmount { pair: TokenPair, sell_amount: f64 },
-    TransitiveOrderbook { market: Market, spread: Option<f64> },
+    OrderForSellAmount {
+        pair_range: TokenPairRange,
+        sell_amount: f64,
+    },
+    TransitiveOrderbook {
+        market: Market,
+        hops: Option<u16>,
+        spread: Option<f64>,
+    },
 }
 
 #[derive(Arbitrary, Debug)]
@@ -36,16 +43,23 @@ fuzz_target!(|arguments: Arguments| {
 
     let pricegraph = Pricegraph::new(arguments.elements);
     match arguments.operation {
-        Operation::OrderForSellAmount { pair, sell_amount } => {
-            pricegraph.order_for_sell_amount(pair, sell_amount);
+        Operation::OrderForSellAmount {
+            pair_range,
+            sell_amount,
+        } => {
+            pricegraph.order_for_sell_amount(pair_range, sell_amount);
         }
-        Operation::TransitiveOrderbook { market, spread } => {
+        Operation::TransitiveOrderbook {
+            market,
+            hops,
+            spread,
+        } => {
             if let Some(spread) = spread {
                 if !spread.is_finite() || spread <= 0.0 {
                     return;
                 }
             }
-            pricegraph.transitive_orderbook(market, spread);
+            pricegraph.transitive_orderbook(market, hops, spread);
         }
     };
 });

--- a/pricegraph/src/encoding.rs
+++ b/pricegraph/src/encoding.rs
@@ -70,6 +70,33 @@ pub struct Element {
     pub id: OrderId,
 }
 
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct TokenPairRange {
+    /// The traded pair.
+    pub pair: TokenPair,
+    /// The maximum number of transitive trades allowed to trade the pair.
+    pub hops: Option<u16>,
+}
+
+impl TokenPair {
+    pub fn inverse(self) -> Self {
+        TokenPair {
+            buy: self.sell,
+            sell: self.buy,
+        }
+    }
+}
+
+impl TokenPairRange {
+    pub fn inverse(self) -> Self {
+        TokenPairRange {
+            pair: self.pair.inverse(),
+            hops: self.hops,
+        }
+    }
+}
+
 impl Element {
     pub fn read_all<'a>(bytes: &'a [u8]) -> Result<impl Iterator<Item = Self> + 'a, InvalidLength> {
         if bytes.len() % ELEMENT_STRIDE != 0 {

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -109,11 +109,16 @@ mod tests {
         let volume = 1.0 * base_unit;
         let spread = 0.05;
 
+        let pair_range = TokenPairRange {
+            pair: dai_weth.bid_pair(),
+            hops: None,
+        };
+
         for (batch_id, raw_orderbook) in data::ORDERBOOKS.iter() {
             let pricegraph = Pricegraph::read(raw_orderbook).unwrap();
 
             let order = pricegraph
-                .order_for_sell_amount(dai_weth.bid_pair(), volume)
+                .order_for_sell_amount(pair_range, volume)
                 .unwrap();
             println!(
                 "#{}: estimated order for buying {} DAI for {} WETH",
@@ -123,7 +128,7 @@ mod tests {
             );
 
             let TransitiveOrderbook { asks, bids } =
-                pricegraph.transitive_orderbook(dai_weth, Some(spread));
+                pricegraph.transitive_orderbook(dai_weth, None, Some(spread));
             println!(
                 "#{}: DAI-WETH market contains {} ask orders and {} bid orders within a {}% spread:",
                 batch_id,

--- a/pricegraph/src/orderbook/reduced.rs
+++ b/pricegraph/src/orderbook/reduced.rs
@@ -1,6 +1,6 @@
 //! Module containing reduced orderbook wrapper type.
 
-use crate::encoding::TokenPair;
+use crate::encoding::TokenPairRange;
 use crate::orderbook::{Flow, Orderbook};
 
 /// A graph representation of a reduced orderbook. Reduced orderbooks are
@@ -18,16 +18,16 @@ impl ReducedOrderbook {
     /// method is similar to
     /// `ReducedOrderbook::fill_optimal_transitive_order_if` except it does not
     /// check a condition on the discovered path's flow before filling.
-    pub fn fill_optimal_transitive_order(&mut self, pair: TokenPair) -> Option<Flow> {
-        self.fill_optimal_transitive_order_if(pair, |_| true)
+    pub fn fill_optimal_transitive_order(&mut self, pair_range: TokenPairRange) -> Option<Flow> {
+        self.fill_optimal_transitive_order_if(pair_range, |_| true)
     }
 
     /// Finds and returns the optimal transitive order for the specified token
     /// pair without filling it. Returns `None` if no such transitive order
     /// exists.
-    pub fn find_optimal_transitive_order(&mut self, pair: TokenPair) -> Option<Flow> {
+    pub fn find_optimal_transitive_order(&mut self, pair_range: TokenPairRange) -> Option<Flow> {
         self.0
-            .find_optimal_transitive_order(pair)
+            .find_optimal_transitive_order(pair_range)
             .expect("negative cycle in reduced orderbook")
     }
 
@@ -42,11 +42,11 @@ impl ReducedOrderbook {
     /// the token pair.
     pub fn fill_optimal_transitive_order_if(
         &mut self,
-        pair: TokenPair,
+        pair_range: TokenPairRange,
         condition: impl FnMut(&Flow) -> bool,
     ) -> Option<Flow> {
         self.0
-            .fill_optimal_transitive_order_if(pair, condition)
+            .fill_optimal_transitive_order_if(pair_range, condition)
             .expect("negative cycle in reduced orderbook")
     }
 

--- a/pricegraph/wasm/src/lib.rs
+++ b/pricegraph/wasm/src/lib.rs
@@ -1,7 +1,7 @@
 //! This crate provides a thin WASM-compatible wrapper around the `pricegraph`
 //! crate and can be used for estimating prices for a given orderbook.
 
-use pricegraph::{Pricegraph, TokenId, TokenPair};
+use pricegraph::{Pricegraph, TokenId, TokenPair, TokenPairRange};
 use wasm_bindgen::prelude::*;
 
 /// A graph representation of a complete orderbook.
@@ -40,8 +40,19 @@ impl PriceEstimator {
     /// Estimates price for the specified trade. Returns `undefined` if the
     /// volume cannot be fully filled.
     #[wasm_bindgen(js_name = "estimatePrice")]
-    pub fn estimate_price(&self, buy: TokenId, sell: TokenId, volume: f64) -> Option<f64> {
-        self.pricegraph
-            .estimate_limit_price(TokenPair { buy, sell }, volume)
+    pub fn estimate_price(
+        &self,
+        buy: TokenId,
+        sell: TokenId,
+        volume: f64,
+        hops: Option<u16>,
+    ) -> Option<f64> {
+        self.pricegraph.estimate_limit_price(
+            TokenPairRange {
+                pair: TokenPair { buy, sell },
+                hops,
+            },
+            volume,
+        )
     }
 }

--- a/pricegraph/wasm/tests/nodejs.rs
+++ b/pricegraph/wasm/tests/nodejs.rs
@@ -22,7 +22,7 @@ fn time<T>(f: impl FnOnce() -> T) -> (T, f64) {
 #[wasm_bindgen_test]
 fn estimate_price() {
     let (estimator, load_time) = time(|| PriceEstimator::new(&*data::DEFAULT_ORDERBOOK).unwrap());
-    let (price, estimate_time) = time(|| estimator.estimate_price(7, 1, 100e18).unwrap());
+    let (price, estimate_time) = time(|| estimator.estimate_price(7, 1, 100e18, None).unwrap());
 
     console_log!(
         "DAI-WETH price for selling 100 WETH: 1 WETH = {} DAI (load {}ms, estimate {}ms)",


### PR DESCRIPTION
**This PR will be subject to changes and will be rebased after PR #1368 is merged.
It can be used to estimate the performance cost of using the algorithm from that PR.**

Implementation of the `hops` parameter for the price estimation.
Many, many minor changes needed to implement the number of hops in the price estimator and make the various subprojects of this repo work.

Note that the order graph is intentionally reduced with unlimited hops. This is because even if a user wishes to only see orders with at most `n` hops, matching orders that require a larger number of hops will be cleared anyway by the solver.

Most of the line changes are related to the tests.

### Performance

All benchmarks are run multiple times for different values of `hops`: `None`, 2, 30, 2¹⁶-1.

This allows us to compare the performance of the same function when a different number of hops is used with the default orderbook.

Short version:
| Function | `None` | `Some(2)` | `Some(30)` | `Some(65535)` |
| ----------- | --------- | -------------- |  --------------- | -------------------- |
|estimate_limit_price/volume: 100000000000000000|57.893 us|58.977 us|65.675 us|66.083 us|
|estimate_limit_price/volume: 1000000000000000000|61.671 us|60.801 us|72.253 us|72.690 us|
|estimate_limit_price/volume: 10000000000000000000|107.38 us|60.260 us|175.34 us|175.83 us|
|estimate_limit_price/volume: 100000000000000000000|203.65 us|72.988 us|408.71 us|409.86 us|
|estimate_limit_price/volume: 1000000000000000000000|453.61 us|225.50 us|996.60 us|999.52 us|
|order_for_limit_price/price: 200|51.716 us|52.642 us|57.854 us|58.867 us|
|order_for_limit_price/price: 190|134.43 us|55.603 us|237.08 us|239.17 us|
|order_for_limit_price/price: 180|215.54 us|64.614 us|449.85 us|448.78 us|
|order_for_limit_price/price: 150|443.67 us|212.69 us|1.0070 ms|1.0135 ms|
|order_for_limit_price/price: 100|484.56 us|261.49 us|1.0754 ms|1.1076 ms|


For this run, I incremented the number of samples to `500` (from `50`).
The `change` part in the raw output that follows should be ignored, since no meaningful comparison was performed.
<details>
  <summary>$ cargo bench -p pricegraph</summary>

```
     Running target/release/deps/pricegraph-c4a70d9d337eb8b6
Gnuplot not found, using plotters backend
Pricegraph::read        time:   [4.3700 ms 4.3769 ms 4.3838 ms]                              
                        change: [-35.014% -34.046% -33.124%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 500 measurements (2.00%)
  8 (1.60%) high mild
  2 (0.40%) high severe

Transitive orderbook/batch id: 5298183, hops: None                                                                             
                        time:   [4.3452 ms 4.3505 ms 4.3558 ms]
                        change: [-24.484% -24.163% -23.860%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 500 measurements (2.40%)
  1 (0.20%) low mild
  10 (2.00%) high mild
  1 (0.20%) high severe
Transitive orderbook/batch id: 5298183, hops: Some(2)                                                                             
                        time:   [4.0539 ms 4.0638 ms 4.0746 ms]
                        change: [-22.457% -22.114% -21.778%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 500 measurements (3.20%)
  3 (0.60%) high mild
  13 (2.60%) high severe
Transitive orderbook/batch id: 5298183, hops: Some(30)                                                                             
                        time:   [5.2189 ms 5.2231 ms 5.2278 ms]
                        change: [-24.985% -24.488% -24.029%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 23 outliers among 500 measurements (4.60%)
  9 (1.80%) high mild
  14 (2.80%) high severe
Transitive orderbook/batch id: 5298183, hops: Some(65535)                                                                             
                        time:   [5.2293 ms 5.2332 ms 5.2373 ms]
                        change: [-38.295% -36.144% -33.945%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 50 outliers among 500 measurements (10.00%)
  11 (2.20%) high mild
  39 (7.80%) high severe

Benchmarking Pricegraph::estimate_limit_price/volume: 100000000000000000, hops: None: Warming up for 3.0000 s
Warning: Unable to complete 500 samples in 5.0s. You may wish to increase target time to 7.4s, enable flat sampling, or reduce sample count to 280.
Pricegraph::estimate_limit_price/volume: 100000000000000000, hops: None                                                                             
                        time:   [57.798 us 57.893 us 57.989 us]
                        change: [-19.706% -19.369% -18.985%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 500 measurements (1.20%)
  3 (0.60%) high mild
  3 (0.60%) high severe
Benchmarking Pricegraph::estimate_limit_price/volume: 100000000000000000, hops: Some(2): Warming up for 3.0000 s
Warning: Unable to complete 500 samples in 5.0s. You may wish to increase target time to 7.4s, enable flat sampling, or reduce sample count to 290.
Pricegraph::estimate_limit_price/volume: 100000000000000000, hops: Some(2)                                                                             
                        time:   [58.825 us 58.977 us 59.140 us]
                        change: [-17.082% -15.992% -14.635%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 45 outliers among 500 measurements (9.00%)
  10 (2.00%) high mild
  35 (7.00%) high severe
Benchmarking Pricegraph::estimate_limit_price/volume: 100000000000000000, hops: Some(30): Warming up for 3.0000 s
Warning: Unable to complete 500 samples in 5.0s. You may wish to increase target time to 8.4s, enable flat sampling, or reduce sample count to 270.
Pricegraph::estimate_limit_price/volume: 100000000000000000, hops: Some(30)                                                                             
                        time:   [65.559 us 65.675 us 65.795 us]
                        change: [-22.082% -21.663% -21.233%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 500 measurements (2.20%)
  4 (0.80%) high mild
  7 (1.40%) high severe
Benchmarking Pricegraph::estimate_limit_price/volume: 100000000000000000, hops: Some(65535): Warming up for 3.0000 s
Warning: Unable to complete 500 samples in 5.0s. You may wish to increase target time to 8.6s, enable flat sampling, or reduce sample count to 260.
Pricegraph::estimate_limit_price/volume: 100000000000000000, hops: Some(65535)                                                                             
                        time:   [65.981 us 66.083 us 66.185 us]
                        change: [-20.095% -19.781% -19.477%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 500 measurements (1.60%)
  4 (0.80%) high mild
  4 (0.80%) high severe
Benchmarking Pricegraph::estimate_limit_price/volume: 1000000000000000000, hops: None: Warming up for 3.0000 s
Warning: Unable to complete 500 samples in 5.0s. You may wish to increase target time to 8.0s, enable flat sampling, or reduce sample count to 270.
Pricegraph::estimate_limit_price/volume: 1000000000000000000, hops: None                                                                             
                        time:   [61.569 us 61.671 us 61.774 us]
                        change: [-22.703% -22.228% -21.794%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 500 measurements (1.60%)
  5 (1.00%) high mild
  3 (0.60%) high severe
Benchmarking Pricegraph::estimate_limit_price/volume: 1000000000000000000, hops: Some(2): Warming up for 3.0000 s
Warning: Unable to complete 500 samples in 5.0s. You may wish to increase target time to 7.7s, enable flat sampling, or reduce sample count to 280.
Pricegraph::estimate_limit_price/volume: 1000000000000000000, hops: Some(2)                                                                             
                        time:   [60.680 us 60.801 us 60.935 us]
                        change: [-28.984% -26.852% -24.686%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 500 measurements (1.40%)
  5 (1.00%) high mild
  2 (0.40%) high severe
Benchmarking Pricegraph::estimate_limit_price/volume: 1000000000000000000, hops: Some(30): Warming up for 3.0000 s
Warning: Unable to complete 500 samples in 5.0s. You may wish to increase target time to 9.1s, enable flat sampling, or reduce sample count to 260.
Pricegraph::estimate_limit_price/volume: 1000000000000000000, hops: Some(30)                                                                             
                        time:   [72.140 us 72.253 us 72.364 us]
                        change: [-40.379% -38.385% -36.299%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 500 measurements (2.80%)
  10 (2.00%) high mild
  4 (0.80%) high severe
Benchmarking Pricegraph::estimate_limit_price/volume: 1000000000000000000, hops: Some(65535): Warming up for 3.0000 s
Warning: Unable to complete 500 samples in 5.0s. You may wish to increase target time to 9.3s, enable flat sampling, or reduce sample count to 250.
Pricegraph::estimate_limit_price/volume: 1000000000000000000, hops: Some(65535)                                                                             
                        time:   [72.476 us 72.690 us 72.947 us]
                        change: [-38.986% -36.924% -34.727%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 500 measurements (3.20%)
  4 (0.80%) high mild
  12 (2.40%) high severe
Pricegraph::estimate_limit_price/volume: 10000000000000000000, hops: None                                                                            
                        time:   [107.26 us 107.38 us 107.54 us]
                        change: [-33.571% -31.587% -29.571%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 63 outliers among 500 measurements (12.60%)
  7 (1.40%) high mild
  56 (11.20%) high severe
Benchmarking Pricegraph::estimate_limit_price/volume: 10000000000000000000, hops: Some(2): Warming up for 3.0000 s
Warning: Unable to complete 500 samples in 5.0s. You may wish to increase target time to 7.8s, enable flat sampling, or reduce sample count to 280.
Pricegraph::estimate_limit_price/volume: 10000000000000000000, hops: Some(2)                                                                             
                        time:   [60.142 us 60.260 us 60.390 us]
                        change: [-32.247% -29.502% -26.592%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 33 outliers among 500 measurements (6.60%)
  6 (1.20%) high mild
  27 (5.40%) high severe
Pricegraph::estimate_limit_price/volume: 10000000000000000000, hops: Some(30)                                                                            
                        time:   [174.93 us 175.34 us 175.80 us]
                        change: [-7.0077% -6.2059% -5.4702%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 500 measurements (2.20%)
  5 (1.00%) high mild
  6 (1.20%) high severe
Pricegraph::estimate_limit_price/volume: 10000000000000000000, hops: Some(65535)                                                                            
                        time:   [175.47 us 175.83 us 176.27 us]
                        change: [-8.5232% -7.4128% -6.4858%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 93 outliers among 500 measurements (18.60%)
  2 (0.40%) high mild
  91 (18.20%) high severe
Pricegraph::estimate_limit_price/volume: 100000000000000000000, hops: None                                                                            
                        time:   [203.37 us 203.65 us 203.95 us]
                        change: [-15.654% -13.102% -10.634%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 121 outliers among 500 measurements (24.20%)
  32 (6.40%) low severe
  28 (5.60%) low mild
  22 (4.40%) high mild
  39 (7.80%) high severe
Benchmarking Pricegraph::estimate_limit_price/volume: 100000000000000000000, hops: Some(2): Warming up for 3.0000 s
Warning: Unable to complete 500 samples in 5.0s. You may wish to increase target time to 9.2s, enable flat sampling, or reduce sample count to 250.
Pricegraph::estimate_limit_price/volume: 100000000000000000000, hops: Some(2)                                                                             
                        time:   [72.832 us 72.988 us 73.150 us]
                        change: [-3.6862% -3.1084% -2.5606%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 500 measurements (3.40%)
  10 (2.00%) high mild
  7 (1.40%) high severe
Pricegraph::estimate_limit_price/volume: 100000000000000000000, hops: Some(30)                                                                            
                        time:   [408.41 us 408.71 us 409.03 us]
                        change: [-15.726% -13.286% -10.971%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 53 outliers among 500 measurements (10.60%)
  10 (2.00%) high mild
  43 (8.60%) high severe
Pricegraph::estimate_limit_price/volume: 100000000000000000000, hops: Some(65535)                                                                            
                        time:   [409.56 us 409.86 us 410.18 us]
                        change: [-8.0371% -7.4576% -6.9222%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 36 outliers among 500 measurements (7.20%)
  14 (2.80%) high mild
  22 (4.40%) high severe
Pricegraph::estimate_limit_price/volume: 1000000000000000000000, hops: None                                                                            
                        time:   [452.55 us 453.61 us 455.07 us]
                        change: [-4.6327% -4.3416% -3.9455%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 69 outliers among 500 measurements (13.80%)
  24 (4.80%) low mild
  25 (5.00%) high mild
  20 (4.00%) high severe
Pricegraph::estimate_limit_price/volume: 1000000000000000000000, hops: Some(2)                                                                            
                        time:   [224.83 us 225.50 us 226.32 us]
                        change: [-3.3383% -2.9687% -2.5230%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 18 outliers among 500 measurements (3.60%)
  15 (3.00%) high mild
  3 (0.60%) high severe
Pricegraph::estimate_limit_price/volume: 1000000000000000000000, hops: Some(30)                                                                             
                        time:   [993.44 us 996.60 us 1.0005 ms]
                        change: [-3.4093% -3.0246% -2.6017%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 89 outliers among 500 measurements (17.80%)
  11 (2.20%) high mild
  78 (15.60%) high severe
Pricegraph::estimate_limit_price/volume: 1000000000000000000000, hops: Some(65535)                                                                             
                        time:   [996.94 us 999.52 us 1.0026 ms]
                        change: [-3.2258% -2.9479% -2.6635%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 31 outliers among 500 measurements (6.20%)
  2 (0.40%) low severe
  8 (1.60%) high mild
  21 (4.20%) high severe

Benchmarking Pricegraph::order_for_limit_price/price: 200, hops: None: Warming up for 3.0000 s
Warning: Unable to complete 500 samples in 5.0s. You may wish to increase target time to 6.7s, enable flat sampling, or reduce sample count to 300.
Pricegraph::order_for_limit_price/price: 200, hops: None                                                                             
                        time:   [51.636 us 51.716 us 51.795 us]
                        change: [-0.9549% -0.6888% -0.3834%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 136 outliers among 500 measurements (27.20%)
  83 (16.60%) low severe
  7 (1.40%) low mild
  2 (0.40%) high mild
  44 (8.80%) high severe
Benchmarking Pricegraph::order_for_limit_price/price: 200, hops: Some(2): Warming up for 3.0000 s
Warning: Unable to complete 500 samples in 5.0s. You may wish to increase target time to 6.8s, enable flat sampling, or reduce sample count to 300.
Pricegraph::order_for_limit_price/price: 200, hops: Some(2)                                                                             
                        time:   [52.449 us 52.642 us 52.969 us]
                        change: [-1.4643% -1.1299% -0.7672%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 126 outliers among 500 measurements (25.20%)
  50 (10.00%) low severe
  5 (1.00%) low mild
  10 (2.00%) high mild
  61 (12.20%) high severe
Benchmarking Pricegraph::order_for_limit_price/price: 200, hops: Some(30): Warming up for 3.0000 s
Warning: Unable to complete 500 samples in 5.0s. You may wish to increase target time to 7.5s, enable flat sampling, or reduce sample count to 280.
Pricegraph::order_for_limit_price/price: 200, hops: Some(30)                                                                             
                        time:   [57.767 us 57.854 us 57.939 us]
                        change: [-2.4099% -2.0665% -1.6962%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 500 measurements (3.40%)
  12 (2.40%) high mild
  5 (1.00%) high severe
Benchmarking Pricegraph::order_for_limit_price/price: 200, hops: Some(65535): Warming up for 3.0000 s
Warning: Unable to complete 500 samples in 5.0s. You may wish to increase target time to 7.6s, enable flat sampling, or reduce sample count to 280.
Pricegraph::order_for_limit_price/price: 200, hops: Some(65535)                                                                             
                        time:   [58.778 us 58.867 us 58.954 us]
                        change: [-0.8721% -0.5393% -0.1481%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 179 outliers among 500 measurements (35.80%)
  98 (19.60%) low severe
  12 (2.40%) low mild
  12 (2.40%) high mild
  57 (11.40%) high severe
Pricegraph::order_for_limit_price/price: 190, hops: None                                                                            
                        time:   [134.29 us 134.43 us 134.58 us]
                        change: [-5.6717% -5.4463% -5.2558%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 70 outliers among 500 measurements (14.00%)
  24 (4.80%) low severe
  9 (1.80%) low mild
  15 (3.00%) high mild
  22 (4.40%) high severe
Benchmarking Pricegraph::order_for_limit_price/price: 190, hops: Some(2): Warming up for 3.0000 s
Warning: Unable to complete 500 samples in 5.0s. You may wish to increase target time to 7.1s, enable flat sampling, or reduce sample count to 290.
Pricegraph::order_for_limit_price/price: 190, hops: Some(2)                                                                             
                        time:   [55.531 us 55.603 us 55.673 us]
                        change: [-0.7194% -0.3852% +0.0007%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 127 outliers among 500 measurements (25.40%)
  60 (12.00%) low severe
  1 (0.20%) low mild
  8 (1.60%) high mild
  58 (11.60%) high severe
Pricegraph::order_for_limit_price/price: 190, hops: Some(30)                                                                            
                        time:   [236.86 us 237.08 us 237.31 us]
                        change: [-10.975% -10.758% -10.563%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 67 outliers among 500 measurements (13.40%)
  4 (0.80%) high mild
  63 (12.60%) high severe
Pricegraph::order_for_limit_price/price: 190, hops: Some(65535)                                                                            
                        time:   [238.90 us 239.17 us 239.46 us]
                        change: [-9.4294% -8.9790% -8.5977%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 92 outliers among 500 measurements (18.40%)
  7 (1.40%) high mild
  85 (17.00%) high severe
Pricegraph::order_for_limit_price/price: 180, hops: None                                                                            
                        time:   [215.28 us 215.54 us 215.82 us]
                        change: [-5.9710% -5.7319% -5.4961%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 126 outliers among 500 measurements (25.20%)
  34 (6.80%) low severe
  31 (6.20%) low mild
  24 (4.80%) high mild
  37 (7.40%) high severe
Benchmarking Pricegraph::order_for_limit_price/price: 180, hops: Some(2): Warming up for 3.0000 s
Warning: Unable to complete 500 samples in 5.0s. You may wish to increase target time to 8.3s, enable flat sampling, or reduce sample count to 270.
Pricegraph::order_for_limit_price/price: 180, hops: Some(2)                                                                             
                        time:   [64.511 us 64.614 us 64.718 us]
                        change: [-2.7876% -2.4550% -2.0264%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 27 outliers among 500 measurements (5.40%)
  20 (4.00%) high mild
  7 (1.40%) high severe
Pricegraph::order_for_limit_price/price: 180, hops: Some(30)                                                                            
                        time:   [449.52 us 449.85 us 450.21 us]
                        change: [-9.7701% -8.9425% -8.2192%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 44 outliers among 500 measurements (8.80%)
  2 (0.40%) low severe
  1 (0.20%) low mild
  10 (2.00%) high mild
  31 (6.20%) high severe
Pricegraph::order_for_limit_price/price: 180, hops: Some(65535)                                                                            
                        time:   [448.46 us 448.78 us 449.12 us]
                        change: [-9.7520% -9.3957% -9.1250%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 69 outliers among 500 measurements (13.80%)
  20 (4.00%) low severe
  4 (0.80%) low mild
  11 (2.20%) high mild
  34 (6.80%) high severe
Pricegraph::order_for_limit_price/price: 150, hops: None                                                                            
                        time:   [443.34 us 443.67 us 444.04 us]
                        change: [-5.8604% -5.4532% -5.1338%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 47 outliers among 500 measurements (9.40%)
  1 (0.20%) low severe
  4 (0.80%) low mild
  16 (3.20%) high mild
  26 (5.20%) high severe
Pricegraph::order_for_limit_price/price: 150, hops: Some(2)                                                                            
                        time:   [212.55 us 212.69 us 212.84 us]
                        change: [-5.4972% -5.3058% -5.1218%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 35 outliers among 500 measurements (7.00%)
  14 (2.80%) high mild
  21 (4.20%) high severe
Pricegraph::order_for_limit_price/price: 150, hops: Some(30)                                                                             
                        time:   [1.0060 ms 1.0070 ms 1.0081 ms]
                        change: [-4.0540% -3.7406% -3.4336%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 500 measurements (1.00%)
  4 (0.80%) high mild
  1 (0.20%) high severe
Pricegraph::order_for_limit_price/price: 150, hops: Some(65535)                                                                             
                        time:   [1.0110 ms 1.0135 ms 1.0164 ms]
                        change: [-3.7208% -3.2749% -2.8869%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 35 outliers among 500 measurements (7.00%)
  20 (4.00%) low mild
  2 (0.40%) high mild
  13 (2.60%) high severe
Pricegraph::order_for_limit_price/price: 100, hops: None                                                                            
                        time:   [483.87 us 484.56 us 485.29 us]
                        change: [-18.571% -17.217% -15.890%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 79 outliers among 500 measurements (15.80%)
  34 (6.80%) low mild
  19 (3.80%) high mild
  26 (5.20%) high severe
Pricegraph::order_for_limit_price/price: 100, hops: Some(2)                                                                            
                        time:   [260.89 us 261.49 us 262.17 us]
                        change: [-13.571% -12.258% -10.996%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 500 measurements (2.80%)
  3 (0.60%) high mild
  11 (2.20%) high severe
Pricegraph::order_for_limit_price/price: 100, hops: Some(30)                                                                             
                        time:   [1.0743 ms 1.0754 ms 1.0765 ms]
                        change: [-6.3832% -5.9705% -5.5952%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 74 outliers among 500 measurements (14.80%)
  49 (9.80%) high mild
  25 (5.00%) high severe
Pricegraph::order_for_limit_price/price: 100, hops: Some(65535)                                                                             
                        time:   [1.1024 ms 1.1076 ms 1.1136 ms]
                        change: [-3.3628% -2.9069% -2.4071%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 59 outliers among 500 measurements (11.80%)
  25 (5.00%) high mild
  34 (6.80%) high severe
```
</details>

### Test Plan
Most related unit tests are updated to include different numbers of hops.

#### Compare master with this PR

Start price estimator on master at port 8080.
```
git checkout master
env RUST_LOG="price_estimator=info" cargo run --release -p price-estimator -- --node-url https://address.of.ethereum.node --orderbook-file ../orderbook-file-mainnet --orderbook-update-interval 1000000 --price-source-update-interval 1000000 --bind-address 0.0.0.0:8080
```

After it's up and running, switch to this branch and start price estimator at port 8081.
```
git checkout price-estimator-with-hops
env RUST_LOG="price_estimator=info" cargo run --release -p price-estimator -- --node-url https://address.of.ethereum.node --orderbook-file ../orderbook-file-mainnet --orderbook-update-interval 1000000 --price-source-update-interval 1000000 --bind-address 0.0.0.0:8081
```

Make some test queries and compare to the current existing orders. For example, to compare:
- the price on master
- the price on this PR with 65000 hops
- the price on this PR with one hop (direct order)
```
$ TOKEN1=7; TOKEN2=1
$ curl "localhost:8080/api/v1/markets/${TOKEN1}-${TOKEN2}/estimated-buy-amount/1?atoms=false"; echo; curl "localhost:8081/api/v1/markets/${TOKEN1}-${TOKEN2}/estimated-buy-amount/1?atoms=false&hops=65000"; echo; curl "localhost:8081/api/v1/markets/${TOKEN1}-${TOKEN2}/estimated-buy-amount/1?atoms=false&hops=1"; echo;
{"baseTokenId":7,"quoteTokenId":1,"buyAmountInBase":"378.8264725401764","sellAmountInQuote":"1"}
{"baseTokenId":7,"quoteTokenId":1,"buyAmountInBase":"378.82647253903804","sellAmountInQuote":"1"}
{"baseTokenId":7,"quoteTokenId":1,"buyAmountInBase":"296.3658226112714","sellAmountInQuote":"1"}
```

#### See the orderbook
Start price estimator on port 8080.
```
$ cargo run -p price-estimator -- --node-url https://dev-openethereum.mainnet.gnosisdev.com --orderbook-file path/to/orderbook-file-mainnet --orderbook-update-interval 1000000 --price-source-update-interval 1000000 --bind-address 0.0.0.0:8080
```

Create a file `index.html` in an empty folder with the following content.
(This is the code from Felix's orderbook visualization, minimally modified to work with a local price estimator.)
<details>
  <summary>index.html</summary>

```
<!-- Styles -->
<style>
  #chartdiv {
    height: 500px;
  }

  .loader {
    position: fixed;
    top: 20%;
    left: 20%;
    border: 16px solid #f3f3f3; /* Light grey */
    border-top: 16px solid #3498db; /* Blue */
    border-radius: 50%;
    width: 120px;
    height: 120px;
    animation: spin 2s linear infinite;
  }

  @keyframes spin {
    0% {
      transform: rotate(0deg);
    }
    100% {
      transform: rotate(360deg);
    }
  }
</style>

<!-- Resources -->
<script src="https://www.amcharts.com/lib/4/core.js"></script>
<script src="https://www.amcharts.com/lib/4/charts.js"></script>
<script src="https://www.amcharts.com/lib/4/themes/spiritedaway.js"></script>
<script src="https://cdn.jsdelivr.net/npm/web3@latest/dist/web3.min.js"></script>
<script src="https://cdn.jsdelivr.net/npm/bn.js@5.1.1/lib/bn.min.js"></script>

<!-- Chart code -->
<script>
  const draw = function() {
    document.getElementById("spinner").style.display = "block";

    // Themes begin
    am4core.useTheme(am4themes_spiritedaway);
    // Themes end

    let buyTokenSelect = document.getElementById("buy_token");
    let buyTokenSelectIndex = buyTokenSelect.selectedIndex;
    let buyTokenName = buyTokenSelect.options[buyTokenSelectIndex].innerText;
    let buyTokenIndex = buyTokenSelect.options[buyTokenSelectIndex].value;
    let buyTokenDecimals = parseInt(
      buyTokenSelect.options[buyTokenSelectIndex].getAttribute("decimals")
    );

    let sellTokenSelect = document.getElementById("sell_token");
    let sellTokenSelectIndex = sellTokenSelect.selectedIndex;
    let sellTokenName = sellTokenSelect.options[sellTokenSelectIndex].innerText;
    let sellTokenIndex = sellTokenSelect.options[sellTokenSelectIndex].value;
    let sellTokenDecimals = parseInt(
      sellTokenSelect.options[sellTokenSelectIndex].getAttribute("decimals")
    );
    // Create chart instance
    var chart = am4core.create("chartdiv", am4charts.XYChart);

    const hops = document.getElementById("hops").value;

    // Add data
    const url = `http://127.0.0.1:8080/api/v1/markets/${buyTokenIndex}-${sellTokenIndex}?atoms=true&hops=${hops}`;
    document.getElementById("request").innerHTML = `<a href=${url}>${url}</a>`;
    chart.dataSource.url = url;
    //chart.dataSource.url = `${hops}.json`;
    chart.dataSource.adapter.add("parsedData", function(data) {
      document.getElementById("spinner").style.display = "none";
      // Double check the selected tokens are still correct
      if (
        document.getElementById("sell_token").selectedIndex !=
          sellTokenSelectIndex ||
        document.getElementById("buy_token").selectedIndex !=
          buyTokenSelectIndex
      ) {
        return;
      }
      // Function to process (sort and calculate cummulative volume)
      function processData(list, type, desc) {
        // Convert to data points
        const decimals = type == "bid" ? sellTokenDecimals : buyTokenDecimals;
        for (var i = 0; i < list.length; i++) {
          list[i] = {
            value: Number(
              list[i].price / 10 ** (sellTokenDecimals - buyTokenDecimals)
            ),
            volume: Number(list[i].volume / 10 ** decimals)
          };
        }

        list = list.filter(item => item.volume > 0.01);
        for (var i = 0; i < list.length; i++) {
          var dp = {};
          if (i > 0) {
            list[i].totalvolume = list[i - 1].totalvolume + list[i].volume;
            dp[type + "offsettotalvolume"] = list[i - 1].totalvolume;
          } else {
            dp[type + "offsettotalvolume"] = 0;
            list[i].totalvolume = list[i].volume;
          }
          dp["value"] = list[i].value;
          dp[type + "volume"] = list[i].volume;
          dp[type + "totalvolume"] = list[i].totalvolume;
          res.push(dp);
        }
      }

      // Init
      const res = [];
      //data.bids.reverse();
      processData(data.bids, "bids", false);
      processData(data.asks, "asks", false);
      res.sort((lhs, rhs) => lhs["value"] - rhs["value"]);
      console.log(res);
      return res;
    });

    // Set up precision for numbers
    chart.numberFormatter.numberFormat = "#,###.####";

    // Create axes
    var xAxis = chart.xAxes.push(new am4charts.CategoryAxis());
    xAxis.dataFields.category = "value";
    //xAxis.renderer.grid.template.location = 0;
    xAxis.title.text = `Price (${buyTokenName}/${sellTokenName})`;

    var yAxis = chart.yAxes.push(new am4charts.ValueAxis());
    yAxis.title.text = "Volume";

    // Create series
    var series = chart.series.push(new am4charts.StepLineSeries());
    series.dataFields.categoryX = "value";
    series.dataFields.valueY = "bidsoffsettotalvolume";
    series.strokeWidth = 2;
    series.stroke = am4core.color("#0f0");
    series.fill = series.stroke;
    series.startLocation = 0.5;
    series.fillOpacity = 0.1;
    series.tooltipText =
      "Bid: [bold]{categoryX}[/]\nTotal volume: [bold]{bidstotalvolume}[/]\nVolume: [bold]{bidsvolume}[/]";

    var series2 = chart.series.push(new am4charts.StepLineSeries());
    series2.dataFields.categoryX = "value";
    series2.dataFields.valueY = "askstotalvolume";
    series2.strokeWidth = 2;
    series2.stroke = am4core.color("#f00");
    series2.fill = series2.stroke;
    series2.fillOpacity = 0.1;
    series2.startLocation = 0.5;
    series2.tooltipText =
      "Ask: [bold]{categoryX}[/]\nTotal volume: [bold]{valueY}[/]\nVolume: [bold]{asksvolume}[/]";

    var series3 = chart.series.push(new am4charts.ColumnSeries());
    series3.dataFields.categoryX = "value";
    series3.dataFields.valueY = "bidsvolume";
    series3.strokeWidth = 0;
    series3.fill = am4core.color("#000");
    series3.fillOpacity = 0.2;

    var series4 = chart.series.push(new am4charts.ColumnSeries());
    series4.dataFields.categoryX = "value";
    series4.dataFields.valueY = "asksvolume";
    series4.strokeWidth = 0;
    series4.fill = am4core.color("#000");
    series4.fillOpacity = 0.2;

    // Add cursor
    chart.cursor = new am4charts.XYCursor();
  }; // end am4core.ready()
</script>

<!-- HTML -->
<div id="token_picket">
  <label for="buy_token">Buy Token:</label>
  <select onchange="draw()" id="buy_token">
    <option value="0" decimals="18">OWL</option>
    <option value="1" decimals="18">ETH</option>
    <option value="2" decimals="6">USDT</option>
    <option value="3" decimals="18">TUSD</option>
    <option value="4" decimals="6">USDC</option>
    <option value="5" decimals="18">PAX</option>
    <option value="6" decimals="2">GUSD</option>
    <option value="7" decimals="18">DAI</option>
    <option value="8" decimals="18">sETH</option>
    <option value="9" decimals="18">sUSD</option>
    <option value="15" decimals="18">SNX</option>
    <option value="16" decimals="18">CHAI</option>
  </select>
  <label for="sell_token">Sell Token:</label>
  <select onchange="draw()" id="sell_token">
    <option value="0" decimals="18">OWL</option>
    <option value="1" decimals="18">ETH</option>
    <option value="2" decimals="6">USDT</option>
    <option value="3" decimals="18">TUSD</option>
    <option value="4" decimals="6">USDC</option>
    <option value="5" decimals="18">PAX</option>
    <option value="6" decimals="2">GUSD</option>
    <option value="7" decimals="18">DAI</option>
    <option value="8" decimals="18">sETH</option>
    <option value="9" decimals="18">sUSD</option>
    <option value="15" decimals="18">SNX</option>
    <option value="16" decimals="18">CHAI</option>
  </select>
  <label for="hops">Hops:</label>
  <select onchange="draw()" id="hops">
    <option value="1">1</option>
    <option value="2">2</option>
    <option value="3">3</option>
    <option value="4">4</option>
    <option value="5">5</option>
    <option value="6">6</option>
    <option value="7">7</option>
    <option value="8">8</option>
    <option value="9">9</option>
    <option value="10">10</option>
    <option value="30">30</option>
    <option value="65000">65000</option>
    <option value="9999999">9999999</option>
    <option value="0">0, nonsense</option>
  </select>
  <button onclick="draw()">Reload</button>
</div>
<div id="spinner" class="loader" style="display:none"></div>
<div id="chartdiv"></div>
<div id="request"></div>
```
</details>

Serve `index.html` from a local server, e.g., by running in the folder with `index.html`:
```
$ python3 -m http.server
```
Visit `http://127.0.0.1:8000/` in a web browser to see the orderbook.

#### Historic prices

Compare historic prices on current master with those of this PR. This PR change historic prices to work with `hops=Some(30)`.

```
$ git checkout master; cargo build --release -p e2e; time cargo run --release -p e2e --bin historic_prices -- --orderbook-file ../orderbook-file-mainnet; git checkout price-estimator-with-hops; cargo build --release -p e2e; time cargo run --release -p e2e --bin historic_prices -- --orderbook-file ../orderbook-file-mainnet
```
No difference is detected in an actual run. (Note that the number of orders considered changes because I was using the orderbook file in the meantime.)

Shortened result:
```
     Running `target/release/historic_prices --orderbook-file ../orderbook-file-mainnet`
62100 / 62100 [===] 100.00 % 203.65/s
Processed 17255 token prices: average error 22530.55%, bad 2.86%, missed 9.04%.

real    5m5.390s
user    35m22.586s
sys     0m7.352s

Switched to branch 'price-estimator-with-hops'
     Running `target/release/historic_prices --orderbook-file ../orderbook-file-mainnet`
62101 / 62101 [==] 100.00 % 173.70/s Processed 17255 token prices: average error 22753.54%, bad 2.86%, missed 9.01%.

real    5m58.046s
user    36m38.299s
sys     0m7.674s

Switched to branch 'master'
     Running `target/release/historic_trades --orderbook-file ../orderbook-file-mainnet`
62102 / 62102 [==] 100.00 % 28.71/s
Processed 101375 orders: 90.21% correct, 2.06% missed, 6.19% failed, 1.54% skipped.

real    36m3.274s
user    256m45.174s
sys     0m37.437s

Switched to branch 'price-estimator-with-hops'
     Running `target/release/historic_trades --orderbook-file ../orderbook-file-mainnet`
62110 / 62110 [==] 100.00 % 24.83/s
Processed 101375 orders: 90.21% correct, 2.06% missed, 6.19% failed, 1.54% skipped.

real    41m42.764s
user    268m38.472s
sys     0m30.699s
```