### PR TITLE
Use smarter gas prices for solution submission

### DIFF
--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -368,7 +368,7 @@ fn setup_monitoring() -> (
 async fn setup_http_services(
     http_factory: &HttpFactory,
     options: &Options,
-) -> (Web3, Arc<dyn GasPriceEstimating + Send + Sync>) {
+) -> (Web3, Arc<dyn GasPriceEstimating>) {
     let web3 = web3_provider(http_factory, options.node_url.as_str(), options.rpc_timeout).unwrap();
     let gas_station = gas_price::create_estimator(&http_factory, &web3)
         .await

--- a/services-core/src/contracts/stablex_contract.rs
+++ b/services-core/src/contracts/stablex_contract.rs
@@ -21,6 +21,8 @@ use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::time::Duration;
 
+pub const SOLUTION_SUBMISSION_GAS_LIMIT: u32 = 6_000_000;
+
 lazy_static! {
     // In the BatchExchange smart contract, the objective value will be multiplied by
     // 1 + IMPROVEMENT_DENOMINATOR = 101. Hence, the maximal possible objective value is:
@@ -280,7 +282,7 @@ impl StableXContract for StableXContractImpl {
                 // NOTE: Gas estimate might be off, as we race with other solution
                 //   submissions and thus might have to revert trades which costs
                 //   more gas than expected.
-                .gas(6_000_000.into())
+                .gas(SOLUTION_SUBMISSION_GAS_LIMIT.into())
                 .nonce(nonce);
             method.tx.resolve = Some(ResolveCondition::Confirmed(ConfirmParams::mined()));
             method.send().await.map(|_| ())

--- a/services-core/src/economic_viability.rs
+++ b/services-core/src/economic_viability.rs
@@ -30,7 +30,7 @@ impl EconomicViabilityStrategy {
         static_min_avg_fee_per_order: Option<u128>,
         static_max_gas_price: Option<u128>,
         native_token_price: Arc<dyn NativeTokenPricing + Send + Sync>,
-        gas_station: Arc<dyn GasPriceEstimating + Send + Sync>,
+        gas_station: Arc<dyn GasPriceEstimating>,
     ) -> Result<Arc<dyn EconomicViabilityComputing>> {
         let make_dynamic = || {
             DynamicEconomicViabilityComputer::new(
@@ -84,7 +84,7 @@ pub trait EconomicViabilityComputing: Send + Sync + 'static {
 /// Economic viability constraints based on the current gas and native token price.
 pub struct DynamicEconomicViabilityComputer {
     price_oracle: Arc<dyn NativeTokenPricing + Send + Sync>,
-    gas_station: Arc<dyn GasPriceEstimating + Send + Sync>,
+    gas_station: Arc<dyn GasPriceEstimating>,
     subsidy_factor: f64,
     /// We multiply the min average fee by this amount to ensure that if a solution has this minimum
     /// amount it will still be end up economically viable even when the gas or native token price moves
@@ -95,7 +95,7 @@ pub struct DynamicEconomicViabilityComputer {
 impl DynamicEconomicViabilityComputer {
     pub fn new(
         price_oracle: Arc<dyn NativeTokenPricing + Send + Sync>,
-        gas_station: Arc<dyn GasPriceEstimating + Send + Sync>,
+        gas_station: Arc<dyn GasPriceEstimating>,
         subsidy_factor: f64,
         min_avg_fee_factor: f64,
     ) -> Self {

--- a/services-core/src/gas_price.rs
+++ b/services-core/src/gas_price.rs
@@ -8,8 +8,8 @@ use crate::{contracts::Web3, http::HttpFactory};
 use anyhow::Result;
 use std::{sync::Arc, time::Duration};
 
-const DEFAULT_GAS_LIMIT: f64 = 21000.0;
-const DEFAULT_TIME_LIMIT: Duration = Duration::from_secs(30);
+pub const DEFAULT_GAS_LIMIT: f64 = 21000.0;
+pub const DEFAULT_TIME_LIMIT: Duration = Duration::from_secs(30);
 
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]

--- a/services-core/src/gas_price.rs
+++ b/services-core/src/gas_price.rs
@@ -32,7 +32,7 @@ pub async fn create_estimator(
     let network_id = web3.net().version().await?;
     let mut estimators = Vec::<Box<dyn GasPriceEstimating>>::new();
 
-    if network_id == "1" {
+    if is_mainnet(&network_id) {
         let gasnow = gasnow::GasNow::new(http_factory)?;
         estimators.push(Box::new(gasnow));
 
@@ -48,4 +48,8 @@ pub async fn create_estimator(
     estimators.push(Box::new(web3.clone()));
 
     Ok(Arc::new(priority::PriorityGasPrice::new(estimators)))
+}
+
+fn is_mainnet(network_id: &str) -> bool {
+    network_id == "1"
 }

--- a/services-core/src/gas_price.rs
+++ b/services-core/src/gas_price.rs
@@ -3,6 +3,7 @@ mod ethgasstation;
 mod gasnow;
 mod gnosis_safe;
 mod linear_interpolation;
+mod priority;
 
 use crate::{contracts::Web3, http::HttpFactory};
 use anyhow::Result;
@@ -27,10 +28,24 @@ pub trait GasPriceEstimating: Send + Sync {
 pub async fn create_estimator(
     http_factory: &HttpFactory,
     web3: &Web3,
-) -> Result<Arc<dyn GasPriceEstimating + Send + Sync>> {
+) -> Result<Arc<dyn GasPriceEstimating>> {
     let network_id = web3.net().version().await?;
-    Ok(match gnosis_safe::api_url_from_network_id(&network_id) {
-        Some(url) => Arc::new(gnosis_safe::GnosisSafeGasStation::new(http_factory, url)?),
-        None => Arc::new(web3.clone()),
-    })
+    let mut estimators = Vec::<Box<dyn GasPriceEstimating>>::new();
+
+    if network_id == "1" {
+        let gasnow = gasnow::GasNow::new(http_factory)?;
+        estimators.push(Box::new(gasnow));
+
+        let ethgasstation = ethgasstation::EthGasStation::new(http_factory)?;
+        estimators.push(Box::new(ethgasstation));
+    }
+
+    if let Some(gnosis_url) = gnosis_safe::api_url_from_network_id(&network_id) {
+        let gnosis_estimator = gnosis_safe::GnosisSafeGasStation::new(http_factory, gnosis_url)?;
+        estimators.push(Box::new(gnosis_estimator));
+    }
+
+    estimators.push(Box::new(web3.clone()));
+
+    Ok(Arc::new(priority::PriorityGasPrice::new(estimators)))
 }

--- a/services-core/src/gas_price/ethgasstation.rs
+++ b/services-core/src/gas_price/ethgasstation.rs
@@ -29,8 +29,7 @@ struct Response {
 }
 
 impl EthGasStation {
-    #[allow(dead_code)]
-    fn new(http_factory: &HttpFactory) -> Result<Self> {
+    pub fn new(http_factory: &HttpFactory) -> Result<Self> {
         let client = http_factory.create()?;
         let uri = Uri::from_static(API_URI);
         Ok(Self { client, uri })

--- a/services-core/src/gas_price/gasnow.rs
+++ b/services-core/src/gas_price/gasnow.rs
@@ -34,8 +34,7 @@ const STANDARD: Duration = Duration::from_secs(300);
 const SLOW: Duration = Duration::from_secs(600);
 
 impl GasNow {
-    #[allow(dead_code)]
-    fn new(http_factory: &HttpFactory) -> Result<Self> {
+    pub fn new(http_factory: &HttpFactory) -> Result<Self> {
         let client = http_factory.create()?;
         let uri = Uri::from_static(API_URI);
         Ok(Self { client, uri })

--- a/services-core/src/gas_price/priority.rs
+++ b/services-core/src/gas_price/priority.rs
@@ -1,0 +1,76 @@
+use super::GasPriceEstimating;
+use anyhow::{anyhow, Result};
+use std::{future::Future, time::Duration};
+
+// Uses the first successful estimator.
+pub struct PriorityGasPrice {
+    estimators: Vec<Box<dyn GasPriceEstimating>>,
+}
+
+impl PriorityGasPrice {
+    pub fn new(estimators: Vec<Box<dyn GasPriceEstimating>>) -> Self {
+        Self { estimators }
+    }
+
+    async fn prioritize<'a, T, F>(&'a self, operation: T) -> Result<f64>
+    where
+        T: Fn(&'a dyn GasPriceEstimating) -> F,
+        F: Future<Output = Result<f64>>,
+    {
+        for estimator in &self.estimators {
+            match operation(estimator.as_ref()).await {
+                Ok(result) => return Ok(result),
+                Err(err) => log::error!("gas estimator failed: {:?}", err),
+            }
+        }
+        Err(anyhow!("all gas estimators failed"))
+    }
+}
+
+#[async_trait::async_trait]
+impl GasPriceEstimating for PriorityGasPrice {
+    async fn estimate_with_limits(&self, gas_limit: f64, time_limit: Duration) -> Result<f64> {
+        self.prioritize(|estimator| estimator.estimate_with_limits(gas_limit, time_limit))
+            .await
+    }
+
+    async fn estimate(&self) -> Result<f64> {
+        self.prioritize(|estimator| estimator.estimate()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::MockGasPriceEstimating;
+    use super::*;
+    use assert_approx_eq::assert_approx_eq;
+    use futures::future::FutureExt;
+
+    #[test]
+    fn prioritize_picks_first() {
+        let mut estimator_0 = MockGasPriceEstimating::new();
+        let estimator_1 = MockGasPriceEstimating::new();
+
+        estimator_0.expect_estimate().times(1).returning(|| Ok(1.0));
+
+        let priority = PriorityGasPrice::new(vec![Box::new(estimator_0), Box::new(estimator_1)]);
+        let result = priority.estimate().now_or_never().unwrap().unwrap();
+        assert_approx_eq!(result, 1.0);
+    }
+
+    #[test]
+    fn prioritize_picks_second() {
+        let mut estimator_0 = MockGasPriceEstimating::new();
+        let mut estimator_1 = MockGasPriceEstimating::new();
+
+        estimator_0
+            .expect_estimate()
+            .times(1)
+            .returning(|| Err(anyhow!("")));
+        estimator_1.expect_estimate().times(1).returning(|| Ok(2.0));
+
+        let priority = PriorityGasPrice::new(vec![Box::new(estimator_0), Box::new(estimator_1)]);
+        let result = priority.estimate().now_or_never().unwrap().unwrap();
+        assert_approx_eq!(result, 2.0);
+    }
+}

--- a/services-core/src/solution_submission.rs
+++ b/services-core/src/solution_submission.rs
@@ -201,7 +201,7 @@ impl<'a> StableXSolutionSubmitting for StableXSolutionSubmitter<'a> {
             + BatchId::from(batch_index)
                 .solve_end_time()
                 .duration_since(SystemTime::now())
-                .unwrap_or_default();
+                .unwrap_or_else(|_| Duration::from_secs(0));
         let nonce = self.contract.get_transaction_count().await?;
         let submit_future = self.retry_with_gas_price_increase.retry(retry::Args {
             batch_index,

--- a/services-core/src/solution_submission.rs
+++ b/services-core/src/solution_submission.rs
@@ -101,7 +101,7 @@ pub struct StableXSolutionSubmitter<'a> {
 impl<'a> StableXSolutionSubmitter<'a> {
     pub fn new(
         contract: Arc<dyn StableXContract>,
-        gas_price_estimating: Arc<dyn GasPriceEstimating + Send + Sync>,
+        gas_price_estimating: Arc<dyn GasPriceEstimating>,
     ) -> Self {
         Self::with_retry_and_sleep(
             contract.clone(),

--- a/services-core/src/solution_submission.rs
+++ b/services-core/src/solution_submission.rs
@@ -18,7 +18,7 @@ use pricegraph::num;
 use retry::SolutionTransactionSending;
 use std::{
     sync::Arc,
-    time::{Duration, SystemTime},
+    time::{Duration, Instant, SystemTime},
 };
 use thiserror::Error;
 
@@ -94,7 +94,6 @@ impl From<Error> for SolutionSubmissionError {
 
 pub struct StableXSolutionSubmitter<'a> {
     contract: Arc<dyn StableXContract>,
-    gas_price_estimating: Arc<dyn GasPriceEstimating + Send + Sync>,
     retry_with_gas_price_increase: Box<dyn SolutionTransactionSending + Send + Sync + 'a>,
     async_sleep: Box<dyn AsyncSleeping + 'a>,
 }
@@ -106,7 +105,6 @@ impl<'a> StableXSolutionSubmitter<'a> {
     ) -> Self {
         Self::with_retry_and_sleep(
             contract.clone(),
-            gas_price_estimating.clone(),
             retry::RetryWithGasPriceIncrease::new(contract, gas_price_estimating),
             crate::util::AsyncSleep {},
         )
@@ -114,13 +112,11 @@ impl<'a> StableXSolutionSubmitter<'a> {
 
     fn with_retry_and_sleep(
         contract: Arc<dyn StableXContract>,
-        gas_price_estimating: Arc<dyn GasPriceEstimating + Send + Sync>,
         retry_with_gas_price_increase: impl SolutionTransactionSending + Send + Sync + 'a,
         async_sleep: impl AsyncSleeping + 'a,
     ) -> Self {
         Self {
             contract,
-            gas_price_estimating,
             retry_with_gas_price_increase: Box::new(retry_with_gas_price_increase),
             async_sleep: Box::new(async_sleep),
         }
@@ -161,14 +157,12 @@ impl<'a> StableXSolutionSubmitter<'a> {
 
     async fn cancel_transaction_after_deadline(
         &self,
-        batch_index: u32,
         nonce: U256,
         gas_price_cap: f64,
+        deadline: Instant,
     ) -> Result<(), NoopTransactionError> {
-        // Add some extra time in case of desync between real time and ethereum node current block time.
-        let deadline = BatchId::from(batch_index).solve_end_time() + Duration::from_secs(30);
         let remaining = deadline
-            .duration_since(SystemTime::now())
+            .checked_duration_since(Instant::now())
             .unwrap_or_default();
         self.async_sleep.sleep(remaining).await;
         let gas_price = (gas_price_cap * MIN_GAS_PRICE_INCREASE_FACTOR).ceil();
@@ -203,20 +197,11 @@ impl<'a> StableXSolutionSubmitting for StableXSolutionSubmitter<'a> {
         claimed_objective_value: U256,
         gas_price_cap: f64,
     ) -> Result<(), SolutionSubmissionError> {
-        // If the gas price cap is not at least the fast gas price then submitting the solution
-        // is not feasible because it would take too long.
-        match self.gas_price_estimating.estimate().await {
-            Ok(gas_price) => {
-                if gas_price_cap < gas_price {
-                    return Err(SolutionSubmissionError::Benign(format!(
-                        "Solution does not generate enough fees for the transaction \
-                             to execute quickly enough: price cap {} < fast gas price {}",
-                        gas_price_cap, gas_price,
-                    )));
-                }
-            }
-            Err(err) => log::warn!("failed to estimate gas price: {:?}", err),
-        }
+        let target_confirm_time = Instant::now()
+            + BatchId::from(batch_index)
+                .solve_end_time()
+                .duration_since(SystemTime::now())
+                .unwrap_or_default();
         let nonce = self.contract.get_transaction_count().await?;
         let submit_future = self.retry_with_gas_price_increase.retry(retry::Args {
             batch_index,
@@ -224,9 +209,11 @@ impl<'a> StableXSolutionSubmitting for StableXSolutionSubmitter<'a> {
             claimed_objective_value,
             gas_price_cap,
             nonce,
+            target_confirm_time,
         });
-        let cancel_future =
-            self.cancel_transaction_after_deadline(batch_index, nonce, gas_price_cap);
+        // Add some extra time in case of desync between real time and ethereum node current block time.
+        let deadline = target_confirm_time + Duration::from_secs(30);
+        let cancel_future = self.cancel_transaction_after_deadline(nonce, gas_price_cap, deadline);
 
         // Run both futures at the same time. When one of them completes check whether the
         // result is a "nonce already used error". If this is the case then the other future's
@@ -315,7 +302,6 @@ mod tests {
     use super::*;
     use crate::{
         contracts::stablex_contract::{MockStableXContract, NoopTransactionError},
-        gas_price::MockGasPriceEstimating,
         util::{FutureWaitExt as _, MockAsyncSleeping},
     };
     use anyhow::anyhow;
@@ -323,14 +309,6 @@ mod tests {
     use futures::FutureExt as _;
     use mockall::predicate::{always, eq};
     use retry::MockSolutionTransactionSending;
-
-    fn erroring_gas_station() -> impl GasPriceEstimating {
-        let mut gas_price_estimating = MockGasPriceEstimating::new();
-        gas_price_estimating
-            .expect_estimate()
-            .returning(|| Err(anyhow!("")));
-        gas_price_estimating
-    }
 
     #[test]
     fn test_benign_verification_failure() {
@@ -350,15 +328,10 @@ mod tests {
             });
 
         let retry = MockSolutionTransactionSending::new();
-        let gas_price = erroring_gas_station();
         let sleep = MockAsyncSleeping::new();
 
-        let submitter = StableXSolutionSubmitter::with_retry_and_sleep(
-            Arc::new(contract),
-            Arc::new(gas_price),
-            retry,
-            sleep,
-        );
+        let submitter =
+            StableXSolutionSubmitter::with_retry_and_sleep(Arc::new(contract), retry, sleep);
         let result = submitter
             .get_solution_objective_value(0, Solution::trivial())
             .now_or_never()
@@ -424,13 +397,8 @@ mod tests {
             .expect_sleep()
             .returning(|_| future::pending().boxed());
 
-        let gas_price = erroring_gas_station();
-        let submitter = StableXSolutionSubmitter::with_retry_and_sleep(
-            Arc::new(contract),
-            Arc::new(gas_price),
-            retry,
-            sleep,
-        );
+        let submitter =
+            StableXSolutionSubmitter::with_retry_and_sleep(Arc::new(contract), retry, sleep);
         let result = submitter
             .submit_solution(0, Solution::trivial(), U256::zero(), 0.0)
             .now_or_never()
@@ -464,38 +432,13 @@ mod tests {
             .times(1)
             .returning(|_, _| immediate!(Err(NoopTransactionError::NoAccount)));
 
-        let gas_price = erroring_gas_station();
-        let submitter = StableXSolutionSubmitter::with_retry_and_sleep(
-            Arc::new(contract),
-            Arc::new(gas_price),
-            retry,
-            sleep,
-        );
+        let submitter =
+            StableXSolutionSubmitter::with_retry_and_sleep(Arc::new(contract), retry, sleep);
         let result = submitter
             .submit_solution(0, Solution::trivial(), 0.into(), 0.into())
             .now_or_never()
             .unwrap();
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn benign_error_if_gas_price_too_low() {
-        let contract = MockStableXContract::new();
-        let retry = MockSolutionTransactionSending::new();
-        let sleep = MockAsyncSleeping::new();
-        let mut gas_price = MockGasPriceEstimating::new();
-        gas_price.expect_estimate().returning(|| Ok(10.into()));
-        let submitter = StableXSolutionSubmitter::with_retry_and_sleep(
-            Arc::new(contract),
-            Arc::new(gas_price),
-            retry,
-            sleep,
-        );
-        let result = submitter
-            .submit_solution(0, Solution::trivial(), 0.into(), 9.into())
-            .now_or_never()
-            .unwrap();
-        assert!(matches!(result, Err(SolutionSubmissionError::Benign(_))));
     }
 
     #[test]
@@ -524,13 +467,8 @@ mod tests {
                 futures::future::pending().boxed()
             });
 
-        let gas_price = erroring_gas_station();
-        let submitter = StableXSolutionSubmitter::with_retry_and_sleep(
-            Arc::new(contract),
-            Arc::new(gas_price),
-            retry,
-            async_sleep,
-        );
+        let submitter =
+            StableXSolutionSubmitter::with_retry_and_sleep(Arc::new(contract), retry, async_sleep);
         let result = submitter
             .submit_solution(0, Solution::trivial(), 0.into(), 0.into())
             .wait();
@@ -571,13 +509,8 @@ mod tests {
                 immediate!(Err(nonce_error().into()))
             });
 
-        let gas_price = erroring_gas_station();
-        let submitter = StableXSolutionSubmitter::with_retry_and_sleep(
-            Arc::new(contract),
-            Arc::new(gas_price),
-            retry,
-            async_sleep,
-        );
+        let submitter =
+            StableXSolutionSubmitter::with_retry_and_sleep(Arc::new(contract), retry, async_sleep);
         let result = submitter
             .submit_solution(0, Solution::trivial(), 0.into(), 0.into())
             .wait();

--- a/services-core/src/solution_submission/retry.rs
+++ b/services-core/src/solution_submission/retry.rs
@@ -39,7 +39,7 @@ pub trait SolutionTransactionSending {
 
 pub struct RetryWithGasPriceIncrease<'a> {
     contract: Arc<dyn StableXContract>,
-    gas_price_estimating: Arc<dyn GasPriceEstimating + Send + Sync>,
+    gas_price_estimating: Arc<dyn GasPriceEstimating>,
     async_sleep: Box<dyn AsyncSleeping + 'a>,
     now: Box<dyn Now + 'a>,
 }
@@ -47,7 +47,7 @@ pub struct RetryWithGasPriceIncrease<'a> {
 impl<'a> RetryWithGasPriceIncrease<'a> {
     pub fn new(
         contract: Arc<dyn StableXContract>,
-        gas_price_estimating: Arc<dyn GasPriceEstimating + Send + Sync>,
+        gas_price_estimating: Arc<dyn GasPriceEstimating>,
     ) -> Self {
         Self::with_sleep_and_now(
             contract,
@@ -59,7 +59,7 @@ impl<'a> RetryWithGasPriceIncrease<'a> {
 
     pub fn with_sleep_and_now(
         contract: Arc<dyn StableXContract>,
-        gas_price_estimating: Arc<dyn GasPriceEstimating + Send + Sync>,
+        gas_price_estimating: Arc<dyn GasPriceEstimating>,
         async_sleep: impl AsyncSleeping + 'a,
         now: impl Now + 'a,
     ) -> Self {


### PR DESCRIPTION
Our current algorithm starts at fast gas price and increases the gas price
of the transaction by 50% every 30 seconds that the transaction hasn't
been mined up to the max gas economically viable gas price.
The new algorithm always uses the correct gas price according to our
smarter gas estimation which is based on the time it should take to mine
the transaction. This gas price is updated in short intervals and the
transaction is resubmitted if the gas price increases. The gas price is
still capped by economic viability.
This should lead to lower gas prices as we can pick a lower starting gas
price when there is still more time left to solve the batch and because
we never pick a gas price that is higher than what the gas station
predict we need to pay to get into the next block.

### Test Plan
Adjusted unit tests