### PR TITLE
Bump private solver to v0.8.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ language: rust
 env:
   global:
     - OPEN_SOLVER_VERSION=v0.1.2
-    - PRIVATE_SOLVER_VERSION=v0.8.6
+    - PRIVATE_SOLVER_VERSION=v0.8.7
 
 jobs:
   fast_finish: true


### PR DESCRIPTION
Contains https://github.com/gnosis/dex-solver/pull/338 which prunes the result JSON to only contain information relevant to the solution (i.e., no untouched-token prices, no accounts that didn't trade).