### PR TITLE
Move StableXContract to async_trait

### DIFF
--- a/services-core/src/driver/scheduler/evm.rs
+++ b/services-core/src/driver/scheduler/evm.rs
@@ -201,12 +201,12 @@ mod tests {
             .expect_get_current_auction_index()
             .times(1)
             .in_sequence(&mut sequence)
-            .returning(|| async { Ok(42) }.boxed());
+            .returning(|| Ok(42));
         exchange
             .expect_get_current_auction_index()
             .times(1)
             .in_sequence(&mut sequence)
-            .returning(|| async { Ok(43) }.boxed());
+            .returning(|| Ok(43));
         health
             .expect_notify_ready()
             .times(1)
@@ -215,10 +215,10 @@ mod tests {
 
         exchange
             .expect_get_current_auction_index()
-            .returning(|| async { Ok(43) }.boxed());
+            .returning(|| Ok(43));
         exchange
             .expect_get_current_auction_remaining_time()
-            .returning(|| async { Ok(Duration::from_secs(270)) }.boxed());
+            .returning(|| Ok(Duration::from_secs(270)));
 
         let mut driver = MockStableXDriver::new();
         driver
@@ -246,13 +246,13 @@ mod tests {
         exchange
             .expect_get_current_auction_index()
             .times(2)
-            .returning(|| async { Ok(41) }.boxed());
+            .returning(|| Ok(41));
         exchange
             .expect_get_current_auction_index()
-            .returning(|| async { Ok(42) }.boxed());
+            .returning(|| Ok(42));
         exchange
             .expect_get_current_auction_remaining_time()
-            .returning(|| async { Ok(Duration::from_secs(240)) }.boxed());
+            .returning(|| Ok(Duration::from_secs(240)));
 
         let mut driver = MockStableXDriver::new();
         driver
@@ -285,14 +285,14 @@ mod tests {
         exchange
             .expect_get_current_auction_index()
             .times(1)
-            .returning(|| async { Ok(42) }.boxed());
+            .returning(|| Ok(42));
         exchange
             .expect_get_current_auction_remaining_time()
-            .returning(|| async { Ok(Duration::from_secs(270)) }.boxed());
+            .returning(|| Ok(Duration::from_secs(270)));
         exchange
             .expect_get_current_auction_index()
             .times(1)
-            .returning(|| async { Ok(43) }.boxed());
+            .returning(|| Ok(43));
 
         let driver = MockStableXDriver::new();
 
@@ -318,10 +318,10 @@ mod tests {
         let mut exchange = MockStableXContract::new();
         exchange
             .expect_get_current_auction_index()
-            .returning(|| async { Ok(42) }.boxed());
+            .returning(|| Ok(42));
         exchange
             .expect_get_current_auction_remaining_time()
-            .returning(|| async { Ok(Duration::from_secs(1)) }.boxed());
+            .returning(|| Ok(Duration::from_secs(1)));
 
         let driver = MockStableXDriver::new();
 
@@ -347,10 +347,10 @@ mod tests {
         let mut exchange = MockStableXContract::new();
         exchange
             .expect_get_current_auction_index()
-            .returning(|| async { Ok(42) }.boxed());
+            .returning(|| Ok(42));
         exchange
             .expect_get_current_auction_remaining_time()
-            .returning(|| async { Ok(Duration::from_secs(270)) }.boxed());
+            .returning(|| Ok(Duration::from_secs(270)));
 
         let mut driver = MockStableXDriver::new();
         driver
@@ -387,10 +387,10 @@ mod tests {
         let mut exchange = MockStableXContract::new();
         exchange
             .expect_get_current_auction_index()
-            .returning(|| async { Ok(42) }.boxed());
+            .returning(|| Ok(42));
         exchange
             .expect_get_current_auction_remaining_time()
-            .returning(|| async { Ok(Duration::from_secs(270)) }.boxed());
+            .returning(|| Ok(Duration::from_secs(270)));
 
         let mut driver = MockStableXDriver::new();
         driver
@@ -419,15 +419,15 @@ mod tests {
         let mut exchange = MockStableXContract::new();
         exchange
             .expect_get_current_auction_index()
-            .returning(|| async { Ok(42) }.boxed());
+            .returning(|| Ok(42));
         exchange
             .expect_get_current_auction_remaining_time()
             .times(2)
-            .returning(|| async { Ok(Duration::from_secs(270)) }.boxed());
+            .returning(|| Ok(Duration::from_secs(270)));
         exchange
             .expect_get_current_auction_remaining_time()
             .times(1)
-            .returning(|| async { Ok(Duration::from_secs(250)) }.boxed());
+            .returning(|| Ok(Duration::from_secs(250)));
 
         let mut driver = MockStableXDriver::new();
         driver

--- a/services-core/src/driver/scheduler/system.rs
+++ b/services-core/src/driver/scheduler/system.rs
@@ -420,17 +420,17 @@ mod tests {
             .expect_get_current_auction_index()
             .times(1)
             .in_sequence(&mut sequence)
-            .returning(|| immediate!(Ok(0)));
+            .returning(|| Ok(0));
         contract
             .expect_get_current_auction_index()
             .times(1)
             .in_sequence(&mut sequence)
-            .returning(|| immediate!(Ok(0)));
+            .returning(|| Ok(0));
         contract
             .expect_get_current_auction_index()
             .times(1)
             .in_sequence(&mut sequence)
-            .returning(|| immediate!(Ok(1)));
+            .returning(|| Ok(1));
         driver
             .expect_submit_solution()
             .times(1)
@@ -498,7 +498,7 @@ mod tests {
         let mut contract = MockStableXContract::new();
         contract
             .expect_get_current_auction_index()
-            .returning(|| immediate!(Err(anyhow!(""))));
+            .returning(|| Err(anyhow!("")));
 
         let mut counter = 0;
         driver


### PR DESCRIPTION
Here it did not work perfectly. Mockall only allows setting immediately
ready values on expectations. However for `submit_solution` and
`send_noop_transaction` we have tests that explicitly make use of
expectations that block for some time. This is not possible with
mockall. I filed a bug report.
Until that is fixed I've kept these methods as BoxFuture.

### Test Plan
No logic change. CI.