### PR TITLE
Give more control over economic viability computation

### DIFF
--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -310,7 +310,6 @@ fn main() {
         Some(Fee::default()),
         options.solver_type,
         price_oracle,
-        economic_viability.clone(),
         options.solver_internal_optimizer,
         solver_metrics,
         stablex_metrics.clone(),

--- a/services-core/src/driver/stablex_driver.rs
+++ b/services-core/src/driver/stablex_driver.rs
@@ -77,9 +77,10 @@ impl StableXDriverImpl {
             info!("No orders in batch {}", batch_to_solve);
             return Ok(Solution::trivial());
         }
+        let min_avg_fee = self.economic_viability.min_average_fee().await?;
         let price_finder_result = self
             .price_finder
-            .find_prices(&orders, &account_state, deadline)
+            .find_prices(&orders, &account_state, deadline, min_avg_fee)
             .await;
         self.metrics
             .auction_solution_computed(batch_to_solve.into(), &price_finder_result);
@@ -237,7 +238,7 @@ mod tests {
         let submitter = MockStableXSolutionSubmitting::default();
         let mut pf = MockPriceFinding::default();
         let economic_viability =
-            Arc::new(FixedEconomicViabilityComputer::new(None, Some(0.into())));
+            Arc::new(FixedEconomicViabilityComputer::new(Some(0), Some(0.into())));
         let metrics = StableXMetrics::default();
 
         let orders = vec![create_order_for_test(), create_order_for_test()];
@@ -262,10 +263,10 @@ mod tests {
             ],
         };
         pf.expect_find_prices()
-            .withf(move |o, s, t| {
+            .withf(move |o, s, t, _| {
                 o == orders.as_slice() && *s == state && *t <= latest_solution_submit_time
             })
-            .return_once(move |_, _, _| Ok(solution));
+            .return_once(move |_, _, _, _| Ok(solution));
 
         let driver = StableXDriverImpl::new(
             Arc::new(pf),
@@ -316,7 +317,7 @@ mod tests {
         let submitter = MockStableXSolutionSubmitting::default();
         let mut pf = MockPriceFinding::default();
         let economic_viability =
-            Arc::new(FixedEconomicViabilityComputer::new(None, Some(0.into())));
+            Arc::new(FixedEconomicViabilityComputer::new(Some(0), Some(0.into())));
         let metrics = StableXMetrics::default();
 
         let orders = vec![create_order_for_test(), create_order_for_test()];
@@ -331,7 +332,7 @@ mod tests {
             .return_once(|_| Ok((state, orders)));
 
         pf.expect_find_prices()
-            .returning(|_, _, _| Err(anyhow!("Error")));
+            .returning(|_, _, _, _| Err(anyhow!("Error")));
 
         let driver = StableXDriverImpl::new(
             Arc::new(pf),

--- a/services-core/src/price_finding.rs
+++ b/services-core/src/price_finding.rs
@@ -8,7 +8,6 @@ pub use self::{
     price_finder_interface::{Fee, InternalOptimizer, PriceFinding, SolverType},
 };
 use crate::{
-    economic_viability::EconomicViabilityComputing,
     metrics::{SolverMetrics, StableXMetrics},
     price_estimation::PriceEstimating,
 };
@@ -19,7 +18,6 @@ pub fn create_price_finder(
     fee: Option<Fee>,
     solver_type: SolverType,
     price_oracle: Arc<dyn PriceEstimating + Send + Sync>,
-    min_avg_fee: Arc<dyn EconomicViabilityComputing>,
     internal_optimizer: InternalOptimizer,
     solver_metrics: SolverMetrics,
     stablex_metrics: Arc<StableXMetrics>,
@@ -33,7 +31,6 @@ pub fn create_price_finder(
             fee,
             solver_type,
             price_oracle,
-            min_avg_fee,
             internal_optimizer,
             solver_metrics,
             stablex_metrics,

--- a/services-core/src/price_finding/naive_solver.rs
+++ b/services-core/src/price_finding/naive_solver.rs
@@ -129,6 +129,7 @@ impl PriceFinding for NaiveSolver {
         orders: &[Order],
         state: &AccountState,
         _: Duration,
+        _: u128,
     ) -> Result<Solution> {
         // Convert orders into the form where they have remaining == denominator.
         let orders = orders
@@ -345,7 +346,7 @@ pub mod tests {
 
         let solver = NaiveSolver::new(None);
         let res = solver
-            .find_prices(&orders, &state, Duration::default())
+            .find_prices(&orders, &state, Duration::default(), 0)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -374,7 +375,7 @@ pub mod tests {
 
         let solver = NaiveSolver::new(fee.clone());
         let res = solver
-            .find_prices(&orders, &state, Duration::default())
+            .find_prices(&orders, &state, Duration::default(), 0)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -389,7 +390,7 @@ pub mod tests {
 
         let solver = NaiveSolver::new(None);
         let res = solver
-            .find_prices(&orders, &state, Duration::default())
+            .find_prices(&orders, &state, Duration::default(), 0)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -419,7 +420,7 @@ pub mod tests {
 
         let solver = NaiveSolver::new(fee.clone());
         let res = solver
-            .find_prices(&orders, &state, Duration::default())
+            .find_prices(&orders, &state, Duration::default(), 0)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -433,7 +434,7 @@ pub mod tests {
 
         let solver = NaiveSolver::new(None);
         let res = solver
-            .find_prices(&orders, &state, Duration::default())
+            .find_prices(&orders, &state, Duration::default(), 0)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -461,7 +462,7 @@ pub mod tests {
         });
         let solver = NaiveSolver::new(fee.clone());
         let res = solver
-            .find_prices(&orders, &state, Duration::default())
+            .find_prices(&orders, &state, Duration::default(), 0)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -542,7 +543,7 @@ pub mod tests {
 
         let solver = NaiveSolver::new(None);
         let res = solver
-            .find_prices(&orders, &state, Duration::default())
+            .find_prices(&orders, &state, Duration::default(), 0)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -591,7 +592,7 @@ pub mod tests {
 
         let solver = NaiveSolver::new(None);
         let res = solver
-            .find_prices(&orders, &state, Duration::default())
+            .find_prices(&orders, &state, Duration::default(), 0)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -628,7 +629,7 @@ pub mod tests {
 
         let solver = NaiveSolver::new(None);
         let res = solver
-            .find_prices(&orders, &state, Duration::default())
+            .find_prices(&orders, &state, Duration::default(), 0)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -669,7 +670,7 @@ pub mod tests {
         });
         let solver = NaiveSolver::new(fee.clone());
         let res = solver
-            .find_prices(&orders, &state, Duration::default())
+            .find_prices(&orders, &state, Duration::default(), 0)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -727,7 +728,7 @@ pub mod tests {
         });
         let solver = NaiveSolver::new(fee.clone());
         let res = solver
-            .find_prices(&orders, &state, Duration::default())
+            .find_prices(&orders, &state, Duration::default(), 0)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -770,7 +771,7 @@ pub mod tests {
         });
         let solver = NaiveSolver::new(fee);
         let res = solver
-            .find_prices(&orders, &state, Duration::default())
+            .find_prices(&orders, &state, Duration::default(), 0)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -784,7 +785,7 @@ pub mod tests {
 
         let solver = NaiveSolver::new(None);
         let res = solver
-            .find_prices(&orders, &state, Duration::default())
+            .find_prices(&orders, &state, Duration::default(), 0)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -821,7 +822,7 @@ pub mod tests {
 
         let solver = NaiveSolver::new(None);
         let res = solver
-            .find_prices(&orders, &state, Duration::default())
+            .find_prices(&orders, &state, Duration::default(), 0)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -873,7 +874,7 @@ pub mod tests {
 
         let solver = NaiveSolver::new(fee.clone());
         let res = solver
-            .find_prices(&orders, &state, Duration::default())
+            .find_prices(&orders, &state, Duration::default(), 0)
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -936,7 +937,7 @@ pub mod tests {
 
         let solver = NaiveSolver::new(fee.clone());
         let res = solver
-            .find_prices(&orders, &state, Duration::default())
+            .find_prices(&orders, &state, Duration::default(), 0)
             .now_or_never()
             .unwrap()
             .unwrap();

--- a/services-core/src/price_finding/price_finder_interface.rs
+++ b/services-core/src/price_finding/price_finder_interface.rs
@@ -153,5 +153,6 @@ pub trait PriceFinding {
         orders: &[models::Order],
         state: &models::AccountState,
         time_limit: Duration,
+        min_avg_earned_fee: u128,
     ) -> Result<models::Solution>;
 }


### PR DESCRIPTION
Instead of storing an EconomicViabilityComputing in
OptimizationPriceFinder we pass the min_avg_fee directly in the
find_prices method.
This makes the price finding code simpler because it has to access one
les external interface and gives us more control over the economic
viability strategy in StableXDriver.
I plan on making use of to implement a new economic viability strategy
which is a mix of dynamic and static.

Related to #1479 

### Test Plan
Existing tests, no logic change