### PR TITLE
[Trivial] More generic logging

### DIFF
--- a/services-core/src/driver/scheduler/evm.rs
+++ b/services-core/src/driver/scheduler/evm.rs
@@ -112,7 +112,7 @@ impl EvmScheduler {
             );
             match self.driver.solve_batch(batch_id.into(), time_limit).await {
                 Ok(solution) => {
-                    info!("successfully solved batch {}", batch_id);
+                    info!("received solution for batch {}", batch_id);
                     return Ok(Some(solution));
                 }
                 Err(DriverError::Retry(err)) => {
@@ -140,7 +140,7 @@ impl EvmScheduler {
         }
 
         match self.driver.submit_solution(batch_id.into(), solution).await {
-            Ok(()) => info!("successfully submitted solution for batch {}", batch_id),
+            Ok(()) => info!("successfully completed batch {}", batch_id),
             Err(err) => error!(
                 "failed to submit solution for batch {}: {:?}",
                 batch_id, err


### PR DESCRIPTION
Just a minor change to the info logging around solution finding and submitting that is more generic in cases when we don't actually submit a solution:

We now see a slight change of wording in lines 2 and 4

```
Computed solution for batch 5331852: Solution { prices: {}, executed_orders: [] }
received solution for batch 5331852 <---- HERE!
Not submitting trivial solution for batch 5331852
successfully completed batch 5331852 <---- HERE!
```

Rather than;

```
Computed solution for batch 5331852: Solution { prices: {}, executed_orders: [] }
successfully solved batch 5331852 <---- HERE!
Not submitting trivial solution for batch 5331852
successfully submitted solution for batch 5331852 <---- HERE!
```

Since, in some cases we don't actually submit the solution

### Test Plan
No changed logic, Unit tests should suffice.