### PR TITLE
Calculate gas limit based on number of trades

### DIFF
--- a/services-core/src/contracts/stablex_contract.rs
+++ b/services-core/src/contracts/stablex_contract.rs
@@ -136,6 +136,7 @@ pub trait StableXContract: Send + Sync {
         claimed_objective_value: U256,
         gas_price: U256,
         nonce: U256,
+        gas_limit: U256,
     ) -> BoxFuture<'a, Result<(), MethodError>>;
 
     async fn past_events(
@@ -260,6 +261,7 @@ impl StableXContract for StableXContractImpl {
         claimed_objective_value: U256,
         gas_price: U256,
         nonce: U256,
+        gas_limit: U256,
     ) -> BoxFuture<'a, Result<(), MethodError>> {
         async move {
             let (prices, token_ids_for_price) = encode_prices_for_contract(&solution.prices);
@@ -277,10 +279,7 @@ impl StableXContract for StableXContractImpl {
                     token_ids_for_price,
                 )
                 .gas_price(GasPrice::Value(gas_price))
-                // NOTE: Gas estimate might be off, as we race with other solution
-                //   submissions and thus might have to revert trades which costs
-                //   more gas than expected.
-                .gas(6_000_000.into())
+                .gas(gas_limit)
                 .nonce(nonce);
             method.tx.resolve = Some(ResolveCondition::Confirmed(ConfirmParams::mined()));
             method.send().await.map(|_| ())

--- a/services-core/src/economic_viability.rs
+++ b/services-core/src/economic_viability.rs
@@ -1,14 +1,13 @@
 //! Module implementing minimum average fee computation based on reference token
 //! price estimates.
 
-use crate::{gas_price::GasPriceEstimating, models::solution::EconomicViabilityInfo};
+use crate::{
+    gas_price::GasPriceEstimating,
+    models::solution::{EconomicViabilityInfo, GAS_PER_TRADE},
+};
 use anyhow::{anyhow, Context as _, Result};
 use ethcontract::U256;
 use std::{num::NonZeroU128, sync::Arc};
-
-/// The approximate amount of gas used in a solution per trade. In practice the value depends on how
-/// much gas is used in the reversion of the previous solution.
-const GAS_PER_TRADE: f64 = 120_000.0;
 
 arg_enum! {
     #[derive(Debug)]
@@ -159,13 +158,13 @@ impl EconomicViabilityComputing for EconomicViabilityComputer {
 fn min_average_fee(native_token_price: f64, gas_price: f64) -> f64 {
     let owl_per_eth = native_token_price / 1e18;
     let gas_price_in_owl = owl_per_eth * gas_price;
-    GAS_PER_TRADE * gas_price_in_owl
+    GAS_PER_TRADE as f64 * gas_price_in_owl
 }
 
 /// The gas price cap is selected so that submitting solution is still roughly profitable.
 fn gas_price_cap(native_token_price: f64, earned_fee: f64, num_trades: usize) -> f64 {
     let owl_per_eth = native_token_price / 1e18;
-    let gas_use = GAS_PER_TRADE * (num_trades as f64);
+    let gas_use = GAS_PER_TRADE as f64 * (num_trades as f64);
     earned_fee / (owl_per_eth * gas_use)
 }
 

--- a/services-core/src/models/solution.rs
+++ b/services-core/src/models/solution.rs
@@ -24,9 +24,19 @@ pub struct EconomicViabilityInfo {
     pub earned_fee: U256,
 }
 
-/// The approximate amount of gas used in a solution per trade. In practice the value depends on how
-/// much gas is used in the reversion of the previous solution.
-pub const GAS_PER_TRADE: u32 = 120_000;
+/// The approximate amount of gas used to per trade in a solution or solution reversion.
+pub const GAS_PER_TRADE: u32 = 100_000;
+
+pub fn gas_use(
+    number_of_trades_in_solution: usize,
+    include_reversion_of_previous_solution_with_same_number_of_trades: bool,
+) -> U256 {
+    let mut result = U256::from(number_of_trades_in_solution) * U256::from(GAS_PER_TRADE);
+    if include_reversion_of_previous_solution_with_same_number_of_trades {
+        result *= 2;
+    }
+    result
+}
 
 impl Solution {
     pub fn trivial() -> Self {
@@ -61,10 +71,6 @@ impl Solution {
         }
         token_imbalance /= 2;
         bigint_u256::bigint_to_u256_saturating(&token_imbalance)
-    }
-
-    pub fn gas_limit(&self) -> U256 {
-        U256::from(self.executed_orders.len() * GAS_PER_TRADE as usize)
     }
 }
 

--- a/services-core/src/models/solution.rs
+++ b/services-core/src/models/solution.rs
@@ -24,6 +24,10 @@ pub struct EconomicViabilityInfo {
     pub earned_fee: U256,
 }
 
+/// The approximate amount of gas used in a solution per trade. In practice the value depends on how
+/// much gas is used in the reversion of the previous solution.
+pub const GAS_PER_TRADE: u32 = 120_000;
+
 impl Solution {
     pub fn trivial() -> Self {
         Solution {
@@ -57,6 +61,10 @@ impl Solution {
         }
         token_imbalance /= 2;
         bigint_u256::bigint_to_u256_saturating(&token_imbalance)
+    }
+
+    pub fn gas_limit(&self) -> U256 {
+        U256::from(self.executed_orders.len() * GAS_PER_TRADE as usize)
     }
 }
 

--- a/services-core/src/solution_submission.rs
+++ b/services-core/src/solution_submission.rs
@@ -227,6 +227,7 @@ impl<'a> StableXSolutionSubmitting for StableXSolutionSubmitter<'a> {
             claimed_objective_value,
             gas_price_cap,
             nonce,
+            gas_limit: solution.gas_limit(),
         });
         let cancel_future =
             self.cancel_transaction_after_deadline(batch_index, nonce, gas_price_cap);


### PR DESCRIPTION
instead of setting it to a fixed 6 million. This could mean faster
transaction confirmation as miners might be more likely to include a
transaction with a lower gas limit.

One problem I see is that there could be a large solution (30 trades) that we need to revert but our solution only has 2 trades. In this case the estimate would likely be wrong because we only scale it with the number of new trades but without any information about trades that need to be reverted. This situation seems unlikely so I'm not sure if that means we don't want this change. I would like to discuss that in the PR.

The worst case is 30 trades reverted, 30 trades submitted, which is probably what the 6 million has been calculated at. We could still improve this estimate by using 30 orders reverted and actual number of orders submitted.
We could also check whether we're going to revert another solution and how many trades it has by querying the contract but this will not give us a certain result as the other solution's transaction hasn't been mined yet.

### Test Plan
Existing unit tests.