### PR TITLE
Add flag to ignore external price sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ OPTIONS:
             and exchange REST APIs for fetching price estimates [env: HTTP_TIMEOUT=]  [default: 10000]
         --ignore-external-price-source <ignore-external-price-source>
             Whether to ignore external price sources (e.g. 1Inch, Kraken etc) when estimating token prices [env:
-            IGNORE_EXTERNAL_PRICE_SOURCE=]
+            IGNORE_EXTERNAL_PRICE_SOURCE=true]  [default: false]
         --latest-solution-submit-time <latest-solution-submit-time>
             The offset from the start of the batch to cap the solver's execution time [env:
             LATEST_SOLUTION_SUBMIT_TIME=]  [default: 210]

--- a/README.md
+++ b/README.md
@@ -168,9 +168,6 @@ OPTIONS:
         --http-timeout <http-timeout>
             The default timeout in milliseconds of HTTP requests to remote services such as the Gnosis Safe gas station
             and exchange REST APIs for fetching price estimates [env: HTTP_TIMEOUT=]  [default: 10000]
-        --ignore-external-price-source <ignore-external-price-source>
-            Whether to ignore external price sources (e.g. 1Inch, Kraken etc) when estimating token prices [env:
-            IGNORE_EXTERNAL_PRICE_SOURCE=true]  [default: false]
         --latest-solution-submit-time <latest-solution-submit-time>
             The offset from the start of the batch to cap the solver's execution time [env:
             LATEST_SOLUTION_SUBMIT_TIME=]  [default: 210]
@@ -225,6 +222,9 @@ OPTIONS:
             "decimals": 18, "externalPrice": 200000000000000000000, }, "T0004": { "address":
             "0x0000000000000000000000000000000000000000", "alias": "USDC", "decimals": 6, "externalPrice":
             1000000000000000000000000000000, } }' [env: TOKEN_DATA=]  [default: {}]
+        --use-external-price-source <use-external-price-source>
+            Whether to rely on external price sources (e.g. 1Inch, Kraken etc) when estimating token prices [env:
+            USE_EXTERNAL_PRICE_SOURCE=]  [default: true]
 ```
 
 ### Orderbook Filter Example

--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ OPTIONS:
         --http-timeout <http-timeout>
             The default timeout in milliseconds of HTTP requests to remote services such as the Gnosis Safe gas station
             and exchange REST APIs for fetching price estimates [env: HTTP_TIMEOUT=]  [default: 10000]
+        --ignore-external-price-source <ignore-external-price-source>
+            Whether to ignore external price sources (e.g. 1Inch, Kraken etc) when estimating token prices [env:
+            IGNORE_EXTERNAL_PRICE_SOURCE=]
         --latest-solution-submit-time <latest-solution-submit-time>
             The offset from the start of the batch to cap the solver's execution time [env:
             LATEST_SOLUTION_SUBMIT_TIME=]  [default: 210]

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -242,7 +242,7 @@ struct Options {
 
     /// Whether to ignore external price sources (e.g. 1Inch, Kraken etc)
     /// when estimating token prices
-    #[structopt(long, env="IGNORE_EXTERNAL_PRICE_SOURCE")]
+    #[structopt(long, env="IGNORE_EXTERNAL_PRICE_SOURCE", parse(try_from_str), default_value="false")]
     ignore_external_price_source: bool,
 }
 

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -239,6 +239,11 @@ struct Options {
     /// target chain (e.g. WETH on mainnet, DAI on xDAI).
     #[structopt(long, env = "NATIVE_TOKEN_ID", default_value = "1")]
     native_token_id: u16,
+
+    /// Whether to ignore external price sources (e.g. 1Inch, Kraken etc)
+    /// when estimating token prices
+    #[structopt(long, env="IGNORE_EXTERNAL_PRICE_SOURCE")]
+    ignore_external_price_source: bool,
 }
 
 fn main() {
@@ -281,6 +286,7 @@ fn main() {
             options.token_data,
             options.price_source_update_interval,
             options.native_token_id.into(),
+            options.ignore_external_price_source,
         )
         .unwrap(),
     );

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -240,10 +240,10 @@ struct Options {
     #[structopt(long, env = "NATIVE_TOKEN_ID", default_value = "1")]
     native_token_id: u16,
 
-    /// Whether to ignore external price sources (e.g. 1Inch, Kraken etc)
+    /// Whether to rely on external price sources (e.g. 1Inch, Kraken etc)
     /// when estimating token prices
-    #[structopt(long, env="IGNORE_EXTERNAL_PRICE_SOURCE", parse(try_from_str), default_value="false")]
-    ignore_external_price_source: bool,
+    #[structopt(long, env="USE_EXTERNAL_PRICE_SOURCE", parse(try_from_str), default_value="true")]
+    use_external_price_source: bool,
 }
 
 fn main() {
@@ -286,7 +286,7 @@ fn main() {
             options.token_data,
             options.price_source_update_interval,
             options.native_token_id.into(),
-            options.ignore_external_price_source,
+            options.use_external_price_source,
         )
         .unwrap(),
     );

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -242,7 +242,12 @@ struct Options {
 
     /// Whether to rely on external price sources (e.g. 1Inch, Kraken etc)
     /// when estimating token prices
-    #[structopt(long, env="USE_EXTERNAL_PRICE_SOURCE", parse(try_from_str), default_value="true")]
+    #[structopt(
+        long,
+        env = "USE_EXTERNAL_PRICE_SOURCE",
+        parse(try_from_str),
+        default_value = "true"
+    )]
     use_external_price_source: bool,
 }
 

--- a/services-core/src/price_estimation.rs
+++ b/services-core/src/price_estimation.rs
@@ -68,12 +68,12 @@ impl PriceOracle {
         token_data: TokenData,
         update_interval: Duration,
         native_token: TokenId,
-        ignore_external_price_source: bool,
+        use_external_price_source: bool,
     ) -> Result<Self> {
         let cache: HashMap<_, _> = token_data.clone().into();
         let token_info_fetcher = Arc::new(TokenInfoCache::with_cache(contract, cache));
         let mut price_sources: Vec<Box<dyn PriceSource + Send + Sync>> = vec![Box::new(PricegraphEstimator::new(orderbook_reader))];
-        if !ignore_external_price_source {
+        if use_external_price_source {
             price_sources.extend(external_price_sources(http_factory, token_info_fetcher.clone(), update_interval)?);
         }
         let averaged_source = Box::new(AveragePriceSource::new(price_sources));

--- a/services-core/src/price_estimation.rs
+++ b/services-core/src/price_estimation.rs
@@ -68,12 +68,14 @@ impl PriceOracle {
         token_data: TokenData,
         update_interval: Duration,
         native_token: TokenId,
+        ignore_external_price_source: bool,
     ) -> Result<Self> {
         let cache: HashMap<_, _> = token_data.clone().into();
         let token_info_fetcher = Arc::new(TokenInfoCache::with_cache(contract, cache));
-        let mut price_sources =
-            external_price_sources(http_factory, token_info_fetcher.clone(), update_interval)?;
-        price_sources.push(Box::new(PricegraphEstimator::new(orderbook_reader)));
+        let mut price_sources: Vec<Box<dyn PriceSource + Send + Sync>> = vec![Box::new(PricegraphEstimator::new(orderbook_reader))];
+        if !ignore_external_price_source {
+            price_sources.extend(external_price_sources(http_factory, token_info_fetcher.clone(), update_interval)?);
+        }
         let averaged_source = Box::new(AveragePriceSource::new(price_sources));
         let prioritized_source = Box::new(PriorityPriceSource::new(vec![
             Box::new(token_data),

--- a/services-core/src/price_estimation.rs
+++ b/services-core/src/price_estimation.rs
@@ -72,9 +72,14 @@ impl PriceOracle {
     ) -> Result<Self> {
         let cache: HashMap<_, _> = token_data.clone().into();
         let token_info_fetcher = Arc::new(TokenInfoCache::with_cache(contract, cache));
-        let mut price_sources: Vec<Box<dyn PriceSource + Send + Sync>> = vec![Box::new(PricegraphEstimator::new(orderbook_reader))];
+        let mut price_sources: Vec<Box<dyn PriceSource + Send + Sync>> =
+            vec![Box::new(PricegraphEstimator::new(orderbook_reader))];
         if use_external_price_source {
-            price_sources.extend(external_price_sources(http_factory, token_info_fetcher.clone(), update_interval)?);
+            price_sources.extend(external_price_sources(
+                http_factory,
+                token_info_fetcher.clone(),
+                update_interval,
+            )?);
         }
         let averaged_source = Box::new(AveragePriceSource::new(price_sources));
         let prioritized_source = Box::new(PriorityPriceSource::new(vec![


### PR DESCRIPTION
On rinkeby we occasionally see negative utility solutions which lead to a subtraction overflow (cf. https://github.com/gnosis/dex-solver/issues/325)

The assumption is that external price estimates are too far off the weird prices we might see on an economically not incentivised test net like rinkeby. Therefore the plan is to ignore these external source on rinkeby going forward.

### Test Plan

```bash
cargo run --bin driver -- --node-url https://xdai.poanetwork.dev  --rpc-timeout 60000 --orderbook-file target/orderbook_xdai.bin --private-key c87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3 --solver-type opensolver --native-token-id 0 --log-filter "warn,driver=info,services_core=info,services_core::price_estimation=debg" --ignore-external-price-source true
```

See no log entries coming from `price_estimation::clients::generic_client`