### PR TITLE
Bump private solver version to v0.8.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ language: rust
 env:
   global:
     - OPEN_SOLVER_VERSION=v0.1.1
-    - PRIVATE_SOLVER_VERSION=v0.8.5
+    - PRIVATE_SOLVER_VERSION=v0.8.6
 
 jobs:
   fast_finish: true


### PR DESCRIPTION
Solver bump includes an upgrade of Gurobi from 9.0.1 to 9.1.0