### PR TITLE
New best ask and bid API for Pricegraph

### DIFF
--- a/pricegraph/src/api.rs
+++ b/pricegraph/src/api.rs
@@ -42,6 +42,12 @@ impl TransitiveOrder {
     pub fn effective_exchange_rate(&self) -> f64 {
         self.exchange_rate() * FEE_FACTOR
     }
+
+    /// Retrieves the minimum exchange rate such that it overlaps with the
+    /// transitive order, accounting for fees on both sides of the trade.
+    pub fn overlapping_exchange_rate(&self) -> f64 {
+        1.0 / (self.exchange_rate() * FEE_FACTOR.powi(2))
+    }
 }
 
 /// A struct representing a market.

--- a/pricegraph/src/api.rs
+++ b/pricegraph/src/api.rs
@@ -88,3 +88,27 @@ impl Market {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::prelude::*;
+
+    #[test]
+    fn transitive_order_overlapping_xrate() {
+        // NOTE: A transitive order buying 0.999 (1 minus fees) for 100 overlaps
+        // with an inverse transitive order buying 99.9 (100 minus fees) for 1
+        assert_approx_eq!(
+            TransitiveOrder {
+                buy: 1.0 / FEE_FACTOR,
+                sell: 100.0,
+            }
+            .overlapping_exchange_rate(),
+            TransitiveOrder {
+                buy: 100.0 / FEE_FACTOR,
+                sell: 1.0,
+            }
+            .exchange_rate()
+        )
+    }
+}

--- a/pricegraph/src/api/transitive_orderbook.rs
+++ b/pricegraph/src/api/transitive_orderbook.rs
@@ -91,6 +91,27 @@ impl Pricegraph {
 
         transitive_orderbook
     }
+
+    /// Computes the best ask order for the specified market. Returns `None` if
+    /// there are no remaining transitive orders after all overlapping ring
+    /// trades have been removed.
+    pub fn best_ask_transitive_order(&self, market: Market) -> Option<TransitiveOrder> {
+        Some(
+            self.reduced_orderbook()
+                .find_optimal_transitive_order(market.ask_pair())?
+                .as_transitive_order(),
+        )
+    }
+
+    /// Computes the best bid order for the specified market. See
+    /// `Pricegraph::best_ask_order` for more details.
+    pub fn best_bid_transitive_order(&self, market: Market) -> Option<TransitiveOrder> {
+        Some(
+            self.reduced_orderbook()
+                .find_optimal_transitive_order(market.bid_pair())?
+                .as_transitive_order(),
+        )
+    }
 }
 
 /// Fills transitive orders along a token pair, optionally specifying a


### PR DESCRIPTION
This PR adds new methods for computing best ask and bid orders for a market instead of relying on special values (it used to require estimating a price with a `0.0` max sell amount).

### Test Plan

Added new unit test to check price estimates with invalid sell amounts, also make sure that the the `estimated-best-ask-price` endpoint returns prices in quote:
```
$ curl -s 'http://localhost:8080/api/v1/markets/1-7/estimated-best-ask-price' | jq
362.56585811394814
```

Which makes sense given that the current price of ETH is ~350$ and the quote token is DAI.