### PR TITLE
Make gas estimators configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ OPTIONS:
         --economic-viability-subsidy-factor <economic-viability-subsidy-factor>
             Subsidy factor used to compute the minimum average fee per order in a solution as well as the gas cap for
             economically viable solution [env: ECONOMIC_VIABILITY_SUBSIDY_FACTOR=]  [default: 1.0]
+        --gas-estimators <gas-estimators>...
+            Which gas estimators to use. Multiple estimators are used in sequence if a previous one fails. Individual
+            estimators support different networks. `EthGasStation`: supports mainnet. `GasNow`: supports mainnet.
+            `GnosisSafe`: supports mainnet and rinkeby. `Web3`: supports every network [env: GAS_ESTIMATORS=]  [default:
+            Web3]  [possible values: EthGasStation, GasNow, GnosisSafe, Web3]
         --http-timeout <http-timeout>
             The default timeout in milliseconds of HTTP requests to remote services such as the Gnosis Safe gas station
             and exchange REST APIs for fetching price estimates [env: HTTP_TIMEOUT=]  [default: 10000]

--- a/services-core/src/gas_price.rs
+++ b/services-core/src/gas_price.rs
@@ -6,7 +6,7 @@ mod linear_interpolation;
 mod priority;
 
 use crate::{contracts::Web3, http::HttpFactory};
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use std::{sync::Arc, time::Duration};
 
 pub const DEFAULT_GAS_LIMIT: f64 = 21000.0;
@@ -24,29 +24,43 @@ pub trait GasPriceEstimating: Send + Sync {
     async fn estimate_with_limits(&self, gas_limit: f64, time_limit: Duration) -> Result<f64>;
 }
 
-/// Creates the default gas price estimator for the given network.
-pub async fn create_estimator(
+arg_enum! {
+    #[derive(Debug)]
+    pub enum GasEstimatorType {
+        EthGasStation,
+        GasNow,
+        GnosisSafe,
+        Web3,
+    }
+}
+
+pub async fn create_priority_estimator(
     http_factory: &HttpFactory,
     web3: &Web3,
+    estimator_types: &[GasEstimatorType],
 ) -> Result<Arc<dyn GasPriceEstimating>> {
     let network_id = web3.net().version().await?;
     let mut estimators = Vec::<Box<dyn GasPriceEstimating>>::new();
-
-    if is_mainnet(&network_id) {
-        let gasnow = gasnow::GasNow::new(http_factory)?;
-        estimators.push(Box::new(gasnow));
-
-        let ethgasstation = ethgasstation::EthGasStation::new(http_factory)?;
-        estimators.push(Box::new(ethgasstation));
+    for estimator_type in estimator_types {
+        match estimator_type {
+            GasEstimatorType::EthGasStation => {
+                if !is_mainnet(&network_id) {
+                    return Err(anyhow!("EthGasStation only supports mainnet"));
+                }
+                estimators.push(Box::new(ethgasstation::EthGasStation::new(http_factory)?))
+            }
+            GasEstimatorType::GasNow => {
+                if !is_mainnet(&network_id) {
+                    return Err(anyhow!("GasNow only supports mainnet"));
+                }
+                estimators.push(Box::new(gasnow::GasNow::new(http_factory)?))
+            }
+            GasEstimatorType::GnosisSafe => estimators.push(Box::new(
+                gnosis_safe::GnosisSafeGasStation::with_network_id(&network_id, http_factory)?,
+            )),
+            GasEstimatorType::Web3 => estimators.push(Box::new(web3.clone())),
+        }
     }
-
-    if let Some(gnosis_url) = gnosis_safe::api_url_from_network_id(&network_id) {
-        let gnosis_estimator = gnosis_safe::GnosisSafeGasStation::new(http_factory, gnosis_url)?;
-        estimators.push(Box::new(gnosis_estimator));
-    }
-
-    estimators.push(Box::new(web3.clone()));
-
     Ok(Arc::new(priority::PriorityGasPrice::new(estimators)))
 }
 

--- a/services-core/src/gas_price/gnosis_safe.rs
+++ b/services-core/src/gas_price/gnosis_safe.rs
@@ -3,7 +3,7 @@
 
 use super::{linear_interpolation, GasPriceEstimating};
 use crate::http::{HttpClient, HttpFactory, HttpLabel};
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use isahc::http::uri::Uri;
 use serde::Deserialize;
 use serde_with::rust::display_fromstr;
@@ -71,10 +71,12 @@ pub struct GnosisSafeGasStation {
 }
 
 impl GnosisSafeGasStation {
-    pub fn new(http_factory: &HttpFactory, api_uri: &str) -> Result<GnosisSafeGasStation> {
+    pub fn with_network_id(network_id: &str, http_factory: &HttpFactory) -> Result<Self> {
+        let api_uri = api_url_from_network_id(network_id)
+            .ok_or_else(|| anyhow!("unsupported network id {}", network_id))?;
         let client = http_factory.create()?;
         let uri: Uri = api_uri.parse()?;
-        Ok(GnosisSafeGasStation { client, uri })
+        Ok(Self { client, uri })
     }
 
     /// Retrieves the current gas prices from the gas station.
@@ -151,7 +153,7 @@ pub mod tests {
     #[ignore]
     fn real_request() {
         let gas_station =
-            GnosisSafeGasStation::new(&HttpFactory::default(), DEFAULT_MAINNET_URI).unwrap();
+            GnosisSafeGasStation::with_network_id("1", &HttpFactory::default()).unwrap();
         let response = gas_station.gas_prices().wait().unwrap();
         println!("{:?}", response);
         for i in 0..10 {


### PR DESCRIPTION
This is useful in case an estimator becomes broken and we want to
disable it without recompilation.

I set the default estimator to web3 because this is the only one that works on every network.

This is a config change because we do not want to use the new default.

### Test Plan
Ran the binary locally to make sure arguments are interpreted correctly.