### PR TITLE
Bump private solver to v0.8.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ language: rust
 env:
   global:
     - OPEN_SOLVER_VERSION=v0.1.1
-    - PRIVATE_SOLVER_VERSION=v0.8.4
+    - PRIVATE_SOLVER_VERSION=v0.8.5
 
 jobs:
   fast_finish: true


### PR DESCRIPTION
Includes a small fix by @marcovc to the handling of timeouts: https://github.com/gnosis/dex-solver/pull/335