### PR TITLE
Convert TokenInfoFetching to async_trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2354,6 +2354,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_approx_eq",
+ "async-trait",
  "ethcontract",
  "futures 0.3.5",
  "log 0.4.11",

--- a/price-estimator/Cargo.toml
+++ b/price-estimator/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+async-trait = "0.1.40"
 services-core = { path = "../services-core" }
 ethcontract = "0.7"
 futures = "0.3"

--- a/price-estimator/src/filter.rs
+++ b/price-estimator/src/filter.rs
@@ -345,20 +345,21 @@ mod tests {
     use super::*;
     use crate::infallible_price_source::PriceCacheUpdater;
     use anyhow::{anyhow, Result};
-    use futures::future::{BoxFuture, FutureExt as _};
+    use futures::future::FutureExt as _;
     use services_core::orderbook::NoopOrderbook;
 
     fn empty_token_info() -> impl TokenInfoFetching {
         struct TokenInfoFetcher {}
+        #[async_trait::async_trait]
         impl TokenInfoFetching for TokenInfoFetcher {
-            fn get_token_info<'a>(
-                &'a self,
+            async fn get_token_info(
+                &self,
                 _: TokenId,
-            ) -> BoxFuture<'a, Result<services_core::token_info::TokenBaseInfo>> {
-                async { Err(anyhow!("")) }.boxed()
+            ) -> Result<services_core::token_info::TokenBaseInfo> {
+                Err(anyhow!(""))
             }
-            fn all_ids<'a>(&'a self) -> BoxFuture<'a, Result<Vec<TokenId>>> {
-                async { Ok(Default::default()) }.boxed()
+            async fn all_ids(&self) -> Result<Vec<TokenId>> {
+                Ok(Default::default())
             }
         }
         TokenInfoFetcher {}

--- a/services-core/src/price_estimation/threaded_price_source.rs
+++ b/services-core/src/price_estimation/threaded_price_source.rs
@@ -116,7 +116,7 @@ mod tests {
         let mut token_info_fetcher = MockTokenInfoFetching::new();
         token_info_fetcher
             .expect_all_ids()
-            .returning(|| immediate!(Ok(TOKENS.to_vec())));
+            .returning(|| Ok(TOKENS.to_vec()));
 
         let (tps, handle) =
             ThreadedPriceSource::new(Arc::new(token_info_fetcher), ps, UPDATE_INTERVAL);
@@ -139,7 +139,7 @@ mod tests {
         let mut token_info_fetcher = MockTokenInfoFetching::new();
         token_info_fetcher
             .expect_all_ids()
-            .returning(|| immediate!(Ok(TOKENS.to_vec())));
+            .returning(|| Ok(TOKENS.to_vec()));
 
         let (tps, handle) =
             ThreadedPriceSource::new(Arc::new(token_info_fetcher), price_source, UPDATE_INTERVAL);

--- a/services-core/src/token_info/hardcoded.rs
+++ b/services-core/src/token_info/hardcoded.rs
@@ -53,20 +53,18 @@ impl Into<TokenBaseInfo> for TokenInfoOverride {
 #[serde(transparent)]
 pub struct TokenData(HashMap<TokenId, TokenInfoOverride>);
 
+#[async_trait::async_trait]
 impl TokenInfoFetching for TokenData {
-    fn get_token_info<'a>(&'a self, id: TokenId) -> BoxFuture<'a, Result<TokenBaseInfo>> {
-        let info = self
-            .0
+    async fn get_token_info(&self, id: TokenId) -> Result<TokenBaseInfo> {
+        self.0
             .get(&id)
             .cloned()
             .ok_or_else(|| anyhow!("Token {:?} not found in hardcoded data", id))
-            .map(Into::into);
-        immediate!(info)
+            .map(Into::into)
     }
 
-    fn all_ids<'a>(&'a self) -> BoxFuture<'a, Result<Vec<TokenId>>> {
-        let ids = Vec::from_iter(self.0.keys().copied());
-        immediate!(Ok(ids))
+    async fn all_ids(&self) -> Result<Vec<TokenId>> {
+        Ok(Vec::from_iter(self.0.keys().copied()))
     }
 }
 

--- a/services-core/src/token_info/onchain.rs
+++ b/services-core/src/token_info/onchain.rs
@@ -1,29 +1,23 @@
 use anyhow::Result;
-use futures::future::{BoxFuture, FutureExt};
 
 use super::{TokenBaseInfo, TokenId, TokenInfoFetching};
 use crate::contracts::stablex_contract::StableXContractImpl;
 
+#[async_trait::async_trait]
 impl TokenInfoFetching for StableXContractImpl {
-    fn get_token_info<'a>(&'a self, id: TokenId) -> BoxFuture<'a, Result<TokenBaseInfo>> {
-        async move {
-            let (address, alias, decimals) = self.get_token_info(id.into()).await?;
-            Ok(TokenBaseInfo {
-                address,
-                alias,
-                decimals,
-            })
-        }
-        .boxed()
+    async fn get_token_info(&self, id: TokenId) -> Result<TokenBaseInfo> {
+        let (address, alias, decimals) = self.get_token_info(id.into()).await?;
+        Ok(TokenBaseInfo {
+            address,
+            alias,
+            decimals,
+        })
     }
 
-    fn all_ids<'a>(&'a self) -> BoxFuture<'a, Result<Vec<TokenId>>> {
-        async move {
-            let num_tokens = self.num_tokens().await?;
-            let ids: Vec<TokenId> = (0..num_tokens).map(|token| token.into()).collect();
-            Ok(ids)
-        }
-        .boxed()
+    async fn all_ids(&self) -> Result<Vec<TokenId>> {
+        let num_tokens = self.num_tokens().await?;
+        let ids: Vec<TokenId> = (0..num_tokens).map(|token| token.into()).collect();
+        Ok(ids)
     }
 }
 


### PR DESCRIPTION
A welcome side effect of the conversion is that the mockall workaround
for lifetimes is no longer needed.
In this commit I also had to change one test slightly and move the the
default implementation of find_token_by_address into its own function.
Otherwise we cannot test it as mockall overrides the default
implementation.

### Test Plan
No logic change. CI.