### PR TITLE
Make CI enforce that help output is up to date in README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
         # Unit Tests and Linting
         - cargo test
         # Make sure README is up to date
-        - (! diff README.md <(cargo run --bin driver -- --help) | grep -E "^>" || (echo "[ERROR] README.md doesn't contain output of \`cargo run --bin driver -- --help\`"; false))
+        - diff <(sed -n '/^driver /,/^```/p' README.md | ghead -n -1) <(cargo run --bin driver -- --help)
         # Build image with compiled binary
         - docker build --tag stablex-binary-public --build-arg SOLVER_BASE=gnosispm/dex-open-solver:$OPEN_SOLVER_VERSION -f driver/docker/rust/Dockerfile .
         # StableX e2e Tests (Ganache) - open solver

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
         # Unit Tests and Linting
         - cargo test
         # Make sure README is up to date
-        - diff <(sed -n '/^driver /,/^```/p' README.md | ghead -n -1) <(cargo run --bin driver -- --help)
+        - diff <(sed -n '/^driver /,/^```/p' README.md | head -n -1) <(cargo run --bin driver -- --help)
         # Build image with compiled binary
         - docker build --tag stablex-binary-public --build-arg SOLVER_BASE=gnosispm/dex-open-solver:$OPEN_SOLVER_VERSION -f driver/docker/rust/Dockerfile .
         # StableX e2e Tests (Ganache) - open solver

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ jobs:
         - cargo build --locked --workspace --all-targets
         # Unit Tests and Linting
         - cargo test
+        # Make sure README is up to date
+        - ! diff README.md <(cargo run --bin driver -- --help) | grep -E "^>" || (echo "[ERROR] README.md doesn't contain output of \`cargo run --bin driver -- --help\`"; false)
         # Build image with compiled binary
         - docker build --tag stablex-binary-public --build-arg SOLVER_BASE=gnosispm/dex-open-solver:$OPEN_SOLVER_VERSION -f driver/docker/rust/Dockerfile .
         # StableX e2e Tests (Ganache) - open solver

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
         # Unit Tests and Linting
         - cargo test
         # Make sure README is up to date
-        - ! diff README.md <(cargo run --bin driver -- --help) | grep -E "^>" || (echo "[ERROR] README.md doesn't contain output of \`cargo run --bin driver -- --help\`"; false)
+        - (! diff README.md <(cargo run --bin driver -- --help) | grep -E "^>" || (echo "[ERROR] README.md doesn't contain output of \`cargo run --bin driver -- --help\`"; false))
         # Build image with compiled binary
         - docker build --tag stablex-binary-public --build-arg SOLVER_BASE=gnosispm/dex-open-solver:$OPEN_SOLVER_VERSION -f driver/docker/rust/Dockerfile .
         # StableX e2e Tests (Ganache) - open solver


### PR DESCRIPTION
Inspired by #1429 this PR adds a step to the travis config that makes sure we have the exact output of `cargo run --bin driver -- --help\` in the README.

This is done by diffing the output of the command and content of README.md and making sure that README only contains additions.

### Test Plan
```sh
git checkout contracts_4.3
! diff README.md <(cargo run --bin driver -- --help) | grep -E "^>" || (echo "[ERROR] README doesn't contain output of \`cargo run --bin driver -- --help\`"; false)
```

outputs 

```sh
  Finished dev [unoptimized + debuginfo] target(s) in 0.22s
  Running `target/debug/driver --help`
>     driver [OPTIONS] --node-url <node-url> --private-key <private-key>
[ERROR] README doesn't contain output of `cargo run --bin driver -- --help`
```