### PR TITLE
Add GasNow gas price estimator

### DIFF
--- a/services-core/src/gas_price.rs
+++ b/services-core/src/gas_price.rs
@@ -1,5 +1,7 @@
 mod eth_node;
 mod gas_station;
+mod gasnow;
+mod linear_interpolation;
 
 pub use self::gas_station::GnosisSafeGasStation;
 use crate::{contracts::Web3, http::HttpFactory};
@@ -7,13 +9,19 @@ use anyhow::Result;
 use ethcontract::U256;
 use std::{sync::Arc, time::Duration};
 
+const DEFAULT_GAS_LIMIT: u32 = 21000;
+const DEFAULT_TIME_LIMIT: Duration = Duration::from_secs(30);
+
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
-pub trait GasPriceEstimating {
+pub trait GasPriceEstimating: Send + Sync {
     /// Estimate the gas price for a transaction to be mined "quickly".
-    async fn estimate(&self) -> Result<U256>;
+    async fn estimate(&self) -> Result<U256> {
+        self.estimate_with_limits(DEFAULT_GAS_LIMIT.into(), DEFAULT_TIME_LIMIT)
+            .await
+    }
     /// Estimate the gas price for a transaction that uses <gas> to be mined within <time_limit>.
-    async fn estimate_with_limits(&self, gas: U256, time_limit: Duration) -> Result<U256>;
+    async fn estimate_with_limits(&self, gas_limit: U256, time_limit: Duration) -> Result<U256>;
 }
 
 /// Creates the default gas price estimator for the given network.

--- a/services-core/src/gas_price/eth_node.rs
+++ b/services-core/src/gas_price/eth_node.rs
@@ -8,11 +8,7 @@ use std::time::Duration;
 
 #[async_trait::async_trait]
 impl GasPriceEstimating for Web3 {
-    async fn estimate(&self) -> Result<U256> {
-        self.eth().gas_price().await.map_err(From::from)
-    }
-
     async fn estimate_with_limits(&self, _gas_limit: U256, _time_limit: Duration) -> Result<U256> {
-        self.estimate().await
+        self.eth().gas_price().await.map_err(From::from)
     }
 }

--- a/services-core/src/gas_price/gas_station.rs
+++ b/services-core/src/gas_price/gas_station.rs
@@ -1,4 +1,5 @@
 //! Gnosis Safe gas station `GasPriceEstimating` implementation.
+//! Api documentation at https://safe-relay.gnosis.io/ .
 
 use super::GasPriceEstimating;
 use crate::http::{HttpClient, HttpFactory, HttpLabel};
@@ -63,12 +64,8 @@ impl GnosisSafeGasStation {
 
 #[async_trait::async_trait]
 impl GasPriceEstimating for GnosisSafeGasStation {
-    async fn estimate(&self) -> Result<U256> {
-        Ok(self.gas_prices().await?.fast)
-    }
-
     async fn estimate_with_limits(&self, _gas_limit: U256, _time_limit: Duration) -> Result<U256> {
-        self.estimate().await
+        Ok(self.gas_prices().await?.fast)
     }
 }
 

--- a/services-core/src/gas_price/gasnow.rs
+++ b/services-core/src/gas_price/gasnow.rs
@@ -1,0 +1,81 @@
+use super::{linear_interpolation, GasPriceEstimating};
+use crate::http::{HttpClient, HttpFactory, HttpLabel};
+use anyhow::Result;
+use ethcontract::U256;
+use isahc::http::uri::Uri;
+use pricegraph::num;
+use std::time::Duration;
+
+// Gas price estimation with https://www.gasnow.org/ , api at https://taichi.network/#gasnow .
+
+const API_URI: &str = "https://www.gasnow.org/api/v3/gas/price";
+
+pub struct GasNow {
+    client: HttpClient,
+    uri: Uri,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct Response {
+    code: u32,
+    data: ResponseData,
+}
+
+// gas prices in wei
+#[derive(Debug, serde::Deserialize)]
+struct ResponseData {
+    rapid: f64,
+    fast: f64,
+    standard: f64,
+    slow: f64,
+}
+
+const RAPID: Duration = Duration::from_secs(15);
+const FAST: Duration = Duration::from_secs(60);
+const STANDARD: Duration = Duration::from_secs(300);
+const SLOW: Duration = Duration::from_secs(600);
+
+impl GasNow {
+    #[allow(dead_code)]
+    fn new(http_factory: &HttpFactory) -> Result<Self> {
+        let client = http_factory.create()?;
+        let uri = Uri::from_static(API_URI);
+        Ok(Self { client, uri })
+    }
+
+    async fn gas_price(&self) -> Result<Response> {
+        self.client
+            .get_json_async(&self.uri, HttpLabel::GasStation)
+            .await
+    }
+}
+
+#[async_trait::async_trait]
+impl GasPriceEstimating for GasNow {
+    async fn estimate_with_limits(&self, _gas_limit: U256, time_limit: Duration) -> Result<U256> {
+        let response = self.gas_price().await?.data;
+        let points = &[
+            (RAPID.as_secs_f64(), response.rapid),
+            (FAST.as_secs_f64(), response.fast),
+            (STANDARD.as_secs_f64(), response.standard),
+            (SLOW.as_secs_f64(), response.slow),
+        ];
+        let result = linear_interpolation::interpolate(time_limit.as_secs_f64(), points);
+        Ok(num::f64_to_u256(result))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::FutureWaitExt;
+
+    // cargo test -p services-core gasnow -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn real_request() {
+        let gasnow = GasNow::new(&HttpFactory::default()).unwrap();
+        let response = gasnow.gas_price().wait();
+        println!("{:?}", response);
+    }
+}

--- a/services-core/src/gas_price/linear_interpolation.rs
+++ b/services-core/src/gas_price/linear_interpolation.rs
@@ -1,0 +1,61 @@
+/// Linearly interpolate `value` between `points`.
+///
+/// `points` must not be empty and contain unique x values sorted in ascending order.
+/// If `value` is smaller than the first point or larger than the last it is clamped.
+pub fn interpolate(value: f64, points: &[(f64, f64)]) -> f64 {
+    assert!(!points.is_empty());
+    assert!(points.windows(2).all(|window| window[0].0 < window[1].0));
+
+    if value < points[0].0 {
+        points[0].1
+    } else if let Some(window) = points
+        .windows(2)
+        .find(|window| value >= window[0].0 && value < window[1].0)
+    {
+        // https://en.wikipedia.org/wiki/Linear_interpolation#Linear_interpolation_between_two_known_points
+        let (x, x0, y0, x1, y1) = (value, window[0].0, window[0].1, window[1].0, window[1].1);
+        y0 + (x - x0) * ((y1 - y0) / (x1 - x0))
+    } else {
+        points.last().unwrap().1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_approx_eq::assert_approx_eq;
+
+    #[test]
+    fn interpolate_() {
+        let points = &[(1.0, 1.0), (2.0, 2.0), (3.0, 3.0)];
+        assert_approx_eq!(interpolate(0.5, points), 1.0);
+        assert_approx_eq!(interpolate(1.0, points), 1.0);
+        assert_approx_eq!(interpolate(1.5, points), 1.5);
+        assert_approx_eq!(interpolate(2.0, points), 2.0);
+        assert_approx_eq!(interpolate(2.5, points), 2.5);
+        assert_approx_eq!(interpolate(3.0, points), 3.0);
+        assert_approx_eq!(interpolate(3.5, points), 3.0);
+    }
+
+    #[test]
+    fn interpolate_works_with_single_point() {
+        let points = &[(1.0, 1.0)];
+        assert_approx_eq!(interpolate(0.5, points), 1.0);
+        assert_approx_eq!(interpolate(1.0, points), 1.0);
+        assert_approx_eq!(interpolate(1.5, points), 1.0);
+    }
+
+    #[test]
+    fn interpolate_works_with_varying_x_and_y_deltas() {
+        let points = &[(0.0, 1.0), (1.0, 0.0), (3.0, 1.0)];
+        assert_approx_eq!(interpolate(0.0, points), 1.0);
+        assert_approx_eq!(interpolate(0.4, points), 0.6);
+        assert_approx_eq!(interpolate(0.5, points), 0.5);
+        assert_approx_eq!(interpolate(0.6, points), 0.4);
+        assert_approx_eq!(interpolate(1.0, points), 0.0);
+        assert_approx_eq!(interpolate(1.5, points), 0.25);
+        assert_approx_eq!(interpolate(2.0, points), 0.5);
+        assert_approx_eq!(interpolate(2.5, points), 0.75);
+        assert_approx_eq!(interpolate(3.0, points), 1.0);
+    }
+}


### PR DESCRIPTION
They predict based on the pending transaction queue and the currently
mining block (in sparkpool).
This estimation should be more accurate than the gnosis gas station and
react more quickly to changes in gas price.

This is part of an effort to have better gas price estimates (also for oba). I will also make a similar implementation based on pending blocks reported by our ethereum node.

Btw this service also offers sending transactions directly to their mining pool. This allows for potentially faster transactions because the transactions and also potentially private transactions where they ensure that only they mine the transaction and do not broadcast.
Just noting that, not saying we should use it.

### Test Plan
New tests.