### PR TITLE
Do not cap flows for unlimited orders to u128::MAX

### DIFF
--- a/pricegraph/src/api/transitive_orderbook.rs
+++ b/pricegraph/src/api/transitive_orderbook.rs
@@ -155,7 +155,9 @@ fn fill_transitive_orders(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::encoding::{Element, PriceFraction, Validity};
     use crate::test::prelude::*;
+    use primitive_types::U256;
 
     #[test]
     fn transitive_orderbook_empty_same_token() {
@@ -453,5 +455,23 @@ mod tests {
         let transitive_orderbook =
             pricegraph.transitive_orderbook(Market { base: 3, quote: 2 }, None);
         assert!(transitive_orderbook.asks.is_empty() && transitive_orderbook.bids.is_empty());
+    }
+
+    #[test]
+    fn transitive_orderbook_with_unlimited_order_and_large_balance() {
+        let pricegraph = Pricegraph::new(vec![Element {
+            user: Default::default(),
+            balance: U256::MAX,
+            pair: TokenPair { buy: 0, sell: 1 },
+            valid: Validity { from: 0, to: 0 },
+            price: PriceFraction {
+                numerator: u128::MAX,
+                denominator: 10u128.pow(18),
+            },
+            remaining_sell_amount: 10u128.pow(18),
+            id: 0,
+        }]);
+
+        pricegraph.transitive_orderbook(Market { base: 1, quote: 0 }, None);
     }
 }

--- a/pricegraph/src/num.rs
+++ b/pricegraph/src/num.rs
@@ -182,4 +182,87 @@ mod tests {
         );
         assert_eq!(u256_to_u128_saturating(U256::MAX), u128::MAX);
     }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn convert_u256_to_f64() {
+        assert_eq!(u256_to_f64(0.into()), 0.0);
+        assert_eq!(u256_to_f64(42.into()), 42.0);
+        assert_eq!(
+            u256_to_f64(1_000_000_000_000_000_000u128.into()),
+            1_000_000_000_000_000_000.0,
+        );
+    }
+
+    #[test]
+    #[allow(
+        clippy::excessive_precision,
+        clippy::float_cmp,
+        clippy::unreadable_literal
+    )]
+    fn convert_u256_to_f64_precision_loss() {
+        assert_eq!(
+            u256_to_f64(u64::max_value().into()),
+            u64::max_value() as f64,
+        );
+        assert_eq!(
+            u256_to_f64(U256::MAX),
+            115792089237316195423570985008687907853269984665640564039457584007913129639935.0,
+        );
+        assert_eq!(
+            u256_to_f64(U256::MAX),
+            115792089237316200000000000000000000000000000000000000000000000000000000000000.0,
+        );
+    }
+
+    #[test]
+    fn convert_f64_to_u256() {
+        assert_eq!(f64_to_u256(0.0), 0.into());
+        assert_eq!(f64_to_u256(13.37), 13.into());
+        assert_eq!(f64_to_u256(42.0), 42.into());
+        assert_eq!(f64_to_u256(999.999), 999.into());
+        assert_eq!(
+            f64_to_u256(1_000_000_000_000_000_000.0),
+            1_000_000_000_000_000_000u128.into(),
+        );
+    }
+
+    #[test]
+    fn convert_f64_to_u256_large() {
+        let value = U256::from(1) << U256::from(255);
+        assert_eq!(
+            f64_to_u256(
+                format!("{}", value)
+                    .parse::<f64>()
+                    .expect("unexpected error parsing f64")
+            ),
+            value,
+        );
+    }
+
+    #[test]
+    #[allow(clippy::unreadable_literal)]
+    fn convert_f64_to_u256_overflow() {
+        assert_eq!(
+            f64_to_u256(
+                115792089237316200000000000000000000000000000000000000000000000000000000000000.0
+            ),
+            U256::MAX,
+        );
+        assert_eq!(
+            f64_to_u256(
+                999999999999999999999999999999999999999999999999999999999999999999999999999999.0
+            ),
+            U256::MAX,
+        );
+    }
+
+    #[test]
+    fn convert_f64_to_u256_non_normal() {
+        assert_eq!(f64_to_u256(f64::EPSILON), 0.into());
+        assert_eq!(f64_to_u256(f64::from_bits(0)), 0.into());
+        assert_eq!(f64_to_u256(f64::NAN), 0.into());
+        assert_eq!(f64_to_u256(f64::NEG_INFINITY), 0.into());
+        assert_eq!(f64_to_u256(f64::INFINITY), U256::MAX);
+    }
 }

--- a/pricegraph/src/orderbook/order.rs
+++ b/pricegraph/src/orderbook/order.rs
@@ -2,6 +2,7 @@
 
 use super::{map::Map, ExchangeRate, LimitPrice, UserMap};
 use crate::encoding::{Element, OrderId, TokenId, TokenPair, UserId};
+use primitive_types::U256;
 use std::cmp::Reverse;
 
 /// A type for collecting orders and building an order map that garantees that
@@ -159,11 +160,11 @@ impl Order {
     /// Retrieves the effective remaining amount for this order based on user
     /// balances. This is the minimum between the remaining order amount and
     /// the user's sell token balance.
-    pub fn get_effective_amount(&self, users: &UserMap) -> u128 {
+    pub fn get_effective_amount(&self, users: &UserMap) -> U256 {
         let balance = users[&self.user].balance_of(self.pair.sell);
         match self.amount {
             Amount::Unlimited => balance,
-            Amount::Remaining(amount) => amount.min(balance),
+            Amount::Remaining(amount) => balance.min(amount.into()),
         }
     }
 }


### PR DESCRIPTION
Fixes #1431 

This PR removes the cap on transitive order "flows" for unlimited orders. The reasoning behind this is that for price estimates and transitive orderbook computations, unlimited orders with balances `>> u128::MAX` would generate too many transitive orders, as they would be capped to `u128::MAX` instead of the user's actual balance.

While the smart contract limits trades to `u128::MAX`, this is not required for price estimates, as the large balance would be repeatedly reduced over multiple iterations. Now they get reduced all at once :tada:.

### Test Plan

New unit test added. By returning to the old behaviour, you can verify that this test indeed does cause the issue to happen:
```diff
diff --git a/pricegraph/src/orderbook/user.rs b/pricegraph/src/orderbook/user.rs
index 5bc11af..3ce06c4 100644
--- a/pricegraph/src/orderbook/user.rs
+++ b/pricegraph/src/orderbook/user.rs
@@ -24,7 +24,7 @@ impl User {
     /// Return's the user's balance for the specified token.
     /// Panics if the user doesn't have a balance.
     pub fn balance_of(&self, token: TokenId) -> U256 {
-        self.balances.get(&token).copied().unwrap_or_default()
+        self.balances.get(&token).copied().unwrap_or_default().min(u128::MAX.into())
     }
 
     /// Deducts an amount from the balance for the given token. Returns the new
```

Benchmarks were run to determine the impact of this issue and found no significant changes in performance:

<details><summary>Benchmarks</summary>

```
$ cargo bench -p pricegraph-bench -- --baseline master 
    Finished bench [optimized] target(s) in 0.08s
     Running /var/home/nlordell/Developer/dex-services/target/release/deps/pricegraph-4889484856ca8c99
Gnuplot not found, using plotters backend
Pricegraph::read        time:   [6.6880 ms 6.7900 ms 6.9124 ms]                             
                        change: [-0.5615% +1.2319% +2.9784%] (p = 0.18 > 0.05)
                        No change in performance detected.
Found 37 outliers among 100 measurements (37.00%)
  15 (15.00%) low severe
  7 (7.00%) low mild
  3 (3.00%) high mild
  12 (12.00%) high severe

Pricegraph::transitive_orderbook/5298183                                                                            
                        time:   [6.4790 ms 6.5226 ms 6.5801 ms]
                        change: [-1.5986% +0.0589% +1.7140%] (p = 0.95 > 0.05)
                        No change in performance detected.

Pricegraph::estimate_limit_price/100000000000000000                                                                             
                        time:   [56.845 us 56.868 us 56.894 us]
                        change: [-16.271% -13.153% -10.152%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
Pricegraph::estimate_limit_price/1000000000000000000                                                                             
                        time:   [57.415 us 57.487 us 57.573 us]
                        change: [-8.3413% -6.9433% -5.7976%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  2 (2.00%) high mild
  13 (13.00%) high severe
Pricegraph::estimate_limit_price/10000000000000000000                                                                            
                        time:   [117.59 us 118.09 us 118.63 us]
                        change: [-3.5470% -1.2446% +0.7880%] (p = 0.29 > 0.05)
                        No change in performance detected.
Found 15 outliers among 100 measurements (15.00%)
  11 (11.00%) low severe
  1 (1.00%) high mild
  3 (3.00%) high severe
Pricegraph::estimate_limit_price/100000000000000000000                                                                            
                        time:   [215.75 us 216.30 us 217.25 us]
                        change: [-8.9916% -8.1519% -7.3956%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) high mild
  9 (9.00%) high severe
Pricegraph::estimate_limit_price/1000000000000000000000                                                                            
                        time:   [573.01 us 573.86 us 574.77 us]
                        change: [-10.082% -7.8667% -5.6236%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild

Pricegraph::order_for_limit_price/200                                                                             
                        time:   [49.420 us 49.463 us 49.517 us]
                        change: [-11.154% -9.7598% -8.4945%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) high mild
  9 (9.00%) high severe
Pricegraph::order_for_limit_price/190                                                                            
                        time:   [147.28 us 147.81 us 148.66 us]
                        change: [-1.9594% -0.6766% +0.5309%] (p = 0.30 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  4 (4.00%) high severe
Pricegraph::order_for_limit_price/180                                                                            
                        time:   [252.07 us 253.42 us 255.20 us]
                        change: [+1.3814% +1.8331% +2.4366%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 21 outliers among 100 measurements (21.00%)
  1 (1.00%) low mild
  9 (9.00%) high mild
  11 (11.00%) high severe
Pricegraph::order_for_limit_price/150                                                                            
                        time:   [547.37 us 547.84 us 548.42 us]
                        change: [-4.3717% -2.6473% -0.9427%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe
Pricegraph::order_for_limit_price/100                                                                            
                        time:   [610.88 us 611.83 us 613.14 us]
                        change: [-1.0885% +1.0080% +3.1165%] (p = 0.35 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  4 (4.00%) high severe

```

</details>