### PR TITLE
Add more fine grained gas price estimation method

### DIFF
--- a/services-core/src/economic_viability.rs
+++ b/services-core/src/economic_viability.rs
@@ -115,7 +115,7 @@ impl EconomicViabilityComputer {
     async fn gas_price(&self) -> Result<f64> {
         let gas_price = self
             .gas_station
-            .estimate_gas_price()
+            .estimate()
             .await
             .context("failed to get gas price")?;
         Ok(pricegraph::num::u256_to_f64(gas_price))
@@ -225,7 +225,7 @@ mod tests {
 
         let mut gas_station = MockGasPriceEstimating::new();
         gas_station
-            .expect_estimate_gas_price()
+            .expect_estimate()
             .returning(|| Ok((40e9 as u128).into()));
         let subsidy = 10.0f64;
         let min_avg_fee_factor = 1.1f64;

--- a/services-core/src/gas_price.rs
+++ b/services-core/src/gas_price.rs
@@ -5,13 +5,15 @@ pub use self::gas_station::GnosisSafeGasStation;
 use crate::{contracts::Web3, http::HttpFactory};
 use anyhow::Result;
 use ethcontract::U256;
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
 pub trait GasPriceEstimating {
-    /// Retrieves gas prices from the Gnosis Safe Relay api.
-    async fn estimate_gas_price(&self) -> Result<U256>;
+    /// Estimate the gas price for a transaction to be mined "quickly".
+    async fn estimate(&self) -> Result<U256>;
+    /// Estimate the gas price for a transaction that uses <gas> to be mined within <time_limit>.
+    async fn estimate_with_limits(&self, gas: U256, time_limit: Duration) -> Result<U256>;
 }
 
 /// Creates the default gas price estimator for the given network.

--- a/services-core/src/gas_price/eth_node.rs
+++ b/services-core/src/gas_price/eth_node.rs
@@ -4,10 +4,15 @@ use super::GasPriceEstimating;
 use crate::contracts::Web3;
 use anyhow::Result;
 use ethcontract::U256;
+use std::time::Duration;
 
 #[async_trait::async_trait]
 impl GasPriceEstimating for Web3 {
-    async fn estimate_gas_price(&self) -> Result<U256> {
+    async fn estimate(&self) -> Result<U256> {
         self.eth().gas_price().await.map_err(From::from)
+    }
+
+    async fn estimate_with_limits(&self, _gas_limit: U256, _time_limit: Duration) -> Result<U256> {
+        self.estimate().await
     }
 }

--- a/services-core/src/gas_price/gas_station.rs
+++ b/services-core/src/gas_price/gas_station.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use ethcontract::U256;
 use isahc::http::uri::Uri;
 use serde::Deserialize;
+use std::time::Duration;
 use uint::FromDecStrErr;
 
 /// The default uris at which the gas station api is available under.
@@ -62,9 +63,12 @@ impl GnosisSafeGasStation {
 
 #[async_trait::async_trait]
 impl GasPriceEstimating for GnosisSafeGasStation {
-    /// Retrieves the current gas prices from the gas station.
-    async fn estimate_gas_price(&self) -> Result<U256> {
+    async fn estimate(&self) -> Result<U256> {
         Ok(self.gas_prices().await?.fast)
+    }
+
+    async fn estimate_with_limits(&self, _gas_limit: U256, _time_limit: Duration) -> Result<U256> {
+        self.estimate().await
     }
 }
 
@@ -117,7 +121,7 @@ pub mod tests {
     fn real_request() {
         let gas_station =
             GnosisSafeGasStation::new(&HttpFactory::default(), DEFAULT_MAINNET_URI).unwrap();
-        let gas_price = gas_station.estimate_gas_price().wait().unwrap();
+        let gas_price = gas_station.estimate().wait().unwrap();
         println!("{:?}", gas_price);
     }
 }

--- a/services-core/src/solution_submission.rs
+++ b/services-core/src/solution_submission.rs
@@ -208,7 +208,7 @@ impl<'a> StableXSolutionSubmitting for StableXSolutionSubmitter<'a> {
     ) -> Result<(), SolutionSubmissionError> {
         // If the gas price cap is not at least the fast gas price then submitting the solution
         // is not feasible because it would take too long.
-        match self.gas_price_estimating.estimate_gas_price().await {
+        match self.gas_price_estimating.estimate().await {
             Ok(gas_price) => {
                 if gas_price_cap < gas_price {
                     return Err(SolutionSubmissionError::Benign(format!(
@@ -330,7 +330,7 @@ mod tests {
     fn erroring_gas_station() -> impl GasPriceEstimating {
         let mut gas_price_estimating = MockGasPriceEstimating::new();
         gas_price_estimating
-            .expect_estimate_gas_price()
+            .expect_estimate()
             .returning(|| Err(anyhow!("")));
         gas_price_estimating
     }
@@ -487,9 +487,7 @@ mod tests {
         let retry = MockSolutionTransactionSending::new();
         let sleep = MockAsyncSleeping::new();
         let mut gas_price = MockGasPriceEstimating::new();
-        gas_price
-            .expect_estimate_gas_price()
-            .returning(|| Ok(10.into()));
+        gas_price.expect_estimate().returning(|| Ok(10.into()));
         let submitter = StableXSolutionSubmitter::with_retry_and_sleep(
             Arc::new(contract),
             Arc::new(gas_price),

--- a/services-core/src/solution_submission/retry.rs
+++ b/services-core/src/solution_submission/retry.rs
@@ -87,7 +87,7 @@ impl<'a> InfallibleGasPriceEstimator<'a> {
 
     /// Get a fresh price estimate or if that fails return the most recent previous result.
     async fn estimate(&mut self) -> U256 {
-        match self.gas_price_estimating.estimate_gas_price().await {
+        match self.gas_price_estimating.estimate().await {
             Ok(gas_estimate) => {
                 // `retry` relies on the gas price always increasing.
                 self.previous_gas_price = self.previous_gas_price.max(gas_estimate);
@@ -195,19 +195,19 @@ mod tests {
     fn infallible_gas_price_estimator_uses_default_and_previous_result() {
         let mut gas_station = MockGasPriceEstimating::new();
         gas_station
-            .expect_estimate_gas_price()
+            .expect_estimate()
             .times(1)
             .return_once(|| Err(anyhow!("")));
         gas_station
-            .expect_estimate_gas_price()
+            .expect_estimate()
             .times(1)
             .return_once(|| Ok(5.into()));
         gas_station
-            .expect_estimate_gas_price()
+            .expect_estimate()
             .times(1)
             .return_once(|| Ok(6.into()));
         gas_station
-            .expect_estimate_gas_price()
+            .expect_estimate()
             .times(1)
             .return_once(|| Err(anyhow!("")));
 
@@ -222,11 +222,11 @@ mod tests {
     fn infallible_gas_price_estimator_does_not_decrease() {
         let mut gas_station = MockGasPriceEstimating::new();
         gas_station
-            .expect_estimate_gas_price()
+            .expect_estimate()
             .times(1)
             .return_once(|| Ok(10.into()));
         gas_station
-            .expect_estimate_gas_price()
+            .expect_estimate()
             .times(1)
             .return_once(|| Ok(9.into()));
 
@@ -269,9 +269,7 @@ mod tests {
             });
 
         let mut gas_station = MockGasPriceEstimating::new();
-        gas_station
-            .expect_estimate_gas_price()
-            .returning(|| Err(anyhow!("")));
+        gas_station.expect_estimate().returning(|| Err(anyhow!("")));
 
         let args = Args {
             batch_index: 1,
@@ -306,7 +304,7 @@ mod tests {
 
         let mut gas_station = MockGasPriceEstimating::new();
         gas_station
-            .expect_estimate_gas_price()
+            .expect_estimate()
             .returning(|| Ok((DEFAULT_GAS_PRICE * 90).into()));
 
         let sleep = MockAsyncSleeping::new();
@@ -329,9 +327,7 @@ mod tests {
         let mut sleep = MockAsyncSleeping::new();
         let (sender, receiver) = futures::channel::oneshot::channel();
 
-        gas_station
-            .expect_estimate_gas_price()
-            .returning(|| Err(anyhow!("")));
+        gas_station.expect_estimate().returning(|| Err(anyhow!("")));
         contract
             .expect_submit_solution()
             .times(1)
@@ -379,9 +375,7 @@ mod tests {
         let mut sleep = MockAsyncSleeping::new();
         let (sender, receiver) = futures::channel::oneshot::channel();
 
-        gas_station
-            .expect_estimate_gas_price()
-            .returning(|| Err(anyhow!("")));
+        gas_station.expect_estimate().returning(|| Err(anyhow!("")));
         contract
             .expect_submit_solution()
             .times(1)


### PR DESCRIPTION
In preparation for using more advanced gas estimation this commit adds a
new method to the trait which estimates gas price based on the
transaction's gas use and time limit.

After this is merged I want to implement the trait for other "gas stations" than the gnosis one.

### Test Plan
Ci. New function is not used anywhere.