### PR TITLE
[GasEstimate] refactor gas estimators to use abstract transport trait

### DIFF
--- a/services-core/src/gas_price.rs
+++ b/services-core/src/gas_price.rs
@@ -5,8 +5,10 @@ mod gnosis_safe;
 mod linear_interpolation;
 mod priority;
 
-use crate::{contracts::Web3, http::HttpFactory};
+use crate::{contracts::Web3, http::HttpClient, http::HttpFactory, metrics::HttpLabel};
 use anyhow::Result;
+use isahc::http::uri::Uri;
+use serde::de::DeserializeOwned;
 use std::{sync::Arc, time::Duration};
 
 pub const DEFAULT_GAS_LIMIT: f64 = 21000.0;
@@ -24,6 +26,19 @@ pub trait GasPriceEstimating: Send + Sync {
     async fn estimate_with_limits(&self, gas_limit: f64, time_limit: Duration) -> Result<f64>;
 }
 
+#[async_trait::async_trait]
+pub trait Transport: Send + Sync {
+    async fn get_json<T: DeserializeOwned>(&self, url: &'static str) -> Result<T>;
+}
+
+#[async_trait::async_trait]
+impl Transport for HttpClient {
+    async fn get_json<T: DeserializeOwned>(&self, url: &'static str) -> Result<T> {
+        let uri = Uri::from_static(url);
+        self.get_json_async(uri, HttpLabel::GasStation).await
+    }
+}
+
 /// Creates the default gas price estimator for the given network.
 pub async fn create_estimator(
     http_factory: &HttpFactory,
@@ -33,15 +48,16 @@ pub async fn create_estimator(
     let mut estimators = Vec::<Box<dyn GasPriceEstimating>>::new();
 
     if is_mainnet(&network_id) {
-        let gasnow = gasnow::GasNow::new(http_factory)?;
+        let gasnow = gasnow::GasNow::new(http_factory.create()?);
         estimators.push(Box::new(gasnow));
 
-        let ethgasstation = ethgasstation::EthGasStation::new(http_factory)?;
+        let ethgasstation = ethgasstation::EthGasStation::new(http_factory.create()?);
         estimators.push(Box::new(ethgasstation));
     }
 
     if let Some(gnosis_url) = gnosis_safe::api_url_from_network_id(&network_id) {
-        let gnosis_estimator = gnosis_safe::GnosisSafeGasStation::new(http_factory, gnosis_url)?;
+        let gnosis_estimator =
+            gnosis_safe::GnosisSafeGasStation::new(http_factory.create()?, gnosis_url);
         estimators.push(Box::new(gnosis_estimator));
     }
 
@@ -52,4 +68,22 @@ pub async fn create_estimator(
 
 fn is_mainnet(network_id: &str) -> bool {
     network_id == "1"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use isahc::ResponseExt;
+
+    #[derive(Default)]
+    pub struct TestTransport {}
+
+    #[async_trait::async_trait]
+    impl Transport for TestTransport {
+        async fn get_json<T: DeserializeOwned>(&self, url: &'static str) -> Result<T> {
+            let uri = Uri::from_static(url);
+            let json: String = isahc::get_async(uri).await?.text()?;
+            Ok(serde_json::from_str(&json)?)
+        }
+    }
 }

--- a/services-core/src/gas_price/ethgasstation.rs
+++ b/services-core/src/gas_price/ethgasstation.rs
@@ -69,7 +69,7 @@ fn estimate_with_limits(response: &Response, time_limit: Duration) -> Result<f64
 mod tests {
     use super::super::tests::TestTransport;
     use super::*;
-    use crate::util::FutureWaitExt;
+    use crate::util::FutureWaitExt as _;
 
     // cargo test -p services-core ethgasstation -- --ignored --nocapture
     #[test]

--- a/services-core/src/gas_price/ethgasstation.rs
+++ b/services-core/src/gas_price/ethgasstation.rs
@@ -1,16 +1,13 @@
-use super::{linear_interpolation, GasPriceEstimating};
-use crate::http::{HttpClient, HttpFactory, HttpLabel};
+use super::{linear_interpolation, GasPriceEstimating, Transport};
 use anyhow::Result;
-use isahc::http::uri::Uri;
 use std::{convert::TryInto, time::Duration};
 
 // Gas price estimation with https://ethgasstation.info/ , api https://docs.ethgasstation.info/gas-price .
 
 const API_URI: &str = "https://ethgasstation.info/api/ethgasAPI.json";
 
-pub struct EthGasStation {
-    client: HttpClient,
-    uri: Uri,
+pub struct EthGasStation<T> {
+    transport: T,
 }
 
 // gas prices in gwei*10 (2 gwei is transmitted as `20`)
@@ -28,22 +25,18 @@ struct Response {
     safe_low_wait: f64,
 }
 
-impl EthGasStation {
-    pub fn new(http_factory: &HttpFactory) -> Result<Self> {
-        let client = http_factory.create()?;
-        let uri = Uri::from_static(API_URI);
-        Ok(Self { client, uri })
+impl<T: Transport> EthGasStation<T> {
+    pub fn new(transport: T) -> Self {
+        Self { transport }
     }
 
     async fn gas_price(&self) -> Result<Response> {
-        self.client
-            .get_json_async(&self.uri, HttpLabel::GasStation)
-            .await
+        self.transport.get_json(API_URI).await
     }
 }
 
 #[async_trait::async_trait]
-impl GasPriceEstimating for EthGasStation {
+impl<T: Transport> GasPriceEstimating for EthGasStation<T> {
     async fn estimate_with_limits(&self, _gas_limit: f64, time_limit: Duration) -> Result<f64> {
         let response = self.gas_price().await?;
         let result = estimate_with_limits(&response, time_limit)?;
@@ -74,6 +67,7 @@ fn estimate_with_limits(response: &Response, time_limit: Duration) -> Result<f64
 
 #[cfg(test)]
 mod tests {
+    use super::super::tests::TestTransport;
     use super::*;
     use crate::util::FutureWaitExt;
 
@@ -81,7 +75,7 @@ mod tests {
     #[test]
     #[ignore]
     fn real_request() {
-        let ethgasstation = EthGasStation::new(&HttpFactory::default()).unwrap();
+        let ethgasstation = EthGasStation::new(TestTransport::default());
         let response = ethgasstation.gas_price().wait().unwrap();
         println!("{:?}", response);
         for i in 0..10 {

--- a/services-core/src/gas_price/gasnow.rs
+++ b/services-core/src/gas_price/gasnow.rs
@@ -60,7 +60,7 @@ impl<T: Transport> GasPriceEstimating for GasNow<T> {
 mod tests {
     use super::super::tests::TestTransport;
     use super::*;
-    use crate::util::FutureWaitExt;
+    use crate::util::FutureWaitExt as _;
 
     // cargo test -p services-core gasnow -- --ignored --nocapture
     #[test]

--- a/services-core/src/gas_price/gnosis_safe.rs
+++ b/services-core/src/gas_price/gnosis_safe.rs
@@ -59,9 +59,9 @@ const SAFE_LOW_PERCENTILE: f64 = 0.3;
 // price can be 1000 times the fast gas price which is not reasonable.
 const SECONDS_PER_BLOCK: f64 = 15.0;
 // Treat percentiles as probabilities for geometric distribution.
-const FAST_TIME: f64 = SECONDS_PER_BLOCK * FAST_PERCENTILE;
-const STANDARD_TIME: f64 = SECONDS_PER_BLOCK * STANDARD_PERCENTILE;
-const SAFE_LOW_TIME: f64 = SECONDS_PER_BLOCK * SAFE_LOW_PERCENTILE;
+const FAST_TIME: f64 = SECONDS_PER_BLOCK / FAST_PERCENTILE;
+const STANDARD_TIME: f64 = SECONDS_PER_BLOCK / STANDARD_PERCENTILE;
+const SAFE_LOW_TIME: f64 = SECONDS_PER_BLOCK / SAFE_LOW_PERCENTILE;
 
 /// Retrieve gas prices from the Gnosis Safe gas station service.
 #[derive(Debug)]
@@ -144,6 +144,20 @@ pub mod tests {
         assert_approx_eq!(result.standard, 12000000001.0);
         assert_approx_eq!(result.fast, 20000000001.0);
         assert_approx_eq!(result.fastest, 1377000000001.0);
+    }
+
+    #[test]
+    fn returns_standard_gas_price_for_30_second_limit() {
+        let price = GasPrices {
+            last_update: String::new(),
+            lowest: 100.0,
+            safe_low: 200.0,
+            standard: 300.0,
+            fast: 400.0,
+            fastest: 500.0,
+        };
+        let estimate = estimate_with_limits(&price, 0.0, Duration::from_secs(30)).unwrap();
+        assert_approx_eq!(estimate, 300.0);
     }
 
     // cargo test -p services-core gnosis_safe -- --ignored --nocapture

--- a/services-core/src/gas_price/gnosis_safe.rs
+++ b/services-core/src/gas_price/gnosis_safe.rs
@@ -119,7 +119,7 @@ pub mod tests {
     use super::super::tests::TestTransport;
     use super::super::DEFAULT_GAS_LIMIT;
     use super::*;
-    use crate::util::FutureWaitExt;
+    use crate::util::FutureWaitExt as _;
     use assert_approx_eq::assert_approx_eq;
 
     #[test]

--- a/services-core/src/gas_price/gnosis_safe.rs
+++ b/services-core/src/gas_price/gnosis_safe.rs
@@ -1,10 +1,9 @@
 //! Gnosis Safe gas station `GasPriceEstimating` implementation.
 //! Api documentation at https://safe-relay.gnosis.io/ .
 
-use super::{linear_interpolation, GasPriceEstimating};
-use crate::http::{HttpClient, HttpFactory, HttpLabel};
+use super::{linear_interpolation, GasPriceEstimating, Transport};
+
 use anyhow::Result;
-use isahc::http::uri::Uri;
 use serde::Deserialize;
 use serde_with::rust::display_fromstr;
 use std::{convert::TryInto, time::Duration};
@@ -65,28 +64,24 @@ const SAFE_LOW_TIME: f64 = SECONDS_PER_BLOCK / SAFE_LOW_PERCENTILE;
 
 /// Retrieve gas prices from the Gnosis Safe gas station service.
 #[derive(Debug)]
-pub struct GnosisSafeGasStation {
-    client: HttpClient,
-    uri: Uri,
+pub struct GnosisSafeGasStation<T> {
+    transport: T,
+    uri: &'static str,
 }
 
-impl GnosisSafeGasStation {
-    pub fn new(http_factory: &HttpFactory, api_uri: &str) -> Result<GnosisSafeGasStation> {
-        let client = http_factory.create()?;
-        let uri: Uri = api_uri.parse()?;
-        Ok(GnosisSafeGasStation { client, uri })
+impl<T: Transport> GnosisSafeGasStation<T> {
+    pub fn new(transport: T, uri: &'static str) -> GnosisSafeGasStation<T> {
+        GnosisSafeGasStation { transport, uri }
     }
 
     /// Retrieves the current gas prices from the gas station.
     pub async fn gas_prices(&self) -> Result<GasPrices> {
-        self.client
-            .get_json_async(&self.uri, HttpLabel::GasStation)
-            .await
+        self.transport.get_json(&self.uri).await
     }
 }
 
 #[async_trait::async_trait]
-impl GasPriceEstimating for GnosisSafeGasStation {
+impl<T: Transport + Send + Sync> GasPriceEstimating for GnosisSafeGasStation<T> {
     // The default implementation calls estimate_with_limits with 30 seconds which would result in
     // the standard time instead of fast. So to keep that behavior we implement it manually.
     async fn estimate(&self) -> Result<f64> {
@@ -121,9 +116,10 @@ fn estimate_with_limits(
 
 #[cfg(test)]
 pub mod tests {
+    use super::super::tests::TestTransport;
     use super::super::DEFAULT_GAS_LIMIT;
     use super::*;
-    use crate::util::FutureWaitExt as _;
+    use crate::util::FutureWaitExt;
     use assert_approx_eq::assert_approx_eq;
 
     #[test]
@@ -164,8 +160,7 @@ pub mod tests {
     #[test]
     #[ignore]
     fn real_request() {
-        let gas_station =
-            GnosisSafeGasStation::new(&HttpFactory::default(), DEFAULT_MAINNET_URI).unwrap();
+        let gas_station = GnosisSafeGasStation::new(TestTransport::default(), DEFAULT_MAINNET_URI);
         let response = gas_station.gas_prices().wait().unwrap();
         println!("{:?}", response);
         for i in 0..10 {

--- a/services-core/src/gas_price/gnosis_safe.rs
+++ b/services-core/src/gas_price/gnosis_safe.rs
@@ -66,11 +66,11 @@ const SAFE_LOW_TIME: f64 = SECONDS_PER_BLOCK / SAFE_LOW_PERCENTILE;
 #[derive(Debug)]
 pub struct GnosisSafeGasStation<T> {
     transport: T,
-    uri: &'static str,
+    uri: String,
 }
 
 impl<T: Transport> GnosisSafeGasStation<T> {
-    pub fn new(transport: T, uri: &'static str) -> GnosisSafeGasStation<T> {
+    pub fn new(transport: T, uri: String) -> GnosisSafeGasStation<T> {
         GnosisSafeGasStation { transport, uri }
     }
 
@@ -81,7 +81,7 @@ impl<T: Transport> GnosisSafeGasStation<T> {
 }
 
 #[async_trait::async_trait]
-impl<T: Transport + Send + Sync> GasPriceEstimating for GnosisSafeGasStation<T> {
+impl<T: Transport> GasPriceEstimating for GnosisSafeGasStation<T> {
     // The default implementation calls estimate_with_limits with 30 seconds which would result in
     // the standard time instead of fast. So to keep that behavior we implement it manually.
     async fn estimate(&self) -> Result<f64> {
@@ -160,7 +160,8 @@ pub mod tests {
     #[test]
     #[ignore]
     fn real_request() {
-        let gas_station = GnosisSafeGasStation::new(TestTransport::default(), DEFAULT_MAINNET_URI);
+        let gas_station =
+            GnosisSafeGasStation::new(TestTransport::default(), DEFAULT_MAINNET_URI.into());
         let response = gas_station.gas_prices().wait().unwrap();
         println!("{:?}", response);
         for i in 0..10 {

--- a/services-core/src/token_info/onchain.rs
+++ b/services-core/src/token_info/onchain.rs
@@ -26,7 +26,7 @@ mod tests {
     use super::*;
     use crate::contracts::web3_provider;
     use crate::http::HttpFactory;
-    use crate::util::FutureWaitExt;
+    use crate::util::FutureWaitExt as _;
     use ethcontract::secret::PrivateKey;
     use std::time::Duration;
 


### PR DESCRIPTION
This will allow extracting the gas estimation logic into its own crate and reuse it e.g. in the gas token miner as well as in oba services without requiring logic that is specific to `services-core` (e.g. HTTPTransport, MetricLabels, etc). 
The `eth_node` implementation will likely not be extractable as it is bound to the web3 struct and doesn't add much custom logic.

### Test Plan
CI + `cargo test gas_price -- --ignored`