### PR TITLE
Automatically determine chain id through web3

### DIFF
--- a/price-estimator/src/main.rs
+++ b/price-estimator/src/main.rs
@@ -55,11 +55,6 @@ struct Options {
     #[structopt(long, env = "ETHEREUM_NODE_URL")]
     node_url: Url,
 
-    /// The network ID used for gas estimations.
-    /// For example 1 for mainnet, 4 for rinkeby.
-    #[structopt(long, env = "NETWORK_ID", default_value = "1")]
-    network_id: u64,
-
     /// The timeout in seconds of web3 JSON RPC calls.
     #[structopt(
         long,
@@ -154,13 +149,10 @@ fn main() {
     let web3 = web3_provider(&http_factory, options.node_url.as_str(), options.timeout).unwrap();
     // The private key is not actually used but StableXContractImpl requires it.
     let private_key = PrivateKey::from_raw([1u8; 32]).unwrap();
-    let contract = Arc::new(
-        StableXContractImpl::new(&web3, private_key, 0)
-            .wait()
-            .unwrap(),
-    );
-    let gas_station =
-        gas_price::create_estimator(options.network_id, &http_factory, &web3).unwrap();
+    let contract = Arc::new(StableXContractImpl::new(&web3, private_key).wait().unwrap());
+    let gas_station = gas_price::create_estimator(&http_factory, &web3)
+        .wait()
+        .unwrap();
 
     let cache: HashMap<_, _> = options.token_data.clone().into();
     let token_info = TokenInfoCache::with_cache(contract.clone(), cache);

--- a/services-core/src/contracts.rs
+++ b/services-core/src/contracts.rs
@@ -17,8 +17,8 @@ pub fn web3_provider(http_factory: &HttpFactory, url: &str, timeout: Duration) -
     Ok(web3)
 }
 
-fn method_defaults(key: PrivateKey, network_id: u64) -> Result<MethodDefaults> {
-    let account = Account::Offline(key, Some(network_id));
+fn method_defaults(key: PrivateKey, chain_id: u64) -> Result<MethodDefaults> {
+    let account = Account::Offline(key, Some(chain_id));
     let defaults = MethodDefaults {
         from: Some(account),
         gas: None,

--- a/services-core/src/gas_price.rs
+++ b/services-core/src/gas_price.rs
@@ -3,7 +3,7 @@ mod gas_station;
 
 pub use self::gas_station::GnosisSafeGasStation;
 use crate::{contracts::Web3, http::HttpFactory};
-use anyhow::{Context as _, Result};
+use anyhow::Result;
 use ethcontract::U256;
 use futures::compat::Future01CompatExt as _;
 use std::sync::Arc;
@@ -20,14 +20,8 @@ pub async fn create_estimator(
     http_factory: &HttpFactory,
     web3: &Web3,
 ) -> Result<Arc<dyn GasPriceEstimating + Send + Sync>> {
-    let network_id: u64 = web3
-        .net()
-        .version()
-        .compat()
-        .await?
-        .parse()
-        .context("failed to parse network_id")?;
-    Ok(match gas_station::api_url_from_network_id(network_id) {
+    let network_id = web3.net().version().compat().await?;
+    Ok(match gas_station::api_url_from_network_id(&network_id) {
         Some(url) => Arc::new(GnosisSafeGasStation::new(http_factory, url)?),
         None => Arc::new(web3.clone()),
     })

--- a/services-core/src/gas_price.rs
+++ b/services-core/src/gas_price.rs
@@ -3,7 +3,7 @@ mod gas_station;
 
 pub use self::gas_station::GnosisSafeGasStation;
 use crate::{contracts::Web3, http::HttpFactory};
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use ethcontract::U256;
 use futures::compat::Future01CompatExt as _;
 use std::sync::Arc;
@@ -20,8 +20,14 @@ pub async fn create_estimator(
     http_factory: &HttpFactory,
     web3: &Web3,
 ) -> Result<Arc<dyn GasPriceEstimating + Send + Sync>> {
-    let chain_id = web3.eth().chain_id().compat().await?.as_u64();
-    Ok(match gas_station::api_url_from_chain_id(chain_id) {
+    let network_id: u64 = web3
+        .net()
+        .version()
+        .compat()
+        .await?
+        .parse()
+        .context("failed to parse network_id")?;
+    Ok(match gas_station::api_url_from_network_id(network_id) {
         Some(url) => Arc::new(GnosisSafeGasStation::new(http_factory, url)?),
         None => Arc::new(web3.clone()),
     })

--- a/services-core/src/gas_price.rs
+++ b/services-core/src/gas_price.rs
@@ -5,6 +5,7 @@ pub use self::gas_station::GnosisSafeGasStation;
 use crate::{contracts::Web3, http::HttpFactory};
 use anyhow::Result;
 use ethcontract::U256;
+use futures::compat::Future01CompatExt as _;
 use std::sync::Arc;
 
 #[cfg_attr(test, mockall::automock)]
@@ -15,12 +16,12 @@ pub trait GasPriceEstimating {
 }
 
 /// Creates the default gas price estimator for the given network.
-pub fn create_estimator(
-    network_id: u64,
+pub async fn create_estimator(
     http_factory: &HttpFactory,
     web3: &Web3,
 ) -> Result<Arc<dyn GasPriceEstimating + Send + Sync>> {
-    Ok(match gas_station::api_url_from_network_id(network_id) {
+    let chain_id = web3.eth().chain_id().compat().await?.as_u64();
+    Ok(match gas_station::api_url_from_chain_id(chain_id) {
         Some(url) => Arc::new(GnosisSafeGasStation::new(http_factory, url)?),
         None => Arc::new(web3.clone()),
     })

--- a/services-core/src/gas_price/gas_station.rs
+++ b/services-core/src/gas_price/gas_station.rs
@@ -12,10 +12,10 @@ use uint::FromDecStrErr;
 const DEFAULT_MAINNET_URI: &str = "https://safe-relay.gnosis.io/api/v1/gas-station/";
 const DEFAULT_RINKEBY_URI: &str = "https://safe-relay.rinkeby.gnosis.io/api/v1/gas-station/";
 
-pub fn api_url_from_network_id(network_id: u64) -> Option<&'static str> {
+pub fn api_url_from_network_id(network_id: &str) -> Option<&'static str> {
     match network_id {
-        1 => Some(DEFAULT_MAINNET_URI),
-        4 => Some(DEFAULT_RINKEBY_URI),
+        "1" => Some(DEFAULT_MAINNET_URI),
+        "4" => Some(DEFAULT_RINKEBY_URI),
         _ => None,
     }
 }

--- a/services-core/src/gas_price/gas_station.rs
+++ b/services-core/src/gas_price/gas_station.rs
@@ -12,8 +12,8 @@ use uint::FromDecStrErr;
 const DEFAULT_MAINNET_URI: &str = "https://safe-relay.gnosis.io/api/v1/gas-station/";
 const DEFAULT_RINKEBY_URI: &str = "https://safe-relay.rinkeby.gnosis.io/api/v1/gas-station/";
 
-pub fn api_url_from_network_id(network_id: u64) -> Option<&'static str> {
-    match network_id {
+pub fn api_url_from_chain_id(chain_id: u64) -> Option<&'static str> {
+    match chain_id {
         1 => Some(DEFAULT_MAINNET_URI),
         4 => Some(DEFAULT_RINKEBY_URI),
         _ => None,

--- a/services-core/src/gas_price/gas_station.rs
+++ b/services-core/src/gas_price/gas_station.rs
@@ -12,8 +12,8 @@ use uint::FromDecStrErr;
 const DEFAULT_MAINNET_URI: &str = "https://safe-relay.gnosis.io/api/v1/gas-station/";
 const DEFAULT_RINKEBY_URI: &str = "https://safe-relay.rinkeby.gnosis.io/api/v1/gas-station/";
 
-pub fn api_url_from_chain_id(chain_id: u64) -> Option<&'static str> {
-    match chain_id {
+pub fn api_url_from_network_id(network_id: u64) -> Option<&'static str> {
+    match network_id {
         1 => Some(DEFAULT_MAINNET_URI),
         4 => Some(DEFAULT_RINKEBY_URI),
         _ => None,

--- a/services-core/src/token_info/onchain.rs
+++ b/services-core/src/token_info/onchain.rs
@@ -44,7 +44,6 @@ mod tests {
                 "0x0102030405060708091011121314151617181920212223242526272829303132",
             )
             .expect("Invalid private key"),
-            1,
         )
         .wait()
         .expect("Error creating contract")


### PR DESCRIPTION
instead of having to specify it on the command line.

For the contract using the chain id instead of network id is what was
intended anyway and for the gas station it doesn't matter whether we
match on network id or chain id because they are the same for mainnet
and rinkeby.

Based on Felix' suggestion.

### Test Plan
Added a debug print to the gas station to see which chain id is used and tried it with mainnet and rinkeby node url.