### PR TITLE
Add Benchmarks for bounded bellman ford

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,6 +2322,7 @@ name = "pricegraph-bench"
 version = "0.0.0"
 dependencies = [
  "criterion",
+ "itertools",
  "pricegraph",
  "pricegraph-data",
 ]

--- a/pricegraph/bench/Cargo.toml
+++ b/pricegraph/bench/Cargo.toml
@@ -12,5 +12,6 @@ harness = false
 
 [dependencies]
 criterion = "0.3"
+itertools = "0.9"
 pricegraph = { path = "..", features = ["bench"] }
 pricegraph-data = { path = "../data" }

--- a/pricegraph/bench/pricegraph.rs
+++ b/pricegraph/bench/pricegraph.rs
@@ -2,6 +2,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use pricegraph::{Market, Pricegraph, TokenPair};
 use pricegraph_data::{DEFAULT_ORDERBOOK};
 use std::time::Duration;
+use itertools::Itertools;
 
 fn read_default_pricegraph() -> Pricegraph {
     Pricegraph::read(&*DEFAULT_ORDERBOOK).expect("error reading orderbook")
@@ -16,10 +17,10 @@ pub fn transitive_orderbook(c: &mut Criterion) {
     let dai_weth = Market { base: 7, quote: 1 };
     let hops = &[None, Some(1), Some(2), Some(5), Some(10), Some(30)];
 
-    let mut group = c.benchmark_group("Pricegraph::transitive_orderbook_with_hops");
+    let mut group = c.benchmark_group("Pricegraph::transitive_orderbook");
     for hops in hops {
         group.bench_with_input(
-            BenchmarkId::from_parameter(format!("{:?}", hops)),
+            BenchmarkId::from_parameter(format!("hops:{:?}", hops)),
             &(&pricegraph, dai_weth, hops),
             |b, &(pricegraph, dai_weth, hops)| {
                 b.iter(|| pricegraph.transitive_orderbook(dai_weth, *hops, None))
@@ -31,17 +32,18 @@ pub fn transitive_orderbook(c: &mut Criterion) {
 
 pub fn estimate_limit_price(c: &mut Criterion) {
     let pricegraph = read_default_pricegraph();
-    let dai_weth = TokenPair { buy: 7, sell: 1 }.into_unbounded_range();
+    let dai_weth = TokenPair { buy: 7, sell: 1 };
     let eth = 1e18;
     let volumes = &[0.1 * eth, eth, 10.0 * eth, 100.0 * eth, 1000.0 * eth];
+    let hops = &[None, Some(1), Some(2), Some(5), Some(10), Some(30)];
 
     let mut group = c.benchmark_group("Pricegraph::estimate_limit_price");
-    for volume in volumes {
+    for (volume, hops) in volumes.iter().cartesian_product(hops) {
         group.bench_with_input(
-            BenchmarkId::from_parameter(volume),
-            &(&pricegraph, dai_weth, *volume),
-            |b, &(pricegraph, pair, volume)| {
-                b.iter(|| pricegraph.estimate_limit_price(pair, volume))
+            BenchmarkId::from_parameter(format!("volume:{}-hops{:?}",volume,hops)),
+            &(&pricegraph, dai_weth, *volume, *hops),
+            |b, &(pricegraph, pair, volume, hops)| {
+                b.iter(|| pricegraph.estimate_limit_price(pair.into_range(hops), volume))
             },
         );
     }
@@ -50,16 +52,17 @@ pub fn estimate_limit_price(c: &mut Criterion) {
 
 pub fn order_for_limit_price(c: &mut Criterion) {
     let pricegraph = read_default_pricegraph();
-    let dai_weth = TokenPair { buy: 7, sell: 1 }.into_unbounded_range();
+    let dai_weth = TokenPair { buy: 7, sell: 1 };
     let prices = &[200.0, 190.0, 180.0, 150.0, 100.0];
+    let hops = &[None, Some(1), Some(2), Some(5), Some(10), Some(30)];
 
     let mut group = c.benchmark_group("Pricegraph::order_for_limit_price");
-    for price in prices {
+    for (price, hops) in prices.iter().cartesian_product(hops) {
         group.bench_with_input(
-            BenchmarkId::from_parameter(price),
-            &(&pricegraph, dai_weth, *price),
-            |b, &(pricegraph, pair, price)| {
-                b.iter(|| pricegraph.order_for_limit_price(pair, price))
+            BenchmarkId::from_parameter(format!("price:{}-hops:{:?}",price,hops)),
+            &(&pricegraph, dai_weth, *price, *hops),
+            |b, &(pricegraph, pair, price, hops)| {
+                b.iter(|| pricegraph.order_for_limit_price(pair.into_range(hops), price))
             },
         );
     }

--- a/pricegraph/bench/pricegraph.rs
+++ b/pricegraph/bench/pricegraph.rs
@@ -1,8 +1,8 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use pricegraph::{Market, Pricegraph, TokenPair};
-use pricegraph_data::{DEFAULT_ORDERBOOK};
-use std::time::Duration;
 use itertools::Itertools;
+use pricegraph::{Market, Pricegraph, TokenPair};
+use pricegraph_data::DEFAULT_ORDERBOOK;
+use std::time::Duration;
 
 fn read_default_pricegraph() -> Pricegraph {
     Pricegraph::read(&*DEFAULT_ORDERBOOK).expect("error reading orderbook")
@@ -40,7 +40,7 @@ pub fn estimate_limit_price(c: &mut Criterion) {
     let mut group = c.benchmark_group("Pricegraph::estimate_limit_price");
     for (volume, hops) in volumes.iter().cartesian_product(hops) {
         group.bench_with_input(
-            BenchmarkId::from_parameter(format!("volume:{}-hops{:?}",volume,hops)),
+            BenchmarkId::from_parameter(format!("volume:{}-hops{:?}", volume, hops)),
             &(&pricegraph, dai_weth, *volume, *hops),
             |b, &(pricegraph, pair, volume, hops)| {
                 b.iter(|| pricegraph.estimate_limit_price(pair.into_range(hops), volume))
@@ -59,7 +59,7 @@ pub fn order_for_limit_price(c: &mut Criterion) {
     let mut group = c.benchmark_group("Pricegraph::order_for_limit_price");
     for (price, hops) in prices.iter().cartesian_product(hops) {
         group.bench_with_input(
-            BenchmarkId::from_parameter(format!("price:{}-hops:{:?}",price,hops)),
+            BenchmarkId::from_parameter(format!("price:{}-hops:{:?}", price, hops)),
             &(&pricegraph, dai_weth, *price, *hops),
             |b, &(pricegraph, pair, price, hops)| {
                 b.iter(|| pricegraph.order_for_limit_price(pair.into_range(hops), price))


### PR DESCRIPTION
This PR adds benchmarks for the added bounded bellman ford implementation. I only added it to the transitive orderbook computation as this seems to be the most expensive operation anyways

### Test Plan
`cd pricegraph/bench && cargo bench`