### PR TITLE
Add mix of dynamic and static economic viability strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,10 @@ USAGE:
     driver [OPTIONS] --node-url <node-url> --private-key <private-key>
 
 FLAGS:
-    -h, --help       
+    -h, --help
             Prints help information
 
-    -V, --version    
+    -V, --version
             Prints version information
 
 
@@ -153,9 +153,12 @@ OPTIONS:
             slightly between solution computation and submission [env: ECONOMIC_VIABILITY_MIN_AVG_FEE_FACTOR=]
             [default: 1.1]
         --economic-viability-strategy <economic-viability-strategy>
-            How to calculate the economic viability constraints. `Dynamic` means that current native token price is
-            taken into account while `Static` means that fallback_min_avg_fee_per_order and fallback_max_gas_price will
-            always be used [env: ECONOMIC_VIABILITY_STRATEGY=]  [default: Dynamic]  [possible values: Dynamic, Static]
+            How to calculate the economic viability constraints. `Static`: Use fallback_min_avg_fee_per_order and
+            fallback_max_gas_price. `Dynamic`: Use current native token price, gas price and subsidy factor. Use Static
+            if cannot get prices. `DynamicBoundedByStatic`: Use Dynamic first. If it fails or the result is worse
+            (larger min-avg-fee, lower max-gas-price) than Static, use Static instead [env:
+            ECONOMIC_VIABILITY_STRATEGY=]  [default: Dynamic]  [possible values: Static, Dynamic,
+            DynamicBoundedByStatic]
         --economic-viability-subsidy-factor <economic-viability-subsidy-factor>
             Subsidy factor used to compute the minimum average fee per order in a solution as well as the gas cap for
             economically viable solution [env: ECONOMIC_VIABILITY_SUBSIDY_FACTOR=]  [default: 10.0]
@@ -173,7 +176,7 @@ OPTIONS:
             LATEST_SOLUTION_SUBMIT_TIME=]  [default: 210]
         --log-filter <log-filter>
             The log filter to use.
-            
+
             This follows the `slog-envlogger` syntax (e.g. 'info,driver=debug'). [env: LOG_FILTER=]  [default:
             warn,driver=info,services_core=info]
         --native-token-id <native-token-id>
@@ -187,7 +190,7 @@ OPTIONS:
             ORDERBOOK_FILE=]
         --orderbook-filter <orderbook-filter>
             JSON encoded object of which tokens/orders to ignore.
-            
+
             For example: '{ "tokens": {"Whitelist": [1, 2]}, "users": { "0x7b60655Ca240AC6c76dD29c13C45BEd969Ee6F0A": {
             "OrderIds": [0, 1] }, "0x7b60655Ca240AC6c76dD29c13C45BEd969Ee6F0B": "All" } }' More examples can be found in
             the tests of orderbook/filtered_orderboook.rs [env: ORDERBOOK_FILTER=]  [default: {}]
@@ -217,7 +220,7 @@ OPTIONS:
             TARGET_START_SOLVE_TIME=]  [default: 30]
         --token-data <token-data>
             JSON encoded backup token information to provide to the solver.
-            
+
             For example: '{ "T0001": { "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "alias": "WETH",
             "decimals": 18, "externalPrice": 200000000000000000000, }, "T0004": { "address":
             "0x0000000000000000000000000000000000000000", "alias": "USDC", "decimals": 6, "externalPrice":

--- a/price-estimator/src/main.rs
+++ b/price-estimator/src/main.rs
@@ -192,14 +192,14 @@ fn main() {
     let _ = orderbook.update().wait();
     log::info!("Orderbook initialized.");
 
-    let economic_viability = Arc::new(options.economic_viability_strategy.from_arguments(
+    let economic_viability = options.economic_viability_strategy.from_arguments(
         options.economic_viability_subsidy_factor,
         options.economic_viability_min_avg_fee_factor,
         options.fallback_min_avg_fee_per_order,
         options.fallback_max_gas_price,
         orderbook.clone(),
         gas_station.clone(),
-    ));
+    );
 
     let mut runtime = runtime::Builder::new()
         .threaded_scheduler()

--- a/services-core/src/driver/stablex_driver.rs
+++ b/services-core/src/driver/stablex_driver.rs
@@ -35,7 +35,7 @@ pub struct StableXDriverImpl {
     price_finder: Arc<dyn PriceFinding + Send + Sync>,
     orderbook_reader: Arc<dyn StableXOrderBookReading>,
     solution_submitter: Arc<dyn StableXSolutionSubmitting + Send + Sync>,
-    economic_viability: Arc<dyn EconomicViabilityComputing + Send + Sync>,
+    economic_viability: Arc<dyn EconomicViabilityComputing>,
     metrics: Arc<StableXMetrics>,
 }
 
@@ -44,7 +44,7 @@ impl StableXDriverImpl {
         price_finder: Arc<dyn PriceFinding + Send + Sync>,
         orderbook_reader: Arc<dyn StableXOrderBookReading>,
         solution_submitter: Arc<dyn StableXSolutionSubmitting + Send + Sync>,
-        economic_viability: Arc<dyn EconomicViabilityComputing + Send + Sync>,
+        economic_viability: Arc<dyn EconomicViabilityComputing>,
         metrics: Arc<StableXMetrics>,
     ) -> Self {
         Self {

--- a/services-core/src/models/solution.rs
+++ b/services-core/src/models/solution.rs
@@ -18,7 +18,7 @@ pub struct Solution {
     pub executed_orders: Vec<ExecutedOrder>,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct EconomicViabilityInfo {
     pub num_executed_orders: usize,
     pub earned_fee: U256,


### PR DESCRIPTION
called DynamicBoundedByStatic: Use Dynamic first. If it fails or the
result is worse (larger min-avg-fee, lower max-gas-price) than Static,
use Static instead.

This is useful because for ease of use we want to guarantee a minimum
viable order size but still lower it when this is economically viable
because of low gas price.

Note that this doesn't affect our running solvers until we switch them to the new strategy.

### Test Plan
New unit tests