### PR TITLE
Bump the orderbook file version to see if things work now

### DIFF
--- a/services-core/src/history/events.rs
+++ b/services-core/src/history/events.rs
@@ -15,7 +15,7 @@ use std::{
     ops::Bound,
     path::Path,
 };
-use typenum::U1;
+use typenum::U2;
 
 // Ethereum events (logs) can be both created and removed. Removals happen if the chain reorganizes
 // and ends up not including block that was previously thought to be part of the chain.
@@ -40,7 +40,7 @@ struct Value {
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct EventRegistry {
-    version: Version<U1>,
+    version: Version<U2>,
     events: BTreeMap<EventSortKey, Value>,
 }
 


### PR DESCRIPTION
Just bump the orderbook file version to force it to get re-created to make sure that the rolling update works as expected now.

### Test Plan

Solvers eventually startup.