### PR TITLE
Fix PR CI being less strict than master CI

### DIFF
--- a/ci/setup_contracts.sh
+++ b/ci/setup_contracts.sh
@@ -3,4 +3,4 @@
 set -e
 
 docker-compose up -d ganache-cli
-(cd contracts; cargo run --bin deploy --features bin)
+(cd contracts; cargo run --locked --bin deploy --features bin)


### PR DESCRIPTION
To ensure that Cargo.lock is up to date we build with `--locked` on CI.
However the setup_contracts script which is run only for PRs but not for
master didn't have this flag which resulted in a PR being accepted into
master where Cargo.lock was not up to date.

https://github.com/gnosis/dex-services/pull/1482
https://github.com/gnosis/dex-services/pull/1485

### Test Plan
CI