### PR TITLE
Pricegraph: Store order remaining amount and user balances as integers

### DIFF
--- a/pricegraph/src/api/price_estimation.rs
+++ b/pricegraph/src/api/price_estimation.rs
@@ -16,7 +16,7 @@ impl Pricegraph {
     /// the ratio between buy and sell amounts, with implicit fees.
     pub fn estimate_limit_price(&self, pair: TokenPair, max_sell_amount: f64) -> Option<f64> {
         if !num::is_strictly_positive_and_finite(max_sell_amount)
-            || num::is_dust_amount(max_sell_amount)
+            || num::is_dust_amount_f(max_sell_amount)
         {
             return None;
         }
@@ -75,7 +75,7 @@ impl Pricegraph {
         // be overlapping with existing orders such that an executed buy amount
         // could be found greater than the dust amount.
         let min_buy_amount = max_sell_amount * price;
-        if num::is_dust_amount(min_buy_amount) {
+        if num::is_dust_amount_f(min_buy_amount) {
             return None;
         }
 

--- a/pricegraph/src/api/price_estimation.rs
+++ b/pricegraph/src/api/price_estimation.rs
@@ -16,7 +16,7 @@ impl Pricegraph {
     /// the ratio between buy and sell amounts, with implicit fees.
     pub fn estimate_limit_price(&self, pair: TokenPair, max_sell_amount: f64) -> Option<f64> {
         if !num::is_strictly_positive_and_finite(max_sell_amount)
-            || num::is_dust_amount_f(max_sell_amount)
+            || num::is_dust_amount(max_sell_amount as u128)
         {
             return None;
         }
@@ -75,7 +75,7 @@ impl Pricegraph {
         // be overlapping with existing orders such that an executed buy amount
         // could be found greater than the dust amount.
         let min_buy_amount = max_sell_amount * price;
-        if num::is_dust_amount_f(min_buy_amount) {
+        if num::is_dust_amount(min_buy_amount as u128) {
             return None;
         }
 

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -24,7 +24,7 @@ const FEE_TOKEN: TokenId = 0;
 /// solution. Orders with effective sell amounts smaller than this amount can
 /// safely be ignored, and transitive orders with flows that trade amounts
 /// smaller than this are not considered for price estimates.
-pub const MIN_AMOUNT: f64 = 10_000.0;
+pub const MIN_AMOUNT: u128 = 10_000;
 
 /// API entry point for computing price estimates and transitive orderbooks for
 /// a give auction.

--- a/pricegraph/src/num.rs
+++ b/pricegraph/src/num.rs
@@ -80,13 +80,7 @@ pub fn is_strictly_positive_and_finite(value: f64) -> bool {
 
 /// Returns true if an amount is considered a dust amount. See `MIN_AMOUNT`
 /// documentation for more details.
-pub fn is_dust_amount_f(amount: f64) -> bool {
-    amount < MIN_AMOUNT as f64
-}
-
-/// Returns true if an amount is considered a dust amount. See `MIN_AMOUNT`
-/// documentation for more details.
-pub fn is_dust_amount_i(amount: u128) -> bool {
+pub fn is_dust_amount(amount: u128) -> bool {
     amount < MIN_AMOUNT
 }
 

--- a/pricegraph/src/num.rs
+++ b/pricegraph/src/num.rs
@@ -80,7 +80,13 @@ pub fn is_strictly_positive_and_finite(value: f64) -> bool {
 
 /// Returns true if an amount is considered a dust amount. See `MIN_AMOUNT`
 /// documentation for more details.
-pub fn is_dust_amount(amount: f64) -> bool {
+pub fn is_dust_amount_f(amount: f64) -> bool {
+    amount < MIN_AMOUNT as f64
+}
+
+/// Returns true if an amount is considered a dust amount. See `MIN_AMOUNT`
+/// documentation for more details.
+pub fn is_dust_amount_i(amount: u128) -> bool {
     amount < MIN_AMOUNT
 }
 

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -363,6 +363,8 @@ impl Orderbook {
                 user.clear_balance(pair.sell);
                 self.update_projection_graph_node(pair.sell);
             } else if let Amount::Remaining(amount) = &mut order.amount {
+                // TODO: add a debug assert to see that we are not over filling orders.
+                // Will do this when we use BigRational.
                 *amount = amount.saturating_sub(fill_amount);
                 if num::is_dust_amount(*amount) {
                     self.update_projection_graph_edge(pair);

--- a/pricegraph/src/orderbook.rs
+++ b/pricegraph/src/orderbook.rs
@@ -250,7 +250,7 @@ impl Orderbook {
         while let Some(true) = self
             .orders
             .best_order_for_pair(pair)
-            .map(|order| num::is_dust_amount_i(order.get_effective_amount(&self.users)))
+            .map(|order| num::is_dust_amount(order.get_effective_amount(&self.users)))
         {
             self.orders.remove_pair_order(pair);
         }
@@ -359,12 +359,12 @@ impl Orderbook {
             let fill_amount = (flow.capacity / transitive_xrate.value()) as u128;
             let new_balance = user.deduct_from_balance(pair.sell, fill_amount);
 
-            if num::is_dust_amount_i(new_balance) {
+            if num::is_dust_amount(new_balance) {
                 user.clear_balance(pair.sell);
                 self.update_projection_graph_node(pair.sell);
             } else if let Some(amount) = &mut order.amount {
                 *amount = amount.saturating_sub(fill_amount);
-                if num::is_dust_amount_i(*amount) {
+                if num::is_dust_amount(*amount) {
                     self.update_projection_graph_edge(pair);
                 }
             }
@@ -432,9 +432,9 @@ fn format_path(path: &[NodeIndex]) -> String {
 /// amount or balance is less than the minimum amount that the exchange allows
 /// for trades
 fn is_dust_order(element: &Element) -> bool {
-    num::is_dust_amount_i(element.remaining_sell_amount as _)
+    num::is_dust_amount(element.remaining_sell_amount as _)
         || (element.balance < U256::from(u128::MAX)
-            && num::is_dust_amount_i(element.balance.low_u128()))
+            && num::is_dust_amount(element.balance.low_u128()))
 }
 
 /// An error indicating an invalid operation was performed on an overlapping

--- a/pricegraph/src/orderbook/flow.rs
+++ b/pricegraph/src/orderbook/flow.rs
@@ -32,7 +32,7 @@ impl Flow {
 
     /// Returns true if this flow is a dust trade.
     pub fn is_dust_trade(&self) -> bool {
-        num::is_dust_amount(self.min_trade)
+        num::is_dust_amount_f(self.min_trade)
     }
 }
 

--- a/pricegraph/src/orderbook/flow.rs
+++ b/pricegraph/src/orderbook/flow.rs
@@ -32,7 +32,7 @@ impl Flow {
 
     /// Returns true if this flow is a dust trade.
     pub fn is_dust_trade(&self) -> bool {
-        num::is_dust_amount_f(self.min_trade)
+        num::is_dust_amount(self.min_trade as u128)
     }
 }
 

--- a/pricegraph/src/orderbook/user.rs
+++ b/pricegraph/src/orderbook/user.rs
@@ -61,11 +61,7 @@ impl User {
 }
 
 fn u256_to_u128_saturating(u256: &U256) -> u128 {
-    if u256.0[2] == 0 && u256.0[3] == 0 {
-        u256.low_u128()
-    } else {
-        u128::MAX
-    }
+    u256.min(&u128::MAX.into()).low_u128()
 }
 
 #[cfg(test)]

--- a/pricegraph/src/orderbook/weight.rs
+++ b/pricegraph/src/orderbook/weight.rs
@@ -135,7 +135,7 @@ mod tests {
         assert_eq!(-f64::MAX as i128, i128::MIN);
 
         const MAX_TOKENS: f64 = (1 << 16) as _;
-        let max_xrate = 2.0f64.powi(128) / MIN_AMOUNT;
+        let max_xrate = 2.0f64.powi(128) / MIN_AMOUNT as f64;
 
         let max_total_weight = {
             let weight = max_xrate.log2() * MAX_TOKENS * FIXED_24X104_SCALING_FACTOR;


### PR DESCRIPTION
instead of floats.

While working on a using a BigRational type for ExchangeRate in a different branch I noticed
that this change also makes sense and could be refactored it into its own PR.

With the BigRational change Flow::capacity and min_trade would also become u128s.

Benchmark
<details>Pricegraph::read        time:   [5.6543 ms 5.6597 ms 5.6654 ms]
                        change: [-0.6112% -0.4534% -0.2954%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Pricegraph::transitive_orderbook/5298183
                        time:   [5.5705 ms 5.5748 ms 5.5794 ms]
                        change: [+0.7394% +0.8957% +1.0439%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Pricegraph::estimate_limit_price/100000000000000000
                        time:   [47.531 us 47.607 us 47.670 us]
                        change: [+8.3493% +8.4750% +8.5964%] (p = 0.00 < 0.05)
                        Performance has regressed.

Pricegraph::estimate_limit_price/1000000000000000000
                        time:   [48.837 us 48.874 us 48.922 us]
                        change: [+1.8688% +2.1218% +2.3802%] (p = 0.00 < 0.05)
                        Performance has regressed.

Pricegraph::estimate_limit_price/10000000000000000000
                        time:   [94.161 us 94.197 us 94.240 us]
                        change: [+2.0211% +2.2254% +2.4099%] (p = 0.00 < 0.05)
                        Performance has regressed.

Pricegraph::estimate_limit_price/100000000000000000000
                        time:   [192.46 us 192.72 us 193.05 us]
                        change: [+1.5835% +1.8608% +2.0939%] (p = 0.00 < 0.05)
                        Performance has regressed.

Pricegraph::estimate_limit_price/1000000000000000000000
                        time:   [477.25 us 477.63 us 478.07 us]
                        change: [+7.6418% +7.8084% +7.9628%] (p = 0.00 < 0.05)
                        Performance has regressed.

Pricegraph::order_for_limit_price/200
                        time:   [42.607 us 42.744 us 42.921 us]
                        change: [+4.3753% +4.8784% +5.4368%] (p = 0.00 < 0.05)
                        Performance has regressed.

Pricegraph::order_for_limit_price/190
                        time:   [122.03 us 122.29 us 122.61 us]
                        change: [+1.9331% +2.3399% +2.6983%] (p = 0.00 < 0.05)
                        Performance has regressed.

Pricegraph::order_for_limit_price/180
                        time:   [208.11 us 208.35 us 208.58 us]
                        change: [+2.1229% +2.5886% +3.0075%] (p = 0.00 < 0.05)
                        Performance has regressed.

Pricegraph::order_for_limit_price/150
                        time:   [452.56 us 452.84 us 453.11 us]
                        change: [+2.9362% +3.0678% +3.1991%] (p = 0.00 < 0.05)
                        Performance has regressed.

Pricegraph::order_for_limit_price/100
                        time:   [509.79 us 510.08 us 510.46 us]
                        change: [+6.5567% +6.7537% +6.9483%] (p = 0.00 < 0.05)
                        Performance has regressed.
</details>

Benchmark now with balance as U256
<details>
Pricegraph::read        time:   [5.9581 ms 5.9664 ms 5.9754 ms]
                        change: [+2.0925% +2.6443% +3.1203%] (p = 0.00 < 0.05)
                        Performance has regressed.

Pricegraph::transitive_orderbook/5298183
                        time:   [5.8476 ms 5.8520 ms 5.8571 ms]
                        change: [+2.1179% +2.6124% +3.0897%] (p = 0.00 < 0.05)
                        Performance has regressed.

Pricegraph::estimate_limit_price/100000000000000000
                        time:   [47.819 us 47.846 us 47.873 us]
                        change: [+8.1399% +8.8444% +9.4816%] (p = 0.00 < 0.05)
                        Performance has regressed.

Pricegraph::estimate_limit_price/1000000000000000000
                        time:   [49.410 us 49.513 us 49.632 us]
                        change: [+1.9095% +2.8321% +3.6865%] (p = 0.00 < 0.05)
                        Performance has regressed.

Pricegraph::estimate_limit_price/10000000000000000000
                        time:   [96.026 us 96.119 us 96.240 us]
                        change: [+1.8636% +2.7113% +3.3794%] (p = 0.00 < 0.05)
                        Performance has regressed.

Pricegraph::estimate_limit_price/100000000000000000000
                        time:   [197.57 us 197.73 us 197.95 us]
                        change: [-0.4474% +0.8413% +2.0184%] (p = 0.18 > 0.05)
                        No change in performance detected.

Pricegraph::estimate_limit_price/1000000000000000000000
                        time:   [488.48 us 489.17 us 490.14 us]
                        change: [+7.3693% +8.1000% +8.7454%] (p = 0.00 < 0.05)
                        Performance has regressed.

Pricegraph::order_for_limit_price/200
                        time:   [41.826 us 41.905 us 42.000 us]
                        change: [+3.6122% +4.2047% +4.7273%] (p = 0.00 < 0.05)
                        Performance has regressed.

Pricegraph::order_for_limit_price/190
                        time:   [121.74 us 121.89 us 122.08 us]
                        change: [-1.0053% -0.2611% +0.3924%] (p = 0.48 > 0.05)
                        No change in performance detected.

Pricegraph::order_for_limit_price/180
                        time:   [213.23 us 213.31 us 213.41 us]
                        change: [+0.1689% +1.2980% +2.2842%] (p = 0.01 < 0.05)
                        Change within noise threshold.

Pricegraph::order_for_limit_price/150
                        time:   [464.76 us 465.16 us 465.65 us]
                        change: [+5.2298% +5.4621% +5.6739%] (p = 0.00 < 0.05)
                        Performance has regressed.

Pricegraph::order_for_limit_price/100
                        time:   [521.98 us 522.61 us 523.40 us]
                        change: [+8.5424% +8.7334% +8.9668%] (p = 0.00 < 0.05)
                        Performance has regressed.
</details>

### Test Plan
Existing unit tests.