### PR TITLE
Panic when reducing zero flow

### DIFF
--- a/pricegraph/src/orderbook/flow.rs
+++ b/pricegraph/src/orderbook/flow.rs
@@ -34,6 +34,12 @@ impl Flow {
     pub fn is_dust_trade(&self) -> bool {
         num::is_dust_amount(self.min_trade as u128)
     }
+
+    /// Returns whether or not the flow is empty. An empty flow is one that does
+    /// not further reduce the orderbook, so has a 0 capacity.
+    pub fn is_empty(&self) -> bool {
+        self.capacity <= 0.
+    }
 }
 
 /// A representation of flow on two halves of a ring trade through the orderbook


### PR DESCRIPTION
One half of #1566 

This PR adds an additional check when reducing a path's flow to make sure its not empty. This can happen in cases where the computed exchange and capacity along a path would become zero because of rounding errors as the smallest possible float is around `2e-308` while the exchange rate for an order can be `8e-73`, so it doesn't take many orders to reach this limit.

For more details, see the issue linked above and the added unit test.

### Test Plan

Added unit test demonstrating problem. Note that this test **still** passes in release mode which used to not be the case and cause infinite loops.
```
$ cargo test -p pricegraph --release -- panics_on_empty_flow
    Finished release [optimized] target(s) in 0.07s
     Running target/release/deps/pricegraph-4287836eda7f370d

running 1 test
test orderbook::tests::panics_on_empty_flow ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 53 filtered out
```

Additionally, running the price estimator in release mode we can see the error when requesting `curl -s "http://localhost:8080/api/v1/markets/157-4?batchId=5355804"` which used to cause an **infinite loop** previously:
```
$ cargo run --release -p price-estimator -- --orderbook-file target/stablex_orderbook_mainnet.bin
# ...
2020-12-01T18:25:20.243Z ERRO [services_core::logging] thread 'tokio-runtime-worker' panicked at 'stuck reducing path with empty flow: 181->4->157->158->159->160->161->162->163->164->165->166->167->168->169->170->171->172->173->174->175->176->177->178->179->180->181', pricegraph/src/orderbook.rs:368:13
```