### PR TITLE
Use multiple gas stations

### DIFF
--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -368,7 +368,7 @@ fn setup_monitoring() -> (
 async fn setup_http_services(
     http_factory: &HttpFactory,
     options: &Options,
-) -> (Web3, Arc<dyn GasPriceEstimating + Send + Sync>) {
+) -> (Web3, Arc<dyn GasPriceEstimating>) {
     let web3 = web3_provider(http_factory, options.node_url.as_str(), options.rpc_timeout).unwrap();
     let gas_station = gas_price::create_estimator(&http_factory, &web3)
         .await

--- a/services-core/src/economic_viability.rs
+++ b/services-core/src/economic_viability.rs
@@ -30,7 +30,7 @@ impl EconomicViabilityStrategy {
         static_min_avg_fee_per_order: Option<u128>,
         static_max_gas_price: Option<u128>,
         native_token_price: Arc<dyn NativeTokenPricing + Send + Sync>,
-        gas_station: Arc<dyn GasPriceEstimating + Send + Sync>,
+        gas_station: Arc<dyn GasPriceEstimating>,
     ) -> Result<Arc<dyn EconomicViabilityComputing>> {
         let make_dynamic = || {
             DynamicEconomicViabilityComputer::new(
@@ -84,7 +84,7 @@ pub trait EconomicViabilityComputing: Send + Sync + 'static {
 /// Economic viability constraints based on the current gas and native token price.
 pub struct DynamicEconomicViabilityComputer {
     price_oracle: Arc<dyn NativeTokenPricing + Send + Sync>,
-    gas_station: Arc<dyn GasPriceEstimating + Send + Sync>,
+    gas_station: Arc<dyn GasPriceEstimating>,
     subsidy_factor: f64,
     /// We multiply the min average fee by this amount to ensure that if a solution has this minimum
     /// amount it will still be end up economically viable even when the gas or native token price moves
@@ -95,7 +95,7 @@ pub struct DynamicEconomicViabilityComputer {
 impl DynamicEconomicViabilityComputer {
     pub fn new(
         price_oracle: Arc<dyn NativeTokenPricing + Send + Sync>,
-        gas_station: Arc<dyn GasPriceEstimating + Send + Sync>,
+        gas_station: Arc<dyn GasPriceEstimating>,
         subsidy_factor: f64,
         min_avg_fee_factor: f64,
     ) -> Self {

--- a/services-core/src/gas_price.rs
+++ b/services-core/src/gas_price.rs
@@ -32,7 +32,7 @@ pub async fn create_estimator(
     let network_id = web3.net().version().await?;
     let mut estimators = Vec::<Box<dyn GasPriceEstimating>>::new();
 
-    if network_id == "1" {
+    if is_mainnet(&network_id) {
         let gasnow = gasnow::GasNow::new(http_factory)?;
         estimators.push(Box::new(gasnow));
 
@@ -48,4 +48,8 @@ pub async fn create_estimator(
     estimators.push(Box::new(web3.clone()));
 
     Ok(Arc::new(priority::PriorityGasPrice::new(estimators)))
+}
+
+fn is_mainnet(network_id: &str) -> bool {
+    network_id == "1"
 }

--- a/services-core/src/gas_price.rs
+++ b/services-core/src/gas_price.rs
@@ -3,6 +3,7 @@ mod ethgasstation;
 mod gasnow;
 mod gnosis_safe;
 mod linear_interpolation;
+mod priority;
 
 use crate::{contracts::Web3, http::HttpFactory};
 use anyhow::Result;
@@ -27,10 +28,24 @@ pub trait GasPriceEstimating: Send + Sync {
 pub async fn create_estimator(
     http_factory: &HttpFactory,
     web3: &Web3,
-) -> Result<Arc<dyn GasPriceEstimating + Send + Sync>> {
+) -> Result<Arc<dyn GasPriceEstimating>> {
     let network_id = web3.net().version().await?;
-    Ok(match gnosis_safe::api_url_from_network_id(&network_id) {
-        Some(url) => Arc::new(gnosis_safe::GnosisSafeGasStation::new(http_factory, url)?),
-        None => Arc::new(web3.clone()),
-    })
+    let mut estimators = Vec::<Box<dyn GasPriceEstimating>>::new();
+
+    if network_id == "1" {
+        let gasnow = gasnow::GasNow::new(http_factory)?;
+        estimators.push(Box::new(gasnow));
+
+        let ethgasstation = ethgasstation::EthGasStation::new(http_factory)?;
+        estimators.push(Box::new(ethgasstation));
+    }
+
+    if let Some(gnosis_url) = gnosis_safe::api_url_from_network_id(&network_id) {
+        let gnosis_estimator = gnosis_safe::GnosisSafeGasStation::new(http_factory, gnosis_url)?;
+        estimators.push(Box::new(gnosis_estimator));
+    }
+
+    estimators.push(Box::new(web3.clone()));
+
+    Ok(Arc::new(priority::PriorityGasPrice::new(estimators)))
 }

--- a/services-core/src/gas_price/ethgasstation.rs
+++ b/services-core/src/gas_price/ethgasstation.rs
@@ -29,8 +29,7 @@ struct Response {
 }
 
 impl EthGasStation {
-    #[allow(dead_code)]
-    fn new(http_factory: &HttpFactory) -> Result<Self> {
+    pub fn new(http_factory: &HttpFactory) -> Result<Self> {
         let client = http_factory.create()?;
         let uri = Uri::from_static(API_URI);
         Ok(Self { client, uri })

--- a/services-core/src/gas_price/gasnow.rs
+++ b/services-core/src/gas_price/gasnow.rs
@@ -34,8 +34,7 @@ const STANDARD: Duration = Duration::from_secs(300);
 const SLOW: Duration = Duration::from_secs(600);
 
 impl GasNow {
-    #[allow(dead_code)]
-    fn new(http_factory: &HttpFactory) -> Result<Self> {
+    pub fn new(http_factory: &HttpFactory) -> Result<Self> {
         let client = http_factory.create()?;
         let uri = Uri::from_static(API_URI);
         Ok(Self { client, uri })

--- a/services-core/src/gas_price/priority.rs
+++ b/services-core/src/gas_price/priority.rs
@@ -1,0 +1,76 @@
+use super::GasPriceEstimating;
+use anyhow::{anyhow, Result};
+use std::{future::Future, time::Duration};
+
+// Uses the first successful estimator.
+pub struct PriorityGasPrice {
+    estimators: Vec<Box<dyn GasPriceEstimating>>,
+}
+
+impl PriorityGasPrice {
+    pub fn new(estimators: Vec<Box<dyn GasPriceEstimating>>) -> Self {
+        Self { estimators }
+    }
+
+    async fn prioritize<'a, T, F>(&'a self, operation: T) -> Result<f64>
+    where
+        T: Fn(&'a dyn GasPriceEstimating) -> F,
+        F: Future<Output = Result<f64>>,
+    {
+        for estimator in &self.estimators {
+            match operation(estimator.as_ref()).await {
+                Ok(result) => return Ok(result),
+                Err(err) => log::error!("gas estimator failed: {:?}", err),
+            }
+        }
+        Err(anyhow!("all gas estimators failed"))
+    }
+}
+
+#[async_trait::async_trait]
+impl GasPriceEstimating for PriorityGasPrice {
+    async fn estimate_with_limits(&self, gas_limit: f64, time_limit: Duration) -> Result<f64> {
+        self.prioritize(|estimator| estimator.estimate_with_limits(gas_limit, time_limit))
+            .await
+    }
+
+    async fn estimate(&self) -> Result<f64> {
+        self.prioritize(|estimator| estimator.estimate()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::MockGasPriceEstimating;
+    use super::*;
+    use assert_approx_eq::assert_approx_eq;
+    use futures::future::FutureExt;
+
+    #[test]
+    fn prioritize_picks_first() {
+        let mut estimator_0 = MockGasPriceEstimating::new();
+        let estimator_1 = MockGasPriceEstimating::new();
+
+        estimator_0.expect_estimate().times(1).returning(|| Ok(1.0));
+
+        let priority = PriorityGasPrice::new(vec![Box::new(estimator_0), Box::new(estimator_1)]);
+        let result = priority.estimate().now_or_never().unwrap().unwrap();
+        assert_approx_eq!(result, 1.0);
+    }
+
+    #[test]
+    fn prioritize_picks_second() {
+        let mut estimator_0 = MockGasPriceEstimating::new();
+        let mut estimator_1 = MockGasPriceEstimating::new();
+
+        estimator_0
+            .expect_estimate()
+            .times(1)
+            .returning(|| Err(anyhow!("")));
+        estimator_1.expect_estimate().times(1).returning(|| Ok(2.0));
+
+        let priority = PriorityGasPrice::new(vec![Box::new(estimator_0), Box::new(estimator_1)]);
+        let result = priority.estimate().now_or_never().unwrap().unwrap();
+        assert_approx_eq!(result, 2.0);
+    }
+}

--- a/services-core/src/solution_submission.rs
+++ b/services-core/src/solution_submission.rs
@@ -101,7 +101,7 @@ pub struct StableXSolutionSubmitter<'a> {
 impl<'a> StableXSolutionSubmitter<'a> {
     pub fn new(
         contract: Arc<dyn StableXContract>,
-        gas_price_estimating: Arc<dyn GasPriceEstimating + Send + Sync>,
+        gas_price_estimating: Arc<dyn GasPriceEstimating>,
     ) -> Self {
         Self::with_retry_and_sleep(
             contract.clone(),

--- a/services-core/src/solution_submission/retry.rs
+++ b/services-core/src/solution_submission/retry.rs
@@ -39,7 +39,7 @@ pub trait SolutionTransactionSending {
 
 pub struct RetryWithGasPriceIncrease<'a> {
     contract: Arc<dyn StableXContract>,
-    gas_price_estimating: Arc<dyn GasPriceEstimating + Send + Sync>,
+    gas_price_estimating: Arc<dyn GasPriceEstimating>,
     async_sleep: Box<dyn AsyncSleeping + 'a>,
     now: Box<dyn Now + 'a>,
 }
@@ -47,7 +47,7 @@ pub struct RetryWithGasPriceIncrease<'a> {
 impl<'a> RetryWithGasPriceIncrease<'a> {
     pub fn new(
         contract: Arc<dyn StableXContract>,
-        gas_price_estimating: Arc<dyn GasPriceEstimating + Send + Sync>,
+        gas_price_estimating: Arc<dyn GasPriceEstimating>,
     ) -> Self {
         Self::with_sleep_and_now(
             contract,
@@ -59,7 +59,7 @@ impl<'a> RetryWithGasPriceIncrease<'a> {
 
     pub fn with_sleep_and_now(
         contract: Arc<dyn StableXContract>,
-        gas_price_estimating: Arc<dyn GasPriceEstimating + Send + Sync>,
+        gas_price_estimating: Arc<dyn GasPriceEstimating>,
         async_sleep: impl AsyncSleeping + 'a,
         now: impl Now + 'a,
     ) -> Self {


### PR DESCRIPTION
to be more resilient against failure.

We should use either ethgasstation or gasnow as the highest priority because they react to changing gas prices much faster than the gnosis gas station. Between those I am not totally sure which is better but my gut feeling is that like the way gasnow works more.

### Test Plan
New unit tests of the priority estimator