### PR TITLE
Add metric for min_avg_fee

### DIFF
--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -277,6 +277,7 @@ fn main() {
         economic_viability.clone(),
         options.solver_internal_optimizer,
         solver_metrics,
+        stablex_metrics.clone(),
     );
 
     // Set up solution submitter.

--- a/services-core/src/price_finding.rs
+++ b/services-core/src/price_finding.rs
@@ -8,7 +8,8 @@ pub use self::{
     price_finder_interface::{Fee, InternalOptimizer, PriceFinding, SolverType},
 };
 use crate::{
-    economic_viability::EconomicViabilityComputing, metrics::SolverMetrics,
+    economic_viability::EconomicViabilityComputing,
+    metrics::{SolverMetrics, StableXMetrics},
     price_estimation::PriceEstimating,
 };
 use log::info;
@@ -21,6 +22,7 @@ pub fn create_price_finder(
     min_avg_fee: Arc<dyn EconomicViabilityComputing>,
     internal_optimizer: InternalOptimizer,
     solver_metrics: SolverMetrics,
+    stablex_metrics: Arc<StableXMetrics>,
 ) -> Arc<dyn PriceFinding + Send + Sync> {
     if solver_type == SolverType::NaiveSolver {
         info!("Using naive price finder");
@@ -34,6 +36,7 @@ pub fn create_price_finder(
             min_avg_fee,
             internal_optimizer,
             solver_metrics,
+            stablex_metrics,
         ))
     }
 }


### PR DESCRIPTION
Will make debugging easier by not having to check kibana logs for the
parameter.

I put this into stablex_metrics. Alternatively it could go into solver_metrics but those were intended to capture all the metrics from the solution file which this metric isn't.

Fixes  #1398 

### Test Plan
I tested that the gauge shows. Didn't test that it is actually set because I don't have a solver set up but code is simple so it should be fine.