### PR TITLE
[EASY] Runtime argumentss; default to fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,10 @@ OPTIONS:
             Specify the number of blocks to fetch events for at a time for constructing the orderbook for the solver
             [env: AUCTION_DATA_PAGE_SIZE=]  [default: 500]
         --fallback-max-gas-price <fallback-max-gas-price>
-            The default maximum gas price. This is used when computing the maximum gas price based on ether price in owl
+            The fallback maximum gas price. This is used when computing the maximum gas price based on ether price in owl
             fails [env: FALLBACK_MAX_GAS_PRICE=]  [default: 100000000000]
         --fallback-min-avg-fee-per-order <fallback-min-avg-fee-per-order>
-            The default minimum average fee per order. This is passed to the solver in case the computing its value
+            The fallback minimum average fee per order. This is passed to the solver in case the computing its value
             fails. Its unit is [OWL] [env: MIN_AVG_FEE_PER_ORDER=]  [default: 0]
         --earliest-solution-submit-time <earliest-solution-submit-time>
             The earliest offset from the start of a batch in seconds at which point we should submit the solution. This

--- a/README.md
+++ b/README.md
@@ -6,16 +6,17 @@
 1. [Introduction](#introduction)
 2. [Getting Started](#getting-started)
     1. [Requirements](#requirements)
-    2. [Installation](#installation)
+    2. [Installation](#setup)
 3. [Batch Exchange](#batchexchange)
     1. [Running](#running-batchexchange)
 4. [Testing](#tests)
     1. [End to End](#end-to-end-tests)
     2. [Unit tests](#unit-tests)
-5. [Optimization Solver](#running-with-optimization-solver)
-6. [Configuration](#configuration)
+5. [Open Solver](#running-with-open-solver)
+6. [Optimization Solver](#running-with-linear-optimization-solver)
+7. [Configuration](#configuration)
     1. [Orderbook Filtering](#orderbook-filter-example)
-7. [Troubleshooting](#troubleshooting)
+8. [Troubleshooting](#troubleshooting)
     1. [Logging](#logging)
     2. [Docker Compose](#docker-compose-build)
     3. [Different Networks](#different-networks)
@@ -33,7 +34,7 @@ This repository contains the backend logic for the Gnosis Protocol based on [thi
 - Rust (stable)
 - Docker and Docker-compose (stable)
 
-The project may work with other versions of these tools but they are not tested.
+The project may work with other versions of these tools, but they are not tested.
 
 ### Setup
 
@@ -141,10 +142,10 @@ OPTIONS:
         --auction-data-page-size <auction-data-page-size>
             Specify the number of blocks to fetch events for at a time for constructing the orderbook for the solver
             [env: AUCTION_DATA_PAGE_SIZE=]  [default: 500]
-        --default-max-gas-price <default-max-gas-price>
+        --fallback-max-gas-price <fallback-max-gas-price>
             The default maximum gas price. This is used when computing the maximum gas price based on ether price in owl
-            fails [env: DEFAULT_MAX_GAS_PRICE=]  [default: 100000000000]
-        --default-min-avg-fee-per-order <default-min-avg-fee-per-order>
+            fails [env: FALLBACK_MAX_GAS_PRICE=]  [default: 100000000000]
+        --fallback-min-avg-fee-per-order <fallback-min-avg-fee-per-order>
             The default minimum average fee per order. This is passed to the solver in case the computing its value
             fails. Its unit is [OWL] [env: MIN_AVG_FEE_PER_ORDER=]  [default: 0]
         --earliest-solution-submit-time <earliest-solution-submit-time>

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -184,15 +184,15 @@ struct Options {
     )]
     economic_viability_min_avg_fee_factor: f64,
 
-    /// The default minimum average fee per order. This is passed to the solver
+    /// The fallback minimum average fee per order. This is passed to the solver
     /// in case the computing its value fails. Its unit is [OWL]
     #[structopt(long, env = "MIN_AVG_FEE_PER_ORDER", default_value = "0")]
-    default_min_avg_fee_per_order: u128,
+    fallback_min_avg_fee_per_order: u128,
 
-    /// The default maximum gas price. This is used when computing the maximum gas price based on
+    /// The fallback maximum gas price. This is used when computing the maximum gas price based on
     /// ether price in owl fails.
-    #[structopt(long, env = "DEFAULT_MAX_GAS_PRICE", default_value = "100000000000")]
-    default_max_gas_price: u128,
+    #[structopt(long, env = "FALLBACK_MAX_GAS_PRICE", default_value = "100000000000")]
+    fallback_max_gas_price: u128,
 
     /// The kind of scheduler to use.
     #[structopt(long, env = "SCHEDULER", default_value = "system")]
@@ -264,8 +264,8 @@ fn main() {
             options.economic_viability_min_avg_fee_factor,
         )),
         Box::new(FixedEconomicViabilityComputer::new(
-            Some(options.default_min_avg_fee_per_order),
-            Some(options.default_max_gas_price.into()),
+            Some(options.fallback_min_avg_fee_per_order),
+            Some(options.fallback_max_gas_price.into()),
         )),
     ]));
 

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -197,8 +197,8 @@ struct Options {
     fallback_max_gas_price: u128,
 
     /// How to calculate the economic viability constraints. `Dynamic` means that current eth price
-    /// is taken into account while `Static` means that default_min_avg_fee_per_order and
-    /// default_max_gas_price will always be used.
+    /// is taken into account while `Static` means that fallback_min_avg_fee_per_order and
+    /// fallback_max_gas_price will always be used.
     #[structopt(
         long,
         env = "ECONOMIC_VIABILITY_STRATEGY",
@@ -297,8 +297,8 @@ fn main() {
     }
     // This should come after the subsidy calculation so that it is only used when that fails.
     economic_viabilities.push(Box::new(FixedEconomicViabilityComputer::new(
-        Some(options.default_min_avg_fee_per_order),
-        Some(options.default_max_gas_price.into()),
+        Some(options.fallback_min_avg_fee_per_order),
+        Some(options.fallback_max_gas_price.into()),
     )));
     let economic_viability = Arc::new(PriorityEconomicViabilityComputer::new(economic_viabilities));
 


### PR DESCRIPTION
The default-XXX runtime arguments were confusing because they have their own default values and their intended use strikes me as a "fallback" value. Thus, these two arguments name changed from default to fallback.

As an added bonus, the readme table of contents had a couple of broken links

### Test Plan
Unit tests.