### PR TITLE
Add route for current min order size in owl

### DIFF
--- a/price-estimator/src/orderbook.rs
+++ b/price-estimator/src/orderbook.rs
@@ -6,6 +6,7 @@ use ethcontract::Address;
 use futures::future;
 use pricegraph::{Pricegraph, TokenPair};
 use services_core::{
+    economic_viability::EthPricing,
     models::{AccountState, BatchId, Order, TokenId},
     orderbook::StableXOrderBookReading,
 };
@@ -160,6 +161,19 @@ impl Orderbook {
             self.extra_rounding_buffer_factor,
         );
         Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl EthPricing for Orderbook {
+    async fn get_eth_price(&self) -> Option<std::num::NonZeroU128> {
+        let eth_token_id = TokenId(1);
+        Some(
+            self.infallible_price_source
+                .inner()
+                .await
+                .price(eth_token_id),
+        )
     }
 }
 

--- a/services-core/src/price_estimation.rs
+++ b/services-core/src/price_estimation.rs
@@ -13,6 +13,7 @@ use self::orderbook_based::PricegraphEstimator;
 use crate::contracts::stablex_contract::StableXContractImpl;
 use crate::token_info::{cached::TokenInfoCache, hardcoded::TokenData, TokenInfoFetching};
 use crate::{
+    economic_viability::EthPricing,
     http::HttpFactory,
     models::{Order, TokenId, TokenInfo},
     orderbook::StableXOrderBookReading,
@@ -46,11 +47,6 @@ pub trait PriceEstimating {
     /// the solver, so the amount of OWL in atoms to purchase 1e18 of the
     /// corresponding token.
     async fn get_token_prices(&self, orders: &[Order]) -> Tokens;
-
-    /// Retrieves a price estimate for ETH in OWL atoms. This price is in the
-    /// same format as the above method, so the amount of OWL in atoms to
-    /// purchase 1.0 ETH (or 1e18 wei).
-    async fn get_eth_price(&self) -> Option<NonZeroU128>;
 }
 
 pub struct PriceOracle {
@@ -160,7 +156,10 @@ impl PriceEstimating for PriceOracle {
         }
         tokens
     }
+}
 
+#[async_trait::async_trait]
+impl EthPricing for PriceOracle {
     async fn get_eth_price(&self) -> Option<NonZeroU128> {
         let token_id = self.eth_token_id();
         let prices = self.source.get_prices(&[token_id]).await.ok()?;


### PR DESCRIPTION
We want to use this for the frontend.

This commit has several todos that can be improved. We will do these
later so that the route is available as quickly as possible so we stop
blocking the frontend.

Related to #1404 .

I introduced a new trait `EthPricing` which has the `get_eth_price` method that used to be in `PriceEstimating`. This is cleaner because EconomicViability only needs this one method and makes it easier to create EconomicViability with the price source we have in PriceEstimator instead of using PriceOracle.

The todos that we can do after this PR:

1. Avoid code duplication for economic viability related arguments in driver and price estimator.
2. Avoid code duplication for creation of economic viability from arguments in driver and price estimator.
3. Introduce a network_id argument to price estimator which is needed for the gas price estimation to not be hardcoded to mainnet.
4. Create a better version of this route that works per token and returns the amount in that token instead of in owl.
5. Add openapi docs for the route.

### Test Plan
Run price estimator with `--economic-viability-subsidy-factor 5`.
`curl -i "http://localhost:8080/api/v1/minimum-order-size-owl"` returns `1838937853604742400000`
which is 1839 owl and fits with the min avg fee we pass to the solver.
To check the solver look at https://dashboard-projects.gnosisdev.com/d/BOeaAdNGk/solver-metrics?orgId=1 . Note that the open solver is currently using subsidy factor 5 while the others are using 10.