### PR TITLE
Reduce full orderbook sync memory usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,9 +12,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b476ce7103678b0c6d3d395dbbae31d48ff910bd28be979ba5d48c6351131d0d"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
  "memchr",
 ]
@@ -57,9 +57,9 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "ascii"
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.1.10"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54bc4c1c7292475efb2253227dbcfad8fe1ca4c02bc62c510cc2f3da5c4704e"
+checksum = "40a0b2bb8ae20fede194e779150fe283f65a4a08461b496de546ec366b174ad9"
 dependencies = [
  "concurrent-queue",
  "fastrand",
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab27c1aa62945039e44edaeee1dc23c74cc0c303dd5fe0fb462a184f1c3a518"
+checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
 name = "async-trait"
@@ -269,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "blake2b_simd"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -324,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
+checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -480,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce90df4c658c62f12d78f7508cf92f9173e5184a539c10bfe54a3107b3ffd0f2"
+checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
 
 [[package]]
 name = "constant_time_eq"
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.7.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -518,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpuid-bool"
@@ -664,9 +664,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "csv"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
+checksum = "fc4666154fd004af3fd6f1da2e81a96fd5a81927fe8ddb6ecc79e2aa6e138b54"
 dependencies = [
  "bstr",
  "csv-core",
@@ -893,11 +893,11 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.24"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a51b8cf747471cb9499b6d59e59b0444f4c90eba8968c4e44874e92b5b64ace2"
+checksum = "801bbab217d7f79c0062f4f7205b5d4427c6d1a7bd7aafdd1475f7c59d62b283"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -942,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fdf676999e87b8eed25cd7f09dc67d6520b085b87865dac32a78aa3ff4a415"
+checksum = "70d483397a1bca79be56ff5c944e73c3a767ac8b90f3608c4f413f433e1a35b4"
 dependencies = [
  "ethcontract-common",
  "ethcontract-derive",
@@ -964,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-common"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baad5ea355d7779eeb1c24bd2a6ec1c0fe7ac75c2105d77a7090463630ad96c7"
+checksum = "4499d379053509514083e9d59addc6dd76284dcfbb438289871c4acd94e58942"
 dependencies = [
  "ethabi",
  "hex",
@@ -980,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-derive"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "140327000af5583ec8dfef610f0b90f6fbdbe92623d5ff33af5302419b798a62"
+checksum = "0e05a965a663f1850aa64de2d33d5e7f4ccb5dfef9f0492c6ea0601c0d83595d"
 dependencies = [
  "ethcontract-common",
  "ethcontract-generate",
@@ -993,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-generate"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4643e53caf3dbfd6c646ea867c4291ae9ebef4f3f677e6a02952023b481732a"
+checksum = "097a6ef02d97489459cdb6cc4d80a23bb2fa12731e56fa49029cd85676839ebe"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1196,9 +1196,9 @@ checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
 
 [[package]]
 name = "futures-lite"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381a7ad57b1bad34693f63f6f377e1abded7a9c85c9d3eb6771e11c60aaadab9"
+checksum = "5e6c079abfac3ab269e2927ec048dabc89d009ebfdda6b8ee86624f30c689658"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -1307,9 +1307,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
+checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
 dependencies = [
  "bytes",
  "fnv",
@@ -1322,6 +1322,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -1426,9 +1427,9 @@ checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "hyper"
-version = "0.13.8"
+version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3afcfae8af5ad0576a31e768415edb627824129e8e5a29b8bfccb2f234e835"
+checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1440,7 +1441,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 0.4.27",
+ "pin-project 1.0.1",
  "socket2",
  "tokio",
  "tower-service",
@@ -1537,11 +1538,11 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
+checksum = "cb1fc4429a33e1f80d41dc9fea4d108a88bec1de8053878898ae448a0b52f613"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1644,9 +1645,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
+checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1721,9 +1722,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
@@ -1867,9 +1868,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
+checksum = "1a1cda389c26d6b88f3d2dc38aa1b750fe87d298cc5d795ec9e975f402f00372"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1969,9 +1970,9 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5fa6d5f418879385b213d905f7cf5bf4aa553d4c380f0152d1d4f2749186fa9"
+checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg 1.0.1",
  "num-bigint",
@@ -2215,9 +2216,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e555d9e657502182ac97b539fb3dae8b79cda19e3e4f8ffb5e8de4f18df93c95"
+checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
 
 [[package]]
 name = "pin-utils"
@@ -2227,9 +2228,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "plotters"
@@ -2245,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab773feb154f12c49ffcfd66ab8bdcf9a1843f950db48b0d8be9d4393783b058"
+checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -2258,9 +2259,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "predicates"
@@ -2697,9 +2698,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f45b719a674bf4b828ff318906d6c133264c793eff7a41e30074a45b5099e2"
+checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2718,9 +2719,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.19"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17be88d9eaa858870aa5e48cc406c206e4600e983fc4f06bbe5750d93d09761"
+checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
 name = "remove_dir_all"
@@ -2871,9 +2872,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "0.4.4"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
+checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2884,9 +2885,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "0.4.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
+checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3034,12 +3035,12 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a36ea86c864a3f16dd2687712dd6646f7019f301e57537c7f4dc9f5916770"
+checksum = "ce3cdf1b5e620a498ee6f2a171885ac7e22f0e12089ec4b3d22b84921792507c"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -3173,7 +3174,7 @@ dependencies = [
  "httparse",
  "log 0.4.11",
  "rand 0.7.3",
- "sha-1 0.9.1",
+ "sha-1 0.9.2",
 ]
 
 [[package]]
@@ -3536,7 +3537,7 @@ dependencies = [
  "input_buffer",
  "log 0.4.11",
  "rand 0.7.3",
- "sha-1 0.9.1",
+ "sha-1 0.9.2",
  "url 2.2.0",
  "utf-8",
 ]
@@ -3887,9 +3888,9 @@ dependencies = [
 
 [[package]]
 name = "wepoll-sys"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc2cba3fe88be1a8fcb55c727fa4cd5b0cf2d7438722792e22f26f04bc1e0"
+checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
 dependencies = [
  "cc",
 ]

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -27,13 +27,13 @@ bin = [
 ]
 
 [dependencies]
-ethcontract = { version = "0.8", default-features = false }
+ethcontract = { version = "0.9",  default-features = false }
 serde = "1.0.117"
 
 # [bin-dependencies]
 anyhow = { version = "1.0.34", optional = true }
 env_logger = { version = "0.8.1", optional = true }
-ethcontract-generate = { version = "0.8", optional = true }
+ethcontract-generate = { version = "0.9", optional = true }
 filetime = { version = "0.2.13", optional = true }
 futures = { version = "0.3.8", optional = true }
 log = { version = "0.4.11", optional = true }
@@ -41,4 +41,4 @@ serde_json = { version = "1.0.59", optional = true }
 tokio = { version = "0.2", optional = true, features = ["macros"] }
 
 [build-dependencies]
-ethcontract-generate = "0.8"
+ethcontract-generate = "0.9"

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -5,9 +5,8 @@ edition = "2018"
 
 [dependencies]
 services-core = { path = "../services-core" }
-ethcontract = { version = "0.8", default-features = false }
+ethcontract = { version = "0.9", default-features = false }
 log = "0.4.11"
 prometheus = { version = "0.10.0", default-features= false }
 structopt = "0.3.20"
 url = "2.2.0"
-

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 anyhow = "1"
 contracts = { path = "../contracts" }
 services-core = { path = "../services-core" }
-ethcontract = { version = "0.8", default-features = false }
+ethcontract = { version = "0.9",  default-features = false }
 crossbeam = "0.8"
 futures = { version = "0.3.8" }
 pbr = "1.0.3"

--- a/price-estimator/Cargo.toml
+++ b/price-estimator/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 anyhow = "1.0"
 async-trait = "0.1.41"
 services-core = { path = "../services-core" }
-ethcontract = { version = "0.8", default-features = false }
+ethcontract = { version = "0.9",  default-features = false }
 futures = "0.3"
 log = "0.4"
 pricegraph = { path = "../pricegraph" }

--- a/pricegraph/data/bin/Cargo.toml
+++ b/pricegraph/data/bin/Cargo.toml
@@ -17,7 +17,7 @@ path = "fetch.rs"
 anyhow = "1.0.34"
 contracts = { path = "../../../contracts" }
 env_logger = "0.8.1"
-ethcontract = { version = "0.8", features = ["http-tls"] }
+ethcontract = { version = "0.9", features = ["http-tls"] }
 futures = "0.3.8"
 hex = "0.4.2"
 log = "0.4.11"

--- a/services-core/Cargo.toml
+++ b/services-core/Cargo.toml
@@ -13,7 +13,7 @@ blocking = "1.0.0"
 byteorder = "1.3.4"
 chrono = { version = "0.4.19", default-features = false  }
 contracts = { path = "../contracts" }
-ethcontract = { version = "0.8", default-features = false }
+ethcontract = { version = "0.9",  default-features = false }
 futures = "0.3.8"
 isahc = { version = "0.9.11", features = ["json"] }
 lazy_static = "1.4.0"

--- a/services-core/src/contracts/stablex_contract.rs
+++ b/services-core/src/contracts/stablex_contract.rs
@@ -15,7 +15,11 @@ use ethcontract::{
     transaction::{confirm::ConfirmParams, Account, GasPrice, ResolveCondition, TransactionResult},
     Address, BlockId, BlockNumber, PrivateKey, U256,
 };
-use futures::future::{BoxFuture, FutureExt as _};
+use futures::{
+    future::BoxFuture,
+    stream::{BoxStream, StreamExt},
+    FutureExt as _,
+};
 
 use lazy_static::lazy_static;
 use std::collections::HashMap;
@@ -138,12 +142,12 @@ pub trait StableXContract: Send + Sync {
         nonce: U256,
     ) -> BoxFuture<'a, Result<(), MethodError>>;
 
-    async fn past_events(
-        &self,
+    async fn past_events<'a>(
+        &'a self,
         from_block: BlockNumber,
         to_block: BlockNumber,
         block_page_size: u64,
-    ) -> Result<Vec<Event<batch_exchange::Event>>, ExecutionError>;
+    ) -> Result<BoxStream<'a, Result<Event<batch_exchange::Event>, ExecutionError>>, ExecutionError>;
 
     /// Create a noop transaction. Useful to cancel a previous transaction that is stuck due to
     /// low gas price.
@@ -288,19 +292,22 @@ impl StableXContract for StableXContractImpl {
         .boxed()
     }
 
-    async fn past_events(
-        &self,
+    async fn past_events<'a>(
+        &'a self,
         from_block: BlockNumber,
         to_block: BlockNumber,
         block_page_size: u64,
-    ) -> Result<Vec<Event<batch_exchange::Event>>, ExecutionError> {
-        self.instance
+    ) -> Result<BoxStream<'a, Result<Event<batch_exchange::Event>, ExecutionError>>, ExecutionError>
+    {
+        let stream = self
+            .instance
             .all_events()
             .from_block(from_block)
             .to_block(to_block)
             .block_page_size(block_page_size)
             .query_paginated()
-            .await
+            .await?;
+        Ok(stream.boxed())
     }
 
     fn send_noop_transaction<'a>(


### PR DESCRIPTION
By making use of a change in ethcontract that creates a stream for past
events instead of one vector with all of them.
We chunk the stream again so that getting the block timestamps stays
fast as we use a batch transport for that.

This switches to  a specific commit of ethcontract so that we get the above mentioned change. Once ethcontract makes a release with this change we can switch back to a cargo version.

### Test Plan
Unfortunately UpdatingOrderbook cannot easily be tested in the current form because we don't have a mockable web3 trait and because it does file io. I would like to change that but not sure what the best approach is yet and this wouldn't be part of this PR.