### PR TITLE
Record a metric for when the solver ran out of time

### DIFF
--- a/services-core/src/metrics/solver_metrics.rs
+++ b/services-core/src/metrics/solver_metrics.rs
@@ -1,6 +1,6 @@
-use prometheus::{Gauge, Registry, IntCounter};
+use prometheus::{Gauge, IntCounter, Registry};
 use serde::Deserialize;
-use serde_json::{Number, Value, json};
+use serde_json::{json, Number, Value};
 use std::{collections::HashMap, sync::Arc};
 
 /// This struct deserializes the metrics part of the solver generated solution json file.
@@ -52,7 +52,11 @@ impl SolverMetrics {
             gauge
         };
 
-        let interrupted = IntCounter::new("dfusion_solver_interrupted", "Increments when solving ran out of time").unwrap();
+        let interrupted = IntCounter::new(
+            "dfusion_solver_interrupted",
+            "Increments when solving ran out of time",
+        )
+        .unwrap();
         registry.register(Box::new(interrupted.clone())).unwrap();
 
         macro_rules! create {

--- a/services-core/src/metrics/solver_metrics.rs
+++ b/services-core/src/metrics/solver_metrics.rs
@@ -117,7 +117,7 @@ impl SolverMetrics {
         self.obj_val.set(f64_or_0(&stats.solver, "obj_val"));
         self.obj_val_sc.set(f64_or_0(&stats.solver, "obj_val_sc"));
 
-        if stats.solver.get("termination_condition") == Some(&json!("interrupted")) {
+        if stats.solver.get("exit_status") == Some(&json!("interrupted")) {
             self.interrupted.inc();
         }
     }

--- a/services-core/src/metrics/solver_metrics.rs
+++ b/services-core/src/metrics/solver_metrics.rs
@@ -1,6 +1,6 @@
-use prometheus::{Gauge, Registry};
+use prometheus::{Gauge, Registry, IntCounter};
 use serde::Deserialize;
-use serde_json::{Number, Value};
+use serde_json::{Number, Value, json};
 use std::{collections::HashMap, sync::Arc};
 
 /// This struct deserializes the metrics part of the solver generated solution json file.
@@ -36,6 +36,7 @@ pub struct SolverMetrics {
     optimality_gap: Gauge,
     obj_val: Gauge,
     obj_val_sc: Gauge,
+    interrupted: IntCounter,
 }
 
 impl SolverMetrics {
@@ -51,12 +52,16 @@ impl SolverMetrics {
             gauge
         };
 
+        let interrupted = IntCounter::new("dfusion_solver_interrupted", "Increments when solving ran out of time").unwrap();
+        registry.register(Box::new(interrupted.clone())).unwrap();
+
         macro_rules! create {
             ($($name:ident),*) => {
                 Self {
                     $(
                         $name: make_gauge(stringify!($name))
-                    ),*
+                    ),*,
+                    interrupted,
                 }
             };
         }
@@ -111,6 +116,10 @@ impl SolverMetrics {
             .set(f64_or_0(&stats.solver, "optimality_gap"));
         self.obj_val.set(f64_or_0(&stats.solver, "obj_val"));
         self.obj_val_sc.set(f64_or_0(&stats.solver, "obj_val_sc"));
+
+        if stats.solver.get("termination_condition") == Some(&json!("interrupted")) {
+            self.interrupted.inc();
+        }
     }
 }
 


### PR DESCRIPTION
This will help us to measure one of our goals ("Batches with non trivial solutions in which Standard Solver (using Gurobi), Best Ring Solver (using SCIP) and Open Solver finish without interruption before time limit").

At the moment this could be inferred by the optimality gap (close to 0 meaning solved to optimality, but it's not entirely clear what the right threshold is, therefore I think it's easy enough to add this metric as an explicit counter.

Here is an example instance that was interrupted because it ran out of time: https://gnosis-dev-dfusion.s3.amazonaws.com/data/rinkeby_dev/standard-solver/results/2020-10-04/instance_5339384_2020-10-04T12%3A45%3A30.550230225%2B00%3A00/06_solution_int_valid.json

### Test Plan

Run:

```
cargo run --bin driver -- --node-url https://staging-openethereum.mainnet.gnosisdev.com  --rpc-timeout 60000 --orderbook-file target/orderbook_mainnet.bin --private-key c87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3 --solver-type StandardSolver  --latest-solution-submit-time 70 --scheduler SYSTEM
```

to have the SCIP solver run with minimal time (causing an interrupt). Then check `http://localhost:9586/metrics`
Observe

`dfusion_solver_interrupted 1`