### PR TITLE
Update open solver to include solution time limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ dist: bionic
 language: rust
 env:
   global:
-    - OPEN_SOLVER_VERSION=v0.1.2
+    - OPEN_SOLVER_VERSION=v0.2.0
     - PRIVATE_SOLVER_VERSION=v0.8.7
 
 jobs:

--- a/services-core/src/price_finding/price_finder_interface.rs
+++ b/services-core/src/price_finding/price_finder_interface.rs
@@ -76,7 +76,7 @@ impl SolverType {
     ) -> Result<Output> {
         match self {
             SolverType::OpenSolver => {
-                execute_open_solver(result_folder, input_file, min_avg_fee_per_order)
+                execute_open_solver(result_folder, input_file, time_limit, min_avg_fee_per_order)
             }
             SolverType::StandardSolver | SolverType::BestRingSolver => execute_private_solver(
                 result_folder,
@@ -97,6 +97,7 @@ impl SolverType {
 pub fn execute_open_solver(
     result_folder: &str,
     input_file: &str,
+    time_limit: String,
     min_avg_fee_per_order: u128,
 ) -> Result<Output> {
     let mut command = Command::new("gp_match");
@@ -108,6 +109,7 @@ pub fn execute_open_solver(
             "06_solution_int_valid.json",
         ))
         .arg("--logging=WARNING")
+        .arg(format!("--time-limit={}", time_limit))
         .arg(format!("--min-avg-fee-per-order={}", min_avg_fee_per_order))
         .arg(String::from("best-token-pair"));
     debug!("Using open-solver command `{:?}`", open_solver_command);


### PR DESCRIPTION
Update the open solver to the latest version, which [introduces a new `--time-limit` argument](https://github.com/gnosis/dex-open-solver/pull/85).

### Test Plan
Run the driver with the last version of the open solver until something similar to the following lines is printed:
```
2020-12-01T17:30:54.483Z INFO [services_core::driver::stablex_driver] Computed solution for batch 5356145: Solution { prices: {}, executed_orders: [] }
2020-12-01T17:30:54.483Z INFO [services_core::driver::scheduler::system] Batch 5356145 solved successfully.
2020-12-01T17:30:54.804Z INFO [services_core::driver::stablex_driver] Not submitting trivial solution for batch 5356145
2020-12-01T17:30:54.805Z INFO [services_core::driver::scheduler::system] Batch 5356145 solution submitted successfully.
```