### PR TITLE
Fix new clippy lints

### DIFF
--- a/pricegraph/src/encoding.rs
+++ b/pricegraph/src/encoding.rs
@@ -117,7 +117,7 @@ pub struct Element {
 }
 
 impl Element {
-    pub fn read_all<'a>(bytes: &'a [u8]) -> Result<impl Iterator<Item = Self> + 'a, InvalidLength> {
+    pub fn read_all(bytes: &[u8]) -> Result<impl Iterator<Item = Self> + '_, InvalidLength> {
         if bytes.len() % ELEMENT_STRIDE != 0 {
             return Err(InvalidLength(bytes.len()));
         }

--- a/pricegraph/src/num.rs
+++ b/pricegraph/src/num.rs
@@ -94,7 +94,7 @@ mod tests {
             1.0f64,
             42.42,
             83_798_276_971_421_254_262_445_676_335_662_107_162.0,
-            #[allow(clippy::inconsistent_digit_grouping)]
+            #[allow(clippy::unusual_byte_groupings)]
             f64::from_bits(0b0_10101010101_1111111111111111111111111111111111111111111111111111),
         ] {
             let upper_bound = value + max_rounding_error(*value);

--- a/pricegraph/src/orderbook/weight.rs
+++ b/pricegraph/src/orderbook/weight.rs
@@ -68,8 +68,8 @@ impl Weight {
 
         let weight = value.log2() * FIXED_24X104_SCALING_FACTOR;
         debug_assert!(
-            -128.0 * FIXED_24X104_SCALING_FACTOR <= weight
-                && weight < 114.72 * FIXED_24X104_SCALING_FACTOR,
+            (-128.0 * FIXED_24X104_SCALING_FACTOR..114.72 * FIXED_24X104_SCALING_FACTOR)
+                .contains(&weight)
         );
 
         Weight(weight as _)

--- a/services-core/src/orderbook/streamed/block_timestamp_reading.rs
+++ b/services-core/src/orderbook/streamed/block_timestamp_reading.rs
@@ -10,7 +10,6 @@ use ethcontract::{
 use std::{
     collections::{HashMap, HashSet},
     convert::TryFrom,
-    iter::FromIterator,
 };
 
 /// Helper trait to make this functionality mockable for tests.
@@ -52,7 +51,11 @@ impl BatchedBlockReading for Web3 {
     ) -> Result<Vec<BlockPair>> {
         let batched_web3 = ethcontract::web3::Web3::new(Batch::new(self.transport().clone()));
         let mut result = Vec::with_capacity(block_hashes.len());
-        for chunk in Vec::from_iter(block_hashes.into_iter()).chunks(block_batch_size) {
+        for chunk in block_hashes
+            .into_iter()
+            .collect::<Vec<_>>()
+            .chunks(block_batch_size)
+        {
             let partial_result = query_block_timestamps_batched(&batched_web3, chunk).await?;
             result.extend(partial_result);
         }

--- a/services-core/src/price_finding/optimization_price_finder.rs
+++ b/services-core/src/price_finding/optimization_price_finder.rs
@@ -665,7 +665,7 @@ pub mod tests {
         let mut price_oracle = MockPriceEstimating::new();
         price_oracle
             .expect_get_token_prices()
-            .withf(|orders| orders == [])
+            .withf(|orders| orders.is_empty())
             .returning(|_| {
                 btree_map! {
                     TokenId(0) => Some(TokenInfo::new("T1", 18, 1_000_000_000_000_000_000)),

--- a/services-core/src/solution_submission.rs
+++ b/services-core/src/solution_submission.rs
@@ -401,11 +401,11 @@ mod tests {
         contract
             .expect_submit_solution()
             .return_once(|_, _, _, _, _| {
-                immediate!(Err(MethodError::from_parts(
-                "submitSolution(uint32,uint256,address[],uint16[],uint128[],uint128[],uint16[])"
-                    .to_owned(),
-                ExecutionError::Failure(Box::new(receipt)),
-            )))
+                Err(MethodError::from_parts(
+                    "submitSolution(uint32,uint256,address[],uint16[],uint128[],uint128[],uint16[])"
+                        .to_owned(),
+                    ExecutionError::Failure(Box::new(receipt)),
+                ))
             });
         let mut gas_price = MockGasPriceEstimating::new();
         gas_price

--- a/services-core/src/token_info/hardcoded.rs
+++ b/services-core/src/token_info/hardcoded.rs
@@ -5,7 +5,7 @@ use crate::{models::TokenId, price_estimation::price_source::PriceSource};
 use anyhow::{anyhow, Context, Error, Result};
 use ethcontract::Address;
 use serde::Deserialize;
-use std::{collections::HashMap, iter::FromIterator, num::NonZeroU128, str::FromStr};
+use std::{collections::HashMap, num::NonZeroU128, str::FromStr};
 
 use super::{TokenBaseInfo, TokenInfoFetching};
 #[cfg_attr(test, derive(Eq, PartialEq))]
@@ -63,7 +63,7 @@ impl TokenInfoFetching for TokenData {
     }
 
     async fn all_ids(&self) -> Result<Vec<TokenId>> {
-        Ok(Vec::from_iter(self.0.keys().copied()))
+        Ok(self.0.keys().copied().collect())
     }
 }
 


### PR DESCRIPTION
This PR fixes clippy lints that were added with a new Rust release. These were causing lint errors in CI which made, otherwise passing PRs, impossible to merge (such as some dependency updates).

### Test Plan

CI passes.