### PR TITLE
Custom TokenPairRange.arbitrary implementation with 30 hops bound

### DIFF
--- a/pricegraph/src/encoding.rs
+++ b/pricegraph/src/encoding.rs
@@ -1,6 +1,8 @@
 //! This module implements decoding for the standard `BatchExchange` contract
 //! encoded orders.
 
+#[cfg(feature = "arbitrary")]
+use arbitrary::{Arbitrary, Unstructured};
 pub use primitive_types::{H160, U256};
 use thiserror::Error;
 
@@ -47,12 +49,21 @@ impl TokenPair {
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TokenPairRange {
     /// The traded pair.
     pub pair: TokenPair,
     /// The maximum number of transitive trades allowed to trade the pair.
     pub hops: Option<usize>,
+}
+
+#[cfg(feature = "arbitrary")]
+impl Arbitrary for TokenPairRange {
+    fn arbitrary(u: &mut Unstructured<'_>) -> arbitrary::Result<Self> {
+        let pair = u.arbitrary::<TokenPair>()?;
+        // The API doesn't allow creating ranges of more than 30 hops
+        let hops = u.arbitrary::<Option<usize>>()?.map(|hops| hops % 30);
+        Ok(Self { pair, hops })
+    }
 }
 
 impl TokenPairRange {


### PR DESCRIPTION
Fixes the recent fuzzer crashes by implementing arbitrary of TokenPairRange with a hard cap of 30. This is fine, as the query params get sanitized [here](https://github.com/gnosis/dex-services/blob/db7b913f7f8ffc36057787f07a3b4aa901c25a3c/price-estimator/src/models/query.rs#L92-L98) and so we never create a TokenPairRange that is larger.

Not sure if on top of this it makes sense to limit the hops in a TokenPairRange contructor. Not limiting 0 hops as this is still possible from an API perspective and thus should probably be fuzzed as well.

### Test Plan
Unpack [crash.bin.zip](https://github.com/gnosis/dex-services/files/5582570/crash.bin.zip) and run

```
cargo +nightly fuzz run pricegraph ~/Downloads/crash.bin
```

And see no more crash.