### PR TITLE
Turn pricegraph panic into error

### DIFF
--- a/e2e/src/bin/historic_prices.rs
+++ b/e2e/src/bin/historic_prices.rs
@@ -73,7 +73,7 @@ fn check_batch_prices(
     {
         let price = prices[token_index];
         let estimate = pricegraph
-            .estimate_token_price(token, None)
+            .estimate_token_price(token, None)?
             .map(|p| p as u128);
 
         samples.record_sample(Row {

--- a/pricegraph/fuzz/fuzz_targets/pricegraph.rs
+++ b/pricegraph/fuzz/fuzz_targets/pricegraph.rs
@@ -47,7 +47,9 @@ fuzz_target!(|arguments: Arguments| {
             pair_range,
             sell_amount,
         } => {
-            pricegraph.order_for_sell_amount(pair_range, sell_amount);
+            pricegraph
+                .order_for_sell_amount(pair_range, sell_amount)
+                .unwrap();
         }
         Operation::TransitiveOrderbook {
             market,
@@ -59,7 +61,9 @@ fuzz_target!(|arguments: Arguments| {
                     return;
                 }
             }
-            pricegraph.transitive_orderbook(market, hops.map(|hops| 1 + (hops % 30)), spread);
+            pricegraph
+                .transitive_orderbook(market, hops.map(|hops| 1 + (hops % 30)), spread)
+                .unwrap();
         }
     };
 });

--- a/pricegraph/src/api/price_source.rs
+++ b/pricegraph/src/api/price_source.rs
@@ -2,7 +2,7 @@
 //! it can be used for OWL price estimates to the solver.
 
 use crate::encoding::{TokenId, TokenPair, TokenPairRange};
-use crate::{Pricegraph, FEE_TOKEN};
+use crate::{OrderbookError, Pricegraph, FEE_TOKEN};
 
 const OWL_BASE_UNIT: f64 = 1_000_000_000_000_000_000.0;
 
@@ -16,9 +16,13 @@ impl Pricegraph {
     /// token).
     ///
     /// The fee token is defined as the token with ID 0.
-    pub fn estimate_token_price(&self, token: TokenId, hops: Option<usize>) -> Option<f64> {
+    pub fn estimate_token_price(
+        &self,
+        token: TokenId,
+        hops: Option<usize>,
+    ) -> Result<Option<f64>, OrderbookError> {
         if token == FEE_TOKEN {
-            return Some(OWL_BASE_UNIT);
+            return Ok(Some(OWL_BASE_UNIT));
         }
 
         // NOTE: Estimate price of selling 1 unit of the reference token for the
@@ -31,10 +35,13 @@ impl Pricegraph {
         };
         let range = TokenPairRange { pair, hops };
 
-        let price_in_token = self.estimate_limit_price(range, OWL_BASE_UNIT)?;
+        let price_in_token = match self.estimate_limit_price(range, OWL_BASE_UNIT)? {
+            Some(price) => price,
+            None => return Ok(None),
+        };
         let price_in_reference = 1.0 / price_in_token;
 
-        Some(OWL_BASE_UNIT * price_in_reference)
+        Ok(Some(OWL_BASE_UNIT * price_in_reference))
     }
 }
 
@@ -53,7 +60,7 @@ mod tests {
         };
 
         assert_approx_eq!(
-            pricegraph.estimate_token_price(0, None).unwrap(),
+            pricegraph.estimate_token_price(0, None).unwrap().unwrap(),
             OWL_BASE_UNIT
         );
     }
@@ -84,12 +91,12 @@ mod tests {
         let rounding_error = num::max_rounding_error_with_epsilon(OWL_BASE_UNIT);
 
         assert_approx_eq!(
-            pricegraph.estimate_token_price(1, None).unwrap(),
+            pricegraph.estimate_token_price(1, None).unwrap().unwrap(),
             (OWL_BASE_UNIT / 2.0) * FEE_FACTOR.powi(3),
             rounding_error
         );
         assert_approx_eq!(
-            pricegraph.estimate_token_price(2, None).unwrap(),
+            pricegraph.estimate_token_price(2, None).unwrap().unwrap(),
             (OWL_BASE_UNIT / 2.0) * FEE_FACTOR.powi(2),
             rounding_error
         );
@@ -121,13 +128,19 @@ mod tests {
         let rounding_error = num::max_rounding_error_with_epsilon(OWL_BASE_UNIT);
 
         assert_approx_eq!(
-            pricegraph.estimate_token_price(1, Some(1)).unwrap(),
+            pricegraph
+                .estimate_token_price(1, Some(1))
+                .unwrap()
+                .unwrap(),
             OWL_BASE_UNIT * FEE_FACTOR.powi(2),
             2.0 * rounding_error // adjust rounding error by the same factor that is used to adjust the price
         );
         // Same as without hops
         assert_approx_eq!(
-            pricegraph.estimate_token_price(2, Some(1)).unwrap(),
+            pricegraph
+                .estimate_token_price(2, Some(1))
+                .unwrap()
+                .unwrap(),
             (OWL_BASE_UNIT / 2.0) * FEE_FACTOR.powi(2),
             rounding_error
         );

--- a/pricegraph/src/graph/path.rs
+++ b/pricegraph/src/graph/path.rs
@@ -21,7 +21,7 @@ impl<N> From<NegativeCycle<N>> for Path<N> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 /// An ordered collection of nodes that form a cycle of negative weight.
 /// The first node of the cycle coincides with the last.
 pub struct NegativeCycle<N>(pub Vec<N>);

--- a/pricegraph/src/graph/subgraph.rs
+++ b/pricegraph/src/graph/subgraph.rs
@@ -16,13 +16,6 @@ impl<N: Copy + Ord> Subgraphs<N> {
         Subgraphs::<N>(nodes.collect())
     }
 
-    /// Iterate through each subgraph with the provided closure returning the
-    /// predecessor vector for the current node indicating which nodes are
-    /// connected to it.
-    pub fn for_each(self, mut f: impl FnMut(N) -> Vec<N>) {
-        self.for_each_until(|node| <ControlFlow<N, ()>>::Continue(f(node)));
-    }
-
     /// Iterate through each subgraph with the provided closure, returning the
     /// control flow `Break` value if there was an early return.
     pub fn for_each_until<T>(self, mut f: impl FnMut(N) -> ControlFlow<N, T>) -> Option<T> {

--- a/pricegraph/src/lib.rs
+++ b/pricegraph/src/lib.rs
@@ -31,7 +31,7 @@ pub const MIN_AMOUNT: u128 = 10_000;
 #[derive(Clone, Debug)]
 pub struct Pricegraph {
     full_orderbook: Orderbook,
-    reduced_orderbook: ReducedOrderbook,
+    reduced_orderbook: Result<ReducedOrderbook, OrderbookError>,
 }
 
 impl Pricegraph {
@@ -86,7 +86,7 @@ impl Pricegraph {
     /// Gets a clone of the reduced orderbook for operations that prefer there
     /// to be no overlapping transitive orders. A clone is returned because
     /// orderbook operations are destructive.
-    pub fn reduced_orderbook(&self) -> ReducedOrderbook {
+    pub fn reduced_orderbook(&self) -> Result<ReducedOrderbook, OrderbookError> {
         self.reduced_orderbook.clone()
     }
 }
@@ -114,6 +114,7 @@ mod tests {
 
             let order = pricegraph
                 .order_for_sell_amount(dai_weth.bid_pair().into_unbounded_range(), volume)
+                .unwrap()
                 .unwrap();
             println!(
                 "#{}: estimated order for buying {} DAI for {} WETH",
@@ -122,8 +123,9 @@ mod tests {
                 order.sell / base_unit,
             );
 
-            let TransitiveOrderbook { asks, bids } =
-                pricegraph.transitive_orderbook(dai_weth, None, Some(spread));
+            let TransitiveOrderbook { asks, bids } = pricegraph
+                .transitive_orderbook(dai_weth, None, Some(spread))
+                .unwrap();
             println!(
                 "#{}: DAI-WETH market contains {} ask orders and {} bid orders within a {}% spread:",
                 batch_id,

--- a/pricegraph/src/orderbook/flow.rs
+++ b/pricegraph/src/orderbook/flow.rs
@@ -34,12 +34,6 @@ impl Flow {
     pub fn is_dust_trade(&self) -> bool {
         num::is_dust_amount(self.min_trade as u128)
     }
-
-    /// Returns whether or not the flow is empty. An empty flow is one that does
-    /// not further reduce the orderbook, so has a 0 capacity.
-    pub fn is_empty(&self) -> bool {
-        self.capacity <= 0.
-    }
 }
 
 /// A representation of flow on two halves of a ring trade through the orderbook

--- a/pricegraph/src/orderbook/reduced.rs
+++ b/pricegraph/src/orderbook/reduced.rs
@@ -1,7 +1,7 @@
 //! Module containing reduced orderbook wrapper type.
 
 use crate::encoding::TokenPairRange;
-use crate::orderbook::{Flow, Orderbook, TransitiveOrders};
+use crate::orderbook::{Flow, Orderbook, OrderbookError, TransitiveOrders};
 
 /// A graph representation of a reduced orderbook. Reduced orderbooks are
 /// guaranteed to not contain any negative cycles.
@@ -29,9 +29,12 @@ impl ReducedOrderbook {
     pub fn significant_transitive_orders(
         self,
         pair_range: TokenPairRange,
-    ) -> impl Iterator<Item = Flow> {
+    ) -> impl Iterator<Item = Result<Flow, OrderbookError>> {
         self.transitive_orders(pair_range)
-            .filter(|flow| !flow.is_dust_trade())
+            .filter(|flow| match flow {
+                Ok(flow) => !flow.is_dust_trade(),
+                Err(_) => true,
+            })
     }
 
     /// Finds and returns the optimal transitive order for the specified token

--- a/pricegraph/wasm/src/lib.rs
+++ b/pricegraph/wasm/src/lib.rs
@@ -40,8 +40,14 @@ impl PriceEstimator {
     /// Estimates price for the specified trade. Returns `undefined` if the
     /// volume cannot be fully filled.
     #[wasm_bindgen(js_name = "estimatePrice")]
-    pub fn estimate_price(&self, buy: TokenId, sell: TokenId, volume: f64) -> Option<f64> {
+    pub fn estimate_price(
+        &self,
+        buy: TokenId,
+        sell: TokenId,
+        volume: f64,
+    ) -> Result<Option<f64>, JsValue> {
         self.pricegraph
             .estimate_limit_price(TokenPair { buy, sell }.into_unbounded_range(), volume)
+            .map_err(|err| JsValue::from(err.to_string()))
     }
 }

--- a/pricegraph/wasm/tests/nodejs.rs
+++ b/pricegraph/wasm/tests/nodejs.rs
@@ -20,7 +20,7 @@ fn time<T>(f: impl FnOnce() -> T) -> (T, f64) {
 #[wasm_bindgen_test]
 fn estimate_price() {
     let (estimator, load_time) = time(|| PriceEstimator::new(&*DEFAULT_ORDERBOOK).unwrap());
-    let (price, estimate_time) = time(|| estimator.estimate_price(7, 1, 100e18).unwrap());
+    let (price, estimate_time) = time(|| estimator.estimate_price(7, 1, 100e18).unwrap().unwrap());
 
     console_log!(
         "DAI-WETH price for selling 100 WETH: 1 WETH = {} DAI (load {}ms, estimate {}ms)",

--- a/services-core/src/price_estimation/orderbook_based.rs
+++ b/services-core/src/price_estimation/orderbook_based.rs
@@ -61,7 +61,13 @@ mod inner {
 
     impl TokenPriceEstimating for Pricegraph {
         fn estimate_token_price(&self, token: TokenId, hops: Option<usize>) -> Option<f64> {
-            let estimate = self.estimate_token_price(token.0, hops)?;
+            let estimate = match self.estimate_token_price(token.0, hops) {
+                Ok(estimate) => estimate,
+                Err(err) => {
+                    log::error!("price estimator error: {:?}", err);
+                    None
+                }
+            }?;
             Some(estimate)
         }
     }


### PR DESCRIPTION
The meat of the change is Orderbook.rs find_path_flow and fill_path_with_flow which return results now. All the other changes follow from bubbling up the error.

Sadly this makes the code uglier because of a lot of extra `Result`s and
being unable to use `?` in some places because we went from `Option<T>`
to `Result<Option<T>>`.
However, we still need this change to prevent panicking because of
untrusted input (the orderbook).

related to https://github.com/gnosis/dex-services/issues/1566

### Test Plan
Tests still pass. Did a couple of manual requests to my price estimator.