### PR TITLE
Use f64 instead of u256 for gas prices

### DIFF
--- a/services-core/src/gas_price.rs
+++ b/services-core/src/gas_price.rs
@@ -6,22 +6,21 @@ mod linear_interpolation;
 
 use crate::{contracts::Web3, http::HttpFactory};
 use anyhow::Result;
-use ethcontract::U256;
 use std::{sync::Arc, time::Duration};
 
-const DEFAULT_GAS_LIMIT: u32 = 21000;
+const DEFAULT_GAS_LIMIT: f64 = 21000.0;
 const DEFAULT_TIME_LIMIT: Duration = Duration::from_secs(30);
 
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
 pub trait GasPriceEstimating: Send + Sync {
     /// Estimate the gas price for a transaction to be mined "quickly".
-    async fn estimate(&self) -> Result<U256> {
-        self.estimate_with_limits(DEFAULT_GAS_LIMIT.into(), DEFAULT_TIME_LIMIT)
+    async fn estimate(&self) -> Result<f64> {
+        self.estimate_with_limits(DEFAULT_GAS_LIMIT, DEFAULT_TIME_LIMIT)
             .await
     }
     /// Estimate the gas price for a transaction that uses <gas> to be mined within <time_limit>.
-    async fn estimate_with_limits(&self, gas_limit: U256, time_limit: Duration) -> Result<U256>;
+    async fn estimate_with_limits(&self, gas_limit: f64, time_limit: Duration) -> Result<f64>;
 }
 
 /// Creates the default gas price estimator for the given network.

--- a/services-core/src/gas_price/eth_node.rs
+++ b/services-core/src/gas_price/eth_node.rs
@@ -3,12 +3,16 @@
 use super::GasPriceEstimating;
 use crate::contracts::Web3;
 use anyhow::Result;
-use ethcontract::U256;
+use pricegraph::num;
 use std::time::Duration;
 
 #[async_trait::async_trait]
 impl GasPriceEstimating for Web3 {
-    async fn estimate_with_limits(&self, _gas_limit: U256, _time_limit: Duration) -> Result<U256> {
-        self.eth().gas_price().await.map_err(From::from)
+    async fn estimate_with_limits(&self, _gas_limit: f64, _time_limit: Duration) -> Result<f64> {
+        self.eth()
+            .gas_price()
+            .await
+            .map_err(From::from)
+            .map(num::u256_to_f64)
     }
 }

--- a/services-core/src/gas_price/ethgasstation.rs
+++ b/services-core/src/gas_price/ethgasstation.rs
@@ -1,9 +1,7 @@
 use super::{linear_interpolation, GasPriceEstimating};
 use crate::http::{HttpClient, HttpFactory, HttpLabel};
 use anyhow::Result;
-use ethcontract::U256;
 use isahc::http::uri::Uri;
-use pricegraph::num;
 use std::{convert::TryInto, time::Duration};
 
 // Gas price estimation with https://ethgasstation.info/ , api https://docs.ethgasstation.info/gas-price .
@@ -47,10 +45,10 @@ impl EthGasStation {
 
 #[async_trait::async_trait]
 impl GasPriceEstimating for EthGasStation {
-    async fn estimate_with_limits(&self, _gas_limit: U256, time_limit: Duration) -> Result<U256> {
+    async fn estimate_with_limits(&self, _gas_limit: f64, time_limit: Duration) -> Result<f64> {
         let response = self.gas_price().await?;
         let result = estimate_with_limits(&response, time_limit)?;
-        Ok(num::f64_to_u256(result))
+        Ok(result)
     }
 }
 

--- a/services-core/src/gas_price/gasnow.rs
+++ b/services-core/src/gas_price/gasnow.rs
@@ -1,9 +1,7 @@
 use super::{linear_interpolation, GasPriceEstimating};
 use crate::http::{HttpClient, HttpFactory, HttpLabel};
 use anyhow::Result;
-use ethcontract::U256;
 use isahc::http::uri::Uri;
-use pricegraph::num;
 use std::{convert::TryInto, time::Duration};
 
 // Gas price estimation with https://www.gasnow.org/ , api at https://taichi.network/#gasnow .
@@ -52,7 +50,7 @@ impl GasNow {
 
 #[async_trait::async_trait]
 impl GasPriceEstimating for GasNow {
-    async fn estimate_with_limits(&self, _gas_limit: U256, time_limit: Duration) -> Result<U256> {
+    async fn estimate_with_limits(&self, _gas_limit: f64, time_limit: Duration) -> Result<f64> {
         let response = self.gas_price().await?.data;
         let points: &[(f64, f64)] = &[
             (RAPID.as_secs_f64(), response.rapid),
@@ -62,7 +60,7 @@ impl GasPriceEstimating for GasNow {
         ];
         let result =
             linear_interpolation::interpolate(time_limit.as_secs_f64(), points.try_into()?);
-        Ok(num::f64_to_u256(result))
+        Ok(result)
     }
 }
 


### PR DESCRIPTION
Gas prices are technically U256 but most of our code needs to some math
with them so we end up converting between u256 and f64 all the time.
With this commit we use f64 directly everywhere.

### Test Plan
Existing tests