### PR TITLE
Change weight special value

### DIFF
--- a/pricegraph/src/encoding.rs
+++ b/pricegraph/src/encoding.rs
@@ -136,10 +136,8 @@ mod abitrary_impl {
     impl Arbitrary for Element {
         fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
             let price = u.arbitrary::<PriceFraction>()?;
-            let remaining_sell_amount = u
-                .arbitrary::<u128>()?
-                .checked_rem(price.denominator)
-                .unwrap_or_default();
+            let remaining_sell_amount =
+                u.arbitrary::<u128>()? % price.denominator.saturating_add(1);
 
             Ok(Element {
                 user: H160(u.arbitrary()?),

--- a/pricegraph/src/encoding.rs
+++ b/pricegraph/src/encoding.rs
@@ -129,60 +129,31 @@ mod abitrary_impl {
     use super::*;
     use arbitrary::{Arbitrary, Result, Unstructured};
 
-    // We want Element to implement Arbitrary but cannot derive it because Element contains H160
-    // and U256 which do not implement arbitrary and come from foreign crates. Instead of
-    // implementing Arbitrary manually or introducing wrappers for H160 and U256 we create an
-    // equivalent to Element which can derive Arbitrary and forward all methods.
-
-    #[derive(Arbitrary)]
-    struct ArbitraryElement {
-        user: [u8; 20],
-        balance: [u8; 32],
-        pair: TokenPair,
-        valid: Validity,
-        price: PriceFraction,
-        remaining_sell_amount: u128,
-        id: OrderId,
-    }
-
-    impl ArbitraryElement {
-        fn from_element(e: &Element) -> Self {
-            let mut balance = [0u8; 32];
-            e.balance.to_little_endian(&mut balance);
-            Self {
-                user: e.user.to_fixed_bytes(),
-                balance,
-                pair: e.pair,
-                valid: e.valid,
-                price: e.price,
-                remaining_sell_amount: e.remaining_sell_amount,
-                id: e.id,
-            }
-        }
-        fn to_element(&self) -> Element {
-            Element {
-                user: H160::from_slice(&self.user),
-                balance: U256::from_little_endian(&self.balance),
-                pair: self.pair,
-                valid: self.valid,
-                price: self.price,
-                remaining_sell_amount: self.remaining_sell_amount,
-                id: self.id,
-            }
-        }
-    }
-
-    impl arbitrary::Arbitrary for Element {
+    // NOTE: We want `Element` to implement `Arbitrary` but cannot derive it
+    // because:
+    // - `Element` contains foreign types that don't implement `Arbitraty`
+    // - `remaining_sell_amount` is always smaller than `price.denominator`
+    impl Arbitrary for Element {
         fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
-            Ok(ArbitraryElement::arbitrary(u)?.to_element())
+            let price = u.arbitrary::<PriceFraction>()?;
+            let remaining_sell_amount = u
+                .arbitrary::<u128>()?
+                .checked_rem(price.denominator)
+                .unwrap_or_default();
+
+            Ok(Element {
+                user: H160(u.arbitrary()?),
+                balance: U256(u.arbitrary()?),
+                pair: u.arbitrary()?,
+                valid: u.arbitrary()?,
+                price,
+                remaining_sell_amount,
+                id: u.arbitrary()?,
+            })
         }
-        fn size_hint(depth: usize) -> (usize, Option<usize>) {
-            ArbitraryElement::size_hint(depth)
-        }
-        fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
-            let box_iterator = ArbitraryElement::from_element(self).shrink();
-            let mapped = box_iterator.map(|a| a.to_element());
-            Box::new(mapped)
+
+        fn size_hint(_: usize) -> (usize, Option<usize>) {
+            (ELEMENT_STRIDE, Some(ELEMENT_STRIDE))
         }
     }
 }


### PR DESCRIPTION
Running the fuzzer, I discovered an issue with the new `Weight`, specifically with the chosen special value for infinity. It turns out that the logic behind the range of values a `Weight` could have was a bit off, and the more natural choice of `i128::MAX` works better.

This PR updates the the `Weight::infiinite` special value and fixes the `Arbitrary` implementation to only provide `remaining_sell_amounts` less than, or equal the price denominator.

### Test Plan

Run the fuzzer and see it doesn't find a panic right away. Adjusted unit tests.