### PR TITLE
Panic intead of endlessly allocating.

### DIFF
--- a/pricegraph/src/graph/shortest_paths.rs
+++ b/pricegraph/src/graph/shortest_paths.rs
@@ -68,7 +68,7 @@ where
         let mut path = Vec::with_capacity(max_path_len);
         let mut current = dest;
         while current != self.source {
-            debug_assert!(path.len() <= max_path_len, "undetected negative cycle");
+            assert!(path.len() <= max_path_len, "undetected negative cycle");
             path.push(current);
             current = self.predecessor_store.predecessors[self.graph.to_index(current)]?;
         }

--- a/pricegraph/src/graph/shortest_paths.rs
+++ b/pricegraph/src/graph/shortest_paths.rs
@@ -64,9 +64,11 @@ where
 
     /// Returns shortest path from source to destination node, if a path exists.
     pub fn path_to(&self, dest: G::NodeId) -> Option<Path<G::NodeId>> {
+        let max_path_len = self.predecessor_store.predecessors.len();
+        let mut path = Vec::with_capacity(max_path_len);
         let mut current = dest;
-        let mut path = Vec::with_capacity(self.predecessor_store.predecessors.len());
         while current != self.source {
+            debug_assert!(path.len() <= max_path_len, "undetected negative cycle");
             path.push(current);
             current = self.predecessor_store.predecessors[self.graph.to_index(current)]?;
         }

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -758,8 +758,11 @@ mod tests {
         );
     }
 
+    // TODO(nlordell): Once this known issue is fixed, this unit test should no
+    // longer panic.
+    #[should_panic]
     #[test]
-    fn search_is_not_affected_by_rounding_errors() {
+    fn search_panics_on_undetected_negative_cycle_due_to_rounding_errors() {
         //              /---250---v
         // 0 --1.11--> 1          2
         //             ^--0.004--/

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -757,4 +757,30 @@ mod tests {
             10_000_000.0 - flow.capacity / flow.exchange_rate.value()
         );
     }
+
+    #[test]
+    fn search_is_not_affected_by_rounding_errors() {
+        //              /---250---v
+        // 0 --1.11--> 1          2
+        //             ^--0.004--/
+        let mut orderbook = orderbook! {
+            users {
+                @1 {
+                    token 1 => 10_000_000_000,
+                }
+                @2 {
+                    token 2 => 10_000_000_000,
+                }
+            }
+            orders {
+                owner @1 buying 0 [1_000_000_000] selling 1 [1_000_000_000],
+                owner @1 buying 2 [1_000_000] selling 1 [250_000_000],
+                owner @2 buying 1 [249_500_250] selling 2 [1_000_000],
+            }
+        };
+
+        assert!(orderbook
+            .find_optimal_transitive_order(TokenPair { buy: 0, sell: 1 })
+            .is_ok())
+    }
 }


### PR DESCRIPTION
This PR adds a new failing test similar to #1370 except triggered with an actual orderbook instead of one created directly on a `petgraph::Graph` as well as a `panic` to prevent the service from running out of memory in these cases. This will be addressed in #1370 and #1374 at which point the `#[should_panic]` can be removed.

This is just a band-aid to make it so the services don't restart in case we hit these rounding issues as a bandaid fix while the true fix is being worked on.

### Test Plan

Added assert and new unit test covering it.