### PR TITLE
use new transitive order iterator

### DIFF
--- a/pricegraph/src/api/price_estimation.rs
+++ b/pricegraph/src/api/price_estimation.rs
@@ -51,10 +51,7 @@ impl Pricegraph {
         // the marginal exchange rate.
         let mut cumulative_buy_volume = 0.0;
         let mut cumulative_sell_volume = 0.0;
-        for flow in orderbook
-            .transitive_orders(inverse_pair)
-            .filter(|flow| !flow.is_dust_trade())
-        {
+        for flow in orderbook.significant_transitive_orders(inverse_pair) {
             // NOTE: This implies that the added liquidity from the counter
             // transitive order at its exchange rate makes the estimated
             // exchange rate worse, and we are better off just buying off all
@@ -123,8 +120,7 @@ impl Pricegraph {
 
         let (total_buy_volume, total_sell_volume) = self
             .reduced_orderbook()
-            .transitive_orders(inverse_pair)
-            .filter(|flow| !flow.is_dust_trade())
+            .significant_transitive_orders(inverse_pair)
             .take_while(|flow| flow.exchange_rate <= max_xrate)
             .fold((0.0, 0.0), |(total_buy_volume, total_sell_volume), flow| {
                 (

--- a/pricegraph/src/api/price_estimation.rs
+++ b/pricegraph/src/api/price_estimation.rs
@@ -51,22 +51,21 @@ impl Pricegraph {
         // the marginal exchange rate.
         let mut cumulative_buy_volume = 0.0;
         let mut cumulative_sell_volume = 0.0;
-        while let Some(flow) = orderbook.fill_optimal_transitive_order_if(inverse_pair, |flow| {
-            let current_exchange_rate =
-                match ExchangeRate::new(cumulative_buy_volume / max_sell_amount) {
-                    Some(price) => price,
-                    None => return true,
-                };
-
+        for flow in orderbook
+            .transitive_orders(inverse_pair)
+            .filter(|flow| !flow.is_dust_trade())
+        {
             // NOTE: This implies that the added liquidity from the counter
             // transitive order at its exchange rate makes the estimated
             // exchange rate worse, and we are better off just buying off all
             // the previously discovered liquidity instead of including new
             // liquidity from this transitive order.
-            current_exchange_rate < flow.exchange_rate.inverse()
-        }) {
-            if flow.is_dust_trade() {
-                continue;
+            if matches!(
+                ExchangeRate::new(cumulative_buy_volume / max_sell_amount),
+                Some(current_exchange_rate)
+                    if current_exchange_rate >= flow.exchange_rate.inverse()
+            ) {
+                break;
             }
 
             cumulative_buy_volume += flow.capacity / flow.exchange_rate.value();
@@ -113,8 +112,6 @@ impl Pricegraph {
         pair: TokenPair,
         limit_price: f64,
     ) -> Option<TransitiveOrder> {
-        let mut orderbook = self.reduced_orderbook();
-
         // NOTE: This method works by searching for the "best" counter
         // transitive orders, as such we need to fill transitive orders in the
         // inverse direction and need to invert the limit price.
@@ -124,20 +121,17 @@ impl Pricegraph {
         };
         let max_xrate = LimitPrice::new(limit_price)?.exchange_rate().inverse();
 
-        let mut total_buy_volume = 0.0;
-        let mut total_sell_volume = 0.0;
-        while let Some(flow) = orderbook
-            .fill_optimal_transitive_order_if(inverse_pair, |flow| flow.exchange_rate <= max_xrate)
-        {
-            if flow.is_dust_trade() {
-                continue;
-            }
-
-            // NOTE: The transitive orders being filled are **counter orders**
-            // with inverted token pairs.
-            total_buy_volume += flow.capacity / flow.exchange_rate.value();
-            total_sell_volume += flow.capacity;
-        }
+        let (total_buy_volume, total_sell_volume) = self
+            .reduced_orderbook()
+            .transitive_orders(inverse_pair)
+            .filter(|flow| !flow.is_dust_trade())
+            .take_while(|flow| flow.exchange_rate <= max_xrate)
+            .fold((0.0, 0.0), |(total_buy_volume, total_sell_volume), flow| {
+                (
+                    total_buy_volume + flow.capacity / flow.exchange_rate.value(),
+                    total_sell_volume + flow.capacity,
+                )
+            });
 
         if total_buy_volume == 0.0 || total_sell_volume == 0.0 {
             None

--- a/pricegraph/src/orderbook/reduced.rs
+++ b/pricegraph/src/orderbook/reduced.rs
@@ -20,39 +20,12 @@ impl ReducedOrderbook {
         TransitiveOrders::new(self.0, pair).expect("negative cycle in reduced orderbook")
     }
 
-    /// Fills the optimal transitive order for the specified token pair. This
-    /// method is similar to
-    /// `ReducedOrderbook::fill_optimal_transitive_order_if` except it does not
-    /// check a condition on the discovered path's flow before filling.
-    pub fn fill_optimal_transitive_order(&mut self, pair: TokenPair) -> Option<Flow> {
-        self.fill_optimal_transitive_order_if(pair, |_| true)
-    }
-
     /// Finds and returns the optimal transitive order for the specified token
     /// pair without filling it. Returns `None` if no such transitive order
     /// exists.
     pub fn find_optimal_transitive_order(&mut self, pair: TokenPair) -> Option<Flow> {
         self.0
             .find_optimal_transitive_order(pair)
-            .expect("negative cycle in reduced orderbook")
-    }
-
-    /// Fills the optimal transitive order (i.e. with the lowest exchange rate)
-    /// for the specified token pair by pushing flow from the buy token to the
-    /// sell token, if the condition is met. The trading path through the
-    /// orderbook graph is filled to maximum capacity, reducing the remaining
-    /// order amounts and user balances along the way, returning the flow for
-    /// the path.
-    ///
-    /// Returns `None` if the condition is not met or there is no path between
-    /// the token pair.
-    pub fn fill_optimal_transitive_order_if(
-        &mut self,
-        pair: TokenPair,
-        condition: impl FnMut(&Flow) -> bool,
-    ) -> Option<Flow> {
-        self.0
-            .fill_optimal_transitive_order_if(pair, condition)
             .expect("negative cycle in reduced orderbook")
     }
 

--- a/pricegraph/src/orderbook/reduced.rs
+++ b/pricegraph/src/orderbook/reduced.rs
@@ -20,6 +20,17 @@ impl ReducedOrderbook {
         TransitiveOrders::new(self.0, pair).expect("negative cycle in reduced orderbook")
     }
 
+    /// Returns an iterator over all significant transitive orders (i.e. **not**
+    /// dust transitive orders) from lowest to highest limit price for the
+    /// orderbook.
+    ///
+    /// This is a convenience method for:
+    /// `orderbook.transtive_orders().filter(|flow| !flow.is_dust_trade())`.
+    pub fn significant_transitive_orders(self, pair: TokenPair) -> impl Iterator<Item = Flow> {
+        self.transitive_orders(pair)
+            .filter(|flow| !flow.is_dust_trade())
+    }
+
     /// Finds and returns the optimal transitive order for the specified token
     /// pair without filling it. Returns `None` if no such transitive order
     /// exists.


### PR DESCRIPTION
This PR makes use of the new transitive orders iterator method to implement the `pricegraph` API methods in a (hopefully) cleaner way.

### Test Plan

Refactoring, unit tests still pass without modification.

Benchmarks show no changes to the slower methods on overlapping orderbooks. There was some mild regression on benchmarks for the faster methods on reduced orderbooks. I suspect this is because we are filling and extra unneeded transitive order. For estimates that require very few transitive orders (for smaller sell amounts that get filled in the first few transitive orders) this extra overhead becomes more significant. Overall, this only affects the already very fast methods so I'm not worried.
<details><summary>Benchmarks</summary>

```
     Running target/release/deps/pricegraph-656df3332885b719
Gnuplot not found, using plotters backend
Pricegraph::read        time:   [7.2581 ms 7.2629 ms 7.2679 ms]                             
                        change: [-0.2522% -0.0369% +0.2010%] (p = 0.76 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe

Pricegraph::transitive_orderbook/5298183                                                                            
                        time:   [7.1418 ms 7.1496 ms 7.1590 ms]
                        change: [-0.4459% +0.4202% +1.0276%] (p = 0.40 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

Pricegraph::estimate_limit_price/100000000000000000                                                                             
                        time:   [61.611 us 61.697 us 61.788 us]
                        change: [+8.6387% +9.0841% +9.5049%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
Pricegraph::estimate_limit_price/1000000000000000000                                                                             
                        time:   [67.567 us 67.680 us 67.800 us]
                        change: [+11.494% +12.087% +12.796%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe
Pricegraph::estimate_limit_price/10000000000000000000                                                                            
                        time:   [122.62 us 123.03 us 123.58 us]
                        change: [+4.9031% +5.5361% +6.3298%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) high mild
  7 (7.00%) high severe
Pricegraph::estimate_limit_price/100000000000000000000                                                                            
                        time:   [240.16 us 240.49 us 240.85 us]
                        change: [+1.7993% +2.2903% +2.7223%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
Pricegraph::estimate_limit_price/1000000000000000000000                                                                            
                        time:   [547.96 us 548.86 us 549.81 us]
                        change: [+0.2279% +0.7605% +1.3362%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

Pricegraph::order_for_limit_price/200                                                                             
                        time:   [53.674 us 53.742 us 53.817 us]
                        change: [+3.9614% +6.4792% +8.4196%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe
Pricegraph::order_for_limit_price/190                                                                            
                        time:   [152.03 us 152.27 us 152.51 us]
                        change: [+2.5461% +3.1625% +3.7177%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
Pricegraph::order_for_limit_price/180                                                                            
                        time:   [249.95 us 250.66 us 251.54 us]
                        change: [+0.5866% +1.0734% +1.5256%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 14 outliers among 100 measurements (14.00%)
  7 (7.00%) high mild
  7 (7.00%) high severe
Pricegraph::order_for_limit_price/150                                                                            
                        time:   [530.52 us 531.23 us 532.00 us]
                        change: [+0.7383% +1.1234% +1.5936%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
Pricegraph::order_for_limit_price/100                                                                            
                        time:   [580.42 us 581.27 us 582.12 us]
                        change: [-0.4563% +0.0774% +0.5986%] (p = 0.79 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe
```

</details>