### PR TITLE
Fix warnings for new rust version

### DIFF
--- a/pricegraph/src/orderbook/scalar.rs
+++ b/pricegraph/src/orderbook/scalar.rs
@@ -12,7 +12,7 @@ use std::{cmp, ops};
 /// and **never equal to** the limit price of an order.
 ///
 /// Prices are guaranteed to be a strictly positive finite real numbers.
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LimitPrice(f64);
 
 impl LimitPrice {
@@ -63,7 +63,7 @@ impl LimitPrice {
 /// rate for an order.
 ///
 /// Exchange rates are guaranteed to be a strictly positive finite real numbers.
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ExchangeRate(f64);
 
 impl ExchangeRate {
@@ -109,6 +109,12 @@ impl ExchangeRate {
 macro_rules! impl_cmp {
     ($($t:ty),*) => {$(
         impl Eq for $t {}
+
+        impl PartialOrd for $t {
+            fn partial_cmp(&self, rhs: &Self) -> Option<cmp::Ordering> {
+                self.0.partial_cmp(&rhs.0)
+            }
+        }
 
         impl Ord for $t {
             fn cmp(&self, rhs: &Self) -> cmp::Ordering {

--- a/services-core/src/contracts/stablex_contract/search_batches.rs
+++ b/services-core/src/contracts/stablex_contract/search_batches.rs
@@ -113,10 +113,7 @@ pub mod tests {
         let mut mock_batch_id_retrieving = MockBatchIdRetrieving::new();
         mock_batch_id_retrieving
             .expect_batch_id_from_block()
-            .withf(|block_number: &BlockNumber| match block_number {
-                BlockNumber::Number(_) => true,
-                _ => false,
-            })
+            .withf(|block_number: &BlockNumber| matches!(block_number, BlockNumber::Number(_)))
             .returning({
                 let batch_ids = batch_ids.clone();
                 move |block_number: BlockNumber| {


### PR DESCRIPTION
Yesterday there was a no rust version release which introduced two
warnings our code.
In scalar.rs we got https://rust-lang.github.io/rust-clippy/master/index.html#derive_ord_xor_partial_ord
and in search_batches we use `matches!` instead of `match`.

### Test Plan
CI