### PR TITLE
Cancellation refactor 2: Add helper future for keeping track of multiple inner futures

### DIFF
--- a/driver/docker/rust/Dockerfile.debug
+++ b/driver/docker/rust/Dockerfile.debug
@@ -16,4 +16,4 @@ ENV PATH="/root/.cargo/bin:$PATH"
 
 COPY ./ /app/dex-services
 WORKDIR /app/dex-services
-RUN cargo build
+RUN cargo build -p driver

--- a/services-core/src/solution_submission.rs
+++ b/services-core/src/solution_submission.rs
@@ -1,3 +1,4 @@
+mod first_match;
 mod retry;
 
 use crate::{

--- a/services-core/src/solution_submission/first_match.rs
+++ b/services-core/src/solution_submission/first_match.rs
@@ -1,0 +1,102 @@
+use futures::{
+    future::FusedFuture,
+    stream::{futures_unordered::FuturesUnordered, StreamExt as _},
+};
+use std::{future::Future, pin::Pin, task::Context, task::Poll};
+
+/// Resolves to the first result of a set of inner futures that matches a filter.
+/// Futures can be dynamically added to the inner future.
+/// Stays pending until there is at least one future.
+/// If the last inner future is ready its result is returned even if it doesn't match the filter.
+pub struct FirstMatch<Fut, Filter> {
+    futures: FuturesUnordered<Fut>,
+    filter: Filter,
+    is_terminated: bool,
+}
+
+impl<Fut, Filter> FirstMatch<Fut, Filter> {
+    pub fn new(filter: Filter) -> Self {
+        Self {
+            filter,
+            futures: FuturesUnordered::new(),
+            is_terminated: false,
+        }
+    }
+
+    pub fn push(&self, future: Fut) {
+        self.futures.push(future);
+    }
+}
+
+impl<Fut, Filter> Future for FirstMatch<Fut, Filter>
+where
+    Fut: Future,
+    Filter: FnMut(&Fut::Output) -> bool + Unpin,
+{
+    type Output = Fut::Output;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // The stream can only return None if there are no futures. The stream mustn't be polled
+        // after it has yielded None so we ensure that we do not attempt to poll in this case.
+        if self.futures.is_empty() {
+            return Poll::Pending;
+        }
+        while let Poll::Ready(result) = self.futures.poll_next_unpin(cx) {
+            // Unwrap because we checked that it isn't empty.
+            let result = result.unwrap();
+            if self.futures.is_empty() || (self.filter)(&result) {
+                self.is_terminated = true;
+                return Poll::Ready(result);
+            }
+        }
+        Poll::Pending
+    }
+}
+
+// We implement this because this is useful for consumers for example when they want to use
+// `select!`. Usually they would just call `FutureExt::fuse` but for this type it would prevent them
+// from pushing more futures afterwards.
+impl<Fut, Filter> FusedFuture for FirstMatch<Fut, Filter>
+where
+    Fut: Future,
+    Filter: FnMut(&Fut::Output) -> bool + Unpin,
+{
+    fn is_terminated(&self) -> bool {
+        self.is_terminated
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::future::{self, FutureExt as _};
+
+    #[test]
+    fn ready_because_filter() {
+        let first_match = FirstMatch::new(|i: &u8| *i == 3);
+        first_match.push(future::pending().boxed());
+        first_match.push(future::ready(2).boxed());
+        first_match.push(future::ready(3).boxed());
+        assert_eq!(first_match.now_or_never().unwrap(), 3);
+    }
+
+    #[test]
+    fn ready_because_last() {
+        let first_match = FirstMatch::new(|i: &u8| *i == 3);
+        first_match.push(future::ready(2).boxed());
+        assert_eq!(first_match.now_or_never().unwrap(), 2);
+    }
+
+    #[test]
+    fn not_ready_because_pending() {
+        let first_match = FirstMatch::new(|_: &()| false);
+        first_match.push(future::pending().boxed());
+        assert_eq!(first_match.now_or_never(), None);
+    }
+
+    #[test]
+    fn not_ready_before_push() {
+        let first_match = FirstMatch::<future::Pending<()>, _>::new(|_: &()| false);
+        assert_eq!(first_match.now_or_never(), None);
+    }
+}

--- a/services-core/src/solution_submission/retry.rs
+++ b/services-core/src/solution_submission/retry.rs
@@ -179,6 +179,7 @@ impl<'a> RetryWithGasPriceIncrease<'a> {
         let mut last_used_gas_price = 0.0;
         loop {
             futures::select! {
+                // Unwrap because the stream never ends.
                 gas_price = gas_price_stream.next() => match gas_price.unwrap() {
                     Ok(gas_price) => {
                         log::debug!("estimated gas price {}", gas_price);

--- a/services-core/src/solution_submission/retry.rs
+++ b/services-core/src/solution_submission/retry.rs
@@ -245,10 +245,26 @@ mod tests {
         gas_price::MockGasPriceEstimating,
         util::{FutureWaitExt as _, MockAsyncSleeping},
     };
+    use ethcontract::{transaction::TransactionResult, H256};
     use futures::future;
 
+    pub fn nonce_execution_error() -> ExecutionError {
+        ExecutionError::Web3(Web3Error::Rpc(RpcError {
+            code: ethcontract::jsonrpc::types::ErrorCode::ServerError(-32010),
+            message: "Transaction nonce is too low.".to_string(),
+            data: None,
+        }))
+    }
+
+    fn nonce_method_error() -> MethodError {
+        MethodError {
+            signature: String::new(),
+            inner: nonce_execution_error(),
+        }
+    }
+
     #[test]
-    fn new_as_price_estimate_() {
+    fn new_gas_price_estimate_() {
         // new below previous
         assert_eq!(new_gas_price_estimate(1.0, 0.0, 2.0), None);
         //new equal to previous
@@ -271,7 +287,7 @@ mod tests {
     }
 
     #[test]
-    fn test_retry_with_gas_price_respects_minimum_increase() {
+    fn respects_minimum_gas_price_increase() {
         let mut contract = MockStableXContract::new();
         let mut gas_price = MockGasPriceEstimating::new();
         let mut sleep = MockAsyncSleeping::new();
@@ -318,70 +334,8 @@ mod tests {
             sleep,
             util::default_now(),
         );
-        let result = retry.retry(args).wait();
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn previous_transaction_completes_first() {
-        let mut contract = MockStableXContract::new();
-        let mut gas_price = MockGasPriceEstimating::new();
-        let mut sleep = MockAsyncSleeping::new();
-        let (sender, receiver) = futures::channel::oneshot::channel();
-
-        gas_price
-            .expect_estimate_with_limits()
-            .times(1)
-            .returning(|_, _| Ok(1.0));
-        contract
-            .expect_submit_solution()
-            .times(1)
-            .return_once(|_, _, _, _, _| {
-                async move {
-                    receiver.await.unwrap();
-                    Ok(())
-                }
-                .boxed()
-            });
-        sleep.expect_sleep().times(1).returning(|_| immediate!(()));
-        gas_price
-            .expect_estimate_with_limits()
-            .times(1)
-            .returning(|_, _| Ok(2.0));
-        contract
-            .expect_submit_solution()
-            .times(1)
-            .return_once(|_, _, _, _, _| {
-                sender.send(()).unwrap();
-                futures::future::pending().boxed()
-            });
-        sleep
-            .expect_sleep()
-            .returning(|_| future::pending().boxed());
-
-        let args = Args {
-            batch_index: 1,
-            solution: Solution::trivial(),
-            claimed_objective_value: 1.into(),
-            gas_price_cap: 10.0,
-            nonce: 0.into(),
-            target_confirm_time: Instant::now(),
-        };
-        let retry = RetryWithGasPriceIncrease::with_sleep_and_now(
-            Arc::new(contract),
-            Arc::new(gas_price),
-            sleep,
-            util::default_now(),
-        );
-        let result = retry.retry(args).wait();
-        assert!(result.is_ok());
-    }
-
-    fn nonce_error() -> MethodError {
-        MethodError {
-            signature: String::new(),
-            inner: crate::solution_submission::tests::nonce_error(),
-        }
+        let result = retry.retry(args, future::pending().boxed()).wait();
+        assert!(matches!(result, RetryResult::Submitted(Ok(()))));
     }
 
     #[test]
@@ -415,7 +369,7 @@ mod tests {
             .times(1)
             .return_once(|_, _, _, _, _| {
                 sender.send(()).unwrap();
-                immediate!(Err(nonce_error()))
+                immediate!(Err(nonce_method_error()))
             });
         sleep
             .expect_sleep()
@@ -435,7 +389,105 @@ mod tests {
             sleep,
             util::default_now(),
         );
-        let result = retry.retry(args).wait();
-        assert!(result.is_ok());
+        let result = retry.retry(args, future::pending().boxed()).wait();
+        assert!(matches!(dbg!(result), RetryResult::Submitted(Ok(()))));
+    }
+
+    #[test]
+    fn submission_completes_during_cancellation() {
+        let (cancel_sender, cancel_receiver) = futures::channel::oneshot::channel();
+        let (submit_sender, submit_receiver) = futures::channel::oneshot::channel();
+        let mut contract = MockStableXContract::new();
+        let mut gas_price = MockGasPriceEstimating::new();
+        let mut sleep = MockAsyncSleeping::new();
+
+        let cancel_future = async move {
+            cancel_receiver.await.unwrap();
+            submit_sender.send(()).unwrap();
+        }
+        .boxed();
+        gas_price
+            .expect_estimate_with_limits()
+            .times(1)
+            .returning(|_, _| Ok(1.0));
+        contract
+            .expect_submit_solution()
+            .times(1)
+            .return_once(|_, _, _, _, _| {
+                async move {
+                    cancel_sender.send(()).unwrap();
+                    submit_receiver.await.unwrap();
+                    Ok(())
+                }
+                .boxed()
+            });
+        sleep
+            .expect_sleep()
+            .return_once(|_| future::pending().boxed());
+
+        let args = Args {
+            batch_index: 1,
+            solution: Solution::trivial(),
+            claimed_objective_value: 1.into(),
+            gas_price_cap: 10.0,
+            nonce: 0.into(),
+            target_confirm_time: Instant::now(),
+        };
+        let retry = RetryWithGasPriceIncrease::with_sleep_and_now(
+            Arc::new(contract),
+            Arc::new(gas_price),
+            sleep,
+            util::default_now(),
+        );
+        let result = retry.retry(args, cancel_future).wait();
+        assert!(matches!(result, RetryResult::Submitted(Ok(()))));
+    }
+
+    #[test]
+    fn cancellation_completes() {
+        let (cancel_sender, cancel_receiver) = futures::channel::oneshot::channel();
+        let mut contract = MockStableXContract::new();
+        let mut gas_price = MockGasPriceEstimating::new();
+        let mut sleep = MockAsyncSleeping::new();
+
+        let cancel_future = async move {
+            cancel_receiver.await.unwrap();
+        }
+        .boxed();
+        gas_price
+            .expect_estimate_with_limits()
+            .times(1)
+            .returning(|_, _| Ok(1.0));
+        contract
+            .expect_submit_solution()
+            .times(1)
+            .return_once(|_, _, _, _, _| {
+                cancel_sender.send(()).unwrap();
+                future::pending().boxed()
+            });
+        sleep
+            .expect_sleep()
+            .return_once(|_| future::pending().boxed());
+        contract
+            .expect_send_noop_transaction()
+            .times(1)
+            .return_once(|_, _| immediate!(Ok(TransactionResult::Hash(H256::zero()))));
+
+        let args = Args {
+            batch_index: 1,
+            solution: Solution::trivial(),
+            claimed_objective_value: 1.into(),
+            gas_price_cap: 10.0,
+            nonce: 0.into(),
+            target_confirm_time: Instant::now(),
+        };
+        let retry = RetryWithGasPriceIncrease::with_sleep_and_now(
+            Arc::new(contract),
+            Arc::new(gas_price),
+            sleep,
+            util::default_now(),
+        );
+        let result = retry.retry(args, cancel_future).wait();
+        assert!(matches!(result, RetryResult::Cancelled(Ok(()))));
     }
 }


### PR DESCRIPTION
This will be used in the new retry-cancellation api to keep track of several solution transactions and the cancellation transaction. The type encapsulates this so that the `retry` function does not need to deal with it.