### PR TITLE
Improve benchmarking

### DIFF
--- a/pricegraph/benches/pricegraph.rs
+++ b/pricegraph/benches/pricegraph.rs
@@ -3,6 +3,7 @@ mod data;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use pricegraph::{Market, Pricegraph, TokenPair};
+use std::time::Duration;
 
 fn read_default_pricegraph() -> Pricegraph {
     Pricegraph::read(&*data::DEFAULT_ORDERBOOK).expect("error reading orderbook")
@@ -61,8 +62,13 @@ pub fn order_for_limit_price(c: &mut Criterion) {
 }
 
 criterion_group!(
-    name = benches;
-    config = Criterion::default().sample_size(50);
-    targets = read, transitive_orderbook, estimate_limit_price, order_for_limit_price
+    name = overlapping;
+    config = Criterion::default().measurement_time(Duration::from_secs(60));
+    targets = read, transitive_orderbook
 );
-criterion_main!(benches);
+criterion_group!(
+    name = reduced;
+    config = Criterion::default().measurement_time(Duration::from_secs(10));
+    targets =  estimate_limit_price, order_for_limit_price
+);
+criterion_main!(overlapping, reduced);

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -6,6 +6,7 @@
 //! (i.e. orders) connecting a token pair.
 
 mod flow;
+mod map;
 mod order;
 mod reduced;
 mod scalar;

--- a/pricegraph/src/orderbook/map.rs
+++ b/pricegraph/src/orderbook/map.rs
@@ -1,0 +1,19 @@
+//! Module containing definition for `Map` type used for order and user lookup
+//! in the orderbook.
+
+pub use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+#[cfg(test)]
+use std::{collections::hash_map::DefaultHasher, hash::BuildHasherDefault};
+
+/// The map type used internally to look up users and orders in the orderbook.
+#[cfg(not(test))]
+pub type Map<K, V> = HashMap<K, V>;
+
+/// The map type used internally to look up users and orders in the orderbook.
+///
+/// Note that in `test` configuration, the hash map uses a default state instead
+/// of a random one in order for unit tests to not produce semi-random results
+/// and for benchmarks to be more consistent.
+#[cfg(test)]
+pub type Map<K, V> = HashMap<K, V, BuildHasherDefault<DefaultHasher>>;

--- a/pricegraph/src/orderbook/order.rs
+++ b/pricegraph/src/orderbook/order.rs
@@ -1,16 +1,15 @@
 //! Data and logic related to token pair order management.
 
-use super::{ExchangeRate, LimitPrice, UserMap};
+use super::{map::Map, ExchangeRate, LimitPrice, UserMap};
 use crate::encoding::{Element, OrderId, TokenId, TokenPair, UserId};
 use crate::num;
 use std::cmp::Reverse;
-use std::collections::HashMap;
 use std::f64;
 
 /// A type for collecting orders and building an order map that garantees that
 /// per-pair orders are sorted for optimal access.
 #[derive(Debug, Default)]
-pub struct OrderCollector(HashMap<TokenId, HashMap<TokenId, Vec<Order>>>);
+pub struct OrderCollector(Map<TokenId, Map<TokenId, Vec<Order>>>);
 
 impl OrderCollector {
     /// Adds a new order to the order map.
@@ -42,7 +41,7 @@ impl OrderCollector {
 /// pair orders are garanteed to be in order, so that the cheapest order is
 /// always at the end of the token pair order vector.
 #[derive(Clone, Debug)]
-pub struct OrderMap(HashMap<TokenId, HashMap<TokenId, Vec<Order>>>);
+pub struct OrderMap(Map<TokenId, Map<TokenId, Vec<Order>>>);
 
 impl OrderMap {
     /// Returns an iterator over the collection of orders for each token pair.

--- a/pricegraph/src/orderbook/user.rs
+++ b/pricegraph/src/orderbook/user.rs
@@ -1,17 +1,17 @@
 //! Module implementing user and user token balance management.
 
+use super::map::{self, Map};
 use crate::encoding::{Element, TokenId, UserId};
 use crate::num;
-use std::collections::{hash_map, HashMap};
 
 /// A type definiton for a mapping between user IDs to user data.
-pub type UserMap = HashMap<UserId, User>;
+pub type UserMap = Map<UserId, User>;
 
 /// User data containing balances and number of orders.
 #[derive(Clone, Debug, Default)]
 pub struct User {
     /// User balances per token.
-    balances: HashMap<TokenId, f64>,
+    balances: Map<TokenId, f64>,
 }
 
 impl User {
@@ -31,7 +31,7 @@ impl User {
     /// Deducts an amount from the balance for the given token. Returns the new
     /// balance or `None` if the user no longer has any balance.
     pub fn deduct_from_balance(&mut self, token: TokenId, amount: f64) -> f64 {
-        if let hash_map::Entry::Occupied(mut entry) = self.balances.entry(token) {
+        if let map::Entry::Occupied(mut entry) = self.balances.entry(token) {
             let balance = entry.get_mut();
             *balance -= amount;
 


### PR DESCRIPTION
This PR aims at making `pricegraph` benchmarking more precise by:
- Increasing the measurement time to have more samples (the benchmarks are split into groups now since overlapping orderbook operations are 1-2 orders of magnitude slower the reduced orderbook operations and require a separate configuration).
- Use a `HashMap` without `RandomState` for test configuration in order to eliminate variance caused by random iteration order.

### Test Plan

Run the benchmarks:
```
cargo bench -p pricegraph
```