### PR TITLE
Convert BoxFuture to async_trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
 
 [[package]]
+name = "async-trait"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687c230d85c0a52504709705fc8a53e4a692b83a2184f03dae73e38e1e93a783"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3018,6 +3029,7 @@ dependencies = [
  "anyhow",
  "assert_approx_eq",
  "async-std",
+ "async-trait",
  "bincode",
  "blocking 0.6.1",
  "byteorder",

--- a/services-core/Cargo.toml
+++ b/services-core/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1"
 async-std = "1.6"
+async-trait = "0.1.40"
 bincode = "1.3.1"
 blocking = "0.6.1"
 byteorder = "1.3.4"

--- a/services-core/src/economic_viability.rs
+++ b/services-core/src/economic_viability.rs
@@ -228,7 +228,7 @@ mod tests {
         let mut gas_station = MockGasPriceEstimating::new();
         gas_station
             .expect_estimate_gas_price()
-            .returning(|| immediate!(Ok((40e9 as u128).into())));
+            .returning(|| Ok((40e9 as u128).into()));
         let subsidy = 10.0f64;
         let min_avg_fee_factor = 1.1f64;
         let economic_viability = EconomicViabilityComputer::new(

--- a/services-core/src/gas_price.rs
+++ b/services-core/src/gas_price.rs
@@ -5,13 +5,13 @@ pub use self::gas_station::GnosisSafeGasStation;
 use crate::{contracts::Web3, http::HttpFactory};
 use anyhow::Result;
 use ethcontract::U256;
-use futures::future::BoxFuture;
 use std::sync::Arc;
 
 #[cfg_attr(test, mockall::automock)]
+#[async_trait::async_trait]
 pub trait GasPriceEstimating {
     /// Retrieves gas prices from the Gnosis Safe Relay api.
-    fn estimate_gas_price<'a>(&'a self) -> BoxFuture<'a, Result<U256>>;
+    async fn estimate_gas_price(&self) -> Result<U256>;
 }
 
 /// Creates the default gas price estimator for the given network.

--- a/services-core/src/gas_price/eth_node.rs
+++ b/services-core/src/gas_price/eth_node.rs
@@ -4,13 +4,11 @@ use super::GasPriceEstimating;
 use crate::contracts::Web3;
 use anyhow::Result;
 use ethcontract::U256;
-use futures::{
-    compat::Future01CompatExt,
-    future::{BoxFuture, FutureExt as _, TryFutureExt as _},
-};
+use futures::compat::Future01CompatExt;
 
+#[async_trait::async_trait]
 impl GasPriceEstimating for Web3 {
-    fn estimate_gas_price(&self) -> BoxFuture<Result<U256>> {
-        self.eth().gas_price().compat().map_err(From::from).boxed()
+    async fn estimate_gas_price(&self) -> Result<U256> {
+        self.eth().gas_price().compat().await.map_err(From::from)
     }
 }

--- a/services-core/src/gas_price/gas_station.rs
+++ b/services-core/src/gas_price/gas_station.rs
@@ -4,7 +4,6 @@ use super::GasPriceEstimating;
 use crate::http::{HttpClient, HttpFactory, HttpLabel};
 use anyhow::Result;
 use ethcontract::U256;
-use futures::future::{BoxFuture, FutureExt as _};
 use isahc::http::uri::Uri;
 use serde::Deserialize;
 use uint::FromDecStrErr;
@@ -61,10 +60,11 @@ impl GnosisSafeGasStation {
     }
 }
 
+#[async_trait::async_trait]
 impl GasPriceEstimating for GnosisSafeGasStation {
     /// Retrieves the current gas prices from the gas station.
-    fn estimate_gas_price(&self) -> BoxFuture<Result<U256>> {
-        async move { Ok(self.gas_prices().await?.fast) }.boxed()
+    async fn estimate_gas_price(&self) -> Result<U256> {
+        Ok(self.gas_prices().await?.fast)
     }
 }
 

--- a/services-core/src/solution_submission.rs
+++ b/services-core/src/solution_submission.rs
@@ -335,7 +335,7 @@ mod tests {
         let mut gas_price_estimating = MockGasPriceEstimating::new();
         gas_price_estimating
             .expect_estimate_gas_price()
-            .returning(|| immediate!(Err(anyhow!(""))));
+            .returning(|| Err(anyhow!("")));
         gas_price_estimating
     }
 
@@ -492,7 +492,7 @@ mod tests {
         let mut gas_price = MockGasPriceEstimating::new();
         gas_price
             .expect_estimate_gas_price()
-            .returning(|| immediate!(Ok(10.into())));
+            .returning(|| Ok(10.into()));
         let submitter = StableXSolutionSubmitter::with_retry_and_sleep(
             Arc::new(contract),
             Arc::new(gas_price),

--- a/services-core/src/solution_submission/retry.rs
+++ b/services-core/src/solution_submission/retry.rs
@@ -197,19 +197,19 @@ mod tests {
         gas_station
             .expect_estimate_gas_price()
             .times(1)
-            .return_once(|| immediate!(Err(anyhow!(""))));
+            .return_once(|| Err(anyhow!("")));
         gas_station
             .expect_estimate_gas_price()
             .times(1)
-            .return_once(|| immediate!(Ok(5.into())));
+            .return_once(|| Ok(5.into()));
         gas_station
             .expect_estimate_gas_price()
             .times(1)
-            .return_once(|| immediate!(Ok(6.into())));
+            .return_once(|| Ok(6.into()));
         gas_station
             .expect_estimate_gas_price()
             .times(1)
-            .return_once(|| immediate!(Err(anyhow!(""))));
+            .return_once(|| Err(anyhow!("")));
 
         let mut estimator = InfallibleGasPriceEstimator::new(&gas_station, 3.into());
         assert_eq!(estimator.estimate().now_or_never().unwrap(), U256::from(3));
@@ -224,11 +224,11 @@ mod tests {
         gas_station
             .expect_estimate_gas_price()
             .times(1)
-            .return_once(|| immediate!(Ok(10.into())));
+            .return_once(|| Ok(10.into()));
         gas_station
             .expect_estimate_gas_price()
             .times(1)
-            .return_once(|| immediate!(Ok(9.into())));
+            .return_once(|| Ok(9.into()));
 
         let mut estimator = InfallibleGasPriceEstimator::new(&gas_station, 3.into());
         assert_eq!(estimator.estimate().now_or_never().unwrap(), U256::from(10));
@@ -271,7 +271,7 @@ mod tests {
         let mut gas_station = MockGasPriceEstimating::new();
         gas_station
             .expect_estimate_gas_price()
-            .returning(|| immediate!(Err(anyhow!(""))));
+            .returning(|| Err(anyhow!("")));
 
         let args = Args {
             batch_index: 1,
@@ -307,7 +307,7 @@ mod tests {
         let mut gas_station = MockGasPriceEstimating::new();
         gas_station
             .expect_estimate_gas_price()
-            .returning(|| async { Ok((DEFAULT_GAS_PRICE * 90).into()) }.boxed());
+            .returning(|| Ok((DEFAULT_GAS_PRICE * 90).into()));
 
         let sleep = MockAsyncSleeping::new();
 
@@ -331,7 +331,7 @@ mod tests {
 
         gas_station
             .expect_estimate_gas_price()
-            .returning(|| immediate!(Err(anyhow!(""))));
+            .returning(|| Err(anyhow!("")));
         contract
             .expect_submit_solution()
             .times(1)
@@ -381,7 +381,7 @@ mod tests {
 
         gas_station
             .expect_estimate_gas_price()
-            .returning(|| immediate!(Err(anyhow!(""))));
+            .returning(|| Err(anyhow!("")));
         contract
             .expect_submit_solution()
             .times(1)


### PR DESCRIPTION
https://github.com/dtolnay/async-trait allows using `async fn` in traits. We used to be unable to use it because it would not work with mockall. With the most recent update mockall added support it.
This PR changes only one trait so it is easier to understand the change. In future PRs I am going to change multiple traits together.
This conversion also fixes_ #1375 .

### Test Plan
No logic change. CI.