### PR TITLE
Fix sleep not being awaited

### DIFF
--- a/core/src/driver/scheduler/system.rs
+++ b/core/src/driver/scheduler/system.rs
@@ -145,7 +145,7 @@ async fn wait_for_batch_id(
     //   one accepting orders and does not yet accept solutions.
     while batch_id.0 as u32 >= contract.get_current_auction_index().await? {
         log::info!("Solved batch is not yet accepting solutions, waiting for next batch.");
-        sleep.sleep(CONTRACT_BATCH_ID_POLL_INTERVAL);
+        sleep.sleep(CONTRACT_BATCH_ID_POLL_INTERVAL).await;
     }
     Ok(())
 }

--- a/core/src/solution_submission.rs
+++ b/core/src/solution_submission.rs
@@ -169,7 +169,7 @@ impl<'a> StableXSolutionSubmitter<'a> {
         let deadline = BatchId::from(batch_index).solve_end_time() + Duration::from_secs(30);
         let remaining = deadline
             .duration_since(SystemTime::now())
-            .unwrap_or(Duration::from_secs(0));
+            .unwrap_or_default();
         self.async_sleep.sleep(remaining).await;
         let gas_price = U256::from(
             (num::u256_to_f64(gas_price_cap) * MIN_GAS_PRICE_INCREASE_FACTOR).ceil() as u128,

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -63,6 +63,7 @@ where
 
 #[cfg_attr(test, mockall::automock)]
 pub trait AsyncSleeping: Send + Sync {
+    #[must_use]
     fn sleep(&self, duration: Duration) -> BoxFuture<'static, ()> {
         async_std::task::sleep(duration).boxed()
     }


### PR DESCRIPTION
And added marked function as must_use. Usually rust warns about not awaiting the result of async functions but it looks like this doesn't trigger when returning BoxFuture. Technically with this reasoning we should put it everywhere where we are returning BoxFuture but not sure if that is really needed since usually we notice because we want to use the return value. sleep is special because we call it for the side effect.

### Test Plan
Tests don't notice this because mockall still registers the call.