### PR TITLE
Cancellation refactor 4: Update tests for the new retry-cancellation api

### DIFF
--- a/driver/docker/rust/Dockerfile.debug
+++ b/driver/docker/rust/Dockerfile.debug
@@ -16,4 +16,4 @@ ENV PATH="/root/.cargo/bin:$PATH"
 
 COPY ./ /app/dex-services
 WORKDIR /app/dex-services
-RUN cargo build
+RUN cargo build -p driver


### PR DESCRIPTION
This is the final PR and should pass CI.

### Test Plan
New unit tests, CI.