### PR TITLE
Remove error for no local account

### DIFF
--- a/services-core/src/contracts.rs
+++ b/services-core/src/contracts.rs
@@ -17,13 +17,14 @@ pub fn web3_provider(http_factory: &HttpFactory, url: &str, timeout: Duration) -
     Ok(web3)
 }
 
-fn method_defaults(key: PrivateKey, chain_id: u64) -> Result<MethodDefaults> {
-    let account = Account::Offline(key, Some(chain_id));
-    let defaults = MethodDefaults {
+fn account(key: PrivateKey, chain_id: u64) -> Account {
+    Account::Offline(key, Some(chain_id))
+}
+
+fn method_defaults(account: Account) -> MethodDefaults {
+    MethodDefaults {
         from: Some(account),
         gas: None,
         gas_price: None,
-    };
-
-    Ok(defaults)
+    }
 }


### PR DESCRIPTION
We do in fact guarantee that this cannot happen because `new` always
creates an account. By making use of this fact we simplify the api.

### Test Plan
Adjusted unit test.