### PR TITLE
[Easy] fix price estimator dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,13 @@ target
 **/node_modules
 .git
 .vscode
+.github
+.mergify.yml
+.travis.yml
+.gitignore
+.dockerignore
+docker-compose.yml
+
+ci
+hooks
+

--- a/price-estimator/docker/Dockerfile
+++ b/price-estimator/docker/Dockerfile
@@ -1,14 +1,8 @@
 FROM clux/muslrust:stable as builder
 WORKDIR /usr/src/app
-COPY Cargo.toml .
-COPY Cargo.lock .
-COPY contracts contracts
-COPY services-core services-core
-COPY driver driver
-COPY e2e e2e
-COPY gas-estimation gas-estimation
-COPY pricegraph pricegraph
-COPY price-estimator price-estimator
+
+COPY . .
+
 RUN ls -l && cargo build --release -p price-estimator
 
 FROM alpine:latest


### PR DESCRIPTION
Today, when creating a new top-level subcrate we need to also adjust the dockerfile of the price estimator as otherwise we run into build failure like [this](https://travis-ci.com/github/gnosis/dex-services/jobs/448733177#L309)

This PR simplifies the Dockerfile by copying the entirety of the src repository and relying on .dockerignore to not include any unnecessary data.

### Test Plan
See master turn green after merging.