### PR TITLE
Ignore trailing whitespace in readme diff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
         # Unit Tests and Linting
         - cargo test
         # Make sure README is up to date
-        - diff <(sed -n '/^driver /,/^```/p' README.md | head -n -1) <(cargo run --bin driver -- --help)
+        - diff --ignore-trailing-space <(sed -n '/^driver /,/^```/p' README.md | head -n -1) <(cargo run --bin driver -- --help)
         # Build image with compiled binary
         - docker build --tag stablex-binary-public --build-arg SOLVER_BASE=gnosispm/dex-open-solver:$OPEN_SOLVER_VERSION -f driver/docker/rust/Dockerfile .
         # StableX e2e Tests (Ganache) - open solver

--- a/README.md
+++ b/README.md
@@ -131,10 +131,10 @@ USAGE:
     driver [OPTIONS] --node-url <node-url> --private-key <private-key>
 
 FLAGS:
-    -h, --help       
+    -h, --help
             Prints help information
 
-    -V, --version    
+    -V, --version
             Prints version information
 
 
@@ -167,7 +167,7 @@ OPTIONS:
             LATEST_SOLUTION_SUBMIT_TIME=]  [default: 210]
         --log-filter <log-filter>
             The log filter to use.
-            
+
             This follows the `slog-envlogger` syntax (e.g. 'info,driver=debug'). [env: LOG_FILTER=]  [default:
             warn,driver=info,services_core=info]
         --native-token-id <native-token-id>
@@ -181,7 +181,7 @@ OPTIONS:
             ORDERBOOK_FILE=]
         --orderbook-filter <orderbook-filter>
             JSON encoded object of which tokens/orders to ignore.
-            
+
             For example: '{ "tokens": {"Whitelist": [1, 2]}, "users": { "0x7b60655Ca240AC6c76dD29c13C45BEd969Ee6F0A": {
             "OrderIds": [0, 1] }, "0x7b60655Ca240AC6c76dD29c13C45BEd969Ee6F0B": "All" } }' More examples can be found in
             the tests of orderbook/filtered_orderboook.rs [env: ORDERBOOK_FILTER=]  [default: {}]
@@ -217,7 +217,7 @@ OPTIONS:
             TARGET_START_SOLVE_TIME=]  [default: 30]
         --token-data <token-data>
             JSON encoded backup token information to provide to the solver.
-            
+
             For example: '{ "T0001": { "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "alias": "WETH",
             "decimals": 18, "externalPrice": 200000000000000000000, }, "T0004": { "address":
             "0x0000000000000000000000000000000000000000", "alias": "USDC", "decimals": 6, "externalPrice":


### PR DESCRIPTION
`cargo run --help` prints some trailing whitespaces. We don't need to
have them in the readme but our check that the readme is up to date
considers them, which is fixed with this commit.


### Test Plan
No code change