### PR TITLE
Add query parameter to disable rounding buffer

### DIFF
--- a/price-estimator/openapi.yml
+++ b/price-estimator/openapi.yml
@@ -33,6 +33,7 @@ paths:
         - $ref: "#/components/parameters/BatchId"
         - $ref: "#/components/parameters/IgnoreAddresses"
         - $ref: "#/components/parameters/BlockNumber"
+        - $ref: "#/components/parameters/RoundingBuffer"
   /api/v1/markets/{market}/estimated-amounts-at-price/{price}:
     get:
       summary: Estimated Amounts At Price
@@ -56,6 +57,7 @@ paths:
         - $ref: "#/components/parameters/BatchId"
         - $ref: "#/components/parameters/IgnoreAddresses"
         - $ref: "#/components/parameters/BlockNumber"
+        - $ref: "#/components/parameters/RoundingBuffer"
   /api/v1/markets/{market}/estimated-best-ask-price:
     get:
       summary: Estimated Best Ask Price
@@ -75,6 +77,7 @@ paths:
         - $ref: "#/components/parameters/BatchId"
         - $ref: "#/components/parameters/IgnoreAddresses"
         - $ref: "#/components/parameters/BlockNumber"
+        - $ref: "#/components/parameters/RoundingBuffer"
   /api/v1/markets/{market}:
     get:
       summary: Market
@@ -112,6 +115,11 @@ components:
       enum: [baseunits, atoms]
       default: baseunits
       example: baseunits
+    RoundingBuffer:
+      type: string
+      enum: [enabled, disabled]
+      default: enabled
+      example: enabled
     IgnoreAddressesParameter:
       type: string
       default: ""
@@ -182,6 +190,13 @@ components:
       required: false
       schema:
         $ref: "#/components/schemas/Unit"
+    RoundingBuffer:
+      name: roundingBuffer
+      in: query
+      description: If `enabled` (the default) the orderbook is adjusted by a rounding buffer that is used by the solvers internally. This makes the results more accurately reflect how the solvers see the orderbook.  If set to `disabled` no adjustments take place which can lead to for example prices for orders that would not actually get matched by the solver.
+      required: false
+      schema:
+        $ref: "#/components/schemas/RoundingBuffer"
     BatchId:
       name: batchId
       in: query

--- a/price-estimator/src/amounts_at_price.rs
+++ b/price-estimator/src/amounts_at_price.rs
@@ -6,9 +6,15 @@ pub fn order_at_price_with_rounding_buffer(
     token_pair: TokenPair,
     limit_price: f64,
     pricegraph: &Pricegraph,
-    rounding_buffer: f64,
+    rounding_buffer: Option<f64>,
 ) -> Option<TransitiveOrder> {
     let order = pricegraph.order_for_limit_price(token_pair, limit_price)?;
+
+    let rounding_buffer = match rounding_buffer {
+        None => return Some(order),
+        Some(rounding_buffer) => rounding_buffer,
+    };
+
     // We know that an order is still overlapping if it has a limit price <= this one. The limit
     // price of this order is usually larger (better for the seller) than the user requested limit
     // price.
@@ -72,7 +78,7 @@ mod tests {
             TokenPair { buy: 1, sell: 0 },
             limit_price,
             &pricegraph,
-            rounding_buffer,
+            Some(rounding_buffer),
         );
         assert_eq!(
             result,
@@ -106,7 +112,7 @@ mod tests {
             TokenPair { buy: 1, sell: 0 },
             limit_price,
             &pricegraph,
-            rounding_buffer,
+            Some(rounding_buffer),
         );
         let sell = (denominator as f64) * FEE_FACTOR;
         assert_eq!(


### PR DESCRIPTION
It could be useful to use the true raw data ignoring modifications we apply related to how the solver works internally. Would be a simple query parameter like "baseunit" that defaults to use the rounding buffer.

Fixes #1346 

### Test Plan
CI and manually tested openapi comparing prices with and without the parameter.