### PR TITLE
Add network id parameter to price estimator

### DIFF
--- a/price-estimator/openapi.yml
+++ b/price-estimator/openapi.yml
@@ -92,6 +92,17 @@ paths:
         - $ref: "#/components/parameters/BatchId"
         - $ref: "#/components/parameters/IgnoreAddresses"
         - $ref: "#/components/parameters/BlockNumber"
+  /api/v1/minimum-order-size-owl:
+    get:
+      summary: Minimum Order Size Owl
+      description: The minimum size of an order in owl atoms for it to be considered by the solver according to current economic viability constraints.
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MinimumOrderSizeOwlResponse"
 components:
   schemas:
     NumberParameter:
@@ -145,6 +156,8 @@ components:
         bids:
           - price: 5508028446685.359
             volume": 3.2264600472733105
+    MinimumOrderSizeOwlResponse:
+      type: number
   parameters:
     Market:
       name: market

--- a/price-estimator/src/main.rs
+++ b/price-estimator/src/main.rs
@@ -58,6 +58,11 @@ struct Options {
     #[structopt(long, env = "ETHEREUM_NODE_URL")]
     node_url: Url,
 
+    /// The network ID used for gas estimations.
+    /// For example 1 for mainnet, 4 for rinkeby.
+    #[structopt(long, env = "NETWORK_ID", default_value = "1")]
+    network_id: u64,
+
     /// The timeout in seconds of web3 JSON RPC calls.
     #[structopt(
         long,
@@ -165,8 +170,8 @@ fn main() {
             .wait()
             .unwrap(),
     );
-    // TODO: do not hardcode mainnet network id. Can use command line argument like driver.
-    let gas_station = gas_price::create_estimator(1, &http_factory, &web3).unwrap();
+    let gas_station =
+        gas_price::create_estimator(options.network_id, &http_factory, &web3).unwrap();
 
     let cache: HashMap<_, _> = options.token_data.clone().into();
     let token_info = TokenInfoCache::with_cache(contract.clone(), cache);


### PR DESCRIPTION
The same way the driver has it. Used for the current gas price.

Made it default to 1 since that is the most common usage.

### Test Plan
Ran with network  1 and 4 to check that we get different prices.