### PR TITLE
Update the default log filter after `core` name change

### DIFF
--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -44,7 +44,7 @@ struct Options {
     #[structopt(
         long,
         env = "DFUSION_LOG",
-        default_value = "warn,driver=info,core=info"
+        default_value = "warn,driver=info,services_core=info"
     )]
     log_filter: String,
 

--- a/price-estimator/src/main.rs
+++ b/price-estimator/src/main.rs
@@ -39,7 +39,7 @@ struct Options {
     #[structopt(
         long,
         env = "DFUSION_LOG",
-        default_value = "warn,price_estimator=info,core=info,warp::filters::log=info"
+        default_value = "warn,price_estimator=info,services_core=info,warp::filters::log=info"
     )]
     log_filter: String,
 


### PR DESCRIPTION
I forgot this when changing the name of the core crate.