### PR TITLE
Bump private solver to v0.8.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ language: rust
 env:
   global:
     - OPEN_SOLVER_VERSION=v0.2.1
-    - PRIVATE_SOLVER_VERSION=v0.8.7
+    - PRIVATE_SOLVER_VERSION=v0.8.8
 
 jobs:
   fast_finish: true


### PR DESCRIPTION
This update introduces a MIN_TIME_LIMIT constant that is set to 30 seconds. If the time limit that is passed to the solver is below that value, the solver immediately returns the trivial solution. This is to address https://github.com/gnosis/dex-solver/issues/341.