### PR TITLE
Report healthiness at the start of the next batch

### DIFF
--- a/core/src/driver/scheduler.rs
+++ b/core/src/driver/scheduler.rs
@@ -1,11 +1,11 @@
 mod evm;
 mod system;
 
-use self::evm::EvmScheduler;
-use self::system::SystemScheduler;
-use crate::contracts::stablex_contract::StableXContract;
-use crate::driver::stablex_driver::StableXDriver;
-use crate::models::batch_id::SOLVING_WINDOW;
+use self::{evm::EvmScheduler, system::SystemScheduler};
+use crate::{
+    contracts::stablex_contract::StableXContract, driver::stablex_driver::StableXDriver,
+    health::HealthReporting, models::batch_id::SOLVING_WINDOW,
+};
 use anyhow::{anyhow, Error, Result};
 use std::{str::FromStr, sync::Arc, time::Duration};
 
@@ -98,10 +98,13 @@ impl SchedulerKind {
         exchange: Arc<dyn StableXContract>,
         driver: Arc<dyn StableXDriver>,
         config: AuctionTimingConfiguration,
+        health: Arc<dyn HealthReporting>,
     ) -> Box<dyn Scheduler> {
         match self {
-            SchedulerKind::System => Box::new(SystemScheduler::new(exchange, driver, config)),
-            SchedulerKind::Evm => Box::new(EvmScheduler::new(exchange, driver, config)),
+            SchedulerKind::System => {
+                Box::new(SystemScheduler::new(exchange, driver, health, config))
+            }
+            SchedulerKind::Evm => Box::new(EvmScheduler::new(exchange, driver, health, config)),
         }
     }
 }

--- a/core/src/health.rs
+++ b/core/src/health.rs
@@ -8,7 +8,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// Trait for asyncronously notifying health information.
 #[cfg_attr(test, mockall::automock)]
 pub trait HealthReporting: Send + Sync {
-    /// Notify that the service is ready.
+    /// Notify that the service is ready. Can be called multiple times.
+    /// We use this to signal readiness only at the start of a batch in order to not interrupt the
+    /// still running kubernetes pod while it is handling a batch.
     fn notify_ready(&self);
 }
 

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -219,7 +219,7 @@ fn main() {
     info!("Starting driver with runtime options: {:#?}", options);
 
     // Set up metrics and health monitoring and serve in separate thread.
-    let (stablex_metrics, http_metrics, solver_metrics, _health) = setup_monitoring();
+    let (stablex_metrics, http_metrics, solver_metrics, health) = setup_monitoring();
 
     // Set up shared HTTP client and HTTP services.
     let http_factory = HttpFactory::new(options.http_timeout, http_metrics);
@@ -297,9 +297,10 @@ fn main() {
         options.earliest_solution_submit_time,
     );
 
-    let mut scheduler = options
-        .scheduler
-        .create(contract, Arc::new(driver), scheduler_config);
+    let mut scheduler =
+        options
+            .scheduler
+            .create(contract, Arc::new(driver), scheduler_config, health);
     orderbook
         .initialize()
         .wait()


### PR DESCRIPTION
Previously we would never set the status to healthy. This is in preparation for using the health check on kubernetes.

### Test Plan
Unit tests and manually tested running the driver with system scheduler.