### PR TITLE
Simplify trait bounds for AsyncSleeping, Now, SolutionTransactionSending

### DIFF
--- a/services-core/src/solution_submission.rs
+++ b/services-core/src/solution_submission.rs
@@ -87,13 +87,13 @@ impl From<Error> for SolutionSubmissionError {
     }
 }
 
-pub struct StableXSolutionSubmitter<'a> {
+pub struct StableXSolutionSubmitter {
     contract: Arc<dyn StableXContract>,
-    retry_with_gas_price_increase: Box<dyn SolutionTransactionSending + Send + Sync + 'a>,
-    async_sleep: Box<dyn AsyncSleeping + 'a>,
+    retry_with_gas_price_increase: Box<dyn SolutionTransactionSending>,
+    async_sleep: Box<dyn AsyncSleeping>,
 }
 
-impl<'a> StableXSolutionSubmitter<'a> {
+impl StableXSolutionSubmitter {
     pub fn new(
         contract: Arc<dyn StableXContract>,
         gas_price_estimating: Arc<dyn GasPriceEstimating>,
@@ -107,8 +107,8 @@ impl<'a> StableXSolutionSubmitter<'a> {
 
     fn with_retry_and_sleep(
         contract: Arc<dyn StableXContract>,
-        retry_with_gas_price_increase: impl SolutionTransactionSending + Send + Sync + 'a,
-        async_sleep: impl AsyncSleeping + 'a,
+        retry_with_gas_price_increase: impl SolutionTransactionSending + 'static,
+        async_sleep: impl AsyncSleeping,
     ) -> Self {
         Self {
             contract,
@@ -152,7 +152,7 @@ impl<'a> StableXSolutionSubmitter<'a> {
 }
 
 #[async_trait::async_trait]
-impl<'a> StableXSolutionSubmitting for StableXSolutionSubmitter<'a> {
+impl StableXSolutionSubmitting for StableXSolutionSubmitter {
     async fn get_solution_objective_value(
         &self,
         batch_index: u32,

--- a/services-core/src/util.rs
+++ b/services-core/src/util.rs
@@ -62,7 +62,7 @@ where
 }
 
 #[cfg_attr(test, mockall::automock)]
-pub trait AsyncSleeping: Send + Sync {
+pub trait AsyncSleeping: Send + Sync + 'static {
     #[must_use]
     fn sleep(&self, duration: Duration) -> BoxFuture<'static, ()> {
         async_std::task::sleep(duration).boxed()
@@ -73,7 +73,7 @@ pub struct AsyncSleep;
 impl AsyncSleeping for AsyncSleep {}
 
 #[cfg_attr(test, mockall::automock)]
-pub trait Now: Send + Sync {
+pub trait Now: Send + Sync + 'static {
     fn system_now(&self) -> SystemTime;
     fn instant_now(&self) -> Instant;
 }


### PR DESCRIPTION
For AsyncSleeping and and Now we can safely assume that that this trait
is always 'static which gets rid of some generic lifetimes.
For SolutionTransactionSending we can assume that it is always Send and
Sync but here I didn't want to add 'static because it would be
reasonable to create an implementation based on &StablexContract instead
of Arc for example.

### Test Plan
Still compiles.