### PR TITLE
[Easy] Flush the writer before method finishes

### DIFF
--- a/services-core/src/history/events.rs
+++ b/services-core/src/history/events.rs
@@ -93,9 +93,9 @@ impl EventRegistry {
         // Create temp file to be written completely before rename
         let temp_file = File::create(&temp_path)
             .with_context(|| format!("couldn't create {}", temp_path.display()))?;
-        let buffered_writer = BufWriter::new(temp_file);
-        self.write_to(buffered_writer)?;
-
+        let mut buffered_writer = BufWriter::new(temp_file);
+        self.write_to(&mut buffered_writer)?;
+        buffered_writer.flush()?;
         // Rename the temp file to the originally specified path.
         fs::rename(temp_path, path)?;
         Ok(())

--- a/services-core/src/history/events.rs
+++ b/services-core/src/history/events.rs
@@ -89,11 +89,11 @@ impl EventRegistry {
     pub fn write_to_file(&self, path: impl AsRef<Path>) -> Result<()> {
         // Write to tmp file until complete and then rename.
         let temp_path = path.as_ref().with_extension("temp");
-
-        // Create temp file to be written completely before rename
-        let temp_file = File::create(&temp_path)
-            .with_context(|| format!("couldn't create {}", temp_path.display()))?;
         {
+            // Create temp file to be written completely before rename
+            let temp_file = File::create(&temp_path)
+                .with_context(|| format!("couldn't create {}", temp_path.display()))?;
+
             let mut buffered_writer = BufWriter::new(temp_file);
             self.write_to(&mut buffered_writer)?;
             buffered_writer.flush()?;

--- a/services-core/src/history/events.rs
+++ b/services-core/src/history/events.rs
@@ -93,9 +93,11 @@ impl EventRegistry {
         // Create temp file to be written completely before rename
         let temp_file = File::create(&temp_path)
             .with_context(|| format!("couldn't create {}", temp_path.display()))?;
-        let mut buffered_writer = BufWriter::new(temp_file);
-        self.write_to(&mut buffered_writer)?;
-        buffered_writer.flush()?;
+        {
+            let mut buffered_writer = BufWriter::new(temp_file);
+            self.write_to(&mut buffered_writer)?;
+            buffered_writer.flush()?;
+        }
         // Rename the temp file to the originally specified path.
         fs::rename(temp_path, path)?;
         Ok(())


### PR DESCRIPTION
Related to suggestions made in #1394, we also flush the buffered writer before the method completes.

### Test Plan
Unit tests.